### PR TITLE
Mirror Chrome -> Samsung Internet for html/*

### DIFF
--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -205,9 +205,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": true,
                 "notes": "Starting in WebView 65, cross-origin downloads are not supported on the <code>&lt;a&gt;</code> element."
@@ -471,9 +469,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/html/elements/audio.json
+++ b/html/elements/audio.json
@@ -139,9 +139,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -339,9 +337,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -565,9 +561,7 @@
               "safari_ios": {
                 "version_added": true
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/html/elements/body.json
+++ b/html/elements/body.json
@@ -741,9 +741,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/html/elements/button.json
+++ b/html/elements/button.json
@@ -87,9 +87,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -287,9 +285,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -337,9 +333,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -387,9 +381,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/html/elements/canvas.json
+++ b/html/elements/canvas.json
@@ -49,9 +49,7 @@
             "safari_ios": {
               "version_added": "1"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -109,9 +107,7 @@
               "safari_ios": {
                 "version_added": "1"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -220,9 +216,7 @@
               "safari_ios": {
                 "version_added": "1"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/html/elements/col.json
+++ b/html/elements/col.json
@@ -89,9 +89,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -139,9 +137,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -191,9 +187,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -243,9 +237,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -345,9 +337,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/html/elements/colgroup.json
+++ b/html/elements/colgroup.json
@@ -89,9 +89,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -139,9 +137,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -191,9 +187,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -243,9 +237,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -345,9 +337,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/html/elements/element.json
+++ b/html/elements/element.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/html/elements/embed.json
+++ b/html/elements/embed.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -87,9 +85,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -137,9 +133,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -187,9 +181,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -237,9 +229,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/html/elements/form.json
+++ b/html/elements/form.json
@@ -488,9 +488,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -222,9 +222,7 @@
                   "version_added": true
                 }
               ],
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -773,9 +771,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -875,9 +871,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1141,9 +1135,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/html/elements/image.json
+++ b/html/elements/image.json
@@ -40,9 +40,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -449,9 +449,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "71",
                 "flags": [

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -537,9 +537,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": "64"
                 }
@@ -688,9 +686,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }
@@ -838,9 +834,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": "66"
                 }
@@ -992,9 +986,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }
@@ -1096,9 +1088,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }

--- a/html/elements/marquee.json
+++ b/html/elements/marquee.json
@@ -52,9 +52,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "1"
             }
@@ -101,9 +99,7 @@
               "safari_ios": {
                 "version_added": true
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "1"
               }
@@ -151,9 +147,7 @@
               "safari_ios": {
                 "version_added": true
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "1"
               }
@@ -201,9 +195,7 @@
               "safari_ios": {
                 "version_added": true
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "1"
               }
@@ -251,9 +243,7 @@
               "safari_ios": {
                 "version_added": true
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "1"
               }
@@ -301,9 +291,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": true
               }
@@ -351,9 +339,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": true
               }
@@ -401,9 +387,7 @@
               "safari_ios": {
                 "version_added": true
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "1"
               }
@@ -451,9 +435,7 @@
               "safari_ios": {
                 "version_added": true
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "1"
               }
@@ -551,9 +533,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": true
               }
@@ -601,9 +581,7 @@
               "safari_ios": {
                 "version_added": true
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "1"
               }

--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -593,9 +593,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }

--- a/html/elements/meter.json
+++ b/html/elements/meter.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": "10.3"
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": false
             }
@@ -87,9 +85,7 @@
               "safari_ios": {
                 "version_added": "10.3"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -137,9 +133,7 @@
               "safari_ios": {
                 "version_added": "10.3"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -187,9 +181,7 @@
               "safari_ios": {
                 "version_added": "10.3"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -237,9 +229,7 @@
               "safari_ios": {
                 "version_added": "10.3"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -287,9 +277,7 @@
               "safari_ios": {
                 "version_added": "10.3"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -337,9 +325,7 @@
               "safari_ios": {
                 "version_added": "10.3"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }
@@ -387,9 +373,7 @@
               "safari_ios": {
                 "version_added": "10.3"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": false
               }

--- a/html/elements/object.json
+++ b/html/elements/object.json
@@ -737,9 +737,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/html/elements/pre.json
+++ b/html/elements/pre.json
@@ -201,9 +201,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/html/elements/tbody.json
+++ b/html/elements/tbody.json
@@ -89,9 +89,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -139,9 +137,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -191,9 +187,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -243,9 +237,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -295,9 +287,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/html/elements/td.json
+++ b/html/elements/td.json
@@ -139,9 +139,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -239,9 +237,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -291,9 +287,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -343,9 +337,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -646,9 +638,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/html/elements/textarea.json
+++ b/html/elements/textarea.json
@@ -198,9 +198,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -398,9 +396,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -548,9 +544,7 @@
               "safari_ios": {
                 "version_added": "4"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -600,9 +594,7 @@
                 "safari_ios": {
                   "version_added": false
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }

--- a/html/elements/tfoot.json
+++ b/html/elements/tfoot.json
@@ -89,9 +89,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -139,9 +137,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -191,9 +187,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -243,9 +237,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -295,9 +287,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/html/elements/th.json
+++ b/html/elements/th.json
@@ -139,9 +139,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -239,9 +237,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -291,9 +287,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -343,9 +337,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -646,9 +638,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/html/elements/thead.json
+++ b/html/elements/thead.json
@@ -89,9 +89,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -139,9 +137,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -191,9 +187,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -243,9 +237,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -295,9 +287,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/html/elements/tr.json
+++ b/html/elements/tr.json
@@ -89,9 +89,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -139,9 +137,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -191,9 +187,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -243,9 +237,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -295,9 +287,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/html/elements/track.json
+++ b/html/elements/track.json
@@ -421,9 +421,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }

--- a/html/elements/video.json
+++ b/html/elements/video.json
@@ -138,9 +138,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -238,9 +236,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -350,9 +346,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "71",
                 "flags": [
@@ -506,9 +500,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -92,9 +92,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "uc_android": {
               "version_added": null
             },
@@ -1649,9 +1647,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1701,9 +1697,7 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }


### PR DESCRIPTION
This PR is created by a simple script that mirrors the compatibility data of all APIs from Chrome to Samsung Internet when it is set to "null". This should help reduce inconsistencies in the browser data.