### PR TITLE
Mirror Chrome -> Opera for webextensions/*

### DIFF
--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -427,7 +427,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": true
                 }
               }
             }

--- a/webextensions/api/notifications.json
+++ b/webextensions/api/notifications.json
@@ -41,8 +41,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "notes": "Specifying this option doesn't throw an error. It might or might not have any effect.",
-                  "version_added": null
+                  "version_added": true
                 }
               },
               "status": {
@@ -116,8 +115,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "notes": "Specifying this option doesn't throw an error. It might or might not have any effect.",
-                  "version_added": null
+                  "version_added": true
                 }
               }
             }


### PR DESCRIPTION
This PR is created by a simple script that mirrors the compatibility data of all APIs from Chrome to Opera when it is set to "null". This should help reduce inconsistencies in the browser data.