### PR TITLE
Mirror Chrome -> Samsung Internet for css/*

### DIFF
--- a/css/at-rules/charset.json
+++ b/css/at-rules/charset.json
@@ -41,9 +41,7 @@
             "safari_ios": {
               "version_added": "4"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "2"
             }

--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -198,9 +198,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": "3.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "1"
             }
@@ -243,9 +241,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "66"
               }
@@ -295,9 +291,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -347,9 +341,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -399,9 +391,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -451,9 +441,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -503,9 +491,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -555,9 +541,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -661,9 +645,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -713,9 +695,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -815,9 +795,7 @@
               "safari_ios": {
                 "version_added": true
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -867,9 +845,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -918,9 +894,7 @@
               "safari_ios": {
                 "version_added": "3.1"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "1"
               }
@@ -1021,9 +995,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1073,9 +1045,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": true
               }
@@ -1383,9 +1353,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1435,9 +1403,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1491,9 +1457,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false,
                 "notes": "See <a href='https://crbug.com/489957'>bug 489957</a>."
@@ -1595,9 +1559,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1647,9 +1609,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1699,9 +1659,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1751,9 +1709,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1829,9 +1785,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1907,9 +1861,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1989,9 +1941,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -2041,9 +1991,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -2105,9 +2053,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -2157,9 +2103,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/at-rules/namespace.json
+++ b/css/at-rules/namespace.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/at-rules/page.json
+++ b/css/at-rules/page.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -90,9 +88,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -142,9 +138,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -194,9 +188,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/at-rules/viewport.json
+++ b/css/at-rules/viewport.json
@@ -352,9 +352,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -537,9 +535,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -647,9 +643,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/-webkit-border-before.json
+++ b/css/properties/-webkit-border-before.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/css/properties/-webkit-box-reflect.json
+++ b/css/properties/-webkit-box-reflect.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": "3.2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "2.2"
             }

--- a/css/properties/-webkit-mask-attachment.json
+++ b/css/properties/-webkit-mask-attachment.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": "3.2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/properties/-webkit-mask-box-image.json
+++ b/css/properties/-webkit-mask-box-image.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": "3.2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "2"
             }

--- a/css/properties/-webkit-mask-composite.json
+++ b/css/properties/-webkit-mask-composite.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": "3.2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "2.2"
             }

--- a/css/properties/-webkit-mask-position-x.json
+++ b/css/properties/-webkit-mask-position-x.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/properties/-webkit-mask-position-y.json
+++ b/css/properties/-webkit-mask-position-y.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/properties/-webkit-mask-repeat-x.json
+++ b/css/properties/-webkit-mask-repeat-x.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/css/properties/-webkit-mask-repeat-y.json
+++ b/css/properties/-webkit-mask-repeat-y.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/css/properties/-webkit-print-color-adjust.json
+++ b/css/properties/-webkit-print-color-adjust.json
@@ -43,9 +43,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/properties/-webkit-text-fill-color.json
+++ b/css/properties/-webkit-text-fill-color.json
@@ -62,9 +62,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/properties/-webkit-text-stroke-color.json
+++ b/css/properties/-webkit-text-stroke-color.json
@@ -62,9 +62,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -135,9 +135,7 @@
                 "prefix": "-webkit-",
                 "version_added": "7"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": [
                 {
                   "version_added": "52"
@@ -196,9 +194,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }
@@ -247,9 +243,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }
@@ -298,9 +292,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }
@@ -452,9 +444,7 @@
                 "safari_ios": {
                   "version_added": true
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": true
                 }

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -126,9 +126,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": [
                 {
                   "version_added": "37"
@@ -187,9 +185,7 @@
                 "safari_ios": {
                   "version_added": false
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }
@@ -238,9 +234,7 @@
                 "safari_ios": {
                   "version_added": false
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }
@@ -289,9 +283,7 @@
                 "safari_ios": {
                   "version_added": false
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }
@@ -340,9 +332,7 @@
                 "safari_ios": {
                   "version_added": false
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }
@@ -391,9 +381,7 @@
                 "safari_ios": {
                   "version_added": false
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }

--- a/css/properties/animation-delay.json
+++ b/css/properties/animation-delay.json
@@ -135,9 +135,7 @@
                 "version_added": true
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": [
               {
                 "version_added": "43"

--- a/css/properties/animation-timing-function.json
+++ b/css/properties/animation-timing-function.json
@@ -208,9 +208,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/background-blend-mode.json
+++ b/css/properties/background-blend-mode.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": "8"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -241,9 +241,7 @@
                 "prefix": "-webkit-",
                 "notes": "Support the prefixed version of the property only; according to the <a href='https://webkit.org/blog/164/background-clip-text/'>official blog</a>, WebKit does not include text decorations or shadows in the clipping."
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": true,
                 "prefix": "-webkit-",

--- a/css/properties/background-repeat.json
+++ b/css/properties/background-repeat.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -88,9 +86,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -139,9 +135,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -190,9 +184,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/background-size.json
+++ b/css/properties/background-size.json
@@ -159,9 +159,7 @@
               "safari_ios": {
                 "version_added": true
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -210,9 +208,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/background.json
+++ b/css/properties/background.json
@@ -139,9 +139,7 @@
               "safari_ios": {
                 "version_added": "4.2"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "3"
               }
@@ -241,9 +239,7 @@
               "safari_ios": {
                 "version_added": "4"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "3"
               }
@@ -292,9 +288,7 @@
               "safari_ios": {
                 "version_added": "4"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "3"
               }

--- a/css/properties/border-image-slice.json
+++ b/css/properties/border-image-slice.json
@@ -44,9 +44,7 @@
             "safari": {
               "version_added": "6"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "prefix": "-webkit-",
               "version_added": "4.1"

--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -130,9 +130,7 @@
                 "version_added": "3.2"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "prefix": "-webkit-",
               "version_added": "2"

--- a/css/properties/box-align.json
+++ b/css/properties/box-align.json
@@ -70,9 +70,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true,
               "prefix": "-webkit-"

--- a/css/properties/box-direction.json
+++ b/css/properties/box-direction.json
@@ -86,9 +86,7 @@
               "prefix": "-webkit-",
               "version_added": "1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/properties/box-flex-group.json
+++ b/css/properties/box-flex-group.json
@@ -54,9 +54,7 @@
               "version_added": "1",
               "prefix": "-webkit-"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true,
               "version_removed": "67",

--- a/css/properties/box-flex.json
+++ b/css/properties/box-flex.json
@@ -86,9 +86,7 @@
               "prefix": "-webkit-",
               "version_added": "1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/properties/box-lines.json
+++ b/css/properties/box-lines.json
@@ -54,9 +54,7 @@
               "version_added": "1",
               "prefix": "-webkit-"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true,
               "version_removed": "67",

--- a/css/properties/box-ordinal-group.json
+++ b/css/properties/box-ordinal-group.json
@@ -69,9 +69,7 @@
               "version_added": "1",
               "prefix": "-webkit-"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true,
               "prefix": "-webkit-"

--- a/css/properties/box-orient.json
+++ b/css/properties/box-orient.json
@@ -86,9 +86,7 @@
               "prefix": "-webkit-",
               "version_added": "1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/properties/box-pack.json
+++ b/css/properties/box-pack.json
@@ -86,9 +86,7 @@
               "prefix": "-webkit-",
               "version_added": "1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/properties/box-shadow.json
+++ b/css/properties/box-shadow.json
@@ -88,9 +88,7 @@
                 "version_added": true
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "prefix": "-webkit-",
               "version_added": true,
@@ -166,9 +164,7 @@
                   "version_added": true
                 }
               ],
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "prefix": "-webkit-",
                 "version_added": true
@@ -248,9 +244,7 @@
                   "version_added": true
                 }
               ],
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "prefix": "-webkit-",
                 "version_added": true
@@ -326,9 +320,7 @@
                   "version_added": true
                 }
               ],
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "prefix": "-webkit-",
                 "version_added": true

--- a/css/properties/box-sizing.json
+++ b/css/properties/box-sizing.json
@@ -109,9 +109,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": [
               {
                 "version_added": "4",

--- a/css/properties/break-after.json
+++ b/css/properties/break-after.json
@@ -102,9 +102,7 @@
                 "safari_ios": {
                   "version_added": false
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": true
                 }
@@ -320,9 +318,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": "50"
                 }
@@ -372,9 +368,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": "50"
                 }

--- a/css/properties/break-before.json
+++ b/css/properties/break-before.json
@@ -320,9 +320,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": "50"
                 }
@@ -372,9 +370,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": "50"
                 }

--- a/css/properties/caption-side.json
+++ b/css/properties/caption-side.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/css/properties/clip.json
+++ b/css/properties/clip.json
@@ -40,9 +40,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/properties/color-adjust.json
+++ b/css/properties/color-adjust.json
@@ -41,9 +41,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/properties/color.json
+++ b/css/properties/color.json
@@ -350,9 +350,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -402,9 +400,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -453,9 +449,7 @@
               "safari_ios": {
                 "version_added": "8"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": true
               }
@@ -524,9 +518,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -575,9 +567,7 @@
               "safari_ios": {
                 "version_added": "12.2"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "65"
               }

--- a/css/properties/column-gap.json
+++ b/css/properties/column-gap.json
@@ -43,9 +43,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "uc_android": {
                 "version_added": null
               },

--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -140,9 +140,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/cursor.json
+++ b/css/properties/cursor.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -89,9 +87,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -140,9 +136,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -191,9 +185,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -242,9 +234,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -295,9 +285,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -346,9 +334,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -397,9 +383,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -448,9 +432,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -499,9 +481,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -550,9 +530,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -601,9 +579,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -652,9 +628,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -703,9 +677,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -754,9 +726,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -805,9 +775,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -856,9 +824,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -907,9 +873,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -958,9 +922,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -1009,9 +971,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -1060,9 +1020,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -1111,9 +1069,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -1162,9 +1118,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -1213,9 +1167,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -1296,9 +1248,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -1367,9 +1317,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -1419,9 +1367,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -1471,9 +1417,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }

--- a/css/properties/custom-property.json
+++ b/css/properties/custom-property.json
@@ -168,9 +168,7 @@
               "safari_ios": {
                 "version_added": true
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "50"
               }

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -970,9 +970,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1029,9 +1027,7 @@
                 "version_removed": "8",
                 "notes": "Before Safari 5, <code>run-in</code> was not supported before inline elements."
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": true,
                 "version_removed": "4.4.3",

--- a/css/properties/empty-cells.json
+++ b/css/properties/empty-cells.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": "3.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "1"
             }

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -243,9 +243,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -305,9 +303,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }

--- a/css/properties/flex.json
+++ b/css/properties/flex.json
@@ -162,9 +162,7 @@
                 "version_added": "7.1"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": [
               {
                 "version_added": "4.4"

--- a/css/properties/font-kerning.json
+++ b/css/properties/font-kerning.json
@@ -65,9 +65,7 @@
             "safari_ios": {
               "version_added": "7"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/properties/font-optical-sizing.json
+++ b/css/properties/font-optical-sizing.json
@@ -64,9 +64,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/properties/font-size-adjust.json
+++ b/css/properties/font-size-adjust.json
@@ -61,9 +61,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/properties/font-stretch.json
+++ b/css/properties/font-stretch.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "60"
             }
@@ -88,9 +86,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }

--- a/css/properties/font-style.json
+++ b/css/properties/font-style.json
@@ -90,9 +90,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/font-variant.json
+++ b/css/properties/font-variant.json
@@ -53,7 +53,7 @@
         },
         "uppercase_eszett": {
           "__compat": {
-            "description": "<code>ß</code> → <code>SS</code>",
+            "description": "<code>\u00df</code> \u2192 <code>SS</code>",
             "support": {
               "chrome": {
                 "version_added": null
@@ -88,9 +88,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -104,7 +102,7 @@
         },
         "turkic_is": {
           "__compat": {
-            "description": "<code>i</code> → <code>İ</code> and <code>ı</code> → <code>I</code>",
+            "description": "<code>i</code> \u2192 <code>\u0130</code> and <code>\u0131</code> \u2192 <code>I</code>",
             "support": {
               "chrome": {
                 "version_added": false
@@ -267,9 +265,7 @@
               "safari_ios": {
                 "version_added": "9.3"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/font-weight.json
+++ b/css/properties/font-weight.json
@@ -88,9 +88,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/font.json
+++ b/css/properties/font.json
@@ -88,9 +88,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -139,9 +137,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/gap.json
+++ b/css/properties/gap.json
@@ -43,9 +43,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "uc_android": {
                 "version_added": null
               },

--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -214,9 +214,7 @@
               "safari_ios": {
                 "version_added": "10.3"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -337,9 +335,7 @@
               "safari_ios": {
                 "version_added": "10.3"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -214,9 +214,7 @@
               "safari_ios": {
                 "version_added": "10.3"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -325,9 +323,7 @@
               "safari_ios": {
                 "version_added": "10.3"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/hyphens.json
+++ b/css/properties/hyphens.json
@@ -131,9 +131,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -182,9 +180,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -233,9 +229,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -284,9 +278,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -335,9 +327,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -386,9 +376,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -437,9 +425,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -488,9 +474,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -539,9 +523,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -590,9 +572,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -641,9 +621,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -692,9 +670,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -743,9 +719,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -794,9 +768,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -845,9 +817,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -896,9 +866,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -947,9 +915,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -998,9 +964,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1049,9 +1013,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1100,9 +1062,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1151,9 +1111,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1253,9 +1211,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1304,9 +1260,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1320,7 +1274,7 @@
         },
         "norwegian_no": {
           "__compat": {
-            "description": "Hyphenation dictionary for Norwegian (Bokmål) (no, no-*, nb, nb-*)",
+            "description": "Hyphenation dictionary for Norwegian (Bokm\u00e5l) (no, no-*, nb, nb-*)",
             "support": {
               "chrome": {
                 "version_added": null
@@ -1355,9 +1309,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1406,9 +1358,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1457,9 +1407,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1508,9 +1456,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1560,9 +1506,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1611,9 +1555,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1662,9 +1604,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1713,9 +1653,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1764,9 +1702,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1815,9 +1751,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1866,9 +1800,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1917,9 +1849,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1968,9 +1898,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/image-rendering.json
+++ b/css/properties/image-rendering.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "41"
             }

--- a/css/properties/isolation.json
+++ b/css/properties/isolation.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": "8"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "41"
             }

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -219,9 +219,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }
@@ -292,9 +290,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }
@@ -347,9 +343,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }
@@ -453,9 +447,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }

--- a/css/properties/justify-items.json
+++ b/css/properties/justify-items.json
@@ -40,9 +40,7 @@
               "safari_ios": {
                 "version_added": "9.2"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "52"
               }

--- a/css/properties/letter-spacing.json
+++ b/css/properties/letter-spacing.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -88,9 +86,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/margin-bottom.json
+++ b/css/properties/margin-bottom.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": "1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "1"
             }
@@ -89,9 +87,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/margin-left.json
+++ b/css/properties/margin-left.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": "1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "1"
             }
@@ -89,9 +87,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/margin-right.json
+++ b/css/properties/margin-right.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": "1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "1"
             }
@@ -89,9 +87,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/margin-top.json
+++ b/css/properties/margin-top.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": "1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "1"
             }
@@ -89,9 +87,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/margin.json
+++ b/css/properties/margin.json
@@ -89,9 +89,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/mask-clip.json
+++ b/css/properties/mask-clip.json
@@ -41,9 +41,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -91,9 +89,7 @@
               "safari_ios": {
                 "version_added": "3.2"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "2"
               }
@@ -142,9 +138,7 @@
               "safari_ios": {
                 "version_added": "3.2"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "2"
               }
@@ -193,9 +187,7 @@
               "safari_ios": {
                 "version_added": "3.2"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "2"
               }
@@ -244,9 +236,7 @@
               "safari_ios": {
                 "version_added": "3.2"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "2"
               }

--- a/css/properties/mask-image.json
+++ b/css/properties/mask-image.json
@@ -45,9 +45,7 @@
               "version_added": "3.2",
               "notes": "Initially, Safari supported only <code>-webkit-</code> prefixed values for gradients (such as <code>-webkit-linear-gradient()</code>). Later, support for unprefixed values was added."
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "prefix": "-webkit-",
               "version_added": "2",
@@ -97,9 +95,7 @@
               "safari_ios": {
                 "version_added": true
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": true
               }
@@ -148,9 +144,7 @@
               "safari_ios": {
                 "version_added": true
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": true
               }

--- a/css/properties/mask-origin.json
+++ b/css/properties/mask-origin.json
@@ -44,9 +44,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -250,9 +248,7 @@
                 "prefix": "-webkit-",
                 "version_added": "3.2"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "prefix": "-webkit-",
                 "version_added": "2"

--- a/css/properties/mask-position.json
+++ b/css/properties/mask-position.json
@@ -40,9 +40,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/properties/mask-repeat.json
+++ b/css/properties/mask-repeat.json
@@ -41,9 +41,7 @@
               "prefix": "-webkit-",
               "version_added": "3.2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "prefix": "-webkit-",
               "version_added": "2"

--- a/css/properties/mask-size.json
+++ b/css/properties/mask-size.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/properties/mask-type.json
+++ b/css/properties/mask-type.json
@@ -64,9 +64,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/properties/mask.json
+++ b/css/properties/mask.json
@@ -77,9 +77,7 @@
               "prefix": "-webkit-",
               "version_added": "3.2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": [
               {
                 "version_added": "2"
@@ -135,9 +133,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -188,9 +184,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -40,9 +40,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -41,9 +41,7 @@
             "safari_ios": {
               "version_added": "9"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -349,9 +347,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -40,9 +40,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -259,9 +257,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "alternative_name": "-webkit-fill-available",
                 "version_added": "37"
@@ -394,9 +390,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/mix-blend-mode.json
+++ b/css/properties/mix-blend-mode.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": "8"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "41"
             }
@@ -88,9 +86,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }

--- a/css/properties/object-position.json
+++ b/css/properties/object-position.json
@@ -50,9 +50,7 @@
             "safari_ios": {
               "version_added": "10"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "4.4.3"
             }

--- a/css/properties/offset-path.json
+++ b/css/properties/offset-path.json
@@ -139,9 +139,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "64"
               }

--- a/css/properties/order.json
+++ b/css/properties/order.json
@@ -138,9 +138,7 @@
                 "version_added": "7"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": [
               {
                 "version_added": "4.4"
@@ -194,9 +192,7 @@
               "safari_ios": {
                 "version_added": true
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/orphans.json
+++ b/css/properties/orphans.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/css/properties/outline-color.json
+++ b/css/properties/outline-color.json
@@ -45,9 +45,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/properties/outline-offset.json
+++ b/css/properties/outline-offset.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/properties/outline-style.json
+++ b/css/properties/outline-style.json
@@ -45,9 +45,7 @@
             "safari_ios": {
               "version_added": "3.2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "2"
             }
@@ -95,9 +93,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/outline-width.json
+++ b/css/properties/outline-width.json
@@ -45,9 +45,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/properties/outline.json
+++ b/css/properties/outline.json
@@ -46,9 +46,7 @@
             "safari_ios": {
               "version_added": "3.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "1"
             }

--- a/css/properties/overflow-wrap.json
+++ b/css/properties/overflow-wrap.json
@@ -195,9 +195,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -40,9 +40,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/properties/page-break-after.json
+++ b/css/properties/page-break-after.json
@@ -40,9 +40,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/properties/page-break-before.json
+++ b/css/properties/page-break-before.json
@@ -40,9 +40,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/properties/page-break-inside.json
+++ b/css/properties/page-break-inside.json
@@ -40,9 +40,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/properties/perspective-origin.json
+++ b/css/properties/perspective-origin.json
@@ -97,9 +97,7 @@
               "prefix": "-webkit-",
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "prefix": "-webkit-",
               "version_added": "3"

--- a/css/properties/perspective.json
+++ b/css/properties/perspective.json
@@ -102,9 +102,7 @@
               "prefix": "-webkit-",
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "prefix": "-webkit-",
               "version_added": "3"

--- a/css/properties/pointer-events.json
+++ b/css/properties/pointer-events.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "2"
             }
@@ -88,9 +86,7 @@
               "safari_ios": {
                 "version_added": true
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/position.json
+++ b/css/properties/position.json
@@ -209,9 +209,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/quotes.json
+++ b/css/properties/quotes.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/properties/resize.json
+++ b/css/properties/resize.json
@@ -45,9 +45,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -96,9 +94,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/row-gap.json
+++ b/css/properties/row-gap.json
@@ -43,9 +43,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "uc_android": {
                 "version_added": null
               },

--- a/css/properties/scroll-behavior.json
+++ b/css/properties/scroll-behavior.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "61"
             }

--- a/css/properties/tab-size.json
+++ b/css/properties/tab-size.json
@@ -61,9 +61,7 @@
             "safari_ios": {
               "version_added": "7.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "4.4"
             }
@@ -112,9 +110,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "56"
               }

--- a/css/properties/table-layout.json
+++ b/css/properties/table-layout.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": "3"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "1.5"
             }

--- a/css/properties/text-align.json
+++ b/css/properties/text-align.json
@@ -97,9 +97,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -148,9 +146,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -199,9 +195,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -301,9 +295,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/text-decoration.json
+++ b/css/properties/text-decoration.json
@@ -185,9 +185,7 @@
                 "version_added": "8",
                 "notes": "Safari doesn't support <a href='https://developer.mozilla.org/docs/Web/CSS/text-decoration-style'><code>text-decoration-style</code></a>."
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/text-emphasis-color.json
+++ b/css/properties/text-emphasis-color.json
@@ -73,9 +73,7 @@
             "safari_ios": {
               "version_added": "7.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "prefix": "-webkit-",
               "version_added": "4.4"

--- a/css/properties/text-emphasis-style.json
+++ b/css/properties/text-emphasis-style.json
@@ -73,9 +73,7 @@
             "safari_ios": {
               "version_added": "7.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "prefix": "-webkit-",
               "version_added": "4.4"

--- a/css/properties/text-emphasis.json
+++ b/css/properties/text-emphasis.json
@@ -73,9 +73,7 @@
             "safari_ios": {
               "version_added": "7.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "prefix": "-webkit-",
               "version_added": "4.4"

--- a/css/properties/text-overflow.json
+++ b/css/properties/text-overflow.json
@@ -58,9 +58,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/css/properties/text-rendering.json
+++ b/css/properties/text-rendering.json
@@ -46,9 +46,7 @@
             "safari_ios": {
               "version_added": "4.3"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "3",
               "notes": "From version 3 to 4.3, there is a serious bug where <code>text-rendering: optimizeLegibility</code> causes custom web fonts to not render. This was fixed in version 4.4."
@@ -100,9 +98,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -153,9 +149,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/text-shadow.json
+++ b/css/properties/text-shadow.json
@@ -52,9 +52,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/properties/text-size-adjust.json
+++ b/css/properties/text-size-adjust.json
@@ -129,9 +129,7 @@
               "safari_ios": {
                 "version_added": true
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/text-transform.json
+++ b/css/properties/text-transform.json
@@ -42,9 +42,7 @@
               "version_added": "1",
               "notes": "The <code>text-transform</code> property does not work for <code>::first-line</code> pseudo-elements (also not for the old one-colon syntax). See <a href='https://webkit.org/b/3409'>WebKit bug 3409</a>."
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "1",
               "notes": "The <code>text-transform</code> property does not work for <code>::first-line</code> pseudo-elements (nor for the one-colon syntax). See <a href='https://crbug.com/129669'>Chromium bug 129669</a>."
@@ -93,9 +91,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -195,9 +191,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -297,9 +291,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -313,7 +305,7 @@
         },
         "lowercase_sigma": {
           "__compat": {
-            "description": "<code>Σ</code> → <code>σ</code> or word-final <code>ς</code>",
+            "description": "<code>\u03a3</code> \u2192 <code>\u03c3</code> or word-final <code>\u03c2</code>",
             "support": {
               "chrome": {
                 "version_added": "30"
@@ -348,9 +340,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -364,7 +354,7 @@
         },
         "turkic_is": {
           "__compat": {
-            "description": "<code>i</code> → <code>İ</code> and <code>ı</code> → <code>I</code>",
+            "description": "<code>i</code> \u2192 <code>\u0130</code> and <code>\u0131</code> \u2192 <code>I</code>",
             "support": {
               "chrome": {
                 "version_added": false
@@ -415,7 +405,7 @@
         },
         "uppercase_eszett": {
           "__compat": {
-            "description": "<code>ß</code> → <code>SS</code>",
+            "description": "<code>\u00df</code> \u2192 <code>SS</code>",
             "support": {
               "chrome": {
                 "version_added": null
@@ -450,9 +440,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -112,9 +112,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -165,9 +163,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -231,9 +227,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/transform-style.json
+++ b/css/properties/transform-style.json
@@ -97,9 +97,7 @@
               "prefix": "-webkit-",
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "prefix": "-webkit-",
               "version_added": "3"

--- a/css/properties/transition-timing-function.json
+++ b/css/properties/transition-timing-function.json
@@ -200,9 +200,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/user-modify.json
+++ b/css/properties/user-modify.json
@@ -60,9 +60,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -109,9 +107,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/white-space.json
+++ b/css/properties/white-space.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -88,9 +86,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -147,9 +143,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -198,9 +192,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -249,9 +241,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/widows.json
+++ b/css/properties/widows.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -88,9 +88,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/properties/word-spacing.json
+++ b/css/properties/word-spacing.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/properties/word-wrap.json
+++ b/css/properties/word-wrap.json
@@ -80,9 +80,7 @@
                 "version_added": "1"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": [
               {
                 "alternative_name": "overflow-wrap",

--- a/css/properties/zoom.json
+++ b/css/properties/zoom.json
@@ -40,9 +40,7 @@
             "safari_ios": {
               "version_added": "4"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }
@@ -93,9 +91,7 @@
               "safari_ios": {
                 "version_added": true
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": true,
                 "version_removed": "59"

--- a/css/selectors/-moz-focusring.json
+++ b/css/selectors/-moz-focusring.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/selectors/-webkit-autofill.json
+++ b/css/selectors/-webkit-autofill.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/css/selectors/-webkit-inner-spin-button.json
+++ b/css/selectors/-webkit-inner-spin-button.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/css/selectors/-webkit-outer-spin-button.json
+++ b/css/selectors/-webkit-outer-spin-button.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/css/selectors/active.json
+++ b/css/selectors/active.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": "1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "1"
             }
@@ -90,9 +88,7 @@
                 "version_added": true,
                 "notes": "By default, Safari on iOS does not use the <a href='https://developer.mozilla.org/docs/Web/CSS/:active'><code>:active</code></a> state unless there is a <a href='https://developer.mozilla.org/docs/Web/Reference/Events/touchstart'><code>touchstart</code></a> event handler on the relevant element or on the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/body'><code>&lt;body&gt;</code></a> element."
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "1"
               }

--- a/css/selectors/after.json
+++ b/css/selectors/after.json
@@ -91,9 +91,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": [
               {
                 "version_added": true
@@ -147,9 +145,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": true
               }

--- a/css/selectors/backdrop.json
+++ b/css/selectors/backdrop.json
@@ -53,9 +53,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -103,9 +101,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }

--- a/css/selectors/checked.json
+++ b/css/selectors/checked.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": "3.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "2"
             }

--- a/css/selectors/cue.json
+++ b/css/selectors/cue.json
@@ -40,9 +40,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/selectors/default.json
+++ b/css/selectors/default.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": "5"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/selectors/disabled.json
+++ b/css/selectors/disabled.json
@@ -40,9 +40,7 @@
             "safari_ios": {
               "version_added": "3.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "2"
             }

--- a/css/selectors/empty.json
+++ b/css/selectors/empty.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": "3.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "2"
             }

--- a/css/selectors/enabled.json
+++ b/css/selectors/enabled.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": "3.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "2"
             }

--- a/css/selectors/first-letter.json
+++ b/css/selectors/first-letter.json
@@ -93,9 +93,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/selectors/first-line.json
+++ b/css/selectors/first-line.json
@@ -101,9 +101,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/css/selectors/first-of-type.json
+++ b/css/selectors/first-of-type.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": "3.2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "2"
             }

--- a/css/selectors/first.json
+++ b/css/selectors/first.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/selectors/focus.json
+++ b/css/selectors/focus.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": "1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "1"
             }

--- a/css/selectors/fullscreen.json
+++ b/css/selectors/fullscreen.json
@@ -78,9 +78,7 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -128,9 +126,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/selectors/hover.json
+++ b/css/selectors/hover.json
@@ -40,9 +40,7 @@
               "version_added": true,
               "notes": "As of Safari for iOS 7.1.2, tapping a <a href='https://developer.mozilla.org/docs/Web/Events/click#Safari_Mobile'>clickable element</a> causes the element to enter the <code>:hover</code> state. The element will remain in the <code>:hover</code> state until a different element has entered the <code>:hover</code> state."
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -90,9 +88,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -146,9 +142,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -197,9 +191,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/selectors/in-range.json
+++ b/css/selectors/in-range.json
@@ -45,9 +45,7 @@
               "version_added": true,
               "notes": "In Safari, <code>:in-range</code> matched disabled and read-only inputs (see <a href='https://webkit.org/b/156530'>bug 156530</a>). It was later changed to only match enabled read-write inputs."
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "2.3",
               "notes": "Before version 52, <code>:in-range</code> matched disabled and read-only inputs (see <a href='https://crbug.com/602568'>Chromium bug 602568</a>). In version 52, it was changed to only match enabled read-write inputs."

--- a/css/selectors/indeterminate.json
+++ b/css/selectors/indeterminate.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -89,9 +87,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -144,9 +140,7 @@
                 "version_added": false,
                 "notes": "See <a href='https://webkit.org/b/156270'>WebKit bug 156270</a>."
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "39"
               }
@@ -195,9 +189,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/selectors/invalid.json
+++ b/css/selectors/invalid.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": "5"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -89,9 +87,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/selectors/lang.json
+++ b/css/selectors/lang.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": "3.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "1"
             }

--- a/css/selectors/last-of-type.json
+++ b/css/selectors/last-of-type.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": "3.2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "2"
             }

--- a/css/selectors/left.json
+++ b/css/selectors/left.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/selectors/link.json
+++ b/css/selectors/link.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": "3.2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "1.5"
             }

--- a/css/selectors/namespace.json
+++ b/css/selectors/namespace.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/selectors/not.json
+++ b/css/selectors/not.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": "3.2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "2"
             }

--- a/css/selectors/nth-last-of-type.json
+++ b/css/selectors/nth-last-of-type.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": "3.2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "2"
             }

--- a/css/selectors/nth-of-type.json
+++ b/css/selectors/nth-of-type.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": "3.1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "2"
             }

--- a/css/selectors/only-of-type.json
+++ b/css/selectors/only-of-type.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": "3.2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "2"
             }

--- a/css/selectors/out-of-range.json
+++ b/css/selectors/out-of-range.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "2.3"
             }

--- a/css/selectors/placeholder-shown.json
+++ b/css/selectors/placeholder-shown.json
@@ -56,9 +56,7 @@
             "safari_ios": {
               "version_added": "9.2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "51"
             }
@@ -106,9 +104,7 @@
               "safari_ios": {
                 "version_added": true
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/selectors/required.json
+++ b/css/selectors/required.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": "5"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "4.4.3"
             }

--- a/css/selectors/right.json
+++ b/css/selectors/right.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/selectors/root.json
+++ b/css/selectors/root.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/selectors/selection.json
+++ b/css/selectors/selection.json
@@ -45,9 +45,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/css/selectors/target.json
+++ b/css/selectors/target.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": "2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "2"
             }

--- a/css/selectors/valid.json
+++ b/css/selectors/valid.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": "5"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -89,9 +87,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/selectors/visited.json
+++ b/css/selectors/visited.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": "9.3"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "4.4"
             }
@@ -89,9 +87,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/types/calc.json
+++ b/css/types/calc.json
@@ -129,9 +129,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -180,9 +178,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -282,9 +278,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -375,7 +375,7 @@
                     "prefix": "-webkit-",
                     "version_added": "5.1",
                     "notes": [
-                      "Safari 4 was supporting an experimental <code><a href='http://developer.apple.com/safari/library/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(linear,…)</a></code> function. It is more limited than the later standard version: you cannot specify both a position and an angle like in <code>linear-gradient()</code>. This old outdated syntax is still supported for compatibility purposes.",
+                      "Safari 4 was supporting an experimental <code><a href='http://developer.apple.com/safari/library/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(linear,\u2026)</a></code> function. It is more limited than the later standard version: you cannot specify both a position and an angle like in <code>linear-gradient()</code>. This old outdated syntax is still supported for compatibility purposes.",
                       "Considers <code>&lt;angle&gt;</code> to start to the right, instead of the top. I.e. it considered an angle of <code>0deg</code> as a direction indicator pointing to the right."
                     ]
                   }
@@ -743,7 +743,7 @@
                   {
                     "prefix": "-webkit-",
                     "version_added": "5.1",
-                    "notes": "Safari 4 was supporting an experimental <code><a href='http://developer.apple.com/safari/library/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(radial,…)</a></code> function. This old outdated syntax is still supported for compatibility purposes."
+                    "notes": "Safari 4 was supporting an experimental <code><a href='http://developer.apple.com/safari/library/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(radial,\u2026)</a></code> function. This old outdated syntax is still supported for compatibility purposes."
                   }
                 ],
                 "safari_ios": {
@@ -1097,7 +1097,7 @@
                     "prefix": "-webkit-",
                     "version_added": "5.1",
                     "notes": [
-                      "Safari 4 was supporting an experimental <code><a href='http://developer.apple.com/safari/library/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(linear,…)</a></code> function. It is more limited than the later standard version: you cannot specify both a position and an angle like in <code>repeating-linear-gradient()</code>. This old outdated syntax is still supported for compatibility purposes.",
+                      "Safari 4 was supporting an experimental <code><a href='http://developer.apple.com/safari/library/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(linear,\u2026)</a></code> function. It is more limited than the later standard version: you cannot specify both a position and an angle like in <code>repeating-linear-gradient()</code>. This old outdated syntax is still supported for compatibility purposes.",
                       "Considers <code>&lt;angle&gt;</code> to start to the right, instead of the top. I.e. it considered an angle of <code>0deg</code> as a direction indicator pointing to the right."
                     ]
                   }
@@ -1442,7 +1442,7 @@
                   {
                     "prefix": "-webkit-",
                     "version_added": "5.1",
-                    "notes": "Safari 4 was supporting an experimental <code><a href='http://developer.apple.com/safari/library/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(radial,…)</a></code> function. This old outdated syntax is still supported for compatibility purposes."
+                    "notes": "Safari 4 was supporting an experimental <code><a href='http://developer.apple.com/safari/library/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(radial,\u2026)</a></code> function. This old outdated syntax is still supported for compatibility purposes."
                   }
                 ],
                 "safari_ios": {
@@ -1810,9 +1810,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/types/length-percentage.json
+++ b/css/types/length-percentage.json
@@ -865,9 +865,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -916,9 +914,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -865,9 +865,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -916,9 +914,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/types/resolution.json
+++ b/css/types/resolution.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -103,9 +101,7 @@
                   "notes": "See <a href='https://webkit.org/b/16832'>bug 16832</a>."
                 }
               ],
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -154,9 +150,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }

--- a/css/types/shape.json
+++ b/css/types/shape.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -90,9 +88,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/css/types/timing-function.json
+++ b/css/types/timing-function.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": "2"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "4"
             }
@@ -54,7 +52,7 @@
         },
         "cubic-bezier": {
           "__compat": {
-            "description": "<code>cubic-bezier()</code> with ordinate ∉ [0,1]",
+            "description": "<code>cubic-bezier()</code> with ordinate \u2209 [0,1]",
             "support": {
               "chrome": {
                 "version_added": "16"
@@ -190,9 +188,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }


### PR DESCRIPTION
This PR is created by a simple script that mirrors the compatibility data of all APIs from Chrome to Samsung Internet when it is set to "null". This should help reduce inconsistencies in the browser data.