### PR TITLE
Mirror Chrome -> Opera for html/*

### DIFF
--- a/html/elements/button.json
+++ b/html/elements/button.json
@@ -276,7 +276,7 @@
                 "version_added": "10"
               },
               "opera": {
-                "version_added": null
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": null
@@ -376,7 +376,7 @@
                 "version_added": "10"
               },
               "opera": {
-                "version_added": null
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": null

--- a/html/elements/form.json
+++ b/html/elements/form.json
@@ -477,7 +477,7 @@
                 "version_added": "10"
               },
               "opera": {
-                "version_added": null
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": null

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -762,7 +762,7 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -326,7 +326,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": "32"
               },
               "opera_android": {
                 "version_added": null
@@ -526,7 +526,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "51"
                 },
                 "opera_android": {
                   "version_added": null
@@ -727,7 +727,7 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "33"
                 },
                 "opera_android": {
                   "version_added": null
@@ -777,7 +777,7 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "opera_android": {
                   "version_added": null
@@ -931,7 +931,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "33"
                 },
                 "opera_android": {
                   "version_added": null
@@ -1035,7 +1035,7 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "37"
                 },
                 "opera_android": {
                   "version_added": null

--- a/html/elements/menu.json
+++ b/html/elements/menu.json
@@ -136,7 +136,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
                 "version_added": false

--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -582,7 +582,8 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "15",
+                  "notes": "Until Opera 46, <code>content</code> values weren't constrained to the values listed in the spec."
                 },
                 "opera_android": {
                   "version_added": null

--- a/html/elements/source.json
+++ b/html/elements/source.json
@@ -152,7 +152,7 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null
@@ -288,7 +288,7 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null

--- a/html/elements/textarea.json
+++ b/html/elements/textarea.json
@@ -589,7 +589,7 @@
                   "version_added": "10"
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "23"
                 },
                 "opera_android": {
                   "version_added": null

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -236,7 +236,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null
@@ -284,7 +284,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null
@@ -332,7 +332,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null
@@ -380,7 +380,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null
@@ -1638,7 +1638,7 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null


### PR DESCRIPTION
This PR is created by a simple script that mirrors the compatibility data of all APIs from Chrome to Opera when it is set to "null". This should help reduce inconsistencies in the browser data.