### PR TITLE
Mirror Chrome -> Opera for api/*

### DIFF
--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -679,7 +679,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": null

--- a/api/AudioProcessingEvent.json
+++ b/api/AudioProcessingEvent.json
@@ -89,7 +89,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "44"
             },
             "webview_android": {
               "version_added": "57"

--- a/api/AudioWorkletNode.json
+++ b/api/AudioWorkletNode.json
@@ -89,7 +89,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "53"
             },
             "webview_android": {
               "version_added": "66"
@@ -191,7 +191,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "53"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/AudioWorkletProcessor.json
+++ b/api/AudioWorkletProcessor.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "51"
           },
           "webview_android": {
             "version_added": "64"
@@ -89,7 +89,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "51"
             },
             "webview_android": {
               "version_added": "64"
@@ -140,7 +140,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "51"
             },
             "webview_android": {
               "version_added": "64"

--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -1127,7 +1127,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": null

--- a/api/BluetoothRemoteGATTService.json
+++ b/api/BluetoothRemoteGATTService.json
@@ -331,7 +331,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/Console.json
+++ b/api/Console.json
@@ -324,7 +324,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -376,7 +376,8 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true,
+                "notes": "In version 28, if a negative value is passed to <code>%d</code>, it will be rounded down to the closest negative integer. For example, -0.1 becomes -1."
               },
               "webview_android": {
                 "version_added": null
@@ -569,7 +570,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": null
@@ -763,7 +764,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "15"
             },
             "webview_android": {
               "version_added": null
@@ -908,7 +909,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": null
@@ -1006,7 +1007,8 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true,
+                "notes": "In version 28, if a negative value is passed to %d, it will be rounded down to the closest negative integer, so -0.1 becomes -1."
               },
               "webview_android": {
                 "version_added": null
@@ -1055,7 +1057,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "40"
             },
             "webview_android": {
               "version_added": null
@@ -1103,7 +1105,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -1489,7 +1491,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": null

--- a/api/Credential.json
+++ b/api/Credential.json
@@ -192,7 +192,9 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "38",
+              "version_removed": "39",
+              "notes": "See <a href='https://crbug.com/602980'>Bug 602980</a>."
             },
             "webview_android": {
               "version_added": "51",

--- a/api/CredentialUserData.json
+++ b/api/CredentialUserData.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "47"
           },
           "webview_android": {
             "version_added": "60"
@@ -88,7 +88,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "47"
             },
             "webview_android": {
               "version_added": "60"
@@ -139,7 +139,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "47"
             },
             "webview_android": {
               "version_added": "60"

--- a/api/DOMException.json
+++ b/api/DOMException.json
@@ -89,7 +89,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/DeviceMotionEvent.json
+++ b/api/DeviceMotionEvent.json
@@ -89,7 +89,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "46"
             },
             "webview_android": {
               "version_added": "59"

--- a/api/DeviceOrientationEvent.json
+++ b/api/DeviceOrientationEvent.json
@@ -94,7 +94,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "46"
             },
             "webview_android": {
               "version_added": "59"

--- a/api/Document.json
+++ b/api/Document.json
@@ -4283,7 +4283,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "58"
               },
               "webview_android": {
                 "version_added": "71"
@@ -7229,7 +7229,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "webview_android": {
               "version_added": "55"
@@ -7306,7 +7306,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "webview_android": {
               "version_added": "55"
@@ -7383,7 +7383,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "webview_android": {
               "version_added": "55"
@@ -7460,7 +7460,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "webview_android": {
               "version_added": "55"
@@ -7525,9 +7525,16 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "32"
+              },
+              {
+                "version_added": "15",
+                "version_removed": "32",
+                "prefix": "webkit"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "45"
@@ -7598,9 +7605,16 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "32"
+              },
+              {
+                "version_added": "15",
+                "version_removed": "32",
+                "prefix": "webkit"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "45"
@@ -7683,7 +7697,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "webview_android": {
               "version_added": "55"
@@ -7760,7 +7774,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "webview_android": {
               "version_added": "55"
@@ -7837,7 +7851,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "webview_android": {
               "version_added": "55"
@@ -7914,7 +7928,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "webview_android": {
               "version_added": "55"
@@ -9569,7 +9583,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -9621,7 +9635,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -9673,7 +9687,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -9725,7 +9739,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/EXT_color_buffer_float.json
+++ b/api/EXT_color_buffer_float.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "50"
           },
           "webview_android": {
             "version_added": "63"

--- a/api/EXT_color_buffer_half_float.json
+++ b/api/EXT_color_buffer_half_float.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "50"
           },
           "webview_android": {
             "version_added": "63"

--- a/api/Element.json
+++ b/api/Element.json
@@ -375,7 +375,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": null
@@ -478,7 +478,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "53"
             },
             "webview_android": {
               "version_added": "66"
@@ -796,7 +796,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "48"
               },
               "webview_android": {
                 "version_added": null
@@ -1860,7 +1860,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -4623,7 +4623,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "58"
               },
               "webview_android": {
                 "version_added": "71"
@@ -6060,7 +6060,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "30"
             },
             "webview_android": {
               "version_added": null

--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -520,7 +520,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "60"
                 },
                 "webview_android": {
                   "version_added": "73"

--- a/api/ExtendableMessageEvent.json
+++ b/api/ExtendableMessageEvent.json
@@ -39,7 +39,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false
@@ -142,7 +142,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "38"
             },
             "webview_android": {
               "version_added": false

--- a/api/External.json
+++ b/api/External.json
@@ -32,7 +32,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -76,7 +76,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -121,7 +121,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/FormData.json
+++ b/api/FormData.json
@@ -197,7 +197,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": null
@@ -606,7 +606,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "37"
             },
             "webview_android": {
               "version_added": null
@@ -658,7 +658,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "37"
             },
             "webview_android": {
               "version_added": null

--- a/api/FullscreenOptions.json
+++ b/api/FullscreenOptions.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "58"
           },
           "webview_android": {
             "version_added": "71"
@@ -88,7 +88,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "58"
             },
             "webview_android": {
               "version_added": "71"

--- a/api/GamepadButton.json
+++ b/api/GamepadButton.json
@@ -292,7 +292,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -88,7 +88,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -139,7 +139,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -201,9 +201,15 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": true,
+                "alternative_name": "onwebkitanimationend"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": true
@@ -270,9 +276,15 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": true,
+                "alternative_name": "onwebkitanimationiteration"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": true
@@ -339,9 +351,15 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": true,
+                "alternative_name": "onwebkitanimationstart"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": true
@@ -499,7 +517,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -550,7 +568,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -601,7 +619,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -754,7 +772,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -805,7 +823,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -856,7 +874,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -907,7 +925,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -1366,7 +1384,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1417,7 +1435,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1468,7 +1486,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1519,7 +1537,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1774,7 +1792,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1825,7 +1843,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1876,7 +1894,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1978,7 +1996,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -2029,7 +2047,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -2598,7 +2616,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -2649,7 +2667,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -2700,7 +2718,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -2751,7 +2769,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -2827,7 +2845,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "webview_android": {
               "version_added": "55"
@@ -2903,7 +2921,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "webview_android": {
               "version_added": "55"
@@ -2979,7 +2997,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "webview_android": {
               "version_added": "55"
@@ -3055,7 +3073,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "webview_android": {
               "version_added": "55"
@@ -3233,7 +3251,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "webview_android": {
               "version_added": "55"
@@ -3309,7 +3327,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "webview_android": {
               "version_added": "55"
@@ -3385,7 +3403,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "webview_android": {
               "version_added": "55"
@@ -3461,7 +3479,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "webview_android": {
               "version_added": "55"
@@ -3512,7 +3530,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3563,7 +3581,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3614,7 +3632,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3716,7 +3734,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3767,7 +3785,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3818,7 +3836,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3869,7 +3887,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3944,7 +3962,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -4019,7 +4037,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -4070,7 +4088,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -4121,7 +4139,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -4172,7 +4190,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -4274,7 +4292,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -4325,7 +4343,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -4376,7 +4394,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "15"
             },
             "webview_android": {
               "version_added": true
@@ -4427,7 +4445,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "15"
             },
             "webview_android": {
               "version_added": true
@@ -4478,7 +4496,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "15"
             },
             "webview_android": {
               "version_added": true
@@ -4529,7 +4547,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "15"
             },
             "webview_android": {
               "version_added": true
@@ -4580,7 +4598,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -4633,7 +4651,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "alternative_name": "onwebkittransitionend"
             },
             "webview_android": {
               "version_added": true,
@@ -4685,7 +4704,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -4736,7 +4755,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -4787,7 +4806,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -4838,7 +4857,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/HTMLDialogElement.json
+++ b/api/HTMLDialogElement.json
@@ -105,7 +105,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -157,7 +157,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2280,7 +2280,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "webview_android": {
               "version_added": "55"
@@ -2357,7 +2357,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "webview_android": {
               "version_added": "55"
@@ -2434,7 +2434,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "webview_android": {
               "version_added": "55"
@@ -2511,7 +2511,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "webview_android": {
               "version_added": "55"
@@ -2588,7 +2588,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "webview_android": {
               "version_added": "55"
@@ -2665,7 +2665,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "webview_android": {
               "version_added": "55"
@@ -2742,7 +2742,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "webview_android": {
               "version_added": "55"
@@ -2819,7 +2819,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "webview_android": {
               "version_added": "55"
@@ -3075,7 +3075,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -3127,7 +3127,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -3179,7 +3179,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -3231,7 +3231,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -88,7 +88,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/InputDeviceCapabilities.json
+++ b/api/InputDeviceCapabilities.json
@@ -89,7 +89,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "34"
             },
             "webview_android": {
               "version_added": "47"

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -138,7 +138,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "36"
               },
               "webview_android": {
                 "version_added": "49"

--- a/api/Location.json
+++ b/api/Location.json
@@ -343,7 +343,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -391,7 +391,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -753,7 +753,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "39"
             },
             "webview_android": {
               "version_added": "52"
@@ -801,7 +801,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/MIDIAccess.json
+++ b/api/MIDIAccess.json
@@ -241,7 +241,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "30"
             },
             "webview_android": {
               "version_added": "43"

--- a/api/MediaCapabilitiesInfo.json
+++ b/api/MediaCapabilitiesInfo.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "53"
           },
           "webview_android": {
             "version_added": "66"
@@ -88,7 +88,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "53"
             },
             "webview_android": {
               "version_added": "66"
@@ -139,7 +139,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "53"
             },
             "webview_android": {
               "version_added": "66"
@@ -190,7 +190,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "53"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -336,9 +336,23 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "59"
+              },
+              {
+                "version_added": "57",
+                "version_removed": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform features",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Available as a member of <code>Navigator</code> instead of <code>MediaDevices</code> in Opera 70 and 71."
+              }
+            ],
             "webview_android": {
               "version_added": false,
               "notes": "API is available, but will always fail with <code>NotAllowedError</code>."
@@ -559,7 +573,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": null

--- a/api/MediaEncryptedEvent.json
+++ b/api/MediaEncryptedEvent.json
@@ -89,7 +89,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "29"
             },
             "webview_android": {
               "version_added": "43"

--- a/api/MediaStreamAudioSourceOptions.json
+++ b/api/MediaStreamAudioSourceOptions.json
@@ -88,7 +88,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "webview_android": {
               "version_added": "55"

--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -88,7 +88,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "15"
             },
             "webview_android": {
               "version_added": null
@@ -342,7 +342,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": null
@@ -495,7 +495,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": null

--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -147,7 +147,15 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "38",
+                "notes": "Flag needed to retrieve value from <code>MouseEvent.region</code>.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "webview_android": {
                 "version_added": false
@@ -198,7 +206,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "43"
               },
               "webview_android": {
                 "version_added": "56"
@@ -460,7 +468,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "43"
               },
               "webview_android": {
                 "version_added": "56"
@@ -562,7 +570,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "43"
               },
               "webview_android": {
                 "version_added": "56"
@@ -715,7 +723,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": false
@@ -1077,7 +1085,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "43"
               },
               "webview_android": {
                 "version_added": "56"
@@ -1179,7 +1187,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "43"
               },
               "webview_android": {
                 "version_added": "56"
@@ -1281,7 +1289,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "43"
               },
               "webview_android": {
                 "version_added": "56"
@@ -1383,7 +1391,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "43"
               },
               "webview_android": {
                 "version_added": "56"
@@ -1608,7 +1616,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "43"
               },
               "webview_android": {
                 "version_added": "56"
@@ -1710,7 +1718,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "43"
               },
               "webview_android": {
                 "version_added": "56"

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -328,7 +328,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -1461,7 +1461,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/PaintRenderingContext2D.json
+++ b/api/PaintRenderingContext2D.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "52"
           },
           "webview_android": {
             "version_added": "65"
@@ -88,7 +88,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -139,7 +139,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -190,7 +190,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -241,7 +241,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -292,7 +292,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -343,7 +343,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -394,7 +394,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -445,7 +445,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -496,7 +496,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -547,7 +547,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -598,7 +598,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -649,7 +649,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -700,7 +700,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "55"
             },
             "webview_android": {
               "version_added": "68"
@@ -751,7 +751,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -802,7 +802,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -853,7 +853,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -904,7 +904,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -955,7 +955,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -1006,7 +1006,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -1057,7 +1057,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -1108,7 +1108,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -1159,7 +1159,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -1210,7 +1210,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -1261,7 +1261,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -1312,7 +1312,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -1363,7 +1363,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -1414,7 +1414,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -1465,7 +1465,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -1516,7 +1516,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -1567,7 +1567,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -1618,7 +1618,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "55"
             },
             "webview_android": {
               "version_added": "68"
@@ -1669,7 +1669,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -1720,7 +1720,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -1771,7 +1771,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -1822,7 +1822,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -1873,7 +1873,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -1924,7 +1924,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -1975,7 +1975,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -2026,7 +2026,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -2077,7 +2077,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"

--- a/api/PaintSize.json
+++ b/api/PaintSize.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "52"
           },
           "webview_android": {
             "version_added": "65"
@@ -88,7 +88,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -139,7 +139,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"

--- a/api/PaintWorkletGlobalScope.json
+++ b/api/PaintWorkletGlobalScope.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "52"
           },
           "webview_android": {
             "version_added": "65"
@@ -88,7 +88,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"
@@ -139,7 +139,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "52"
             },
             "webview_android": {
               "version_added": "65"

--- a/api/ParentNode.json
+++ b/api/ParentNode.json
@@ -343,7 +343,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": null

--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -139,7 +139,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "33"
             },
             "webview_android": {
               "version_added": "46"
@@ -190,7 +190,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "35"
             },
             "webview_android": {
               "version_added": "48"
@@ -267,7 +267,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "33"
             },
             "webview_android": {
               "version_added": "46"
@@ -318,7 +318,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "webview_android": {
               "version_added": "62"
@@ -369,7 +369,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "webview_android": {
               "version_added": "62"
@@ -420,7 +420,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "webview_android": {
               "version_added": "62"
@@ -471,7 +471,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "webview_android": {
               "version_added": "62"
@@ -522,7 +522,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "51"
             },
             "webview_android": {
               "version_added": "64"
@@ -573,7 +573,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "51"
             },
             "webview_android": {
               "version_added": "64"
@@ -624,7 +624,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "51"
             },
             "webview_android": {
               "version_added": "64"
@@ -726,7 +726,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "38"
             },
             "webview_android": {
               "version_added": "51"
@@ -777,7 +777,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "webview_android": {
               "version_added": "62"
@@ -828,7 +828,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "51"
             },
             "webview_android": {
               "version_added": "64"
@@ -981,7 +981,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "53"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/Plugin.json
+++ b/api/Plugin.json
@@ -349,7 +349,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/PresentationConnectionAvailableEvent.json
+++ b/api/PresentationConnectionAvailableEvent.json
@@ -117,7 +117,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "35"
             },
             "webview_android": {
               "version_added": false

--- a/api/PresentationConnectionCloseEvent.json
+++ b/api/PresentationConnectionCloseEvent.json
@@ -117,7 +117,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "37"
             },
             "webview_android": {
               "version_added": false

--- a/api/RTCAnswerOptions.json
+++ b/api/RTCAnswerOptions.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "37"
           },
           "webview_android": {
             "version_added": "50"

--- a/api/RTCCertificate.json
+++ b/api/RTCCertificate.json
@@ -190,7 +190,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": null

--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -1188,7 +1188,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": null
@@ -1341,7 +1341,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "45"
             },
             "webview_android": {
               "version_added": "58"

--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -752,7 +752,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -803,7 +803,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": null

--- a/api/RTCIceCandidatePairStats.json
+++ b/api/RTCIceCandidatePairStats.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "43"
           },
           "webview_android": {
             "version_added": "56"
@@ -190,7 +190,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -241,7 +241,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -456,9 +456,15 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "58"
+              },
+              {
+                "version_added": true,
+                "alternative_name": "currentRtt"
+              }
+            ],
             "webview_android": {
               "version_added": true
             }
@@ -1617,7 +1623,8 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "notes": "Opera does not currently use the specification's algorithm to determine the value of <code>writable</code>; it may not match the behavior of other browsers."
             },
             "webview_android": {
               "version_added": true

--- a/api/RTCIceCandidateStats.json
+++ b/api/RTCIceCandidateStats.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
             "version_added": false
@@ -100,7 +100,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -151,7 +151,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -204,7 +204,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -255,7 +255,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -306,7 +306,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -359,7 +359,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -410,7 +410,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -473,7 +473,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -536,7 +536,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -589,7 +589,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -640,7 +640,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/RTCIceCandidateType.json
+++ b/api/RTCIceCandidateType.json
@@ -42,7 +42,8 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false,
+            "notes": "An <code>RTCIceCandidate</code> object's <code>type</code> is not maintained by this browser."
           },
           "webview_android": {
             "version_added": false,

--- a/api/RTCIceComponent.json
+++ b/api/RTCIceComponent.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
             "version_added": false

--- a/api/RTCOfferAnswerOptions.json
+++ b/api/RTCOfferAnswerOptions.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "37"
           },
           "webview_android": {
             "version_added": "50"
@@ -88,7 +88,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "37"
             },
             "webview_android": {
               "version_added": "50"

--- a/api/RTCOfferOptions.json
+++ b/api/RTCOfferOptions.json
@@ -50,7 +50,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "37"
           },
           "webview_android": {
             "version_added": "50"
@@ -100,7 +100,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "37"
             },
             "webview_android": {
               "version_added": "50"

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -1375,7 +1375,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -2729,7 +2729,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/RTCPeerConnectionIceEvent.json
+++ b/api/RTCPeerConnectionIceEvent.json
@@ -212,7 +212,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": null

--- a/api/RTCRtpEncodingParameters.json
+++ b/api/RTCRtpEncodingParameters.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "54"
           },
           "webview_android": {
             "version_added": "67"
@@ -88,7 +88,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "54"
             },
             "webview_android": {
               "version_added": "67"
@@ -139,7 +139,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -242,7 +242,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -293,7 +293,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "54"
             },
             "webview_android": {
               "version_added": "67"
@@ -344,7 +344,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -395,7 +395,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -449,7 +449,8 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "54",
+              "notes": "The standard version of this property is <a href='https://developer.mozilla.org/docs/Web/API/RTCRtpSendParameters/priority'><code>RTCRtpSendParameters.priority</code></a>."
             },
             "webview_android": {
               "version_added": "67",
@@ -605,7 +606,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/RTCRtpSendParameters.json
+++ b/api/RTCRtpSendParameters.json
@@ -40,7 +40,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "56"
           },
           "webview_android": {
             "version_added": "69"

--- a/api/RTCRtpTransceiverDirection.json
+++ b/api/RTCRtpTransceiverDirection.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true

--- a/api/RTCRtpTransceiverInit.json
+++ b/api/RTCRtpTransceiverInit.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -88,7 +88,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -141,7 +141,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -192,7 +192,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/Response.json
+++ b/api/Response.json
@@ -1298,7 +1298,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": null

--- a/api/SVGAElement.json
+++ b/api/SVGAElement.json
@@ -87,7 +87,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": null

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -240,7 +240,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -552,7 +552,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null

--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -604,7 +604,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": null

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -260,7 +260,14 @@
               "version_added": "11.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "48",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#service-worker-payment-apps",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "webview_android": {
               "version_added": false
@@ -377,7 +384,14 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "48",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#service-worker-payment-apps",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "webview_android": {
               "version_added": false
@@ -753,7 +767,14 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "44",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#service-worker-payment-apps",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "webview_android": {
               "version_added": false

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -116,7 +116,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "44"
             },
             "webview_android": {
               "version_added": "57"

--- a/api/StorageQuota.json
+++ b/api/StorageQuota.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "15"
           },
           "webview_android": {
             "version_added": null
@@ -88,7 +88,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "15"
             },
             "webview_android": {
               "version_added": null
@@ -139,7 +139,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "15"
             },
             "webview_android": {
               "version_added": null
@@ -190,7 +190,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "15"
             },
             "webview_android": {
               "version_added": null

--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -152,7 +152,13 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "webview_android": {
               "version_added": false
@@ -216,7 +222,13 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "webview_android": {
               "version_added": false
@@ -280,7 +292,13 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "webview_android": {
               "version_added": false
@@ -344,7 +362,13 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "webview_android": {
               "version_added": false
@@ -408,7 +432,13 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "webview_android": {
               "version_added": false
@@ -472,7 +502,13 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "webview_android": {
               "version_added": false
@@ -536,7 +572,13 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "webview_android": {
               "version_added": false
@@ -600,7 +642,13 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "webview_android": {
               "version_added": false
@@ -664,7 +712,13 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "webview_android": {
               "version_added": false
@@ -728,7 +782,13 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "webview_android": {
               "version_added": false
@@ -792,7 +852,13 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "webview_android": {
               "version_added": false

--- a/api/TextTrack.json
+++ b/api/TextTrack.json
@@ -697,7 +697,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": null

--- a/api/UIEvent.json
+++ b/api/UIEvent.json
@@ -505,7 +505,9 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "version_removed": "31",
+              "notes": "Replaced by <code>MouseEvent.pageX</code> in version 45."
             },
             "webview_android": {
               "version_added": true,
@@ -562,7 +564,9 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "version_removed": "31",
+              "notes": "Replaced by <code>MouseEvent.pageY</code> in version 45."
             },
             "webview_android": {
               "version_added": true,

--- a/api/URL.json
+++ b/api/URL.json
@@ -249,7 +249,8 @@
                 "notes": "See <a href='https://webkit.org/b/167518'>here</a> for progress on deprecation."
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": null,
+                "notes": "See <a href='https://crbug.com/591719'>here</a> for progress on deprecation."
               },
               "webview_android": {
                 "version_added": null

--- a/api/WebGL2ComputeRenderingContext.json
+++ b/api/WebGL2ComputeRenderingContext.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "56"
           },
           "webview_android": {
             "version_added": false

--- a/api/WheelEvent.json
+++ b/api/WheelEvent.json
@@ -88,7 +88,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "18"
             },
             "webview_android": {
               "version_added": true

--- a/api/Window.json
+++ b/api/Window.json
@@ -309,9 +309,15 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "30"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "43"
@@ -379,9 +385,15 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "30"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "43"
@@ -449,9 +461,15 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "30"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "43"
@@ -1324,7 +1342,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1730,7 +1748,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1811,9 +1829,17 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "37",
+                "notes": "For absolute values, use <code>ondeviceorientationabsolute</code>."
+              },
+              {
+                "version_added": "15",
+                "version_removed": "37",
+                "notes": "Provided absolute values, not relative."
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "50",
@@ -1871,7 +1897,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "37"
             },
             "webview_android": {
               "version_added": "50"
@@ -2118,7 +2144,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": true
@@ -3438,7 +3464,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": null
@@ -3851,7 +3877,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -4234,7 +4260,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": true
@@ -4541,7 +4567,7 @@
                 "version_added": "7"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "webview_android": {
                 "version_added": null
@@ -4695,7 +4721,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -4797,7 +4823,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -5576,7 +5602,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -5678,7 +5704,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -6397,7 +6423,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -7176,7 +7202,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -7227,7 +7253,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -7278,7 +7304,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -7847,7 +7873,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -7898,7 +7924,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -7949,7 +7975,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -8000,7 +8026,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -8615,7 +8641,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -8717,7 +8743,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -8822,7 +8848,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -8880,7 +8906,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -9239,7 +9265,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -9291,7 +9317,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -9343,7 +9369,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -9395,7 +9421,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -9549,7 +9575,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
This PR is created by a simple script that mirrors the compatibility data of all APIs from Chrome to Opera when it is set to "null". This should help reduce inconsistencies in the browser data.