### PR TITLE
Mirror Chrome -> Samsung Internet for xpath/*

### DIFF
--- a/xpath/axes/self.json
+++ b/xpath/axes/self.json
@@ -38,9 +38,7 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": null,
             "webview_android": {
               "version_added": null
             }


### PR DESCRIPTION
This PR is created by a simple script that mirrors the compatibility data of all APIs from Chrome to Samsung Internet when it is set to "null". This should help reduce inconsistencies in the browser data.