### PR TITLE
Mirror Chrome -> Opera for http/*

### DIFF
--- a/http/headers/accept-ch-lifetime.json
+++ b/http/headers/accept-ch-lifetime.json
@@ -39,7 +39,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "54"
             },
             "webview_android": {
               "version_added": "67"

--- a/http/headers/device-memory.json
+++ b/http/headers/device-memory.json
@@ -39,7 +39,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "48"
             },
             "webview_android": {
               "version_added": "61"

--- a/http/headers/sourcemap.json
+++ b/http/headers/sourcemap.json
@@ -62,9 +62,15 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "prefix": "X-",
+                "version_added": true
+              },
+              {
+                "version_added": true
+              }
+            ],
             "webview_android": {
               "version_added": null
             }


### PR DESCRIPTION
This PR is created by a simple script that mirrors the compatibility data of all APIs from Chrome to Opera when it is set to "null". This should help reduce inconsistencies in the browser data.