### PR TITLE
Mirror Chrome -> Samsung Internet for http/*

### DIFF
--- a/http/headers/accept-ch-lifetime.json
+++ b/http/headers/accept-ch-lifetime.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "67"
             }

--- a/http/headers/accept-ch.json
+++ b/http/headers/accept-ch.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "46"
             }
@@ -88,9 +86,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "46"
               }
@@ -139,9 +135,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "46"
               }
@@ -190,9 +184,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "46"
               }

--- a/http/headers/clear-site-data.json
+++ b/http/headers/clear-site-data.json
@@ -62,9 +62,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "61"
             }

--- a/http/headers/content-dpr.json
+++ b/http/headers/content-dpr.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "46"
             }

--- a/http/headers/device-memory.json
+++ b/http/headers/device-memory.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "61"
             }

--- a/http/headers/downlink.json
+++ b/http/headers/downlink.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "67"
             }

--- a/http/headers/dpr.json
+++ b/http/headers/dpr.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "46"
             }

--- a/http/headers/early-data.json
+++ b/http/headers/early-data.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/http/headers/ect.json
+++ b/http/headers/ect.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "67"
             }

--- a/http/headers/expect.json
+++ b/http/headers/expect.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/http/headers/forwarded.json
+++ b/http/headers/forwarded.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/http/headers/proxy-authenticate.json
+++ b/http/headers/proxy-authenticate.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/http/headers/retry-after.json
+++ b/http/headers/retry-after.json
@@ -39,9 +39,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/http/headers/rtt.json
+++ b/http/headers/rtt.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "67"
             }

--- a/http/headers/save-data.json
+++ b/http/headers/save-data.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "49"
             }

--- a/http/headers/server-timing.json
+++ b/http/headers/server-timing.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "65"
             }

--- a/http/headers/sourcemap.json
+++ b/http/headers/sourcemap.json
@@ -62,9 +62,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/http/headers/tk.json
+++ b/http/headers/tk.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/http/headers/viewport-width.json
+++ b/http/headers/viewport-width.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "46"
             }

--- a/http/headers/width.json
+++ b/http/headers/width.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "46"
             }

--- a/http/headers/www-authenticate.json
+++ b/http/headers/www-authenticate.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/http/headers/x-dns-prefetch-control.json
+++ b/http/headers/x-dns-prefetch-control.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": true
             }

--- a/http/headers/x-forwarded-for.json
+++ b/http/headers/x-forwarded-for.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/http/headers/x-forwarded-host.json
+++ b/http/headers/x-forwarded-host.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/http/headers/x-forwarded-proto.json
+++ b/http/headers/x-forwarded-proto.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/http/methods.json
+++ b/http/methods.json
@@ -395,9 +395,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }

--- a/http/status.json
+++ b/http/status.json
@@ -1059,9 +1059,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }


### PR DESCRIPTION
This PR is created by a simple script that mirrors the compatibility data of all APIs from Chrome to Samsung Internet when it is set to "null". This should help reduce inconsistencies in the browser data.