### PR TITLE
Mirror Chrome -> Samsung Internet for api/*

### DIFF
--- a/api/AbsoluteOrientationSensor.json
+++ b/api/AbsoluteOrientationSensor.json
@@ -29,7 +29,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": false
           },
           "webview_android": {
             "version_added": "69"
@@ -71,7 +71,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"

--- a/api/AbstractWorker.json
+++ b/api/AbstractWorker.json
@@ -35,7 +35,7 @@
             "version_added": "5.1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": "4.4"
@@ -82,7 +82,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"

--- a/api/Accelerometer.json
+++ b/api/Accelerometer.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": false
           },
           "webview_android": {
             "version_added": "69"
@@ -83,7 +83,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"
@@ -131,7 +131,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"
@@ -179,7 +179,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"
@@ -227,7 +227,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"

--- a/api/AnalyserNode.json
+++ b/api/AnalyserNode.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -131,7 +131,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -179,7 +179,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -227,7 +227,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -275,7 +275,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -323,7 +323,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -371,7 +371,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -419,7 +419,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -467,7 +467,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -515,7 +515,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/AudioBuffer.json
+++ b/api/AudioBuffer.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -136,7 +136,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -184,7 +184,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -232,7 +232,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -280,7 +280,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -328,7 +328,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -376,7 +376,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -424,7 +424,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/AudioBufferSourceNode.json
+++ b/api/AudioBufferSourceNode.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -136,7 +136,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -184,7 +184,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "44"
@@ -232,7 +232,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -280,7 +280,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -328,7 +328,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -378,7 +378,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -426,7 +426,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -475,7 +475,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -525,7 +525,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -448,7 +448,9 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0",
+              "version_removed": "6.0",
+              "notes": "Available as a part of <code>BaseAudioContext</code>."
             },
             "webview_android": {
               "version_added": true,
@@ -498,7 +500,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -546,7 +548,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -594,7 +596,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -740,7 +742,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/AudioDestinationNode.json
+++ b/api/AudioDestinationNode.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -82,7 +82,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/AudioListener.json
+++ b/api/AudioListener.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -88,7 +88,8 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0",
+              "version_removed": "6.0"
             },
             "webview_android": {
               "version_added": true,
@@ -443,7 +444,8 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0",
+              "version_removed": "6.0"
             },
             "webview_android": {
               "version_added": true,
@@ -642,7 +644,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -690,7 +692,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/AudioNode.json
+++ b/api/AudioNode.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -82,7 +82,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -130,7 +130,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -178,7 +178,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -226,7 +226,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -274,7 +274,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -322,7 +322,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -370,7 +370,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -418,7 +418,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -82,7 +82,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "68"
@@ -213,7 +213,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -261,7 +261,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -313,7 +313,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -365,7 +365,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -509,7 +509,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -557,7 +557,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -605,7 +605,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -653,7 +653,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/AudioProcessingEvent.json
+++ b/api/AudioProcessingEvent.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -83,7 +83,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "57"
@@ -131,7 +131,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -179,7 +179,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -227,7 +227,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/AudioScheduledSourceNode.json
+++ b/api/AudioScheduledSourceNode.json
@@ -132,7 +132,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -180,7 +180,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -228,7 +228,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -276,7 +276,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/AudioTrackList.json
+++ b/api/AudioTrackList.json
@@ -77,7 +77,14 @@
             "version_added": "7.1"
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "5.0",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "enable-experimental-web-platform-features",
+                "value_to_set": "enabled"
+              }
+            ]
           },
           "webview_android": {
             "version_added": "45"
@@ -167,7 +174,14 @@
               "version_added": "7.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "webview_android": {
               "version_added": "45"
@@ -258,7 +272,14 @@
               "version_added": "7.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "webview_android": {
               "version_added": "45"
@@ -348,7 +369,14 @@
               "version_added": "7.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "webview_android": {
               "version_added": "45"
@@ -438,7 +466,14 @@
               "version_added": "7.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "webview_android": {
               "version_added": "45"
@@ -528,7 +563,14 @@
               "version_added": "7.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "webview_android": {
               "version_added": "45"
@@ -618,7 +660,14 @@
               "version_added": "7.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "webview_android": {
               "version_added": "45"
@@ -708,7 +757,14 @@
               "version_added": "7.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "webview_android": {
               "version_added": "45"
@@ -799,7 +855,14 @@
               "version_added": "7.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "webview_android": {
               "version_added": "45"

--- a/api/AudioWorklet.json
+++ b/api/AudioWorklet.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"

--- a/api/AudioWorkletGlobalScope.json
+++ b/api/AudioWorkletGlobalScope.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -178,7 +178,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -226,7 +226,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/AudioWorkletNode.json
+++ b/api/AudioWorkletNode.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -83,7 +83,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -131,7 +131,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -179,7 +179,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -227,7 +227,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -276,7 +276,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/AudioWorkletProcessor.json
+++ b/api/AudioWorkletProcessor.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "64"
@@ -83,7 +83,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "64"
@@ -131,7 +131,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "64"

--- a/api/AuthenticatorAssertionResponse.json
+++ b/api/AuthenticatorAssertionResponse.json
@@ -50,7 +50,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
             "version_added": "70"
@@ -112,7 +112,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "70"
@@ -175,7 +175,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "70"
@@ -238,7 +238,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "70"

--- a/api/AuthenticatorAttestationResponse.json
+++ b/api/AuthenticatorAttestationResponse.json
@@ -50,7 +50,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
             "version_added": "70"
@@ -112,7 +112,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "70"
@@ -160,7 +160,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/AuthenticatorResponse.json
+++ b/api/AuthenticatorResponse.json
@@ -50,7 +50,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
             "version_added": "70"
@@ -112,7 +112,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "70"

--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -95,7 +95,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -157,7 +157,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": true
@@ -219,7 +219,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": true
@@ -281,7 +281,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": true
@@ -343,7 +343,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": true
@@ -405,7 +405,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": true
@@ -467,7 +467,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": true
@@ -515,7 +515,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "56"
@@ -577,7 +577,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": true
@@ -639,7 +639,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": true
@@ -701,7 +701,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": true
@@ -763,7 +763,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": true
@@ -811,7 +811,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -873,7 +873,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": true
@@ -935,7 +935,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": true
@@ -1015,9 +1015,19 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "7.0",
+                "notes": "Default values supported"
+              },
+              {
+                "version_added": "7.0"
+              },
+              {
+                "version_added": "2.0",
+                "prefix": "webkit"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "59",
@@ -1073,7 +1083,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true
@@ -1136,7 +1146,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": true
@@ -1246,7 +1256,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": true
@@ -1308,7 +1318,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": true
@@ -1370,7 +1380,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": true
@@ -1417,7 +1427,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "49"
@@ -1480,7 +1490,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": true
@@ -1542,7 +1552,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": true
@@ -1652,7 +1662,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/BatteryManager.json
+++ b/api/BatteryManager.json
@@ -78,7 +78,8 @@
             "version_removed": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "3.0",
+            "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
           },
           "webview_android": {
             "version_added": "40"
@@ -168,7 +169,8 @@
               "version_removed": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0",
+              "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
             },
             "webview_android": {
               "version_added": "40"
@@ -259,7 +261,8 @@
               "version_removed": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0",
+              "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
             },
             "webview_android": {
               "version_added": "40"
@@ -350,7 +353,8 @@
               "version_removed": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0",
+              "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
             },
             "webview_android": {
               "version_added": "40"
@@ -441,7 +445,8 @@
               "version_removed": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0",
+              "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
             },
             "webview_android": {
               "version_added": "40"
@@ -532,7 +537,8 @@
               "version_removed": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0",
+              "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
             },
             "webview_android": {
               "version_added": "40"
@@ -623,7 +629,8 @@
               "version_removed": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0",
+              "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
             },
             "webview_android": {
               "version_added": "40"
@@ -714,7 +721,8 @@
               "version_removed": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0",
+              "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
             },
             "webview_android": {
               "version_added": "40"
@@ -805,7 +813,8 @@
               "version_removed": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0",
+              "notes": "Values for <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime'><code>BatteryManager.chargingTime</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingTime'><code>BatteryManager.dischargingTime</code></a> are always equal to <code>Infinity</code>."
             },
             "webview_android": {
               "version_added": "40"

--- a/api/BeforeInstallPromptEvent.json
+++ b/api/BeforeInstallPromptEvent.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": "45"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -179,7 +179,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -227,7 +227,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"

--- a/api/BiquadFilterNode.json
+++ b/api/BiquadFilterNode.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -136,7 +136,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -184,7 +184,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -232,7 +232,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -280,7 +280,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -328,7 +328,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -376,7 +376,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/Blob.json
+++ b/api/Blob.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -85,7 +85,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "37"
@@ -251,9 +251,16 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "version_added": "1.0",
+                "version_removed": "1.5",
+                "prefix": "webkit"
+              }
+            ],
             "webview_android": {
               "version_added": true
             }

--- a/api/BlobBuilder.json
+++ b/api/BlobBuilder.json
@@ -44,7 +44,8 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "1.0",
+            "prefix": "Webkit"
           },
           "webview_android": {
             "version_added": "3",

--- a/api/BluetoothRemoteGATTService.json
+++ b/api/BluetoothRemoteGATTService.json
@@ -71,7 +71,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "6.0"
           },
           "webview_android": {
             "version_added": false
@@ -136,7 +136,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -220,7 +220,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false
@@ -268,7 +268,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -316,7 +316,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -400,7 +400,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false
@@ -448,7 +448,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -532,7 +532,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/CSS.json
+++ b/api/CSS.json
@@ -57,7 +57,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": "4.4"
@@ -104,7 +104,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -152,7 +152,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -200,7 +200,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -248,7 +248,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -296,7 +296,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -344,7 +344,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -392,7 +392,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -440,7 +440,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "46"
@@ -488,7 +488,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -536,7 +536,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -584,7 +584,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -632,7 +632,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -680,7 +680,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -776,7 +776,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -872,7 +872,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -920,7 +920,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -968,7 +968,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -1016,7 +1016,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1064,7 +1064,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -1112,7 +1112,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -1160,7 +1160,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -1208,7 +1208,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -1256,7 +1256,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -1304,7 +1304,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -1400,7 +1400,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -1448,7 +1448,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -1601,7 +1601,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -1697,7 +1697,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -1793,7 +1793,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -1841,7 +1841,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -1889,7 +1889,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSImageValue.json
+++ b/api/CSSImageValue.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"

--- a/api/CSSKeywordValue.json
+++ b/api/CSSKeywordValue.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSMathInvert.json
+++ b/api/CSSMathInvert.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSMathMax.json
+++ b/api/CSSMathMax.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSMathMin.json
+++ b/api/CSSMathMin.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSMathNegate.json
+++ b/api/CSSMathNegate.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSMathProduct.json
+++ b/api/CSSMathProduct.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSMathSum.json
+++ b/api/CSSMathSum.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSMathValue.json
+++ b/api/CSSMathValue.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSMatrixComponent.json
+++ b/api/CSSMatrixComponent.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSNumericArray.json
+++ b/api/CSSNumericArray.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -130,7 +130,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -178,7 +178,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -226,7 +226,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -274,7 +274,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -322,7 +322,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -370,7 +370,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSNumericValue.json
+++ b/api/CSSNumericValue.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -130,7 +130,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -178,7 +178,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -226,7 +226,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -274,7 +274,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -322,7 +322,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -374,7 +374,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0",
+              "notes": "Not exposed to PaintWorklet."
             },
             "webview_android": {
               "version_added": "66",
@@ -423,7 +424,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -471,7 +472,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -519,7 +520,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -567,7 +568,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSPageRule.json
+++ b/api/CSSPageRule.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": "45"

--- a/api/CSSPerspective.json
+++ b/api/CSSPerspective.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSPositionValue.json
+++ b/api/CSSPositionValue.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -179,7 +179,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSPrimitiveValue.json
+++ b/api/CSSPrimitiveValue.json
@@ -37,7 +37,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
             "version_added": false
@@ -86,7 +86,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -136,7 +136,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -186,7 +186,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -236,7 +236,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -286,7 +286,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -336,7 +336,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -386,7 +386,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -436,7 +436,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/CSSRotate.json
+++ b/api/CSSRotate.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -179,7 +179,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -227,7 +227,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -275,7 +275,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSScale.json
+++ b/api/CSSScale.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -179,7 +179,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -227,7 +227,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSSkew.json
+++ b/api/CSSSkew.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -179,7 +179,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSSkewX.json
+++ b/api/CSSSkewX.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSSkewY.json
+++ b/api/CSSSkewY.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSStyleValue.json
+++ b/api/CSSStyleValue.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -130,7 +130,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSTransformComponent.json
+++ b/api/CSSTransformComponent.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -130,7 +130,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSTransformValue.json
+++ b/api/CSSTransformValue.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -179,7 +179,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -227,7 +227,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -275,7 +275,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -323,7 +323,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -371,7 +371,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -419,7 +419,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -467,7 +467,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSTranslate.json
+++ b/api/CSSTranslate.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -179,7 +179,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -227,7 +227,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSUnitValue.json
+++ b/api/CSSUnitValue.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -179,7 +179,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSUnparsedValue.json
+++ b/api/CSSUnparsedValue.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -179,7 +179,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -227,7 +227,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -275,7 +275,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -323,7 +323,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -371,7 +371,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -419,7 +419,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CSSVariableReferenceValue.json
+++ b/api/CSSVariableReferenceValue.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -179,7 +179,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/CanvasGradient.json
+++ b/api/CanvasGradient.json
@@ -36,7 +36,7 @@
             "version_added": "3.2"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true

--- a/api/CanvasPattern.json
+++ b/api/CanvasPattern.json
@@ -35,7 +35,7 @@
             "version_added": "3.2"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -2761,7 +2761,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true
@@ -3061,7 +3061,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true
@@ -3171,7 +3171,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true
@@ -4011,7 +4011,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true

--- a/api/ChannelMergerNode.json
+++ b/api/ChannelMergerNode.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true

--- a/api/ChannelSplitterNode.json
+++ b/api/ChannelSplitterNode.json
@@ -39,7 +39,8 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0",
+            "notes": "Starting in Samsung Internet 56, <code>channelCountMode</code> is set to <code>explicit</code> and <code>channelCount</code> is fixed to the number of outputs, as per the latest spec."
           },
           "webview_android": {
             "version_added": true,

--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": false
@@ -98,7 +98,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -148,7 +148,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": false
@@ -212,7 +212,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -262,7 +262,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/ClipboardEvent.json
+++ b/api/ClipboardEvent.json
@@ -83,7 +83,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "58"

--- a/api/CompositionEvent.json
+++ b/api/CompositionEvent.json
@@ -83,7 +83,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -179,7 +179,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -227,7 +227,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/Console.json
+++ b/api/Console.json
@@ -78,7 +78,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -123,7 +123,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -168,7 +168,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -213,7 +213,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -306,7 +306,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -356,7 +356,8 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true,
+                "notes": "In version 28, if a negative value is passed to <code>%d</code>, it will be rounded down to the closest negative integer. For example, -0.1 becomes -1."
               },
               "webview_android": {
                 "version_added": true,
@@ -403,7 +404,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -448,7 +449,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -493,7 +494,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -538,7 +539,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true
@@ -675,7 +676,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -720,7 +721,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -765,7 +766,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -811,7 +812,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -856,7 +857,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true
@@ -902,7 +903,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -949,7 +950,8 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true,
+                "notes": "In version 28, if a negative value is passed to %d, it will be rounded down to the closest negative integer, so -0.1 becomes -1."
               },
               "webview_android": {
                 "version_added": true,
@@ -996,7 +998,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "53"
@@ -1041,7 +1043,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1086,7 +1088,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1131,7 +1133,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -1176,7 +1178,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -1267,7 +1269,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1312,7 +1314,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1357,7 +1359,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1402,7 +1404,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true

--- a/api/ConvolverNode.json
+++ b/api/ConvolverNode.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -131,7 +131,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -179,7 +179,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/Coordinates.json
+++ b/api/Coordinates.json
@@ -94,7 +94,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -154,7 +154,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -214,7 +214,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -274,7 +274,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -334,7 +334,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -394,7 +394,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -454,7 +454,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -514,7 +514,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/api/Credential.json
+++ b/api/Credential.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": "51"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "51"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "51"
@@ -183,7 +183,9 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0",
+              "version_removed": "6.0",
+              "notes": "See <a href='https://crbug.com/602980'>Bug 602980</a>."
             },
             "webview_android": {
               "version_added": "51",

--- a/api/CredentialUserData.json
+++ b/api/CredentialUserData.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "8.0"
           },
           "webview_android": {
             "version_added": "60"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"

--- a/api/Crypto.json
+++ b/api/Crypto.json
@@ -35,7 +35,7 @@
             "version_added": "6.1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -121,7 +121,7 @@
               }
             ],
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -169,7 +169,7 @@
               "version_added": "6.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/CryptoKey.json
+++ b/api/CryptoKey.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "3.0"
           },
           "webview_android": {
             "version_added": "37"
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -130,7 +130,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -178,7 +178,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -226,7 +226,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/api/CryptoKeyPair.json
+++ b/api/CryptoKeyPair.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "3.0"
           },
           "webview_android": {
             "version_added": "37"

--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -537,7 +537,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "68"

--- a/api/DOMQuad.json
+++ b/api/DOMQuad.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "8.0"
           },
           "webview_android": {
             "version_added": "61"

--- a/api/DOMRectReadOnly.json
+++ b/api/DOMRectReadOnly.json
@@ -137,7 +137,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "57"

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -328,7 +328,8 @@
               "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0",
+              "notes": "Before Samsung Internet 50, this property was part of the deprecated child <code>DOMSettableTokenList</code> interface."
             },
             "webview_android": {
               "version_added": "50",
@@ -665,7 +666,7 @@
               "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -713,7 +714,7 @@
               "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -761,7 +762,7 @@
               "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -809,7 +810,7 @@
               "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"

--- a/api/DelayNode.json
+++ b/api/DelayNode.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -134,7 +134,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/DeviceLightEvent.json
+++ b/api/DeviceLightEvent.json
@@ -64,7 +64,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
             "version_added": false
@@ -140,7 +140,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/DeviceMotionEvent.json
+++ b/api/DeviceMotionEvent.json
@@ -83,7 +83,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "59"

--- a/api/DeviceOrientationEvent.json
+++ b/api/DeviceOrientationEvent.json
@@ -39,7 +39,8 @@
             "version_added": "4.2"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": true,
+            "notes": "Before version 50, Samsung Internet provided absolute values instead of relative values for this event. Developers still needing absolute values may use the <code>ondeviceorientationabsolute</code> event."
           },
           "webview_android": {
             "version_added": true,
@@ -88,7 +89,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "59"

--- a/api/DeviceProximityEvent.json
+++ b/api/DeviceProximityEvent.json
@@ -63,7 +63,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
             "version_added": false
@@ -138,7 +138,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -214,7 +214,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -290,7 +290,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/DirectoryEntrySync.json
+++ b/api/DirectoryEntrySync.json
@@ -37,7 +37,8 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "1.0",
+            "prefix": "webkit"
           },
           "webview_android": {
             "version_added": "37",

--- a/api/DirectoryReaderSync.json
+++ b/api/DirectoryReaderSync.json
@@ -37,7 +37,8 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "1.0",
+            "prefix": "webkit"
           },
           "webview_android": {
             "version_added": "37",

--- a/api/Document.json
+++ b/api/Document.json
@@ -414,7 +414,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -463,7 +463,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -512,7 +512,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -561,7 +561,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -1232,7 +1232,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "58"
@@ -1278,7 +1278,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "7.0"
               },
               "webview_android": {
                 "version_added": "58"
@@ -2473,7 +2473,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "58"
@@ -2519,7 +2519,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "7.0"
               },
               "webview_android": {
                 "version_added": "58"
@@ -3987,7 +3987,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": "71"
@@ -4981,7 +4981,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "57"
@@ -5472,7 +5472,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -5525,7 +5525,8 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "notes": "Samsung Internet does not fire the <code>keypress</code> event for <a href='https://crbug.com/13891#c50'>known keyboard shortcuts</a>. Which keyboard shortcuts are known depends on the user's system. Use the <code>keydown</code> event to implement keyboard shortcuts."
             },
             "webview_android": {
               "version_added": true,
@@ -5575,7 +5576,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -5912,7 +5913,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "57"
@@ -6732,7 +6733,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -6930,7 +6931,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "58"
@@ -6976,7 +6977,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "7.0"
               },
               "webview_android": {
                 "version_added": "58"
@@ -7099,7 +7100,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -7173,7 +7174,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -7247,7 +7248,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -7321,7 +7322,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -7383,9 +7384,16 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "5.0"
+              },
+              {
+                "version_added": "1.5",
+                "version_removed": "5.0",
+                "prefix": "webkit"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "45"
@@ -7453,9 +7461,16 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "5.0"
+              },
+              {
+                "version_added": "1.5",
+                "version_removed": "5.0",
+                "prefix": "webkit"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "45"
@@ -7535,7 +7550,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -7609,7 +7624,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -7683,7 +7698,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -7757,7 +7772,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -8904,7 +8919,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -9079,7 +9094,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -9152,7 +9167,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -9384,7 +9399,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -9433,7 +9448,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -9482,7 +9497,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -9531,7 +9546,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -9580,7 +9595,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -9629,7 +9644,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -9678,7 +9693,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -9727,7 +9742,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -10032,7 +10047,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "61"

--- a/api/DoubleRange.json
+++ b/api/DoubleRange.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true

--- a/api/DynamicsCompressorNode.json
+++ b/api/DynamicsCompressorNode.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -134,7 +134,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -182,7 +182,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -230,7 +230,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -280,7 +280,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0",
+              "notes": "Before version 52, this was an <code>AudioParam.</code>."
             },
             "webview_android": {
               "version_added": true,
@@ -329,7 +330,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -377,7 +378,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/EXT_color_buffer_float.json
+++ b/api/EXT_color_buffer_float.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "8.0"
           },
           "webview_android": {
             "version_added": "63"

--- a/api/EXT_color_buffer_half_float.json
+++ b/api/EXT_color_buffer_half_float.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "8.0"
           },
           "webview_android": {
             "version_added": "63"

--- a/api/EffectTiming.json
+++ b/api/EffectTiming.json
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -130,7 +130,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -178,7 +178,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -226,7 +226,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -322,7 +322,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -370,7 +370,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -418,7 +418,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -466,7 +466,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/Element.json
+++ b/api/Element.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -83,7 +83,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -136,7 +136,8 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "notes": "Samsung Internet does not fire the <code>keypress</code> event for <a href='https://crbug.com/13891#c50'>known keyboard shortcuts</a>. Which keyboard shortcuts are known depends on the user's system. Use the <code>keydown</code> event to implement keyboard shortcuts."
             },
             "webview_android": {
               "version_added": true,
@@ -186,7 +187,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -581,7 +582,8 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false,
+              "notes": "Implemented on <a href='https://developer.mozilla.org/docs/Web/API/HTMLElement'>HTMLElement</a>."
             },
             "webview_android": {
               "version_added": false,
@@ -631,7 +633,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -679,7 +681,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -726,7 +728,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "50"
@@ -850,7 +852,7 @@
               "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "53"
@@ -897,7 +899,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true
@@ -994,7 +996,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -1090,7 +1092,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -1146,7 +1148,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -1250,7 +1252,7 @@
                 "version_added": "7"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true
@@ -1298,7 +1300,7 @@
                 "version_added": "7"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true
@@ -1346,7 +1348,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "8.0"
               },
               "webview_android": {
                 "version_added": "61"
@@ -1395,7 +1397,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -1542,7 +1544,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -1590,7 +1592,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -1638,7 +1640,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -1686,7 +1688,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -1734,7 +1736,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -1782,7 +1784,7 @@
               "version_added": "9"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "41"
@@ -1831,7 +1833,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1880,7 +1882,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": null
@@ -1929,7 +1931,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1978,7 +1980,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -2026,7 +2028,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -2075,7 +2077,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "58"
@@ -2121,7 +2123,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "7.0"
               },
               "webview_android": {
                 "version_added": "58"
@@ -2356,7 +2358,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "58"
@@ -2402,7 +2404,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "7.0"
               },
               "webview_android": {
                 "version_added": "58"
@@ -2453,7 +2455,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -2551,7 +2553,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3165,7 +3167,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "61"
@@ -3356,7 +3358,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true
@@ -3403,7 +3405,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true
@@ -3452,7 +3454,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true
@@ -3501,7 +3503,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true
@@ -3701,7 +3703,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true
@@ -3812,7 +3814,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true
@@ -4030,7 +4032,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -4078,7 +4080,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "42"
@@ -4177,7 +4179,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "2.3"
@@ -4226,7 +4228,7 @@
               "version_added": "4"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "2.3"
@@ -4274,7 +4276,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "2.3"
@@ -4326,7 +4328,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0",
+              "notes": "This API was previously available on the <code>Node</code> API."
             },
             "webview_android": {
               "version_added": true,
@@ -5007,7 +5010,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -5059,7 +5062,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0",
+              "notes": "This API was previously available on the <code>Node</code> API."
             },
             "webview_android": {
               "version_added": true,
@@ -5278,7 +5282,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0",
+              "notes": "This API was previously available on the <code>Node</code> API."
             },
             "webview_android": {
               "version_added": true,
@@ -5377,7 +5382,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "58"
@@ -5423,7 +5428,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "7.0"
               },
               "webview_android": {
                 "version_added": "58"
@@ -5476,7 +5481,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0",
+              "notes": "This API was previously available on the <code>Node</code> API."
             },
             "webview_android": {
               "version_added": true
@@ -5664,7 +5670,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -5934,10 +5940,15 @@
               "prefix": "webkit",
               "notes": "Only available on iPad, not on iPhone."
             },
-            "samsunginternet_android": {
-              "version_added": true,
-              "prefix": "webkit"
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": false
+              },
+              {
+                "version_added": true,
+                "prefix": "webkit"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "69"
@@ -6037,7 +6048,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": "71"
@@ -6103,9 +6114,15 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": true,
+                "prefix": "webkit"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": true
@@ -6206,7 +6223,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -6253,7 +6270,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "45"
@@ -6302,7 +6319,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -6349,7 +6366,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "45"
@@ -6399,7 +6416,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -6510,7 +6527,8 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "8.0",
+                "notes": "The <code>block</code> and <code>inline</code> options support the values <code>start</code>, <code>center</code>, <code>end</code>, <code>nearest</code>."
               },
               "webview_android": {
                 "version_added": "61",
@@ -6560,7 +6578,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -6664,7 +6682,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -6760,7 +6778,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -6807,7 +6825,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "45"
@@ -6856,7 +6874,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": true
@@ -6952,7 +6970,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": true
@@ -7001,7 +7019,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -7245,7 +7263,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -7323,7 +7341,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -7398,7 +7416,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -7447,7 +7465,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -7495,7 +7513,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "53"
@@ -7543,7 +7561,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -7591,7 +7609,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -7639,7 +7657,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"
@@ -7688,7 +7706,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -7737,7 +7755,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -7786,7 +7804,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -7835,7 +7853,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -7933,7 +7951,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "61"

--- a/api/EntrySync.json
+++ b/api/EntrySync.json
@@ -37,7 +37,8 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "1.0",
+            "prefix": "webkit"
           },
           "webview_android": {
             "version_added": "37",

--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -49,7 +49,7 @@
             }
           ],
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": "1"
@@ -155,7 +155,8 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0",
+              "notes": "Before Samsung Internet 49, the <code>type</code> and <code>listener</code> parameters were optional."
             },
             "webview_android": {
               "version_added": "1",
@@ -203,7 +204,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"
@@ -490,7 +491,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "webview_android": {
                   "version_added": "73"
@@ -548,7 +549,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4"
@@ -604,7 +605,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -651,7 +652,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"
@@ -701,7 +702,8 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0",
+                "version_removed": "5.0"
               },
               "webview_android": {
                 "version_added": "1",

--- a/api/ExtendableMessageEvent.json
+++ b/api/ExtendableMessageEvent.json
@@ -36,7 +36,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": false
@@ -133,7 +133,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/External.json
+++ b/api/External.json
@@ -29,7 +29,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -70,7 +70,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "54"
@@ -112,7 +112,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "54"

--- a/api/FeaturePolicy.json
+++ b/api/FeaturePolicy.json
@@ -134,7 +134,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
             "version_added": "74"
@@ -241,7 +241,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"
@@ -349,7 +349,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"
@@ -457,7 +457,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"
@@ -505,7 +505,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"

--- a/api/FetchEvent.json
+++ b/api/FetchEvent.json
@@ -576,7 +576,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "72"

--- a/api/FileEntrySync.json
+++ b/api/FileEntrySync.json
@@ -37,7 +37,8 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0",
+            "prefix": "webkit"
           },
           "webview_android": {
             "version_added": "37",

--- a/api/FileError.json
+++ b/api/FileError.json
@@ -45,7 +45,9 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0",
+            "version_removed": "6.0",
+            "prefix": "webkit"
           },
           "webview_android": {
             "version_added": true,

--- a/api/FocusEvent.json
+++ b/api/FocusEvent.json
@@ -83,7 +83,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/FontFaceSetLoadEvent.json
+++ b/api/FontFaceSetLoadEvent.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "3.0"
           },
           "webview_android": {
             "version_added": false
@@ -131,7 +131,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/FormData.json
+++ b/api/FormData.json
@@ -85,7 +85,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -185,7 +185,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true
@@ -234,7 +234,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": true
@@ -282,7 +282,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": true
@@ -330,7 +330,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": true
@@ -378,7 +378,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": true
@@ -426,7 +426,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": true
@@ -474,7 +474,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "50"
@@ -522,7 +522,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "50"
@@ -570,7 +570,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "50"
@@ -619,7 +619,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "50"
@@ -668,7 +668,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/FullscreenOptions.json
+++ b/api/FullscreenOptions.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
             "version_added": "71"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "71"

--- a/api/GainNode.json
+++ b/api/GainNode.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -134,7 +134,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -75,9 +75,16 @@
           "safari_ios": {
             "version_added": "10.3"
           },
-          "samsunginternet_android": {
-            "version_added": true
-          },
+          "samsunginternet_android": [
+            {
+              "version_added": "3.0"
+            },
+            {
+              "prefix": "webkit",
+              "version_added": "1.5",
+              "version_removed": "2.0"
+            }
+          ],
           "webview_android": {
             "version_added": false
           }
@@ -137,7 +144,7 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": false
@@ -225,9 +232,16 @@
             "safari_ios": {
               "version_added": "10.3"
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "3.0"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.5",
+                "version_removed": "2.0"
+              }
+            ],
             "webview_android": {
               "version_added": false
             }
@@ -314,9 +328,16 @@
             "safari_ios": {
               "version_added": "10.3"
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "3.0"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.5",
+                "version_removed": "2.0"
+              }
+            ],
             "webview_android": {
               "version_added": false
             }
@@ -403,9 +424,16 @@
             "safari_ios": {
               "version_added": "10.3"
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "3.0"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.5",
+                "version_removed": "2.0"
+              }
+            ],
             "webview_android": {
               "version_added": false
             }
@@ -464,7 +492,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             },
             "webview_android": {
               "version_added": false
@@ -664,9 +693,16 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "3.0"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.5",
+                "version_removed": "2.0"
+              }
+            ],
             "webview_android": {
               "version_added": false
             }
@@ -753,9 +789,16 @@
             "safari_ios": {
               "version_added": "10.3"
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "3.0"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.5",
+                "version_removed": "2.0"
+              }
+            ],
             "webview_android": {
               "version_added": false
             }
@@ -842,9 +885,16 @@
             "safari_ios": {
               "version_added": "10.3"
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "3.0"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.5",
+                "version_removed": "2.0"
+              }
+            ],
             "webview_android": {
               "version_added": false
             }
@@ -987,9 +1037,16 @@
             "safari_ios": {
               "version_added": "10.3"
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "3.0"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.5",
+                "version_removed": "2.0"
+              }
+            ],
             "webview_android": {
               "version_added": false
             }

--- a/api/GamepadButton.json
+++ b/api/GamepadButton.json
@@ -280,7 +280,7 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false

--- a/api/Geolocation.json
+++ b/api/Geolocation.json
@@ -95,7 +95,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "51",
@@ -276,7 +276,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/GestureEvent.json
+++ b/api/GestureEvent.json
@@ -35,7 +35,7 @@
             "version_added": "2"
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
             "version_added": false
@@ -82,7 +82,7 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -130,7 +130,7 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -178,7 +178,7 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -226,7 +226,7 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -189,9 +189,15 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": true,
+                "alternative_name": "onwebkitanimationend"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": true
@@ -255,9 +261,15 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": true,
+                "alternative_name": "onwebkitanimationiteration"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": true
@@ -321,9 +333,15 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": true
+              },
+              {
+                "version_added": true,
+                "alternative_name": "onwebkitanimationstart"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": true
@@ -472,7 +490,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -520,7 +538,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -568,7 +586,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -712,7 +730,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -760,7 +778,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -822,7 +840,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -870,7 +888,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -918,7 +936,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -966,7 +984,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -1014,7 +1032,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -1062,7 +1080,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -1110,7 +1128,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -1158,7 +1176,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -1206,7 +1224,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -1254,7 +1272,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -1302,7 +1320,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1350,7 +1368,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1398,7 +1416,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1446,7 +1464,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1542,7 +1560,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "57"
@@ -1686,7 +1704,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1734,7 +1752,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1782,7 +1800,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1878,7 +1896,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1926,7 +1944,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1974,7 +1992,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -2078,7 +2096,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "57"
@@ -2462,7 +2480,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -2510,7 +2528,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -2558,7 +2576,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -2606,7 +2624,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -2679,7 +2697,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -2752,7 +2770,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -2825,7 +2843,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -2898,7 +2916,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -3067,7 +3085,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -3140,7 +3158,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -3213,7 +3231,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -3286,7 +3304,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -3334,7 +3352,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3382,7 +3400,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3478,7 +3496,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -3526,7 +3544,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3574,7 +3592,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3622,7 +3640,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3670,7 +3688,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3742,7 +3760,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3814,7 +3832,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -3862,7 +3880,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -3910,7 +3928,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -3958,7 +3976,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -4054,7 +4072,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -4102,7 +4120,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -4151,7 +4169,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -4200,7 +4218,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -4249,7 +4267,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -4298,7 +4316,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -4346,7 +4364,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -4396,7 +4414,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "alternative_name": "onwebkittransitionend"
             },
             "webview_android": {
               "version_added": true,
@@ -4445,7 +4464,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -4493,7 +4512,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -4541,7 +4560,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -4589,7 +4608,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -4637,7 +4656,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "61"

--- a/api/Gyroscope.json
+++ b/api/Gyroscope.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": false
           },
           "webview_android": {
             "version_added": "69"
@@ -83,7 +83,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"
@@ -131,7 +131,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"
@@ -179,7 +179,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"
@@ -227,7 +227,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"

--- a/api/HTMLAnchorElement.json
+++ b/api/HTMLAnchorElement.json
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -370,7 +370,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"

--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -514,7 +514,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -212,9 +212,15 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": [
+                {
+                  "version_added": "2.0"
+                },
+                {
+                  "version_added": "1.0",
+                  "alternative_name": "experimental-webgl"
+                }
+              ],
               "webview_android": [
                 {
                   "version_added": "37"
@@ -805,7 +811,7 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -914,7 +920,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -963,7 +969,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -1012,7 +1018,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true

--- a/api/HTMLContentElement.json
+++ b/api/HTMLContentElement.json
@@ -51,7 +51,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "3.0"
           },
           "webview_android": {
             "version_added": "37"
@@ -114,7 +114,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -178,7 +178,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -216,7 +216,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -265,7 +265,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -314,7 +314,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -964,7 +964,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "57"
@@ -1102,7 +1102,7 @@
               "version_added": "4"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -1203,7 +1203,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -1630,7 +1630,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "57"
@@ -2244,7 +2244,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -2318,7 +2318,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -2392,7 +2392,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -2466,7 +2466,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -2540,7 +2540,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -2614,7 +2614,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -2688,7 +2688,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -2762,7 +2762,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -3001,7 +3001,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"
@@ -3050,7 +3050,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"
@@ -3099,7 +3099,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"
@@ -3148,7 +3148,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"

--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -658,7 +658,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -98,7 +98,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -359,7 +359,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -408,7 +408,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -996,7 +996,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -1045,7 +1045,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -1139,7 +1139,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -1233,7 +1233,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1395,7 +1395,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -1444,7 +1444,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -1493,7 +1493,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -2289,7 +2289,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -2473,7 +2473,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -2600,7 +2600,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -2735,7 +2735,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -2784,7 +2784,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -2878,7 +2878,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -2927,7 +2927,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -3354,7 +3354,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -3403,7 +3403,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -3482,7 +3482,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/HTMLOutputElement.json
+++ b/api/HTMLOutputElement.json
@@ -182,7 +182,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Before Samsung Internet 50, this property returned the deprecated child <code>DOMSettableTokenList</code> instead of <code>DOMTokenList</code>."
             },
             "webview_android": {
               "version_added": true,

--- a/api/HTMLPictureElement.json
+++ b/api/HTMLPictureElement.json
@@ -61,7 +61,7 @@
             "version_added": "9.3"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "3.0"
           },
           "webview_android": {
             "version_added": "38"

--- a/api/HTMLShadowElement.json
+++ b/api/HTMLShadowElement.json
@@ -51,7 +51,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "3.0"
           },
           "webview_android": {
             "version_added": "37"
@@ -98,7 +98,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/api/HTMLSlotElement.json
+++ b/api/HTMLSlotElement.json
@@ -248,7 +248,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"

--- a/api/HTMLTemplateElement.json
+++ b/api/HTMLTemplateElement.json
@@ -35,7 +35,7 @@
             "version_added": "8"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": true
@@ -82,7 +82,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true

--- a/api/IDBDatabase.json
+++ b/api/IDBDatabase.json
@@ -210,7 +210,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -259,7 +259,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": true
@@ -323,7 +323,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -386,7 +386,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -449,7 +449,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -512,7 +512,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -561,7 +561,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": true
@@ -624,7 +624,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -687,7 +687,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -750,7 +750,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -814,7 +814,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -877,7 +877,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -940,7 +940,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -1003,7 +1003,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -1066,7 +1066,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true

--- a/api/IDBEnvironment.json
+++ b/api/IDBEnvironment.json
@@ -50,7 +50,7 @@
             "version_added": "8"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": true

--- a/api/IDBFactory.json
+++ b/api/IDBFactory.json
@@ -181,7 +181,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": [
               {
@@ -301,7 +301,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": [
               {
@@ -371,7 +371,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": [
               {

--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -229,7 +229,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": [
               {
@@ -347,7 +347,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": [
               {
@@ -417,7 +417,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": [
               {
@@ -535,7 +535,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": [
               {
@@ -605,7 +605,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": [
               {
@@ -675,7 +675,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": [
               {
@@ -745,7 +745,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": [
               {
@@ -935,7 +935,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": [
               {
@@ -1005,7 +1005,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": [
               {
@@ -1075,7 +1075,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": [
               {

--- a/api/IDBVersionChangeEvent.json
+++ b/api/IDBVersionChangeEvent.json
@@ -318,7 +318,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/IdleDeadline.json
+++ b/api/IdleDeadline.json
@@ -59,7 +59,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": "47"
@@ -130,7 +130,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "47"
@@ -202,7 +202,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "47"

--- a/api/ImageBitmap.json
+++ b/api/ImageBitmap.json
@@ -82,7 +82,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "50"
@@ -130,7 +130,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "50"

--- a/api/ImageCapture.json
+++ b/api/ImageCapture.json
@@ -179,7 +179,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "61"

--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/InputDeviceCapabilities.json
+++ b/api/InputDeviceCapabilities.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": "47"
@@ -83,7 +83,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "47"
@@ -131,7 +131,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "47"

--- a/api/InputDeviceInfo.json
+++ b/api/InputDeviceInfo.json
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "67"

--- a/api/InputEvent.json
+++ b/api/InputEvent.json
@@ -35,7 +35,7 @@
             "version_added": "10.1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "8.0"
           },
           "webview_android": {
             "version_added": "60"
@@ -83,7 +83,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"
@@ -179,7 +179,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"
@@ -227,7 +227,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"
@@ -275,7 +275,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"
@@ -371,7 +371,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -129,7 +129,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "49"
@@ -370,7 +370,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "56"
@@ -419,7 +419,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "51"
@@ -467,7 +467,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "51"
@@ -516,7 +516,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "51"
@@ -564,7 +564,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "51"
@@ -665,7 +665,8 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.5",
+              "version_removed": "6.0"
             },
             "webview_android": {
               "version_added": true,
@@ -908,7 +909,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -956,7 +957,7 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -1003,7 +1004,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "48"

--- a/api/LinearAccelerationSensor.json
+++ b/api/LinearAccelerationSensor.json
@@ -29,7 +29,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": false
           },
           "webview_android": {
             "version_added": "69"
@@ -71,7 +71,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"
@@ -119,7 +119,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"
@@ -167,7 +167,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"
@@ -215,7 +215,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"

--- a/api/Location.json
+++ b/api/Location.json
@@ -323,7 +323,7 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -371,7 +371,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -715,7 +715,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "52"
@@ -763,7 +763,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/Lock.json
+++ b/api/Lock.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
             "version_added": "69"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"

--- a/api/LockManager.json
+++ b/api/LockManager.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
             "version_added": "69"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"

--- a/api/MIDIAccess.json
+++ b/api/MIDIAccess.json
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -130,7 +130,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -178,7 +178,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -226,7 +226,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"

--- a/api/Magnetometer.json
+++ b/api/Magnetometer.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
             "version_added": "69"
@@ -83,7 +83,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"
@@ -131,7 +131,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"
@@ -179,7 +179,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"
@@ -227,7 +227,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"

--- a/api/MediaCapabilitiesInfo.json
+++ b/api/MediaCapabilitiesInfo.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -178,7 +178,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -35,7 +35,7 @@
             "version_added": "11"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": "47"
@@ -96,7 +96,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -145,7 +145,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -199,7 +199,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "47"
@@ -247,7 +247,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "53"
@@ -319,7 +319,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false,
@@ -485,9 +485,23 @@
             "safari_ios": {
               "version_added": "11"
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "6.0"
+              },
+              {
+                "version_added": "5.0",
+                "version_removed": "6.0",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform features",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Older versions of Samsung Internet implement <code>navigator.webkitGetUserMedia</code>, a prefixed form of the legacy <a href='https://developer.mozilla.org/docs/Web/API/Navigator/getUserMedia'><code>navigator.getUserMedia</code></a> API."
+              }
+            ],
             "webview_android": {
               "version_added": "53"
             }
@@ -533,7 +547,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true

--- a/api/MediaElementAudioSourceNode.json
+++ b/api/MediaElementAudioSourceNode.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true

--- a/api/MediaEncryptedEvent.json
+++ b/api/MediaEncryptedEvent.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "4.0"
           },
           "webview_android": {
             "version_added": "43"
@@ -83,7 +83,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -131,7 +131,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -179,7 +179,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"

--- a/api/MediaMetadata.json
+++ b/api/MediaMetadata.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "7.0"
           },
           "webview_android": {
             "version_added": false
@@ -83,7 +83,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": false
@@ -131,7 +131,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": false
@@ -179,7 +179,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": false
@@ -227,7 +227,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": false
@@ -275,7 +275,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -182,7 +182,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -633,7 +633,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -681,7 +681,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -729,7 +729,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -825,7 +825,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -873,7 +873,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -921,7 +921,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -969,7 +969,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -1017,7 +1017,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -1065,7 +1065,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -1113,7 +1113,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -1161,7 +1161,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"

--- a/api/MediaSource.json
+++ b/api/MediaSource.json
@@ -56,7 +56,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "2.0"
           },
           "webview_android": {
             "version_added": "4.4.3"
@@ -124,7 +124,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -186,7 +186,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -248,7 +248,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -310,7 +310,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -372,7 +372,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -434,7 +434,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -496,7 +496,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -558,7 +558,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -620,7 +620,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -682,7 +682,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -744,7 +744,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -896,7 +896,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4.3"

--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": "37"
@@ -131,7 +131,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -179,7 +179,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -282,7 +282,9 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "6.0",
+              "notes": "Deprecated in Samsung Internet 52."
             },
             "webview_android": {
               "version_added": true,
@@ -336,7 +338,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "6.0"
             },
             "webview_android": {
               "version_added": true,
@@ -385,7 +388,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -433,7 +436,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -481,7 +484,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "37"
@@ -529,7 +532,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -577,7 +580,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "37"
@@ -625,7 +628,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "37"
@@ -673,7 +676,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -723,7 +726,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "37"
@@ -771,7 +774,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "37"
@@ -819,7 +822,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -869,7 +872,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "37"
@@ -917,7 +920,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "37"
@@ -1017,7 +1020,9 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "6.0",
+              "notes": "Deprecated in Samsung Internet 45."
             },
             "webview_android": {
               "version_added": true,

--- a/api/MediaStreamAudioDestinationNode.json
+++ b/api/MediaStreamAudioDestinationNode.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -134,7 +134,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/MediaStreamAudioSourceOptions.json
+++ b/api/MediaStreamAudioSourceOptions.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "6.0"
           },
           "webview_android": {
             "version_added": "55"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"

--- a/api/MediaStreamEvent.json
+++ b/api/MediaStreamEvent.json
@@ -131,7 +131,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/MerchantValidationEvent.json
+++ b/api/MerchantValidationEvent.json
@@ -51,7 +51,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
             "version_added": false
@@ -101,7 +101,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -152,7 +152,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -202,7 +202,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -252,7 +252,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/MessageChannel.json
+++ b/api/MessageChannel.json
@@ -35,7 +35,7 @@
             "version_added": "5.1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": "4.4"
@@ -82,7 +82,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -130,7 +130,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -178,7 +178,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"

--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -82,7 +82,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -321,7 +321,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true
@@ -465,7 +465,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true

--- a/api/MessagePort.json
+++ b/api/MessagePort.json
@@ -35,7 +35,7 @@
             "version_added": "5.1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -130,7 +130,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -179,7 +179,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -228,7 +228,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"
@@ -276,7 +276,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -324,7 +324,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"
@@ -372,7 +372,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -420,7 +420,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/Metadata.json
+++ b/api/Metadata.json
@@ -37,7 +37,8 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true,
+            "prefix": "webkit"
           },
           "webview_android": {
             "version_added": false
@@ -84,7 +85,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -132,7 +133,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false

--- a/api/MimeTypeArray.json
+++ b/api/MimeTypeArray.json
@@ -84,7 +84,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0",
+              "notes": "Prior to version 59, method parameters were optional"
             },
             "webview_android": {
               "version_added": "59",
@@ -183,7 +184,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0",
+              "notes": "Prior to version 59, method parameters were optional"
             },
             "webview_android": {
               "version_added": "59",

--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -83,7 +83,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "47"
@@ -138,7 +138,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": false
@@ -186,7 +186,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "6.0"
               },
               "webview_android": {
                 "version_added": "56"
@@ -338,7 +338,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -433,7 +433,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "6.0"
               },
               "webview_android": {
                 "version_added": "56"
@@ -529,7 +529,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "6.0"
               },
               "webview_android": {
                 "version_added": "56"
@@ -626,7 +626,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "47"
@@ -673,7 +673,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": false
@@ -722,7 +722,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -845,9 +845,16 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "3.0"
+              },
+              {
+                "version_added": true,
+                "version_removed": "3.0",
+                "prefix": "webkit"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "37"
@@ -928,9 +935,16 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "3.0"
+              },
+              {
+                "version_added": true,
+                "version_removed": "3.0",
+                "prefix": "webkit"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "37"
@@ -1031,7 +1045,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "6.0"
               },
               "webview_android": {
                 "version_added": "56"
@@ -1127,7 +1141,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "6.0"
               },
               "webview_android": {
                 "version_added": "56"
@@ -1176,7 +1190,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -1223,7 +1237,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "6.0"
               },
               "webview_android": {
                 "version_added": "56"
@@ -1272,7 +1286,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -1319,7 +1333,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "6.0"
               },
               "webview_android": {
                 "version_added": "56"
@@ -1389,7 +1403,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -1532,7 +1546,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "6.0"
               },
               "webview_android": {
                 "version_added": "56"
@@ -1628,7 +1642,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "6.0"
               },
               "webview_android": {
                 "version_added": "56"
@@ -1727,7 +1741,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/MouseWheelEvent.json
+++ b/api/MouseWheelEvent.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -178,7 +178,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/MutationObserver.json
+++ b/api/MutationObserver.json
@@ -62,9 +62,16 @@
               "prefix": "WebKit"
             }
           ],
-          "samsunginternet_android": {
-            "version_added": true
-          },
+          "samsunginternet_android": [
+            {
+              "version_added": "1.5"
+            },
+            {
+              "version_added": "1.0",
+              "version_removed": "1.5",
+              "prefix": "WebKit"
+            }
+          ],
           "webview_android": [
             {
               "version_added": true
@@ -145,9 +152,16 @@
                 "prefix": "WebKit"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "version_added": "1.0",
+                "version_removed": "1.5",
+                "prefix": "WebKit"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": true
@@ -201,7 +215,7 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -249,7 +263,7 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -297,7 +311,7 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/MutationObserverInit.json
+++ b/api/MutationObserverInit.json
@@ -62,9 +62,16 @@
               "version_removed": "7"
             }
           ],
-          "samsunginternet_android": {
-            "version_added": null
-          }
+          "samsunginternet_android": [
+            {
+              "version_added": "1.5"
+            },
+            {
+              "prefix": "webkit",
+              "version_added": "1.0",
+              "version_removed": "1.5"
+            }
+          ]
         },
         "status": {
           "experimental": false,
@@ -134,9 +141,16 @@
                 "version_removed": "7"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.0",
+                "version_removed": "1.5"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -209,9 +223,16 @@
                 "version_removed": "7"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.0",
+                "version_removed": "1.5"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -284,9 +305,16 @@
                 "version_removed": "7"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.0",
+                "version_removed": "1.5"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -359,9 +387,16 @@
                 "version_removed": "7"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.0",
+                "version_removed": "1.5"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -434,9 +469,16 @@
                 "version_removed": "7"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.0",
+                "version_removed": "1.5"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -507,9 +549,16 @@
                 "version_removed": "7"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.0",
+                "version_removed": "1.5"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -580,9 +629,16 @@
                 "version_removed": "7"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.0",
+                "version_removed": "1.5"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -91,7 +91,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             },
             "webview_android": {
               "version_added": true
@@ -253,7 +254,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -313,7 +314,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -409,7 +410,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -458,7 +459,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "50"
@@ -508,7 +509,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "59"
@@ -556,7 +557,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "51"
@@ -604,7 +605,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "63"
@@ -660,7 +661,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -767,7 +768,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "47"
@@ -820,7 +821,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -891,9 +892,15 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "3.0"
+              },
+              {
+                "version_added": "1.5",
+                "prefix": "webkit"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "37"
@@ -1038,7 +1045,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             },
             "webview_android": {
               "version_added": true
@@ -1134,7 +1142,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"
@@ -1208,7 +1216,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -1256,7 +1264,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -1304,7 +1312,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "51"
@@ -1351,7 +1359,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": "74"
@@ -1400,7 +1408,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": false
@@ -1546,7 +1554,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": false
@@ -1647,7 +1655,8 @@
               "notes": "Always returns <code>20030107</code>."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Always returns <code>20030107</code>."
             },
             "webview_android": {
               "version_added": true
@@ -1745,7 +1754,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -1867,7 +1876,11 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0",
+              "notes": [
+                "The spec requires that the passed <code>supportedConfigurations</code> option contain at least one of <code>audioCapabilities</code> or <code>videoCapabilities</code>, and that said parameters include a codec string.",
+                "The function does not exist in insecure contexts. This was not enforced until Chrome 58."
+              ]
             },
             "webview_android": {
               "version_added": "43",
@@ -1923,7 +1936,8 @@
               "version_added": "11.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0",
+              "notes": "Starting in Samsung Internet 59, this method cannot send a <code>Blob</code> whose type is not CORS safelisted. This is a temporary change until a mitigation can be found for the security issues that this creates. For more information see <a href='https://crbug.com/720283'>Samsung Internet bug 720283</a>."
             },
             "webview_android": {
               "version_added": "40",
@@ -1984,7 +1998,7 @@
               "version_added": "11.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "40"
@@ -2032,7 +2046,7 @@
               "version_added": "12.2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": false
@@ -2201,7 +2215,11 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0",
+              "notes": [
+                "Beginning in Chrome 55, this is not supported in cross-origin iframes.",
+                "Beginning in Chrome 60, this method requires a user gesture. Otherwise it returns <code>false</code>."
+              ]
             },
             "webview_android": {
               "version_added": "4.4.3",
@@ -2253,7 +2271,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "63"

--- a/api/NavigatorConcurrentHardware.json
+++ b/api/NavigatorConcurrentHardware.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "3.0"
           },
           "webview_android": {
             "version_added": "37"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/api/Node.json
+++ b/api/Node.json
@@ -41,7 +41,8 @@
             "notes": "WebKit and old versions of Blink incorrectly do not make <code>Node</code> inherit from <code>EventTarget</code>."
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": true,
+            "notes": "WebKit and old versions of Blink incorrectly do not make <code>Node</code> inherit from <code>EventTarget</code>."
           },
           "webview_android": {
             "version_added": true,
@@ -1100,7 +1101,9 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "5.0",
+              "notes": "This API was moved to the <code>Element</code> and <code>Attr</code> APIs according to the DOM4 standard."
             },
             "webview_android": {
               "version_added": true,
@@ -1246,7 +1249,9 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "5.0",
+              "notes": "This API was moved to the <code>Element</code> and <code>Attr</code> APIs according to the DOM4 standard."
             },
             "webview_android": {
               "version_added": true,
@@ -1396,7 +1401,9 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "5.0",
+              "notes": "This API was moved to the <code>Element</code> and <code>Attr</code> APIs according to the DOM4 standard."
             },
             "webview_android": {
               "version_added": true,

--- a/api/Notification.json
+++ b/api/Notification.json
@@ -101,7 +101,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -149,7 +149,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": false
@@ -216,7 +216,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -264,7 +264,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false
@@ -312,7 +312,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false
@@ -570,7 +570,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false
@@ -954,7 +954,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -1050,7 +1050,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": false
@@ -1244,8 +1244,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "<a href='https://crbug.com/971422'>Does not work</a> on Android O or later regardless of Chrome version."
+              "version_added": "6.0",
+              "notes": "<a href='https://crbug.com/971422'>Does not work</a> on Android O or later regardless of Samsung Internet version."
             },
             "webview_android": {
               "version_added": false
@@ -1341,7 +1341,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/OfflineAudioCompletionEvent.json
+++ b/api/OfflineAudioCompletionEvent.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -134,7 +134,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/OfflineAudioContext.json
+++ b/api/OfflineAudioContext.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -183,7 +183,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -279,7 +279,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -423,7 +423,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/OrientationSensor.json
+++ b/api/OrientationSensor.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": false
           },
           "webview_android": {
             "version_added": "69"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"

--- a/api/OscillatorNode.json
+++ b/api/OscillatorNode.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -134,7 +134,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -182,7 +182,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -230,7 +230,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -278,7 +278,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -326,7 +326,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -376,7 +376,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -426,7 +426,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/OverconstrainedError.json
+++ b/api/OverconstrainedError.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "8.0"
           },
           "webview_android": {
             "version_added": "63"
@@ -83,7 +83,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "63"
@@ -131,7 +131,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "63"
@@ -179,7 +179,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "63"
@@ -227,7 +227,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "63"

--- a/api/PaintRenderingContext2D.json
+++ b/api/PaintRenderingContext2D.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "65"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -178,7 +178,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -226,7 +226,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -274,7 +274,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -322,7 +322,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -370,7 +370,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -418,7 +418,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -466,7 +466,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -514,7 +514,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -562,7 +562,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -610,7 +610,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -658,7 +658,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "68"
@@ -706,7 +706,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -754,7 +754,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -802,7 +802,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -850,7 +850,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -898,7 +898,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -946,7 +946,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -994,7 +994,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1042,7 +1042,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1090,7 +1090,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1138,7 +1138,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1186,7 +1186,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1234,7 +1234,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1282,7 +1282,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1330,7 +1330,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1378,7 +1378,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1426,7 +1426,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1474,7 +1474,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1522,7 +1522,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "68"
@@ -1570,7 +1570,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1618,7 +1618,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1666,7 +1666,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1714,7 +1714,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1762,7 +1762,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1810,7 +1810,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1858,7 +1858,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1906,7 +1906,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1954,7 +1954,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"

--- a/api/PaintSize.json
+++ b/api/PaintSize.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "65"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"

--- a/api/PaintWorkletGlobalScope.json
+++ b/api/PaintWorkletGlobalScope.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "65"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"

--- a/api/PannerNode.json
+++ b/api/PannerNode.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -134,7 +134,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -182,7 +182,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -230,7 +230,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -278,7 +278,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -326,7 +326,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -518,7 +518,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -710,7 +710,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -758,7 +758,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -806,7 +806,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -854,7 +854,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -908,7 +908,8 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0",
+              "version_removed": "6.0"
             },
             "webview_android": {
               "version_added": true,

--- a/api/ParentNode.json
+++ b/api/ParentNode.json
@@ -322,7 +322,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true

--- a/api/PaymentAddress.json
+++ b/api/PaymentAddress.json
@@ -372,7 +372,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/PaymentCurrencyAmount.json
+++ b/api/PaymentCurrencyAmount.json
@@ -87,7 +87,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "6.0"
           },
           "webview_android": [
             {
@@ -189,7 +189,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": [
               {
@@ -268,7 +268,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "53",
@@ -365,7 +365,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": [
               {

--- a/api/PaymentMethodChangeEvent.json
+++ b/api/PaymentMethodChangeEvent.json
@@ -61,7 +61,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
             "version_added": false
@@ -124,7 +124,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -188,7 +188,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -319,7 +319,7 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": false
@@ -512,7 +512,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -771,7 +771,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/PaymentResponse.json
+++ b/api/PaymentResponse.json
@@ -277,7 +277,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -328,7 +328,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -596,7 +596,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -956,7 +956,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PerformanceEntry.json
+++ b/api/PerformanceEntry.json
@@ -46,9 +46,15 @@
           "safari_ios": {
             "version_added": "11"
           },
-          "samsunginternet_android": {
-            "version_added": true
-          },
+          "samsunginternet_android": [
+            {
+              "version_added": "5.0"
+            },
+            {
+              "version_added": "1.5",
+              "prefix": "webkit"
+            }
+          ],
           "webview_android": [
             {
               "version_added": "46"
@@ -100,7 +106,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "62"

--- a/api/PerformanceLongTaskTiming.json
+++ b/api/PerformanceLongTaskTiming.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "7.0"
           },
           "webview_android": {
             "version_added": "58"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "58"

--- a/api/PerformanceMark.json
+++ b/api/PerformanceMark.json
@@ -35,7 +35,7 @@
             "version_added": "11"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "4.0"
           },
           "webview_android": {
             "version_added": "43"

--- a/api/PerformanceMeasure.json
+++ b/api/PerformanceMeasure.json
@@ -35,7 +35,7 @@
             "version_added": "11"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": true

--- a/api/PerformanceNavigation.json
+++ b/api/PerformanceNavigation.json
@@ -182,7 +182,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "56"

--- a/api/PerformanceObserverEntryList.json
+++ b/api/PerformanceObserverEntryList.json
@@ -35,7 +35,7 @@
             "version_added": "11"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "6.0"
           },
           "webview_android": {
             "version_added": false
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false
@@ -130,7 +130,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false
@@ -178,7 +178,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PerformancePaintTiming.json
+++ b/api/PerformancePaintTiming.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "8.0"
           },
           "webview_android": {
             "version_added": "60"

--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -802,7 +802,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"

--- a/api/PerformanceServerTiming.json
+++ b/api/PerformanceServerTiming.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "65"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -178,7 +178,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -226,7 +226,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"

--- a/api/PeriodicWave.json
+++ b/api/PeriodicWave.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true

--- a/api/PermissionStatus.json
+++ b/api/PermissionStatus.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "4.0"
           },
           "webview_android": {
             "version_added": false
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": false
@@ -144,7 +144,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "4.0"
           },
           "webview_android": {
             "version_added": "43"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "46"
@@ -178,7 +178,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "48"
@@ -252,7 +252,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "46"
@@ -300,7 +300,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "62"
@@ -348,7 +348,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "62"
@@ -396,7 +396,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "62"
@@ -444,7 +444,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "62"
@@ -492,7 +492,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "64"
@@ -540,7 +540,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "64"
@@ -588,7 +588,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "64"
@@ -636,7 +636,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": false
@@ -684,7 +684,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "51"
@@ -732,7 +732,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "62"
@@ -780,7 +780,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "64"
@@ -828,7 +828,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": false
@@ -876,7 +876,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": false
@@ -924,7 +924,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -972,7 +972,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -1020,7 +1020,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/Plugin.json
+++ b/api/Plugin.json
@@ -180,7 +180,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Starting with version 59, method parameters are required instead of optional."
             },
             "webview_android": {
               "version_added": true,
@@ -279,7 +280,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Starting with version 59, method parameters are required instead of optional."
             },
             "webview_android": {
               "version_added": true,
@@ -328,7 +330,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/PluginArray.json
+++ b/api/PluginArray.json
@@ -84,7 +84,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Starting with version 59, method parameters are required instead of optional."
             },
             "webview_android": {
               "version_added": true,
@@ -183,7 +184,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Starting with version 59, method parameters are required instead of optional."
             },
             "webview_android": {
               "version_added": true,
@@ -234,7 +236,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Starting with version 59, method parameters are required instead of optional."
             },
             "webview_android": {
               "version_added": true,

--- a/api/PointerEvent.json
+++ b/api/PointerEvent.json
@@ -815,7 +815,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "9.0"
               },
               "webview_android": {
                 "version_added": "64"

--- a/api/PositionOptions.json
+++ b/api/PositionOptions.json
@@ -47,7 +47,7 @@
             "version_added": "5"
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -94,7 +94,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "51",
@@ -155,7 +155,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -215,7 +215,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -275,7 +275,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/Presentation.json
+++ b/api/Presentation.json
@@ -49,7 +49,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": false
@@ -110,7 +110,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -172,7 +172,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PresentationAvailability.json
+++ b/api/PresentationAvailability.json
@@ -49,7 +49,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": false
@@ -110,7 +110,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -172,7 +172,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PresentationConnection.json
+++ b/api/PresentationConnection.json
@@ -49,7 +49,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": false
@@ -172,7 +172,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -234,7 +234,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -296,7 +296,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -358,7 +358,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -482,7 +482,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -544,7 +544,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -606,7 +606,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -730,7 +730,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PresentationConnectionAvailableEvent.json
+++ b/api/PresentationConnectionAvailableEvent.json
@@ -49,7 +49,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": false
@@ -111,7 +111,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -173,7 +173,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PresentationConnectionCloseEvent.json
+++ b/api/PresentationConnectionCloseEvent.json
@@ -49,7 +49,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": false
@@ -111,7 +111,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -173,7 +173,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -235,7 +235,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PresentationConnectionList.json
+++ b/api/PresentationConnectionList.json
@@ -49,7 +49,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": false
@@ -110,7 +110,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -172,7 +172,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PresentationReceiver.json
+++ b/api/PresentationReceiver.json
@@ -49,7 +49,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "6.0"
           },
           "webview_android": {
             "version_added": false
@@ -110,7 +110,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PresentationRequest.json
+++ b/api/PresentationRequest.json
@@ -49,7 +49,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": false
@@ -96,7 +96,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": false
@@ -159,7 +159,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -221,7 +221,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -283,7 +283,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -345,7 +345,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -407,7 +407,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -469,7 +469,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/ProgressEvent.json
+++ b/api/ProgressEvent.json
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": true
@@ -131,7 +131,7 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "50"

--- a/api/PromiseRejectionEvent.json
+++ b/api/PromiseRejectionEvent.json
@@ -54,7 +54,7 @@
             "version_added": "11.3"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": "49"
@@ -121,7 +121,7 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -188,7 +188,7 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -255,7 +255,7 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"

--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -50,7 +50,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
             "version_added": "70"
@@ -112,7 +112,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "70"
@@ -175,7 +175,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "70"
@@ -238,7 +238,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "70"
@@ -301,7 +301,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "70"

--- a/api/RTCAnswerOptions.json
+++ b/api/RTCAnswerOptions.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": "50"

--- a/api/RTCCertificate.json
+++ b/api/RTCCertificate.json
@@ -178,7 +178,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/RTCDTMFSender.json
+++ b/api/RTCDTMFSender.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": "4.4"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -179,7 +179,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -227,7 +227,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -275,7 +275,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true

--- a/api/RTCDTMFToneChangeEvent.json
+++ b/api/RTCDTMFToneChangeEvent.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": "4.4"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -131,7 +131,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4"

--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -49,7 +49,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "2.0"
           },
           "webview_android": {
             "version_added": "4.4"
@@ -96,7 +96,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -1119,7 +1119,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -1263,7 +1263,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "58"

--- a/api/RTCDataChannelEvent.json
+++ b/api/RTCDataChannelEvent.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": true
@@ -131,7 +131,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true

--- a/api/RTCDtlsTransport.json
+++ b/api/RTCDtlsTransport.json
@@ -37,7 +37,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
             "version_added": "72"
@@ -86,7 +86,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "72"
@@ -137,7 +137,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "72"
@@ -187,7 +187,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "72"
@@ -238,7 +238,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "72"
@@ -288,7 +288,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "72"
@@ -340,7 +340,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "72"

--- a/api/RTCErrorEvent.json
+++ b/api/RTCErrorEvent.json
@@ -35,7 +35,7 @@
             "version_added": "6"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": null
           },
           "webview_android": {
             "version_added": null
@@ -82,7 +82,7 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": null
             },
             "webview_android": {
               "version_added": null

--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -133,7 +133,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"
@@ -229,7 +229,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"
@@ -277,7 +277,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -325,7 +325,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"
@@ -373,7 +373,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"
@@ -421,7 +421,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"
@@ -469,7 +469,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"
@@ -517,7 +517,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"
@@ -661,7 +661,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"
@@ -709,7 +709,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"
@@ -757,7 +757,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"
@@ -805,7 +805,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"

--- a/api/RTCIceCandidatePairStats.json
+++ b/api/RTCIceCandidatePairStats.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "6.0"
           },
           "webview_android": {
             "version_added": "56"
@@ -178,7 +178,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -226,7 +226,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -429,9 +429,15 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": false
+              },
+              {
+                "version_added": true,
+                "alternative_name": "currentRtt"
+              }
+            ],
             "webview_android": {
               "version_added": true
             }
@@ -1524,7 +1530,8 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "notes": "Samsung Internet does not currently use the specification's algorithm to determine the value of <code>writable</code>; it may not match the behavior of other browsers."
             },
             "webview_android": {
               "version_added": true

--- a/api/RTCIceCandidateStats.json
+++ b/api/RTCIceCandidateStats.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
             "version_added": false
@@ -94,7 +94,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -142,7 +142,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -192,7 +192,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -240,7 +240,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -288,7 +288,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -338,7 +338,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -386,7 +386,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -446,7 +446,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -506,7 +506,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -556,7 +556,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -604,7 +604,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/RTCIceCandidateType.json
+++ b/api/RTCIceCandidateType.json
@@ -39,7 +39,8 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false,
+            "notes": "An <code>RTCIceCandidate</code> object's <code>type</code> is not maintained by this browser."
           },
           "webview_android": {
             "version_added": false,

--- a/api/RTCIceComponent.json
+++ b/api/RTCIceComponent.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
             "version_added": false

--- a/api/RTCOfferAnswerOptions.json
+++ b/api/RTCOfferAnswerOptions.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": "50"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "50"

--- a/api/RTCOfferOptions.json
+++ b/api/RTCOfferOptions.json
@@ -47,7 +47,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": "50"
@@ -94,7 +94,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "50"

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -1311,7 +1311,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -1660,9 +1660,19 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "7.0",
+                "notes": "Promise resolves with <code>RTCStatsReport</code>."
+              },
+              {
+                "version_added": "6.0",
+                "notes": "Promise-based version."
+              },
+              {
+                "version_added": true
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "58",
@@ -1719,7 +1729,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true
@@ -1767,7 +1777,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "9.0"
               },
               "webview_android": {
                 "version_added": "67"
@@ -2596,7 +2606,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/RTCPeerConnectionIceEvent.json
+++ b/api/RTCPeerConnectionIceEvent.json
@@ -200,7 +200,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/RTCRtpEncodingParameters.json
+++ b/api/RTCRtpEncodingParameters.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "67"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "67"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -227,7 +227,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -275,7 +275,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "67"
@@ -323,7 +323,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -371,7 +371,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -422,7 +422,8 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0",
+              "notes": "The standard version of this property is <a href='https://developer.mozilla.org/docs/Web/API/RTCRtpSendParameters/priority'><code>RTCRtpSendParameters.priority</code></a>."
             },
             "webview_android": {
               "version_added": "67",
@@ -569,7 +570,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -438,7 +438,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": "73"
@@ -603,7 +603,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": "73"

--- a/api/RTCRtpSendParameters.json
+++ b/api/RTCRtpSendParameters.json
@@ -37,7 +37,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
             "version_added": "69"

--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -324,7 +324,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -373,7 +373,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -422,7 +422,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -483,7 +483,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/RTCRtpStreamStats.json
+++ b/api/RTCRtpStreamStats.json
@@ -47,7 +47,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
             "version_added": false
@@ -94,7 +94,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -142,7 +142,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -192,7 +192,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -240,7 +240,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -288,7 +288,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -336,7 +336,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -384,7 +384,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -432,7 +432,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -480,7 +480,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -528,7 +528,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -576,7 +576,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -624,7 +624,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -672,7 +672,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/RTCRtpTransceiverDirection.json
+++ b/api/RTCRtpTransceiverDirection.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true

--- a/api/RTCRtpTransceiverInit.json
+++ b/api/RTCRtpTransceiverInit.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -132,7 +132,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -180,7 +180,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/ReadableStreamDefaultController.json
+++ b/api/ReadableStreamDefaultController.json
@@ -69,7 +69,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "6.0"
           },
           "webview_android": {
             "version_added": "52"

--- a/api/ReadableStreamDefaultReader.json
+++ b/api/ReadableStreamDefaultReader.json
@@ -69,7 +69,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "6.0"
           },
           "webview_android": {
             "version_added": "52"

--- a/api/RelativeOrientationSensor.json
+++ b/api/RelativeOrientationSensor.json
@@ -29,7 +29,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": false
           },
           "webview_android": {
             "version_added": "69"
@@ -71,7 +71,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"

--- a/api/Request.json
+++ b/api/Request.json
@@ -813,7 +813,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": "72"
@@ -862,7 +862,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1465,7 +1465,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/ResizeObserver.json
+++ b/api/ResizeObserver.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "64"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "64"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "64"
@@ -179,7 +179,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "64"
@@ -227,7 +227,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "64"

--- a/api/ResizeObserverEntry.json
+++ b/api/ResizeObserverEntry.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "64"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "64"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "64"

--- a/api/Response.json
+++ b/api/Response.json
@@ -1250,7 +1250,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/SVGAElement.json
+++ b/api/SVGAElement.json
@@ -81,7 +81,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -318,7 +318,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -612,7 +612,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/Screen.json
+++ b/api/Screen.json
@@ -83,7 +83,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "40"
@@ -179,7 +179,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "40"
@@ -278,7 +278,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0",
+              "notes": "Starting with version 59 this property is no longer required to always return 24."
             },
             "webview_android": {
               "version_added": "40",
@@ -426,7 +427,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"
@@ -661,7 +662,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": false
@@ -711,7 +712,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Starting with version 59 this property is no longer required to always return 24."
             },
             "webview_android": {
               "version_added": true,
@@ -811,7 +813,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"
@@ -859,7 +861,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "40"

--- a/api/ScreenOrientation.json
+++ b/api/ScreenOrientation.json
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"
@@ -130,7 +130,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"
@@ -178,7 +178,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"
@@ -226,7 +226,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"
@@ -274,7 +274,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"

--- a/api/ScriptProcessorNode.json
+++ b/api/ScriptProcessorNode.json
@@ -113,7 +113,7 @@
               "prefix": "webkit"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/ScrollToOptions.json
+++ b/api/ScrollToOptions.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": "45"
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -130,7 +130,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -178,7 +178,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"

--- a/api/Sensor.json
+++ b/api/Sensor.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": false
           },
           "webview_android": {
             "version_added": "69"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"
@@ -178,7 +178,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"
@@ -226,7 +226,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"
@@ -274,7 +274,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"
@@ -322,7 +322,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"
@@ -370,7 +370,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"
@@ -418,7 +418,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"

--- a/api/SensorErrorEvent.json
+++ b/api/SensorErrorEvent.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": false
           },
           "webview_android": {
             "version_added": "69"
@@ -83,7 +83,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"
@@ -131,7 +131,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "69"

--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -635,7 +635,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -683,7 +683,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -395,7 +395,14 @@
               "version_added": "11.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#service-worker-payment-apps",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "webview_android": {
               "version_added": false
@@ -506,7 +513,14 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#service-worker-payment-apps",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "webview_android": {
               "version_added": false
@@ -861,7 +875,14 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "7.0",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#service-worker-payment-apps",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "webview_android": {
               "version_added": false

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -408,7 +408,14 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#service-worker-payment-apps",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "webview_android": {
               "version_added": true
@@ -1208,7 +1215,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "68"

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -109,7 +109,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "57"

--- a/api/SharedWorkerGlobalScope.json
+++ b/api/SharedWorkerGlobalScope.json
@@ -133,7 +133,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -229,7 +229,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/StaticRange.json
+++ b/api/StaticRange.json
@@ -35,7 +35,7 @@
             "version_added": "10.1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "8.0"
           },
           "webview_android": {
             "version_added": "60"
@@ -83,7 +83,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"
@@ -131,7 +131,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"
@@ -179,7 +179,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"
@@ -227,7 +227,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"
@@ -275,7 +275,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"
@@ -323,7 +323,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"
@@ -371,7 +371,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"

--- a/api/StorageManager.json
+++ b/api/StorageManager.json
@@ -57,7 +57,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": "48"
@@ -104,7 +104,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "52"
@@ -165,9 +165,16 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "6.0"
+              },
+              {
+                "alternative_name": "requestPersistent",
+                "version_added": "5.0",
+                "version_removed": "6.0"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "52"
@@ -234,9 +241,16 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "6.0"
+              },
+              {
+                "alternative_name": "persistentPermission",
+                "version_added": "5.0",
+                "version_removed": "6.0"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "52"

--- a/api/StorageQuota.json
+++ b/api/StorageQuota.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": "37"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -178,7 +178,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/api/StylePropertyMap.json
+++ b/api/StylePropertyMap.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -130,7 +130,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -178,7 +178,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -226,7 +226,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/StylePropertyMapReadOnly.json
+++ b/api/StylePropertyMapReadOnly.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -130,7 +130,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -178,7 +178,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -226,7 +226,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -274,7 +274,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -322,7 +322,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -370,7 +370,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -418,7 +418,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -466,7 +466,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/TaskAttributionTiming.json
+++ b/api/TaskAttributionTiming.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "7.0"
           },
           "webview_android": {
             "version_added": "58"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "58"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "58"
@@ -178,7 +178,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "58"
@@ -226,7 +226,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "58"

--- a/api/Text.json
+++ b/api/Text.json
@@ -211,7 +211,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "53"

--- a/api/TextDecoder.json
+++ b/api/TextDecoder.json
@@ -49,7 +49,7 @@
             "version_added": "10.1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "3.0"
           },
           "webview_android": {
             "version_added": "38"
@@ -96,7 +96,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"
@@ -159,7 +159,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"
@@ -221,7 +221,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"
@@ -283,7 +283,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"

--- a/api/TextEncoder.json
+++ b/api/TextEncoder.json
@@ -47,7 +47,7 @@
             "version_added": "10.1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "3.0"
           },
           "webview_android": {
             "version_added": "38"
@@ -94,7 +94,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"
@@ -185,7 +185,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"
@@ -245,7 +245,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"
@@ -305,7 +305,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"

--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -143,7 +143,13 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "webview_android": {
               "version_added": false
@@ -204,7 +210,13 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "webview_android": {
               "version_added": false
@@ -265,7 +277,13 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "webview_android": {
               "version_added": false
@@ -326,7 +344,13 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "webview_android": {
               "version_added": false
@@ -387,7 +411,13 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "webview_android": {
               "version_added": false
@@ -448,7 +478,13 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "webview_android": {
               "version_added": false
@@ -509,7 +545,13 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "webview_android": {
               "version_added": false
@@ -570,7 +612,13 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "webview_android": {
               "version_added": false
@@ -631,7 +679,13 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "webview_android": {
               "version_added": false
@@ -692,7 +746,13 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "webview_android": {
               "version_added": false
@@ -753,7 +813,13 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "webview_android": {
               "version_added": false

--- a/api/TextTrack.json
+++ b/api/TextTrack.json
@@ -36,7 +36,7 @@
             "version_added": "7.1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": "4.4"
@@ -84,7 +84,7 @@
               "version_added": "7.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -133,7 +133,7 @@
               "version_added": "7.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -181,7 +181,7 @@
               "version_added": "7.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -229,7 +229,7 @@
               "version_added": "7.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -277,7 +277,7 @@
               "version_added": "7.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -325,7 +325,7 @@
               "version_added": "7.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -373,7 +373,7 @@
               "version_added": "7.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -422,7 +422,7 @@
               "version_added": "7.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -561,7 +561,7 @@
               "version_added": "7.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -609,7 +609,7 @@
               "version_added": "7.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -657,7 +657,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/TextTrackCue.json
+++ b/api/TextTrackCue.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -178,7 +178,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -226,7 +226,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -274,7 +274,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -322,7 +322,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -370,7 +370,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/TextTrackList.json
+++ b/api/TextTrackList.json
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -226,7 +226,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "44"
@@ -274,7 +274,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/Touch.json
+++ b/api/Touch.json
@@ -91,7 +91,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "48"
@@ -467,7 +467,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -515,7 +515,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -563,7 +563,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"

--- a/api/TouchEvent.json
+++ b/api/TouchEvent.json
@@ -99,7 +99,8 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0",
+              "notes": "Samsung Internet only supports the following <code>touchEventInit</code> properties: <code>touches</code>, <code>targetTouches</code>, <code>changedTouches</code>."
             },
             "webview_android": {
               "version_added": "48",

--- a/api/UIEvent.json
+++ b/api/UIEvent.json
@@ -83,7 +83,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -131,7 +131,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -275,7 +275,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -375,7 +375,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -423,7 +423,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -475,7 +475,9 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "version_removed": "4.0",
+              "notes": "Replaced by <code>MouseEvent.pageX</code> in version 45."
             },
             "webview_android": {
               "version_added": true,
@@ -529,7 +531,9 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "version_removed": "4.0",
+              "notes": "Replaced by <code>MouseEvent.pageY</code> in version 45."
             },
             "webview_android": {
               "version_added": true,
@@ -579,7 +583,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "47"

--- a/api/URL.json
+++ b/api/URL.json
@@ -78,9 +78,15 @@
               "prefix": "webkit"
             }
           ],
-          "samsunginternet_android": {
-            "version_added": true
-          },
+          "samsunginternet_android": [
+            {
+              "version_added": "2.0"
+            },
+            {
+              "version_added": "1.0",
+              "prefix": "webkit"
+            }
+          ],
           "webview_android": [
             {
               "version_added": "4.4"
@@ -184,7 +190,7 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -237,7 +243,8 @@
                 "notes": "See <a href='https://webkit.org/b/167518'>here</a> for progress on deprecation."
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": null,
+                "notes": "See <a href='https://crbug.com/591719'>here</a> for progress on deprecation."
               },
               "webview_android": {
                 "version_added": null,
@@ -493,7 +500,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "52"
@@ -541,7 +548,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "52"
@@ -749,7 +756,7 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -859,7 +866,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "51"
@@ -907,7 +914,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "71"
@@ -955,7 +962,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "52"
@@ -1003,7 +1010,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "52"

--- a/api/URLSearchParams.json
+++ b/api/URLSearchParams.json
@@ -37,7 +37,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": "49"
@@ -85,7 +85,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -132,7 +132,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "8.0"
               },
               "webview_android": {
                 "version_added": "61"
@@ -181,7 +181,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -233,7 +233,7 @@
               "notes": "Removing a non-existent query parameter doesn't remove <code>?</code> from the URL. See <a href='https://webkit.org/b/193022'>bug 193022</a>."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -281,7 +281,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -329,7 +329,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -377,7 +377,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -425,7 +425,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -473,7 +473,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -521,7 +521,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -569,7 +569,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -617,7 +617,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "61"
@@ -665,7 +665,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -713,7 +713,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"

--- a/api/UserProximityEvent.json
+++ b/api/UserProximityEvent.json
@@ -135,7 +135,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/VideoTrackList.json
+++ b/api/VideoTrackList.json
@@ -77,7 +77,14 @@
             "version_added": "7.1"
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "5.0",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "enable-experimental-web-platform-features",
+                "value_to_set": "enabled"
+              }
+            ]
           },
           "webview_android": {
             "version_added": "45"
@@ -167,7 +174,14 @@
               "version_added": "7.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "webview_android": {
               "version_added": "45"
@@ -258,7 +272,14 @@
               "version_added": "7.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "webview_android": {
               "version_added": "45"
@@ -348,7 +369,14 @@
               "version_added": "7.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "webview_android": {
               "version_added": "45"
@@ -438,7 +466,14 @@
               "version_added": "7.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "webview_android": {
               "version_added": "45"
@@ -528,7 +563,14 @@
               "version_added": "7.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "webview_android": {
               "version_added": "45"
@@ -618,7 +660,14 @@
               "version_added": "7.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "webview_android": {
               "version_added": "45"
@@ -708,7 +757,14 @@
               "version_added": "7.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "webview_android": {
               "version_added": "45"
@@ -799,7 +855,14 @@
               "version_added": "7.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "webview_android": {
               "version_added": "45"
@@ -889,7 +952,14 @@
               "version_added": "7.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "webview_android": {
               "version_added": "45",

--- a/api/VisualViewport.json
+++ b/api/VisualViewport.json
@@ -54,7 +54,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "8.0"
           },
           "webview_android": {
             "version_added": "61"
@@ -120,7 +120,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "61"
@@ -187,7 +187,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "61"
@@ -254,7 +254,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "61"
@@ -344,9 +344,15 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "8.0"
+              },
+              {
+                "version_added": "8.0",
+                "partial_implementation": true
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "62"
@@ -441,9 +447,15 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "8.0"
+              },
+              {
+                "version_added": "8.0",
+                "partial_implementation": true
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "62"
@@ -515,7 +527,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "61"
@@ -582,7 +594,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "61"
@@ -673,9 +685,15 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "8.0"
+              },
+              {
+                "version_added": "8.0",
+                "partial_implementation": true
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "62"
@@ -771,9 +789,15 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "8.0"
+              },
+              {
+                "version_added": "8.0",
+                "partial_implementation": true
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "62"
@@ -845,7 +869,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "61"
@@ -912,7 +936,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "61"

--- a/api/WEBGL_debug_renderer_info.json
+++ b/api/WEBGL_debug_renderer_info.json
@@ -48,7 +48,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "2.0"
           },
           "webview_android": {
             "version_added": "37"

--- a/api/WaveShaperNode.json
+++ b/api/WaveShaperNode.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -134,7 +134,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -182,7 +182,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/WebGL2ComputeRenderingContext.json
+++ b/api/WebGL2ComputeRenderingContext.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
             "version_added": false

--- a/api/WebGLActiveInfo.json
+++ b/api/WebGLActiveInfo.json
@@ -35,7 +35,7 @@
             "version_added": "8.1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": true
@@ -137,7 +137,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -185,7 +185,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -233,7 +233,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true

--- a/api/WebGLBuffer.json
+++ b/api/WebGLBuffer.json
@@ -35,7 +35,7 @@
             "version_added": "8.1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": true

--- a/api/WebGLContextEvent.json
+++ b/api/WebGLContextEvent.json
@@ -35,7 +35,7 @@
             "version_added": "8.1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": true
@@ -137,7 +137,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true

--- a/api/WebGLFramebuffer.json
+++ b/api/WebGLFramebuffer.json
@@ -35,7 +35,7 @@
             "version_added": "8.1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": true

--- a/api/WebGLProgram.json
+++ b/api/WebGLProgram.json
@@ -35,7 +35,7 @@
             "version_added": "8.1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": true

--- a/api/WebGLRenderbuffer.json
+++ b/api/WebGLRenderbuffer.json
@@ -35,7 +35,7 @@
             "version_added": "8.1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": true

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -37,7 +37,7 @@
             "version_added": "8.1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": true
@@ -139,7 +139,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -187,7 +187,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -235,7 +235,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -283,7 +283,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -378,7 +378,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -473,7 +473,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -521,7 +521,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -616,7 +616,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -664,7 +664,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -759,7 +759,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -854,7 +854,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -902,7 +902,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -998,7 +998,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -1093,7 +1093,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -1188,7 +1188,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -1290,7 +1290,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -1385,7 +1385,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -1433,7 +1433,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -1481,7 +1481,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -1529,7 +1529,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -1577,7 +1577,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -1680,7 +1680,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -1728,7 +1728,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -1871,7 +1871,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -2014,7 +2014,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -2062,7 +2062,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -2110,7 +2110,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -2158,7 +2158,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -2206,7 +2206,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -2254,7 +2254,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -2302,7 +2302,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -2350,7 +2350,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -2398,7 +2398,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -2446,7 +2446,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -2494,7 +2494,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -2542,7 +2542,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -2590,7 +2590,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -2638,7 +2638,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -2686,7 +2686,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -2734,7 +2734,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -2782,7 +2782,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -2830,7 +2830,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -2878,7 +2878,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -2926,7 +2926,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -2974,7 +2974,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -3022,7 +3022,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -3070,7 +3070,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -3118,7 +3118,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -3166,7 +3166,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -3214,7 +3214,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -3262,7 +3262,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -3310,7 +3310,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -3358,7 +3358,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -3406,7 +3406,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -3501,7 +3501,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -3596,7 +3596,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -3644,7 +3644,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -3739,7 +3739,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -3787,7 +3787,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -3835,7 +3835,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -3883,7 +3883,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -3931,7 +3931,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -4026,7 +4026,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -4074,7 +4074,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -4122,7 +4122,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -4170,7 +4170,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -4265,7 +4265,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -4313,7 +4313,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -4361,7 +4361,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -4456,7 +4456,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -4551,7 +4551,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -4599,7 +4599,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -4647,7 +4647,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -4695,7 +4695,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -4743,7 +4743,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -4791,7 +4791,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -4886,7 +4886,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -4981,7 +4981,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -5029,7 +5029,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -5124,7 +5124,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -5172,7 +5172,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -5220,7 +5220,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -5268,7 +5268,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -5316,7 +5316,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -5411,7 +5411,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -5459,7 +5459,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -5507,7 +5507,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -5555,7 +5555,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -5603,7 +5603,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -5699,7 +5699,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -5747,7 +5747,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -5842,7 +5842,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -5890,7 +5890,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -6033,7 +6033,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -6128,7 +6128,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -6176,7 +6176,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -6224,7 +6224,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -6272,7 +6272,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -6320,7 +6320,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -6368,7 +6368,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -6416,7 +6416,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -6464,7 +6464,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -6512,7 +6512,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -6560,7 +6560,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -6703,7 +6703,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -6798,7 +6798,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -6893,7 +6893,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -7036,7 +7036,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -7084,7 +7084,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -7132,7 +7132,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -7180,7 +7180,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -7228,7 +7228,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -7276,7 +7276,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -7324,7 +7324,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -7372,7 +7372,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -7420,7 +7420,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -7468,7 +7468,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -7516,7 +7516,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -7564,7 +7564,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -7612,7 +7612,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -7660,7 +7660,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -7708,7 +7708,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -7756,7 +7756,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -7804,7 +7804,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -7947,7 +7947,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -8090,7 +8090,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -8233,7 +8233,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -8281,7 +8281,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -8329,7 +8329,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -8377,7 +8377,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -8473,7 +8473,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -8521,7 +8521,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -8617,7 +8617,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -8665,7 +8665,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -8761,7 +8761,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -8809,7 +8809,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -8905,7 +8905,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -8953,7 +8953,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true

--- a/api/WebGLShader.json
+++ b/api/WebGLShader.json
@@ -35,7 +35,7 @@
             "version_added": "8.1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": true

--- a/api/WebGLShaderPrecisionFormat.json
+++ b/api/WebGLShaderPrecisionFormat.json
@@ -35,7 +35,7 @@
             "version_added": "8.1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": true
@@ -137,7 +137,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -185,7 +185,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -233,7 +233,7 @@
               "version_added": "8.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true

--- a/api/WebGLTexture.json
+++ b/api/WebGLTexture.json
@@ -35,7 +35,7 @@
             "version_added": "8.1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": true

--- a/api/WebGLUniformLocation.json
+++ b/api/WebGLUniformLocation.json
@@ -35,7 +35,7 @@
             "version_added": "8.1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": true

--- a/api/WheelEvent.json
+++ b/api/WheelEvent.json
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -131,7 +131,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/Window.json
+++ b/api/Window.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -181,7 +181,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Starting with Samsung Internet 46, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
             },
             "webview_android": {
               "version_added": true,
@@ -231,7 +232,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -291,9 +292,15 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "4.0"
+              },
+              {
+                "version_added": "1.0",
+                "prefix": "webkit"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "43"
@@ -358,9 +365,15 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "4.0"
+              },
+              {
+                "version_added": "1.0",
+                "prefix": "webkit"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "43"
@@ -425,9 +438,15 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "4.0"
+              },
+              {
+                "version_added": "1.0",
+                "prefix": "webkit"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "43"
@@ -759,7 +778,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -815,7 +834,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -916,7 +935,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Starting with Samsung Internet 46, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
             },
             "webview_android": {
               "version_added": true,
@@ -966,7 +986,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "58"
@@ -1012,7 +1032,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "7.0"
               },
               "webview_android": {
                 "version_added": "58"
@@ -1154,7 +1174,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "47"
@@ -1202,7 +1222,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -1252,7 +1272,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -1364,7 +1384,7 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "3"
@@ -1413,7 +1433,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1549,7 +1569,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -1760,7 +1780,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -1823,7 +1843,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -1872,7 +1892,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -1921,7 +1941,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1999,9 +2019,17 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "5.0",
+                "notes": "For absolute values, use <code>ondeviceorientationabsolute</code>."
+              },
+              {
+                "version_added": true,
+                "version_removed": "5.0",
+                "notes": "Provided absolute values, not relative."
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "50",
@@ -2056,7 +2084,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "50"
@@ -2105,7 +2133,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -2180,9 +2208,16 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "3.0"
+              },
+              {
+                "version_added": "1.5",
+                "version_removed": "3.0",
+                "prefix": "webkit"
+              }
+            ],
             "webview_android": {
               "version_added": "37"
             }
@@ -2256,9 +2291,16 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "3.0"
+              },
+              {
+                "version_added": "1.5",
+                "version_removed": "3.0",
+                "prefix": "webkit"
+              }
+            ],
             "webview_android": {
               "version_added": null
             }
@@ -2403,7 +2445,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": true
@@ -2580,7 +2622,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -2750,7 +2792,10 @@
             },
             "samsunginternet_android": {
               "version_added": true,
-              "notes": "Supported on Samsung Internet for GearVR."
+              "notes": [
+                "Chrome for Android 56 supports only Google Daydream View.",
+                "Chrome for Android 57 adds support for Google Cardboard."
+              ]
             },
             "webview_android": {
               "version_added": false
@@ -2871,8 +2916,11 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "Supported on Samsung Internet for GearVR."
+              "version_added": "6.0",
+              "notes": [
+                "Chrome for Android 56 supports only Google Daydream View.",
+                "Chrome for Android 57 adds support for Google Cardboard."
+              ]
             },
             "webview_android": {
               "version_added": false
@@ -2986,8 +3034,11 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "Supported on Samsung Internet for GearVR."
+              "version_added": "6.0",
+              "notes": [
+                "Chrome for Android 56 supports only Google Daydream View.",
+                "Chrome for Android 57 adds support for Google Cardboard."
+              ]
             },
             "webview_android": {
               "version_added": false
@@ -3132,7 +3183,7 @@
               "version_added": "6.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -3239,7 +3290,7 @@
               "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "54"
@@ -3288,7 +3339,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "58"
@@ -3334,7 +3385,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "7.0"
               },
               "webview_android": {
                 "version_added": "58"
@@ -3687,7 +3738,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -3735,7 +3786,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -3783,7 +3834,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -3929,7 +3980,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -3976,7 +4027,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": false
@@ -4076,7 +4127,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -4219,7 +4270,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -4438,7 +4489,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": true
@@ -4727,7 +4778,7 @@
                 "version_added": "7"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "2.0"
               },
               "webview_android": {
                 "version_added": "37"
@@ -4872,7 +4923,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -4968,7 +5019,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -5414,7 +5465,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": false
@@ -5702,7 +5753,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -5798,7 +5849,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -5991,7 +6042,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "63"
@@ -6282,7 +6333,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "58"
@@ -6328,7 +6379,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "7.0"
               },
               "webview_android": {
                 "version_added": "58"
@@ -6475,7 +6526,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -6976,9 +7027,15 @@
                 "prefix": "webkit"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "version_added": "1.0",
+                "prefix": "webkit"
+              }
+            ],
             "webview_android": {
               "version_added": true
             }
@@ -7024,7 +7081,7 @@
                 "version_added": "6.1"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.5"
               },
               "webview_android": {
                 "version_added": true
@@ -7075,7 +7132,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "prefix": "webkit"
             },
             "webview_android": {
               "version_added": "37",
@@ -7140,7 +7198,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "47"
@@ -7244,7 +7302,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0",
+              "notes": "Samsung Internet does not emit a <code>resize</code> event on page load."
             },
             "webview_android": {
               "version_added": "45",
@@ -7342,7 +7401,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -7390,7 +7449,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -7438,7 +7497,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -7777,7 +7836,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "45"
@@ -7925,7 +7984,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "45"
@@ -7974,7 +8033,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -8022,7 +8081,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -8070,7 +8129,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -8118,7 +8177,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -8213,7 +8272,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "45"
@@ -8381,7 +8440,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true
@@ -8549,7 +8608,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true
@@ -8694,7 +8753,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -8742,7 +8801,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -8790,7 +8849,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -8889,7 +8948,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -8944,7 +9003,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -9328,7 +9387,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -9377,7 +9436,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -9426,7 +9485,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -9475,7 +9534,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -9637,7 +9696,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -9699,7 +9758,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"
@@ -9872,7 +9931,10 @@
             },
             "samsunginternet_android": {
               "version_added": true,
-              "notes": "Supported on Samsung Internet for GearVR."
+              "notes": [
+                "Chrome for Android 56 supports only Google Daydream View.",
+                "Chrome for Android 57 adds support for Google Cardboard."
+              ]
             },
             "webview_android": {
               "version_added": false
@@ -9995,8 +10057,11 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "Supported on Samsung Internet for GearVR."
+              "version_added": "6.0",
+              "notes": [
+                "Chrome for Android 56 supports only Google Daydream View.",
+                "Chrome for Android 57 adds support for Google Cardboard."
+              ]
             },
             "webview_android": {
               "version_added": false
@@ -10112,8 +10177,11 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "Supported on Samsung Internet for GearVR."
+              "version_added": "6.0",
+              "notes": [
+                "Chrome for Android 56 supports only Google Daydream View.",
+                "Chrome for Android 57 adds support for Google Cardboard."
+              ]
             },
             "webview_android": {
               "version_added": false

--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -582,7 +582,7 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -720,7 +720,7 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -35,7 +35,7 @@
             "version_added": "5.1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": "4"
@@ -83,7 +83,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4"
@@ -182,7 +182,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4"
@@ -279,7 +279,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4"
@@ -424,7 +424,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4"

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -756,7 +756,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": false
               },
               "webview_android": {
                 "version_added": "71"

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "50"

--- a/api/Worklet.json
+++ b/api/Worklet.json
@@ -51,7 +51,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "65"
@@ -114,7 +114,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"

--- a/api/WritableStreamDefaultController.json
+++ b/api/WritableStreamDefaultController.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "7.0"
           },
           "webview_android": {
             "version_added": "58"

--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -41,7 +41,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -346,7 +346,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -533,7 +533,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -589,7 +589,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -643,7 +643,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -737,7 +737,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -783,7 +783,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true
@@ -1268,7 +1268,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -1617,7 +1617,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -1724,7 +1724,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -1773,7 +1773,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -1930,7 +1930,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/XMLHttpRequestEventTarget.json
+++ b/api/XMLHttpRequestEventTarget.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": "1"

--- a/api/XSLTProcessor.json
+++ b/api/XSLTProcessor.json
@@ -134,7 +134,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Samsung Internet only supports string values."
             },
             "webview_android": {
               "version_added": true,
@@ -331,7 +332,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Samsung Internet only supports string values."
             },
             "webview_android": {
               "version_added": true,
@@ -386,7 +388,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Samsung Internet returns <code>null</code>if an error occurs."
             },
             "webview_android": {
               "version_added": true,
@@ -441,7 +444,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Samsung Internet returns <code>null</code>if an error occurs."
             },
             "webview_android": {
               "version_added": true,


### PR DESCRIPTION
This PR is created by a simple script that mirrors the compatibility data of all APIs from Chrome Android to Samsung Internet when it is set to `null` or `true`. This should help reduce inconsistencies in the browser data.  The script changes values set Samsung Internet values that are `null` or `true` to the appropriate Chrome version based upon the engine mappings in the browser JSON file.