### PR TITLE
Mirror Chrome -> Opera for javascript/*

### DIFF
--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -138,7 +138,7 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": "47"
               },
               "opera_android": {
                 "version_added": null
@@ -246,7 +246,7 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "47"
                 },
                 "opera_android": {
                   "version_added": null

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -2724,7 +2724,7 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "15"
                 },
                 "opera_android": {
                   "version_added": null
@@ -2998,7 +2998,7 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "15"
                 },
                 "opera_android": {
                   "version_added": null
@@ -3216,7 +3216,7 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "15"
                 },
                 "opera_android": {
                   "version_added": null

--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -464,7 +464,7 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "30"
                 },
                 "opera_android": {
                   "version_added": null
@@ -518,7 +518,7 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "38"
                 },
                 "opera_android": {
                   "version_added": null
@@ -682,7 +682,7 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "opera_android": {
                   "version_added": null

--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -963,7 +963,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": "59"
               },
               "opera_android": {
                 "version_added": null
@@ -1017,7 +1017,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "59"
                 },
                 "opera_android": {
                   "version_added": null
@@ -1072,7 +1072,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "59"
                 },
                 "opera_android": {
                   "version_added": null
@@ -1127,7 +1127,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "59"
                 },
                 "opera_android": {
                   "version_added": null
@@ -1182,7 +1182,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "59"
                 },
                 "opera_android": {
                   "version_added": null
@@ -1237,7 +1237,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "59"
                 },
                 "opera_android": {
                   "version_added": null
@@ -1457,7 +1457,7 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "51"
                 },
                 "opera_android": {
                   "version_added": null
@@ -1950,7 +1950,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": "58"
               },
               "opera_android": {
                 "version_added": null
@@ -2004,7 +2004,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "58"
                 },
                 "opera_android": {
                   "version_added": null
@@ -2059,7 +2059,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "58"
                 },
                 "opera_android": {
                   "version_added": null
@@ -2114,7 +2114,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "58"
                 },
                 "opera_android": {
                   "version_added": null
@@ -2169,7 +2169,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "58"
                 },
                 "opera_android": {
                   "version_added": null
@@ -2224,7 +2224,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "58"
                 },
                 "opera_android": {
                   "version_added": null

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -1294,7 +1294,7 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "opera_android": {
                   "version_added": null

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -142,7 +142,8 @@
                 "notes": "Negative integers are not considered as indexed properties and therefore return the value of the prototype property."
               },
               "opera": {
-                "version_added": null
+                "version_added": true,
+                "notes": "Negative integers are not considered as indexed properties and therefore return the value of the prototype property."
               },
               "opera_android": {
                 "version_added": null
@@ -251,7 +252,7 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null
@@ -965,7 +966,7 @@
                 "version_added": "4.0.0"
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null
@@ -1918,7 +1919,7 @@
                 "version_added": "4.0.0"
               },
               "opera": {
-                "version_added": null
+                "version_added": "32"
               },
               "opera_android": {
                 "version_added": null
@@ -2397,7 +2398,7 @@
                 }
               ],
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -160,7 +160,7 @@
                 }
               ],
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null

--- a/javascript/builtins/WeakSet.json
+++ b/javascript/builtins/WeakSet.json
@@ -138,7 +138,7 @@
                 "version_added": "0.12"
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null

--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -642,7 +642,7 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": null
+                "version_added": "36"
               },
               "opera_android": {
                 "version_added": null

--- a/javascript/operators/object_initializer.json
+++ b/javascript/operators/object_initializer.json
@@ -247,7 +247,7 @@
                 "version_added": "8.3.0"
               },
               "opera": {
-                "version_added": null
+                "version_added": "47"
               },
               "opera_android": {
                 "version_added": null


### PR DESCRIPTION
This PR is created by a simple script that mirrors the compatibility data of all APIs from Chrome to Opera when it is set to "null". This should help reduce inconsistencies in the browser data.