### PR TITLE
Mirror Chrome -> Opera for html/*

### DIFF
--- a/html/elements/button.json
+++ b/html/elements/button.json
@@ -288,7 +288,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "15"
               },
               "webview_android": {
                 "version_added": null
@@ -388,7 +388,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "15"
               },
               "webview_android": {
                 "version_added": null

--- a/html/elements/form.json
+++ b/html/elements/form.json
@@ -489,7 +489,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "15"
               },
               "webview_android": {
                 "version_added": null

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -774,7 +774,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": null

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -538,7 +538,7 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "51"
                 },
                 "webview_android": {
                   "version_added": "64"

--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -594,7 +594,8 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "15",
+                  "notes": "Until Opera 46, <code>content</code> values weren't constrained to the values listed in the spec."
                 },
                 "webview_android": {
                   "version_added": null

--- a/html/elements/textarea.json
+++ b/html/elements/textarea.json
@@ -601,7 +601,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "23"
                 },
                 "webview_android": {
                   "version_added": null

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1650,7 +1650,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": null


### PR DESCRIPTION
This PR is created by a simple script that mirrors the compatibility data of all APIs from Chrome to Opera when it is set to "null". This should help reduce inconsistencies in the browser data.