### PR TITLE
Mirror Chrome -> Opera for svg/*

### DIFF
--- a/svg/elements/svg.json
+++ b/svg/elements/svg.json
@@ -73,7 +73,7 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null
@@ -120,7 +120,7 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
                 "version_added": null
@@ -167,7 +167,7 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
                 "version_added": null
@@ -308,7 +308,7 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null
@@ -543,7 +543,7 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
                 "version_added": null

--- a/svg/elements/tref.json
+++ b/svg/elements/tref.json
@@ -27,7 +27,7 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
               "version_added": null
@@ -74,7 +74,7 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
                 "version_added": null


### PR DESCRIPTION
This PR is created by a simple script that mirrors the compatibility data of all APIs from Chrome to Opera when it is set to "null". This should help reduce inconsistencies in the browser data.