### PR TITLE
Mirror Chrome -> Samsung Internet for svg/*

### DIFF
--- a/svg/elements/a.json
+++ b/svg/elements/a.json
@@ -87,9 +87,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -488,9 +486,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -590,9 +586,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }
@@ -641,9 +635,7 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": null,
               "webview_android": {
                 "version_added": null
               }


### PR DESCRIPTION
This PR is created by a simple script that mirrors the compatibility data of all APIs from Chrome to Samsung Internet when it is set to "null". This should help reduce inconsistencies in the browser data.