### PR TITLE
Mirror Chrome -> Samsung Internet for javascript/*

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -2011,9 +2011,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }
@@ -2065,9 +2063,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": false
                 }
@@ -2505,9 +2501,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -2560,9 +2554,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -95,9 +95,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -438,9 +436,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -95,9 +95,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -149,9 +147,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -257,9 +253,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -97,9 +97,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -2735,9 +2733,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }
@@ -3009,9 +3005,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }
@@ -3227,9 +3221,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }

--- a/javascript/builtins/Float32Array.json
+++ b/javascript/builtins/Float32Array.json
@@ -95,9 +95,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -149,9 +147,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -203,9 +199,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/javascript/builtins/Float64Array.json
+++ b/javascript/builtins/Float64Array.json
@@ -95,9 +95,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -149,9 +147,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -203,9 +199,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -258,9 +258,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -366,9 +364,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }

--- a/javascript/builtins/Int16Array.json
+++ b/javascript/builtins/Int16Array.json
@@ -95,9 +95,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -149,9 +147,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -203,9 +199,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/javascript/builtins/Int32Array.json
+++ b/javascript/builtins/Int32Array.json
@@ -95,9 +95,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -149,9 +147,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -203,9 +199,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/javascript/builtins/Int8Array.json
+++ b/javascript/builtins/Int8Array.json
@@ -95,9 +95,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -149,9 +147,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -203,9 +199,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -586,9 +586,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }
@@ -862,9 +860,7 @@
                   "safari_ios": {
                     "version_added": "10"
                   },
-                  "samsunginternet_android": {
-                    "version_added": null
-                  },
+                  "samsunginternet_android": null,
                   "webview_android": {
                     "version_added": false
                   }
@@ -974,9 +970,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "72"
               }
@@ -1028,9 +1022,7 @@
                 "safari_ios": {
                   "version_added": false
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": "72"
                 }
@@ -1083,9 +1075,7 @@
                 "safari_ios": {
                   "version_added": false
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": "72"
                 }
@@ -1138,9 +1128,7 @@
                 "safari_ios": {
                   "version_added": false
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": "72"
                 }
@@ -1193,9 +1181,7 @@
                 "safari_ios": {
                   "version_added": false
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": "72"
                 }
@@ -1248,9 +1234,7 @@
                 "safari_ios": {
                   "version_added": false
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": "72"
                 }
@@ -1961,9 +1945,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "71"
               }
@@ -2015,9 +1997,7 @@
                 "safari_ios": {
                   "version_added": false
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": "71"
                 }
@@ -2070,9 +2050,7 @@
                 "safari_ios": {
                   "version_added": false
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": "71"
                 }
@@ -2125,9 +2103,7 @@
                 "safari_ios": {
                   "version_added": false
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": "71"
                 }
@@ -2180,9 +2156,7 @@
                 "safari_ios": {
                   "version_added": false
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": "71"
                 }
@@ -2235,9 +2209,7 @@
                 "safari_ios": {
                   "version_added": false
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": "71"
                 }

--- a/javascript/builtins/Proxy.json
+++ b/javascript/builtins/Proxy.json
@@ -648,9 +648,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }
@@ -870,9 +868,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -761,9 +761,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "62"
               }
@@ -979,9 +977,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "64"
               }
@@ -1251,9 +1247,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }
@@ -1305,9 +1299,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }
@@ -1740,9 +1732,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -2909,9 +2909,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }
@@ -3020,9 +3018,7 @@
                 "safari_ios": {
                   "version_added": null
                 },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
+                "samsunginternet_android": null,
                 "webview_android": {
                   "version_added": null
                 }
@@ -3374,9 +3370,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": [
                 {
                   "version_added": "66"
@@ -3459,9 +3453,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": [
                 {
                   "version_added": "66"

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -1241,9 +1241,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -95,9 +95,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -208,9 +206,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -316,9 +312,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1709,9 +1703,7 @@
               "safari_ios": {
                 "version_added": "10"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1764,9 +1756,7 @@
               "safari_ios": {
                 "version_added": "10"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1819,9 +1809,7 @@
               "safari_ios": {
                 "version_added": "10"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1929,9 +1917,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1984,9 +1970,7 @@
               "safari_ios": {
                 "version_added": "10"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -2039,9 +2023,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -2408,9 +2390,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/javascript/builtins/Uint16Array.json
+++ b/javascript/builtins/Uint16Array.json
@@ -95,9 +95,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -149,9 +147,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -203,9 +199,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/javascript/builtins/Uint32Array.json
+++ b/javascript/builtins/Uint32Array.json
@@ -95,9 +95,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -149,9 +147,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -203,9 +199,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -95,9 +95,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -149,9 +147,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -203,9 +199,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/javascript/builtins/Uint8ClampedArray.json
+++ b/javascript/builtins/Uint8ClampedArray.json
@@ -95,9 +95,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -149,9 +147,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -203,9 +199,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -490,9 +490,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }
@@ -763,9 +761,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -828,9 +824,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -893,9 +887,7 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/javascript/operators/delete.json
+++ b/javascript/operators/delete.json
@@ -95,9 +95,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/javascript/operators/yield.json
+++ b/javascript/operators/yield.json
@@ -108,9 +108,7 @@
               "safari_ios": {
                 "version_added": "10"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1025,9 +1025,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": "63"
             }
@@ -1249,9 +1247,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": "63"
               }
@@ -1412,9 +1408,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -1695,9 +1689,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }


### PR DESCRIPTION
This PR is created by a simple script that mirrors the compatibility data of all APIs from Chrome to Samsung Internet when it is set to "null". This should help reduce inconsistencies in the browser data.