### PR TITLE
Mirror Chrome -> Opera for javascript/*

### DIFF
--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -150,7 +150,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "47"
               },
               "webview_android": {
                 "version_added": null
@@ -258,7 +258,7 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "47"
                 },
                 "webview_android": {
                   "version_added": null

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -2736,7 +2736,7 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "15"
                 },
                 "webview_android": {
                   "version_added": null
@@ -3010,7 +3010,7 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "15"
                 },
                 "webview_android": {
                   "version_added": null
@@ -3228,7 +3228,7 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "15"
                 },
                 "webview_android": {
                   "version_added": null

--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -975,7 +975,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "59"
               },
               "webview_android": {
                 "version_added": "72"
@@ -1029,7 +1029,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "59"
                 },
                 "webview_android": {
                   "version_added": "72"
@@ -1084,7 +1084,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "59"
                 },
                 "webview_android": {
                   "version_added": "72"
@@ -1139,7 +1139,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "59"
                 },
                 "webview_android": {
                   "version_added": "72"
@@ -1194,7 +1194,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "59"
                 },
                 "webview_android": {
                   "version_added": "72"
@@ -1249,7 +1249,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "59"
                 },
                 "webview_android": {
                   "version_added": "72"
@@ -1962,7 +1962,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "58"
               },
               "webview_android": {
                 "version_added": "71"
@@ -2016,7 +2016,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "58"
                 },
                 "webview_android": {
                   "version_added": "71"
@@ -2071,7 +2071,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "58"
                 },
                 "webview_android": {
                   "version_added": "71"
@@ -2126,7 +2126,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "58"
                 },
                 "webview_android": {
                   "version_added": "71"
@@ -2181,7 +2181,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "58"
                 },
                 "webview_android": {
                   "version_added": "71"
@@ -2236,7 +2236,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "58"
                 },
                 "webview_android": {
                   "version_added": "71"

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -1306,7 +1306,7 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "webview_android": {
                   "version_added": null

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -1930,7 +1930,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "32"
               },
               "webview_android": {
                 "version_added": null
@@ -2409,7 +2409,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": null


### PR DESCRIPTION
This PR is created by a simple script that mirrors the compatibility data of all APIs from Chrome to Opera when it is set to "null". This should help reduce inconsistencies in the browser data.