### PR TITLE
Mirror Chrome -> Opera for css/*

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -244,7 +244,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "53"
               },
               "webview_android": {
                 "version_added": "66"
@@ -400,7 +400,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": null
@@ -452,7 +452,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": null
@@ -504,7 +504,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": null
@@ -556,7 +556,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": null
@@ -1700,7 +1700,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": null
@@ -1752,7 +1752,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": null

--- a/css/at-rules/viewport.json
+++ b/css/at-rules/viewport.json
@@ -353,7 +353,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "16"
               },
               "webview_android": {
                 "version_added": null
@@ -538,7 +538,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "16"
               },
               "webview_android": {
                 "version_added": null
@@ -648,7 +648,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "16"
               },
               "webview_android": {
                 "version_added": null

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -453,7 +453,7 @@
                   "version_added": true
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "webview_android": {
                   "version_added": true

--- a/css/properties/cursor.json
+++ b/css/properties/cursor.json
@@ -1367,9 +1367,17 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": [
+                {
+                  "version_added": "55",
+                  "notes": "Opera also continues to support the prefixed versions."
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "15",
+                  "notes": "Opera 22 added Windows support."
+                }
+              ],
               "webview_android": {
                 "version_added": false
               }

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -244,7 +244,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": false
@@ -306,7 +306,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": false

--- a/css/properties/font-kerning.json
+++ b/css/properties/font-kerning.json
@@ -66,7 +66,8 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "prefix": "-webkit-",
+              "version_added": "19"
             },
             "webview_android": {
               "version_added": null

--- a/css/properties/font-optical-sizing.json
+++ b/css/properties/font-optical-sizing.json
@@ -65,7 +65,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": null

--- a/css/properties/font-stretch.json
+++ b/css/properties/font-stretch.json
@@ -89,7 +89,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": false

--- a/css/properties/font-style.json
+++ b/css/properties/font-style.json
@@ -91,7 +91,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": null

--- a/css/properties/font-variant.json
+++ b/css/properties/font-variant.json
@@ -53,7 +53,7 @@
         },
         "uppercase_eszett": {
           "__compat": {
-            "description": "<code>ß</code> → <code>SS</code>",
+            "description": "<code>\u00df</code> \u2192 <code>SS</code>",
             "support": {
               "chrome": {
                 "version_added": null
@@ -104,7 +104,7 @@
         },
         "turkic_is": {
           "__compat": {
-            "description": "<code>i</code> → <code>İ</code> and <code>ı</code> → <code>I</code>",
+            "description": "<code>i</code> \u2192 <code>\u0130</code> and <code>\u0131</code> \u2192 <code>I</code>",
             "support": {
               "chrome": {
                 "version_added": false

--- a/css/properties/font-weight.json
+++ b/css/properties/font-weight.json
@@ -89,7 +89,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "49"
               },
               "webview_android": {
                 "version_added": null

--- a/css/properties/font.json
+++ b/css/properties/font.json
@@ -140,7 +140,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": null

--- a/css/properties/hyphens.json
+++ b/css/properties/hyphens.json
@@ -1320,7 +1320,7 @@
         },
         "norwegian_no": {
           "__compat": {
-            "description": "Hyphenation dictionary for Norwegian (Bokmål) (no, no-*, nb, nb-*)",
+            "description": "Hyphenation dictionary for Norwegian (Bokm\u00e5l) (no, no-*, nb, nb-*)",
             "support": {
               "chrome": {
                 "version_added": null

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -348,7 +348,7 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "44"
                 },
                 "webview_android": {
                   "version_added": null

--- a/css/properties/mask-position.json
+++ b/css/properties/mask-position.json
@@ -41,7 +41,8 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "prefix": "-webkit-",
+              "version_added": "15"
             },
             "webview_android": {
               "version_added": null

--- a/css/properties/mask-repeat.json
+++ b/css/properties/mask-repeat.json
@@ -42,7 +42,8 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "prefix": "-webkit-",
+              "version_added": "15"
             },
             "webview_android": {
               "prefix": "-webkit-",

--- a/css/properties/mask-size.json
+++ b/css/properties/mask-size.json
@@ -39,7 +39,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": null

--- a/css/properties/mask-type.json
+++ b/css/properties/mask-type.json
@@ -65,7 +65,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "15"
             },
             "webview_android": {
               "version_added": null

--- a/css/properties/overflow-wrap.json
+++ b/css/properties/overflow-wrap.json
@@ -196,7 +196,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": null

--- a/css/properties/text-align.json
+++ b/css/properties/text-align.json
@@ -98,7 +98,8 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "prefix": "-webkit-",
+                "version_added": "15"
               },
               "webview_android": {
                 "version_added": null
@@ -149,7 +150,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "15"
               },
               "webview_android": {
                 "version_added": null
@@ -200,7 +201,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "15"
               },
               "webview_android": {
                 "version_added": null
@@ -302,7 +303,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": null

--- a/css/properties/text-rendering.json
+++ b/css/properties/text-rendering.json
@@ -101,7 +101,8 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true,
+                "notes": "Opera treats <code>auto</code> as <code>optimizeSpeed</code>."
               },
               "webview_android": {
                 "version_added": null
@@ -154,7 +155,8 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "15",
+                "notes": "Supports true geometric precision without rounding up or down to the nearest supported font size in the operating system."
               },
               "webview_android": {
                 "version_added": null

--- a/css/properties/text-transform.json
+++ b/css/properties/text-transform.json
@@ -196,7 +196,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": false
@@ -313,7 +313,7 @@
         },
         "lowercase_sigma": {
           "__compat": {
-            "description": "<code>Σ</code> → <code>σ</code> or word-final <code>ς</code>",
+            "description": "<code>\u03a3</code> \u2192 <code>\u03c3</code> or word-final <code>\u03c2</code>",
             "support": {
               "chrome": {
                 "version_added": "30"
@@ -364,7 +364,7 @@
         },
         "turkic_is": {
           "__compat": {
-            "description": "<code>i</code> → <code>İ</code> and <code>ı</code> → <code>I</code>",
+            "description": "<code>i</code> \u2192 <code>\u0130</code> and <code>\u0131</code> \u2192 <code>I</code>",
             "support": {
               "chrome": {
                 "version_added": false
@@ -415,7 +415,7 @@
         },
         "uppercase_eszett": {
           "__compat": {
-            "description": "<code>ß</code> → <code>SS</code>",
+            "description": "<code>\u00df</code> \u2192 <code>SS</code>",
             "support": {
               "chrome": {
                 "version_added": null

--- a/css/selectors/-webkit-autofill.json
+++ b/css/selectors/-webkit-autofill.json
@@ -40,7 +40,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/css/selectors/cue.json
+++ b/css/selectors/cue.json
@@ -41,7 +41,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null

--- a/css/selectors/fullscreen.json
+++ b/css/selectors/fullscreen.json
@@ -79,7 +79,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "alternative_name": ":-webkit-full-screen",
+              "version_added": "15"
             },
             "webview_android": {
               "version_added": null

--- a/css/selectors/indeterminate.json
+++ b/css/selectors/indeterminate.json
@@ -145,7 +145,7 @@
                 "notes": "See <a href='https://webkit.org/b/156270'>WebKit bug 156270</a>."
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "26"
               },
               "webview_android": {
                 "version_added": "39"
@@ -196,7 +196,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "15"
               },
               "webview_android": {
                 "version_added": null

--- a/css/selectors/visited.json
+++ b/css/selectors/visited.json
@@ -90,7 +90,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "15"
               },
               "webview_android": {
                 "version_added": null

--- a/css/types/calc.json
+++ b/css/types/calc.json
@@ -181,7 +181,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "15"
               },
               "webview_android": {
                 "version_added": null

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -375,7 +375,7 @@
                     "prefix": "-webkit-",
                     "version_added": "5.1",
                     "notes": [
-                      "Safari 4 was supporting an experimental <code><a href='http://developer.apple.com/safari/library/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(linear,…)</a></code> function. It is more limited than the later standard version: you cannot specify both a position and an angle like in <code>linear-gradient()</code>. This old outdated syntax is still supported for compatibility purposes.",
+                      "Safari 4 was supporting an experimental <code><a href='http://developer.apple.com/safari/library/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(linear,\u2026)</a></code> function. It is more limited than the later standard version: you cannot specify both a position and an angle like in <code>linear-gradient()</code>. This old outdated syntax is still supported for compatibility purposes.",
                       "Considers <code>&lt;angle&gt;</code> to start to the right, instead of the top. I.e. it considered an angle of <code>0deg</code> as a direction indicator pointing to the right."
                     ]
                   }
@@ -743,7 +743,7 @@
                   {
                     "prefix": "-webkit-",
                     "version_added": "5.1",
-                    "notes": "Safari 4 was supporting an experimental <code><a href='http://developer.apple.com/safari/library/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(radial,…)</a></code> function. This old outdated syntax is still supported for compatibility purposes."
+                    "notes": "Safari 4 was supporting an experimental <code><a href='http://developer.apple.com/safari/library/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(radial,\u2026)</a></code> function. This old outdated syntax is still supported for compatibility purposes."
                   }
                 ],
                 "safari_ios": {
@@ -1097,7 +1097,7 @@
                     "prefix": "-webkit-",
                     "version_added": "5.1",
                     "notes": [
-                      "Safari 4 was supporting an experimental <code><a href='http://developer.apple.com/safari/library/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(linear,…)</a></code> function. It is more limited than the later standard version: you cannot specify both a position and an angle like in <code>repeating-linear-gradient()</code>. This old outdated syntax is still supported for compatibility purposes.",
+                      "Safari 4 was supporting an experimental <code><a href='http://developer.apple.com/safari/library/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(linear,\u2026)</a></code> function. It is more limited than the later standard version: you cannot specify both a position and an angle like in <code>repeating-linear-gradient()</code>. This old outdated syntax is still supported for compatibility purposes.",
                       "Considers <code>&lt;angle&gt;</code> to start to the right, instead of the top. I.e. it considered an angle of <code>0deg</code> as a direction indicator pointing to the right."
                     ]
                   }
@@ -1442,7 +1442,7 @@
                   {
                     "prefix": "-webkit-",
                     "version_added": "5.1",
-                    "notes": "Safari 4 was supporting an experimental <code><a href='http://developer.apple.com/safari/library/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(radial,…)</a></code> function. This old outdated syntax is still supported for compatibility purposes."
+                    "notes": "Safari 4 was supporting an experimental <code><a href='http://developer.apple.com/safari/library/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(radial,\u2026)</a></code> function. This old outdated syntax is still supported for compatibility purposes."
                   }
                 ],
                 "safari_ios": {

--- a/css/types/timing-function.json
+++ b/css/types/timing-function.json
@@ -54,7 +54,7 @@
         },
         "cubic-bezier": {
           "__compat": {
-            "description": "<code>cubic-bezier()</code> with ordinate ∉ [0,1]",
+            "description": "<code>cubic-bezier()</code> with ordinate \u2209 [0,1]",
             "support": {
               "chrome": {
                 "version_added": "16"


### PR DESCRIPTION
This PR is created by a simple script that mirrors the compatibility data of all APIs from Chrome to Opera when it is set to "null". This should help reduce inconsistencies in the browser data.