### PR TITLE
Mirror Chrome -> Samsung Internet for css/*

### DIFF
--- a/css/at-rules/charset.json
+++ b/css/at-rules/charset.json
@@ -39,7 +39,7 @@
               "version_added": "4"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "2"

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -37,7 +37,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -132,7 +132,7 @@
                 "version_added": "3.1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "2.2"
@@ -291,7 +291,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true
@@ -400,7 +400,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true
@@ -448,7 +448,7 @@
                 "version_added": "3.1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "2.2"
@@ -598,7 +598,7 @@
                 "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4.4"

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -229,7 +229,7 @@
                 "version_added": "12"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "9.0"
               },
               "webview_android": {
                 "version_added": "66"
@@ -818,7 +818,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": false
@@ -866,7 +866,7 @@
                 "version_added": "3.1"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"
@@ -1374,7 +1374,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": false
@@ -1427,7 +1427,8 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/489957'>bug 489957</a>."
               },
               "webview_android": {
                 "version_added": false,
@@ -1525,7 +1526,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": false

--- a/css/at-rules/namespace.json
+++ b/css/at-rules/namespace.json
@@ -37,7 +37,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/css/at-rules/page.json
+++ b/css/at-rules/page.json
@@ -37,7 +37,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/css/at-rules/supports.json
+++ b/css/at-rules/supports.json
@@ -63,7 +63,7 @@
               "version_added": "9"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true

--- a/css/at-rules/viewport.json
+++ b/css/at-rules/viewport.json
@@ -94,7 +94,7 @@
               "notes": "See WebKit <a href='https://webkit.org/b/95959'>bug 95959</a>."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -156,7 +156,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
                 "version_added": "4.4"
@@ -219,7 +219,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
                 "version_added": "4.4"
@@ -282,7 +282,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
                 "version_added": "4.4"
@@ -333,7 +333,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "2.0"
               },
               "webview_android": {
                 "version_added": "37"
@@ -396,7 +396,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
                 "version_added": "4.4"
@@ -459,7 +459,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
                 "version_added": "4.4"
@@ -510,7 +510,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "2.0"
               },
               "webview_android": {
                 "version_added": "37"
@@ -614,7 +614,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "2.0"
               },
               "webview_android": {
                 "version_added": "37"
@@ -717,7 +717,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
                 "version_added": "4.4"

--- a/css/properties/-webkit-border-before.json
+++ b/css/properties/-webkit-border-before.json
@@ -36,7 +36,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/css/properties/-webkit-box-reflect.json
+++ b/css/properties/-webkit-box-reflect.json
@@ -36,7 +36,7 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "2.2"

--- a/css/properties/-webkit-mask-attachment.json
+++ b/css/properties/-webkit-mask-attachment.json
@@ -38,8 +38,8 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "version_removed": true
+              "version_added": "1.0",
+              "version_removed": "1.5"
             },
             "webview_android": {
               "version_added": true,

--- a/css/properties/-webkit-mask-box-image.json
+++ b/css/properties/-webkit-mask-box-image.json
@@ -36,7 +36,7 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "2"

--- a/css/properties/-webkit-mask-composite.json
+++ b/css/properties/-webkit-mask-composite.json
@@ -36,7 +36,7 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "2"

--- a/css/properties/-webkit-mask-position-x.json
+++ b/css/properties/-webkit-mask-position-x.json
@@ -36,7 +36,7 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "2"

--- a/css/properties/-webkit-mask-position-y.json
+++ b/css/properties/-webkit-mask-position-y.json
@@ -36,7 +36,7 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "2"

--- a/css/properties/-webkit-mask-repeat-x.json
+++ b/css/properties/-webkit-mask-repeat-x.json
@@ -36,7 +36,7 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/css/properties/-webkit-mask-repeat-y.json
+++ b/css/properties/-webkit-mask-repeat-y.json
@@ -36,7 +36,7 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/css/properties/-webkit-print-color-adjust.json
+++ b/css/properties/-webkit-print-color-adjust.json
@@ -47,9 +47,9 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "notes": [
-                "Samsung Internet does not print backgrounds of the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/body'><code>&lt;body&gt;</code></a> element. If this property is set to <code>exact</code> for the <code>&lt;body&gt;</code> element, it will apply only to its descendants.",
+                "Chrome does not print backgrounds of the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/body'><code>&lt;body&gt;</code></a> element. If this property is set to <code>exact</code> for the <code>&lt;body&gt;</code> element, it will apply only to its descendants.",
                 "Before Chrome 26, if background images are clipped (for example, when using <code>background-image</code> sprites) and <code>-webkit-print-color-adjust</code> is set to <code>exact</code>, then backgrounds will appear distorted when printed. Solid backgrounds and background images that are not clipped (i.e., backgrounds that have narrower and shorter than the element to which they are applied) are printed correctly. See <a href='http://code.google.com/p/chromium/issues/detail?id=131054'>Chromium bug 131054</a>."
               ]
             },

--- a/css/properties/-webkit-text-fill-color.json
+++ b/css/properties/-webkit-text-fill-color.json
@@ -60,7 +60,7 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/css/properties/-webkit-text-stroke-color.json
+++ b/css/properties/-webkit-text-stroke-color.json
@@ -60,7 +60,7 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -101,9 +101,15 @@
                   "version_added": "7.1"
                 }
               ],
-              "samsunginternet_android": {
-                "version_added": true
-              },
+              "samsunginternet_android": [
+                {
+                  "version_added": "2.0"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "1.5"
+                }
+              ],
               "webview_android": [
                 {
                   "version_added": "4.4"
@@ -259,7 +265,8 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": true
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "webview_android": {
                   "version_added": false,
@@ -408,7 +415,8 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": true
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "webview_android": {
                   "version_added": false,

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -206,7 +206,7 @@
                   "version_added": "11"
                 },
                 "samsunginternet_android": {
-                  "version_added": true
+                  "version_added": "7.0"
                 },
                 "webview_android": {
                   "version_added": "59"
@@ -350,7 +350,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": true
+                  "version_added": false
                 },
                 "webview_android": {
                   "version_added": false
@@ -447,7 +447,7 @@
                   "version_added": "11"
                 },
                 "samsunginternet_android": {
-                  "version_added": true
+                  "version_added": "7.0"
                 },
                 "webview_android": {
                   "version_added": "57"

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -199,7 +199,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": true
+                  "version_added": "7.0"
                 },
                 "webview_android": {
                   "version_added": "57"
@@ -247,7 +247,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "7.0"
                 },
                 "webview_android": {
                   "version_added": "57"
@@ -391,7 +391,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": true
+                  "version_added": "7.0"
                 },
                 "webview_android": {
                   "version_added": "57"
@@ -439,7 +439,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": true
+                  "version_added": "7.0"
                 },
                 "webview_android": {
                   "version_added": "57"

--- a/css/properties/animation-delay.json
+++ b/css/properties/animation-delay.json
@@ -132,9 +132,15 @@
                 "version_added": true
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "4.0"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1.0"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "43"

--- a/css/properties/animation-direction.json
+++ b/css/properties/animation-direction.json
@@ -194,7 +194,7 @@
                 "version_added": "6"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.5"
               }
             },
             "status": {
@@ -236,7 +236,7 @@
                 "version_added": "6"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.5"
               },
               "webview_android": {
                 "version_added": false

--- a/css/properties/background-attachment.json
+++ b/css/properties/background-attachment.json
@@ -36,7 +36,7 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -83,7 +83,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "37"
@@ -131,7 +131,7 @@
                 "version_added": "3.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true

--- a/css/properties/background-blend-mode.json
+++ b/css/properties/background-blend-mode.json
@@ -37,7 +37,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/properties/background-color.json
+++ b/css/properties/background-color.json
@@ -37,7 +37,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -38,7 +38,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -144,7 +144,8 @@
                 "notes": "Some versions support only experimental gradients prefixed with <code>-webkit</code>."
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0",
+                "notes": "Some versions support only experimental gradients prefixed with <code>-webkit</code>."
               },
               "webview_android": {
                 "version_added": true
@@ -306,7 +307,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true
@@ -356,7 +357,7 @@
                 "notes": "Support of SVG in CSS background is incomplete."
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": false

--- a/css/properties/background-position.json
+++ b/css/properties/background-position.json
@@ -36,7 +36,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -83,7 +83,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true
@@ -131,7 +131,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.5"
               },
               "webview_android": {
                 "version_added": true

--- a/css/properties/background-repeat.json
+++ b/css/properties/background-repeat.json
@@ -83,7 +83,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "37"

--- a/css/properties/background-size.json
+++ b/css/properties/background-size.json
@@ -99,9 +99,16 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "1.0"
+              },
+              {
+                "version_added": "1.0",
+                "prefix": "-webkit-",
+                "notes": "WebKit-based browsers originally implemented an older draft of CSS3 <code>background-size</code> in which an omitted second value is treated as duplicating the first value; this draft does not include the <code>contain</code> or <code>cover</code> keywords."
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "2.3"
@@ -154,7 +161,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "37"

--- a/css/properties/background.json
+++ b/css/properties/background.json
@@ -36,7 +36,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "2"
@@ -83,7 +83,7 @@
                 "version_added": "4"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.5"
               },
               "webview_android": {
                 "version_added": "3"
@@ -131,7 +131,7 @@
                 "version_added": "4"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.5"
               },
               "webview_android": {
                 "version_added": "3"
@@ -179,7 +179,7 @@
                 "version_added": "4"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.5"
               },
               "webview_android": {
                 "version_added": "3"
@@ -227,7 +227,7 @@
                 "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "2"
@@ -275,7 +275,7 @@
                 "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true

--- a/css/properties/border-bottom-left-radius.json
+++ b/css/properties/border-bottom-left-radius.json
@@ -100,7 +100,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -147,7 +147,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true
@@ -201,7 +201,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true

--- a/css/properties/border-bottom-right-radius.json
+++ b/css/properties/border-bottom-right-radius.json
@@ -100,7 +100,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -147,7 +147,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true
@@ -201,7 +201,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true

--- a/css/properties/border-image-slice.json
+++ b/css/properties/border-image-slice.json
@@ -42,7 +42,7 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "prefix": "-webkit-",

--- a/css/properties/border-left-style.json
+++ b/css/properties/border-left-style.json
@@ -38,7 +38,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "2.3"

--- a/css/properties/border-radius.json
+++ b/css/properties/border-radius.json
@@ -76,7 +76,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "2",
@@ -176,7 +176,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true

--- a/css/properties/border-top-left-radius.json
+++ b/css/properties/border-top-left-radius.json
@@ -100,7 +100,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -147,7 +147,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true
@@ -201,7 +201,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true

--- a/css/properties/border-top-right-radius.json
+++ b/css/properties/border-top-right-radius.json
@@ -100,7 +100,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -147,7 +147,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true
@@ -201,7 +201,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true

--- a/css/properties/bottom.json
+++ b/css/properties/bottom.json
@@ -37,7 +37,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/properties/box-decoration-break.json
+++ b/css/properties/box-decoration-break.json
@@ -70,7 +70,9 @@
               "notes": "This property is only supported for inline elements."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "prefix": "-webkit-",
+              "version_added": "1.0",
+              "notes": "This property is only supported for inline elements."
             },
             "webview_android": {
               "version_added": true,

--- a/css/properties/box-shadow.json
+++ b/css/properties/box-shadow.json
@@ -115,9 +115,16 @@
                 "version_added": true
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "1.0",
+                "notes": "Shadows affect layout in this browser. For example, if you cast an outer shadow to a box with a <code>width</code> of <code>100%</code>, then you'll see a scrollbar."
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1.0"
+              }
+            ],
             "webview_android": {
               "prefix": "-webkit-",
               "version_added": true,
@@ -207,9 +214,15 @@
                   "version_added": true
                 }
               ],
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": [
+                {
+                  "version_added": "1.0"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "1.0"
+                }
+              ],
               "webview_android": {
                 "prefix": "-webkit-",
                 "version_added": true
@@ -295,9 +308,15 @@
                   "version_added": true
                 }
               ],
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": [
+                {
+                  "version_added": "1.0"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "1.0"
+                }
+              ],
               "webview_android": {
                 "prefix": "-webkit-",
                 "version_added": true
@@ -383,9 +402,15 @@
                   "version_added": true
                 }
               ],
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": [
+                {
+                  "version_added": "1.0"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "1.0"
+                }
+              ],
               "webview_android": {
                 "prefix": "-webkit-",
                 "version_added": true

--- a/css/properties/box-sizing.json
+++ b/css/properties/box-sizing.json
@@ -106,9 +106,16 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "1.0",
+                "notes": "<code>box-sizing</code> is not respected when the height is calculated from <a href='https://developer.mozilla.org/docs/Web/API/Window/getComputedStyle'><code>window.getComputedStyle()</code></a>."
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1.0"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "4",

--- a/css/properties/break-after.json
+++ b/css/properties/break-after.json
@@ -193,7 +193,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "5.0"
                 },
                 "webview_android": {
                   "version_added": true
@@ -303,7 +303,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "webview_android": {
                   "version_added": "50"
@@ -352,7 +352,7 @@
                   "version_added": "10"
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "5.0"
                 },
                 "webview_android": {
                   "version_added": "50"

--- a/css/properties/break-before.json
+++ b/css/properties/break-before.json
@@ -303,7 +303,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "webview_android": {
                   "version_added": "50"
@@ -352,7 +352,7 @@
                   "version_added": "10"
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "5.0"
                 },
                 "webview_android": {
                   "version_added": "50"

--- a/css/properties/caption-side.json
+++ b/css/properties/caption-side.json
@@ -36,7 +36,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/properties/clear.json
+++ b/css/properties/clear.json
@@ -36,7 +36,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"

--- a/css/properties/clip.json
+++ b/css/properties/clip.json
@@ -38,7 +38,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/css/properties/color-adjust.json
+++ b/css/properties/color-adjust.json
@@ -40,7 +40,8 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "prefix": "-webkit-",
+              "version_added": "5.0"
             },
             "webview_android": {
               "prefix": "-webkit-",

--- a/css/properties/color.json
+++ b/css/properties/color.json
@@ -84,7 +84,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true
@@ -162,9 +162,20 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": [
+                {
+                  "version_added": "8.0"
+                },
+                {
+                  "version_added": "6.0",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Enable experimental Web Platform features"
+                    }
+                  ]
+                }
+              ],
               "webview_android": [
                 {
                   "version_added": "62"
@@ -223,7 +234,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "37"
@@ -317,7 +328,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true
@@ -367,7 +378,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true
@@ -464,7 +475,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true
@@ -513,7 +524,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true
@@ -561,7 +572,7 @@
                 "version_added": "12.2"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "9.0"
               },
               "webview_android": {
                 "version_added": "65"
@@ -610,7 +621,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "37"

--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -36,7 +36,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -132,7 +132,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "37"

--- a/css/properties/counter-increment.json
+++ b/css/properties/counter-increment.json
@@ -36,7 +36,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/properties/counter-reset.json
+++ b/css/properties/counter-reset.json
@@ -36,7 +36,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/properties/cursor.json
+++ b/css/properties/cursor.json
@@ -38,7 +38,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": false
@@ -85,7 +85,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": false
@@ -133,7 +133,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": false
@@ -181,7 +181,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": false
@@ -229,7 +229,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": false
@@ -277,7 +277,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": false
@@ -325,7 +325,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": false
@@ -376,7 +376,8 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0",
+                "notes": "This cursor is only supported on macOS and Linux."
               },
               "webview_android": {
                 "version_added": false
@@ -424,7 +425,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": false
@@ -472,7 +473,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": false
@@ -520,7 +521,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": false
@@ -603,9 +604,17 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": [
+                {
+                  "version_added": false,
+                  "notes": "Samsung Internet also continues to support the prefixed versions."
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "1.0",
+                  "notes": "Samsung Internet 22 added Windows support."
+                }
+              ],
               "webview_android": {
                 "version_added": false
               }
@@ -652,7 +661,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": false
@@ -700,7 +709,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": false
@@ -748,7 +757,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": false
@@ -796,7 +805,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": false
@@ -844,7 +853,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": false
@@ -892,7 +901,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": false
@@ -940,7 +949,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": false
@@ -988,7 +997,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": false
@@ -1036,7 +1045,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": false
@@ -1084,7 +1093,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": false
@@ -1132,7 +1141,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": false
@@ -1181,7 +1190,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": false
@@ -1230,7 +1239,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": false
@@ -1278,7 +1287,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": false
@@ -1326,7 +1335,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": false
@@ -1411,9 +1420,15 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": [
+                {
+                  "version_added": "3.0"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "1.0"
+                }
+              ],
               "webview_android": {
                 "version_added": false
               }

--- a/css/properties/custom-property.json
+++ b/css/properties/custom-property.json
@@ -238,9 +238,20 @@
               "safari_ios": {
                 "version_added": "9.1"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": [
+                {
+                  "version_added": "5.0"
+                },
+                {
+                  "version_added": "5.0",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Enable experimental Web Platform features"
+                    }
+                  ]
+                }
+              ],
               "webview_android": {
                 "version_added": "50"
               }

--- a/css/properties/direction.json
+++ b/css/properties/direction.json
@@ -36,7 +36,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -36,7 +36,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -142,9 +142,21 @@
               "safari_ios": {
                 "version_added": "11.1"
               },
-              "samsunginternet_android": {
-                "version_added": true
-              },
+              "samsunginternet_android": [
+                {
+                  "version_added": "9.0"
+                },
+                {
+                  "version_added": "7.0",
+                  "version_removed": "9.0",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Enable experimental Web Platform features"
+                    }
+                  ]
+                }
+              ],
               "webview_android": {
                 "version_added": "65"
               }
@@ -190,7 +202,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": true
+                  "version_added": "7.0"
                 },
                 "webview_android": {
                   "version_added": "65"
@@ -426,9 +438,15 @@
                   "version_added": "7.1"
                 }
               ],
-              "samsunginternet_android": {
-                "version_added": true
-              },
+              "samsunginternet_android": [
+                {
+                  "version_added": "2.0"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "1.5"
+                }
+              ],
               "webview_android": [
                 {
                   "version_added": "4.4"
@@ -590,7 +608,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true
@@ -706,9 +724,15 @@
                   "version_added": "6.1"
                 }
               ],
-              "samsunginternet_android": {
-                "version_added": true
-              },
+              "samsunginternet_android": [
+                {
+                  "version_added": "2.0"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "1.5"
+                }
+              ],
               "webview_android": [
                 {
                   "version_added": "4.4"
@@ -816,7 +840,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true
@@ -863,7 +887,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true
@@ -1189,7 +1213,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true

--- a/css/properties/empty-cells.json
+++ b/css/properties/empty-cells.json
@@ -36,7 +36,7 @@
               "version_added": "3.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -283,7 +283,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": false
@@ -342,7 +342,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": false

--- a/css/properties/flex.json
+++ b/css/properties/flex.json
@@ -145,9 +145,15 @@
                 "version_added": "7.1"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "2.0"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1.5"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "4.4"

--- a/css/properties/float.json
+++ b/css/properties/float.json
@@ -36,7 +36,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"

--- a/css/properties/font-family.json
+++ b/css/properties/font-family.json
@@ -37,7 +37,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"

--- a/css/properties/font-kerning.json
+++ b/css/properties/font-kerning.json
@@ -65,7 +65,8 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "prefix": "-webkit-",
+              "version_added": "2.0"
             },
             "webview_android": {
               "prefix": "-webkit-",

--- a/css/properties/font-optical-sizing.json
+++ b/css/properties/font-optical-sizing.json
@@ -62,7 +62,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/css/properties/font-size-adjust.json
+++ b/css/properties/font-size-adjust.json
@@ -59,7 +59,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "43",

--- a/css/properties/font-size.json
+++ b/css/properties/font-size.json
@@ -36,7 +36,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"

--- a/css/properties/font-stretch.json
+++ b/css/properties/font-stretch.json
@@ -40,7 +40,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "8.0",
               "notes": "A <code>font-stretch</code> definition must be added to the <code>@font-face</code> before this property will function."
             },
             "webview_android": {
@@ -89,7 +89,7 @@
                 "version_added": "11.3"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "8.0"
               },
               "webview_android": {
                 "version_added": "62"

--- a/css/properties/font-style.json
+++ b/css/properties/font-style.json
@@ -38,7 +38,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -85,7 +85,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": false

--- a/css/properties/font-variant-ligatures.json
+++ b/css/properties/font-variant-ligatures.json
@@ -92,7 +92,7 @@
               }
             ],
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": [
               {

--- a/css/properties/font-variant.json
+++ b/css/properties/font-variant.json
@@ -36,7 +36,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -109,7 +109,7 @@
                 "version_added": "9.3"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "6.0"
               },
               "webview_android": {
                 "version_added": "52"
@@ -213,7 +213,7 @@
                 "version_added": "8"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
                 "version_added": true

--- a/css/properties/font-weight.json
+++ b/css/properties/font-weight.json
@@ -36,7 +36,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -83,7 +83,7 @@
                 "version_added": "11"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "8.0"
               },
               "webview_android": {
                 "version_added": "62"

--- a/css/properties/font.json
+++ b/css/properties/font.json
@@ -36,7 +36,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -131,7 +131,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "37"

--- a/css/properties/gap.json
+++ b/css/properties/gap.json
@@ -41,7 +41,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "uc_android": {
                 "version_added": null

--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -321,9 +321,20 @@
               "safari_ios": {
                 "version_added": "10.3"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": [
+                {
+                  "version_added": "7.0"
+                },
+                {
+                  "version_added": "2.0",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Enable experimental Web Platform features"
+                    }
+                  ]
+                }
+              ],
               "webview_android": {
                 "version_added": false
               }
@@ -448,9 +459,20 @@
               "safari_ios": {
                 "version_added": "10.3"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": [
+                {
+                  "version_added": "7.0"
+                },
+                {
+                  "version_added": "3.0",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Enable experimental Web Platform features"
+                    }
+                  ]
+                }
+              ],
               "webview_android": {
                 "version_added": "57"
               }

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -321,9 +321,20 @@
               "safari_ios": {
                 "version_added": "10.3"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": [
+                {
+                  "version_added": "7.0"
+                },
+                {
+                  "version_added": "2.0",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Enable experimental Web Platform features"
+                    }
+                  ]
+                }
+              ],
               "webview_android": {
                 "version_added": false
               }
@@ -448,9 +459,20 @@
               "safari_ios": {
                 "version_added": "10.3"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": [
+                {
+                  "version_added": "7.0"
+                },
+                {
+                  "version_added": "3.0",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Enable experimental Web Platform features"
+                    }
+                  ]
+                }
+              ],
               "webview_android": {
                 "version_added": "57"
               }

--- a/css/properties/height.json
+++ b/css/properties/height.json
@@ -36,7 +36,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -135,9 +135,20 @@
                   "version_added": "6.1"
                 }
               ],
-              "samsunginternet_android": {
-                "version_added": true
-              },
+              "samsunginternet_android": [
+                {
+                  "version_added": "6.0"
+                },
+                {
+                  "version_added": "2.0",
+                  "partial_implementation": true,
+                  "notes": "Older versions of the specification treat absolute positioned children as though they are a 0 by 0 flex item. Later specification versions take the children out of the flow and set their positions based on align and justify properties. Samsung Internet implements the new behavior beginning with Samsung Internet 52."
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "1.5"
+                }
+              ],
               "webview_android": [
                 {
                   "version_added": "52"
@@ -198,7 +209,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "7.0"
                 },
                 "webview_android": {
                   "version_added": "57"
@@ -302,7 +313,8 @@
                   "version_added": "9"
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "webview_android": {
                   "version_added": true,
@@ -451,7 +463,8 @@
                   "version_added": "9"
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "webview_android": {
                   "version_added": true,
@@ -501,7 +514,7 @@
                   "version_added": "9"
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "7.0"
                 },
                 "webview_android": {
                   "version_added": "57"

--- a/css/properties/justify-items.json
+++ b/css/properties/justify-items.json
@@ -38,7 +38,7 @@
                 "version_added": "9.2"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "6.0"
               },
               "webview_android": {
                 "version_added": "52"

--- a/css/properties/left.json
+++ b/css/properties/left.json
@@ -36,7 +36,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"

--- a/css/properties/line-height.json
+++ b/css/properties/line-height.json
@@ -36,7 +36,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"

--- a/css/properties/list-style-image.json
+++ b/css/properties/list-style-image.json
@@ -36,7 +36,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"

--- a/css/properties/list-style-position.json
+++ b/css/properties/list-style-position.json
@@ -36,7 +36,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/properties/list-style.json
+++ b/css/properties/list-style.json
@@ -36,7 +36,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"

--- a/css/properties/margin-bottom.json
+++ b/css/properties/margin-bottom.json
@@ -36,7 +36,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -85,7 +85,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "37"

--- a/css/properties/margin-inline-end.json
+++ b/css/properties/margin-inline-end.json
@@ -105,10 +105,15 @@
                 "alternative_name": "-webkit-margin-end"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": true,
-              "alternative_name": "-webkit-margin-end"
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": false
+              },
+              {
+                "version_added": "1.0",
+                "alternative_name": "-webkit-margin-end"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "69"

--- a/css/properties/margin-inline-start.json
+++ b/css/properties/margin-inline-start.json
@@ -105,10 +105,15 @@
                 "alternative_name": "-webkit-margin-start"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": true,
-              "alternative_name": "-webkit-margin-start"
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": false
+              },
+              {
+                "version_added": "1.0",
+                "alternative_name": "-webkit-margin-start"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "69"

--- a/css/properties/margin-left.json
+++ b/css/properties/margin-left.json
@@ -36,7 +36,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -85,7 +85,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "37"

--- a/css/properties/margin-right.json
+++ b/css/properties/margin-right.json
@@ -36,7 +36,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -85,7 +85,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "37"

--- a/css/properties/margin-top.json
+++ b/css/properties/margin-top.json
@@ -36,7 +36,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -85,7 +85,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "37"

--- a/css/properties/margin.json
+++ b/css/properties/margin.json
@@ -36,7 +36,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -85,7 +85,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "37"

--- a/css/properties/mask-clip.json
+++ b/css/properties/mask-clip.json
@@ -69,7 +69,7 @@
             },
             "samsunginternet_android": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "prefix": "-webkit-",
@@ -117,7 +117,7 @@
                 "version_added": "3.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "2"
@@ -165,7 +165,7 @@
                 "version_added": "3.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "2"
@@ -213,7 +213,7 @@
                 "version_added": "3.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "2"
@@ -261,7 +261,7 @@
                 "version_added": "3.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "2"

--- a/css/properties/mask-image.json
+++ b/css/properties/mask-image.json
@@ -45,7 +45,9 @@
               "notes": "Initially, Safari supported only <code>-webkit-</code> prefixed values for gradients (such as <code>-webkit-linear-gradient()</code>). Later, support for unprefixed values was added."
             },
             "samsunginternet_android": {
-              "version_added": null
+              "prefix": "-webkit-",
+              "version_added": "1.0",
+              "notes": "From version 8, Samsung Internet added support for gradient values. Initially, Samsung Internet supported only <code>-webkit-</code> prefixed values for gradients (such as <code>-webkit-linear-gradient()</code>). Later, support for unprefixed values was added."
             },
             "webview_android": {
               "prefix": "-webkit-",
@@ -94,7 +96,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true
@@ -142,7 +144,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true

--- a/css/properties/mask-origin.json
+++ b/css/properties/mask-origin.json
@@ -75,7 +75,7 @@
             },
             "samsunginternet_android": {
               "prefix": "-webkit-",
-              "version_added": true,
+              "version_added": "1.0",
               "notes": "The <code>margin-box</code> value is unsupported."
             },
             "webview_android": {
@@ -180,7 +180,7 @@
               },
               "samsunginternet_android": {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "prefix": "-webkit-",

--- a/css/properties/mask-position.json
+++ b/css/properties/mask-position.json
@@ -69,7 +69,7 @@
             },
             "samsunginternet_android": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "prefix": "-webkit-",

--- a/css/properties/mask-repeat.json
+++ b/css/properties/mask-repeat.json
@@ -69,7 +69,7 @@
             },
             "samsunginternet_android": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "prefix": "-webkit-",

--- a/css/properties/mask-size.json
+++ b/css/properties/mask-size.json
@@ -69,7 +69,7 @@
             },
             "samsunginternet_android": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "prefix": "-webkit-",

--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -38,7 +38,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/properties/max-inline-size.json
+++ b/css/properties/max-inline-size.json
@@ -74,7 +74,7 @@
               }
             ],
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "57"

--- a/css/properties/min-block-size.json
+++ b/css/properties/min-block-size.json
@@ -62,7 +62,7 @@
               "version_added": "12.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "57"

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -91,7 +91,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.5"
               },
               "webview_android": {
                 "version_added": "37"
@@ -358,7 +358,7 @@
               },
               "samsunginternet_android": {
                 "alternative_name": "-webkit-fill-available",
-                "version_added": true
+                "version_added": "1.5"
               },
               "webview_android": {
                 "alternative_name": "-webkit-fill-available",

--- a/css/properties/min-inline-size.json
+++ b/css/properties/min-inline-size.json
@@ -62,7 +62,7 @@
               "version_added": "12.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "57"

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -104,7 +104,8 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.5",
+                "notes": "Samsung Internet uses <code>auto</code> as the initial value for <code>min-width</code>."
               },
               "webview_android": {
                 "version_added": "37",
@@ -394,7 +395,8 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "alternative_name": "-webkit-fill-available",
+                "version_added": "1.5"
               },
               "webview_android": {
                 "alternative_name": "-webkit-fill-available",

--- a/css/properties/mix-blend-mode.json
+++ b/css/properties/mix-blend-mode.json
@@ -36,7 +36,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "41"
@@ -83,7 +83,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": false

--- a/css/properties/object-fit.json
+++ b/css/properties/object-fit.json
@@ -49,7 +49,7 @@
               "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "4.4.3"

--- a/css/properties/object-position.json
+++ b/css/properties/object-position.json
@@ -48,7 +48,7 @@
               "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "4.4.3"

--- a/css/properties/offset-path.json
+++ b/css/properties/offset-path.json
@@ -134,7 +134,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "9.0"
               },
               "webview_android": {
                 "version_added": "64"

--- a/css/properties/opacity.json
+++ b/css/properties/opacity.json
@@ -50,7 +50,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"

--- a/css/properties/order.json
+++ b/css/properties/order.json
@@ -129,9 +129,15 @@
                 "version_added": "7"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "2.0"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1.5"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "4.4"

--- a/css/properties/orphans.json
+++ b/css/properties/orphans.json
@@ -36,7 +36,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true

--- a/css/properties/outline-color.json
+++ b/css/properties/outline-color.json
@@ -43,7 +43,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/css/properties/outline-offset.json
+++ b/css/properties/outline-offset.json
@@ -36,7 +36,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/css/properties/outline-width.json
+++ b/css/properties/outline-width.json
@@ -43,7 +43,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/css/properties/outline.json
+++ b/css/properties/outline.json
@@ -44,7 +44,7 @@
               "version_added": "3.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"

--- a/css/properties/overflow-wrap.json
+++ b/css/properties/overflow-wrap.json
@@ -144,7 +144,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": false

--- a/css/properties/overflow-x.json
+++ b/css/properties/overflow-x.json
@@ -42,7 +42,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"

--- a/css/properties/overflow-y.json
+++ b/css/properties/overflow-y.json
@@ -42,7 +42,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"

--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -38,7 +38,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/css/properties/padding-bottom.json
+++ b/css/properties/padding-bottom.json
@@ -36,7 +36,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/properties/padding-inline-end.json
+++ b/css/properties/padding-inline-end.json
@@ -105,10 +105,15 @@
                 "alternative_name": "-webkit-padding-end"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": true,
-              "alternative_name": "-webkit-padding-end"
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": false
+              },
+              {
+                "version_added": "1.0",
+                "alternative_name": "-webkit-padding-end"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "69"

--- a/css/properties/padding-inline-start.json
+++ b/css/properties/padding-inline-start.json
@@ -105,10 +105,15 @@
                 "alternative_name": "-webkit-padding-start"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": true,
-              "alternative_name": "-webkit-padding-start"
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": false
+              },
+              {
+                "version_added": "1.0",
+                "alternative_name": "-webkit-padding-start"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "69"

--- a/css/properties/padding-left.json
+++ b/css/properties/padding-left.json
@@ -36,7 +36,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/properties/padding-right.json
+++ b/css/properties/padding-right.json
@@ -36,7 +36,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/properties/padding-top.json
+++ b/css/properties/padding-top.json
@@ -36,7 +36,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/properties/padding.json
+++ b/css/properties/padding.json
@@ -36,7 +36,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/properties/page-break-after.json
+++ b/css/properties/page-break-after.json
@@ -38,7 +38,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/css/properties/page-break-before.json
+++ b/css/properties/page-break-before.json
@@ -38,7 +38,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/css/properties/page-break-inside.json
+++ b/css/properties/page-break-inside.json
@@ -38,7 +38,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/css/properties/perspective-origin.json
+++ b/css/properties/perspective-origin.json
@@ -109,9 +109,15 @@
                 "version_added": "2"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "3.0"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1.0"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "37"

--- a/css/properties/perspective.json
+++ b/css/properties/perspective.json
@@ -109,9 +109,15 @@
                 "version_added": "2"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "3.0"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1.0"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "37"

--- a/css/properties/pointer-events.json
+++ b/css/properties/pointer-events.json
@@ -36,7 +36,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "2"
@@ -83,7 +83,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "37"

--- a/css/properties/position.json
+++ b/css/properties/position.json
@@ -44,7 +44,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -142,7 +142,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true

--- a/css/properties/quotes.json
+++ b/css/properties/quotes.json
@@ -36,7 +36,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/css/properties/resize.json
+++ b/css/properties/resize.json
@@ -36,7 +36,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -85,7 +85,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "37"

--- a/css/properties/right.json
+++ b/css/properties/right.json
@@ -36,7 +36,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"

--- a/css/properties/tab-size.json
+++ b/css/properties/tab-size.json
@@ -60,7 +60,8 @@
               "version_added": "7.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.5",
+              "notes": "This property is not yet animatable."
             },
             "webview_android": {
               "version_added": "4.4"
@@ -108,7 +109,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "4.0"
               },
               "webview_android": {
                 "version_added": "56"

--- a/css/properties/table-layout.json
+++ b/css/properties/table-layout.json
@@ -36,7 +36,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1.5"

--- a/css/properties/text-align.json
+++ b/css/properties/text-align.json
@@ -36,7 +36,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -95,7 +95,8 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "prefix": "-webkit-",
+                "version_added": "1.0"
               },
               "webview_android": {
                 "prefix": "-webkit-",
@@ -144,7 +145,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "37"
@@ -240,7 +241,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "37"
@@ -288,7 +289,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": false

--- a/css/properties/text-decoration-line.json
+++ b/css/properties/text-decoration-line.json
@@ -62,7 +62,7 @@
               }
             ],
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/properties/text-decoration.json
+++ b/css/properties/text-decoration.json
@@ -36,7 +36,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -149,7 +149,7 @@
                 "version_added": "8"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "7.0"
               },
               "webview_android": {
                 "version_added": "57"

--- a/css/properties/text-indent.json
+++ b/css/properties/text-indent.json
@@ -36,7 +36,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/properties/text-overflow.json
+++ b/css/properties/text-overflow.json
@@ -56,7 +56,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/properties/text-rendering.json
+++ b/css/properties/text-rendering.json
@@ -159,7 +159,8 @@
                 "version_added": "6"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0",
+                "notes": "Supports true geometric precision without rounding up or down to the nearest supported font size in the operating system."
               },
               "webview_android": {
                 "version_added": "37",

--- a/css/properties/text-shadow.json
+++ b/css/properties/text-shadow.json
@@ -56,7 +56,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/css/properties/text-size-adjust.json
+++ b/css/properties/text-size-adjust.json
@@ -117,7 +117,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "6.0"
               },
               "webview_android": {
                 "version_added": "54"

--- a/css/properties/text-transform.json
+++ b/css/properties/text-transform.json
@@ -330,7 +330,7 @@
                 "version_added": "6"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
                 "version_added": "4.4"
@@ -378,7 +378,7 @@
                 "version_added": "8"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
                 "version_added": true

--- a/css/properties/top.json
+++ b/css/properties/top.json
@@ -37,7 +37,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/properties/touch-action.json
+++ b/css/properties/touch-action.json
@@ -68,7 +68,7 @@
               "version_added": "9.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -147,7 +147,7 @@
                 "version_added": "13"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
                 "version_added": "37"
@@ -279,7 +279,7 @@
                 "version_added": "9.3"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
                 "version_added": "37"
@@ -358,7 +358,7 @@
                 "version_added": "13"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
                 "version_added": "37"

--- a/css/properties/transform-style.json
+++ b/css/properties/transform-style.json
@@ -109,9 +109,15 @@
                 "version_added": "2"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "3.0"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1.0"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "37"

--- a/css/properties/transform.json
+++ b/css/properties/transform.json
@@ -217,7 +217,7 @@
                 "version_added": "3.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "prefix": "-webkit-",

--- a/css/properties/unicode-bidi.json
+++ b/css/properties/unicode-bidi.json
@@ -36,7 +36,7 @@
               "version_added": "3.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"

--- a/css/properties/user-modify.json
+++ b/css/properties/user-modify.json
@@ -60,7 +60,8 @@
               "prefix": "-webkit-"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "prefix": "-webkit-",
+              "version_added": "1.0"
             },
             "webview_android": {
               "prefix": "-webkit-",
@@ -107,7 +108,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "37"

--- a/css/properties/vertical-align.json
+++ b/css/properties/vertical-align.json
@@ -36,7 +36,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"

--- a/css/properties/visibility.json
+++ b/css/properties/visibility.json
@@ -40,7 +40,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"

--- a/css/properties/white-space.json
+++ b/css/properties/white-space.json
@@ -36,7 +36,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -131,7 +131,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "37"
@@ -179,7 +179,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "37"
@@ -235,7 +235,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "37"
@@ -331,7 +331,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "37"

--- a/css/properties/widows.json
+++ b/css/properties/widows.json
@@ -36,7 +36,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": false

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -83,7 +83,7 @@
                 "version_added": "6.1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.5"
               },
               "webview_android": {
                 "version_added": "4.4"

--- a/css/properties/will-change.json
+++ b/css/properties/will-change.json
@@ -64,7 +64,7 @@
               "version_added": "9.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/css/properties/word-break.json
+++ b/css/properties/word-break.json
@@ -44,7 +44,7 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -139,7 +139,7 @@
                 "version_added": "9"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "webview_android": {
                 "version_added": true

--- a/css/properties/word-spacing.json
+++ b/css/properties/word-spacing.json
@@ -36,7 +36,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/css/properties/z-index.json
+++ b/css/properties/z-index.json
@@ -36,7 +36,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -83,7 +83,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true

--- a/css/properties/zoom.json
+++ b/css/properties/zoom.json
@@ -38,7 +38,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -88,7 +88,8 @@
                 "version_added": "3"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0",
+                "version_removed": "7.0"
               },
               "webview_android": {
                 "version_added": true,

--- a/css/selectors/-webkit-resizer.json
+++ b/css/selectors/-webkit-resizer.json
@@ -43,7 +43,7 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "uc_android": {
               "version_added": true

--- a/css/selectors/-webkit-scrollbar-button.json
+++ b/css/selectors/-webkit-scrollbar-button.json
@@ -43,7 +43,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "uc_android": {
               "version_added": true

--- a/css/selectors/-webkit-scrollbar-corner.json
+++ b/css/selectors/-webkit-scrollbar-corner.json
@@ -43,7 +43,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "uc_android": {
               "version_added": true

--- a/css/selectors/-webkit-scrollbar-thumb.json
+++ b/css/selectors/-webkit-scrollbar-thumb.json
@@ -43,7 +43,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "uc_android": {
               "version_added": true

--- a/css/selectors/-webkit-scrollbar-track-piece.json
+++ b/css/selectors/-webkit-scrollbar-track-piece.json
@@ -43,7 +43,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "uc_android": {
               "version_added": true

--- a/css/selectors/-webkit-scrollbar-track.json
+++ b/css/selectors/-webkit-scrollbar-track.json
@@ -43,7 +43,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "uc_android": {
               "version_added": true

--- a/css/selectors/-webkit-scrollbar.json
+++ b/css/selectors/-webkit-scrollbar.json
@@ -43,7 +43,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "uc_android": {
               "version_added": true

--- a/css/selectors/active.json
+++ b/css/selectors/active.json
@@ -37,7 +37,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -85,7 +85,7 @@
                 "notes": "By default, Safari on iOS does not use the <a href='https://developer.mozilla.org/docs/Web/CSS/:active'><code>:active</code></a> state unless there is a <a href='https://developer.mozilla.org/docs/Web/Reference/Events/touchstart'><code>touchstart</code></a> event handler on the relevant element or on the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/body'><code>&lt;body&gt;</code></a> element."
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"

--- a/css/selectors/after.json
+++ b/css/selectors/after.json
@@ -164,7 +164,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.5"
               },
               "webview_android": {
                 "version_added": true

--- a/css/selectors/attribute.json
+++ b/css/selectors/attribute.json
@@ -37,7 +37,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/selectors/backdrop.json
+++ b/css/selectors/backdrop.json
@@ -55,9 +55,15 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "3.0"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "2.0"
+              }
+            ],
             "webview_android": {
               "version_added": false
             }
@@ -103,7 +109,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "2.0"
               },
               "webview_android": {
                 "version_added": false

--- a/css/selectors/before.json
+++ b/css/selectors/before.json
@@ -155,7 +155,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.5"
               },
               "webview_android": {
                 "version_added": true

--- a/css/selectors/checked.json
+++ b/css/selectors/checked.json
@@ -37,7 +37,7 @@
               "version_added": "3.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "2"

--- a/css/selectors/default.json
+++ b/css/selectors/default.json
@@ -37,7 +37,7 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/css/selectors/disabled.json
+++ b/css/selectors/disabled.json
@@ -39,7 +39,7 @@
               "version_added": "3.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "2"

--- a/css/selectors/empty.json
+++ b/css/selectors/empty.json
@@ -37,7 +37,7 @@
               "version_added": "3.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "2"

--- a/css/selectors/enabled.json
+++ b/css/selectors/enabled.json
@@ -37,7 +37,7 @@
               "version_added": "3.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "2"

--- a/css/selectors/first-child.json
+++ b/css/selectors/first-child.json
@@ -41,7 +41,7 @@
               "version_added": "4"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/selectors/first-letter.json
+++ b/css/selectors/first-letter.json
@@ -90,9 +90,15 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "1.0"
+              },
+              {
+                "alternative_name": ":first-letter",
+                "version_added": "1.0"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "37"

--- a/css/selectors/first-line.json
+++ b/css/selectors/first-line.json
@@ -100,9 +100,17 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "1.0",
+                "notes": "Before Samsung Internet 62, the <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work on <code>::first-line</code> pseudo-elements. See <a href='https://crbug.com/129669'>Chromium bug 129669</a>."
+              },
+              {
+                "alternative_name": ":first-line",
+                "version_added": "1.0",
+                "notes": "Before Samsung Internet 62, the <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work on <code>::first-line</code> pseudo-elements. See <a href='https://crbug.com/129669'>Chromium bug 129669</a>."
+              }
+            ],
             "webview_android": {
               "version_added": true
             }

--- a/css/selectors/first-of-type.json
+++ b/css/selectors/first-of-type.json
@@ -37,7 +37,7 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "2"

--- a/css/selectors/first.json
+++ b/css/selectors/first.json
@@ -37,7 +37,7 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"

--- a/css/selectors/focus.json
+++ b/css/selectors/focus.json
@@ -37,7 +37,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"

--- a/css/selectors/fullscreen.json
+++ b/css/selectors/fullscreen.json
@@ -87,9 +87,15 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": false
+              },
+              {
+                "alternative_name": ":-webkit-full-screen",
+                "version_added": "1.0"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "71"
@@ -141,7 +147,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": false

--- a/css/selectors/general_sibling.json
+++ b/css/selectors/general_sibling.json
@@ -37,7 +37,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/selectors/host-context.json
+++ b/css/selectors/host-context.json
@@ -39,7 +39,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "54"

--- a/css/selectors/hostfunction.json
+++ b/css/selectors/hostfunction.json
@@ -66,7 +66,7 @@
               "notes": "Certain CSS selectors do not work (:host > .local-child) and styling slotted content (::slotted) is buggy."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "54"

--- a/css/selectors/hover.json
+++ b/css/selectors/hover.json
@@ -38,7 +38,7 @@
               "notes": "As of Safari for iOS 7.1.2, tapping a <a href='https://developer.mozilla.org/docs/Web/Events/click#Safari_Mobile'>clickable element</a> causes the element to enter the <code>:hover</code> state. The element will remain in the <code>:hover</code> state until a different element has entered the <code>:hover</code> state."
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -85,7 +85,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "37"
@@ -138,7 +138,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "37"
@@ -186,7 +186,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true

--- a/css/selectors/indeterminate.json
+++ b/css/selectors/indeterminate.json
@@ -183,7 +183,7 @@
                 "notes": "See <a href='https://webkit.org/b/156270'>WebKit bug 156270</a>."
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "4.0"
               },
               "webview_android": {
                 "version_added": "39"

--- a/css/selectors/lang.json
+++ b/css/selectors/lang.json
@@ -37,7 +37,7 @@
               "version_added": "3.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"

--- a/css/selectors/last-child.json
+++ b/css/selectors/last-child.json
@@ -37,7 +37,7 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/selectors/last-of-type.json
+++ b/css/selectors/last-of-type.json
@@ -37,7 +37,7 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "2"

--- a/css/selectors/link.json
+++ b/css/selectors/link.json
@@ -37,7 +37,7 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1.5"

--- a/css/selectors/namespace.json
+++ b/css/selectors/namespace.json
@@ -37,7 +37,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/css/selectors/not.json
+++ b/css/selectors/not.json
@@ -37,7 +37,7 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "2"

--- a/css/selectors/nth-child.json
+++ b/css/selectors/nth-child.json
@@ -39,7 +39,7 @@
               "version_added": "3.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/selectors/nth-last-child.json
+++ b/css/selectors/nth-last-child.json
@@ -37,7 +37,7 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/selectors/nth-last-of-type.json
+++ b/css/selectors/nth-last-of-type.json
@@ -37,7 +37,7 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "2"

--- a/css/selectors/nth-of-type.json
+++ b/css/selectors/nth-of-type.json
@@ -37,7 +37,7 @@
               "version_added": "3.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "2"

--- a/css/selectors/only-child.json
+++ b/css/selectors/only-child.json
@@ -37,7 +37,7 @@
               "version_added": "3.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/selectors/only-of-type.json
+++ b/css/selectors/only-of-type.json
@@ -37,7 +37,7 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "2"

--- a/css/selectors/optional.json
+++ b/css/selectors/optional.json
@@ -37,7 +37,7 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/css/selectors/required.json
+++ b/css/selectors/required.json
@@ -37,7 +37,7 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4.3"

--- a/css/selectors/root.json
+++ b/css/selectors/root.json
@@ -37,7 +37,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/css/selectors/selection.json
+++ b/css/selectors/selection.json
@@ -49,7 +49,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/css/selectors/target.json
+++ b/css/selectors/target.json
@@ -37,7 +37,7 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "2"

--- a/css/selectors/visited.json
+++ b/css/selectors/visited.json
@@ -37,7 +37,7 @@
               "version_added": "9.3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -84,7 +84,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "37"

--- a/css/types/attr.json
+++ b/css/types/attr.json
@@ -37,7 +37,7 @@
               "version_added": "3.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -258,7 +258,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true,
+                "version_added": "5.0",
                 "partial_implementation": true,
                 "notes": "Only supported on the <code>offset-path</code> property."
               },

--- a/css/types/calc.json
+++ b/css/types/calc.json
@@ -77,7 +77,7 @@
               }
             ],
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": [
               {
@@ -178,7 +178,7 @@
                 "version_added": "6"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.5"
               },
               "webview_android": {
                 "version_added": "37"
@@ -274,7 +274,7 @@
                 "version_added": "6"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
                 "version_added": "4.4.3"

--- a/css/types/dimension.json
+++ b/css/types/dimension.json
@@ -37,7 +37,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/types/flex.json
+++ b/css/types/flex.json
@@ -37,7 +37,7 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "57"

--- a/css/types/global_keywords.json
+++ b/css/types/global_keywords.json
@@ -36,7 +36,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -83,7 +83,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"
@@ -145,7 +145,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"
@@ -245,7 +245,7 @@
                 "version_added": "9.3"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "webview_android": {
                 "version_added": true

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -110,8 +110,8 @@
               ],
               "samsunginternet_android": {
                 "prefix": "-webkit-",
-                "version_added": true,
-                "notes": "Support for the original dual-image with percentage implementation only."
+                "version_added": "1.0",
+                "notes": "Supports the original dual-image with percentage implementation only."
               },
               "webview_android": {
                 "prefix": "-webkit-",
@@ -284,9 +284,15 @@
                   "version_added": "5.1"
                 }
               ],
-              "samsunginternet_android": {
-                "version_added": true
-              },
+              "samsunginternet_android": [
+                {
+                  "version_added": "1.5"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "1.0"
+                }
+              ],
               "webview_android": {
                 "version_added": true
               }
@@ -585,9 +591,15 @@
                 "safari_ios": {
                   "version_added": true
                 },
-                "samsunginternet_android": {
-                  "version_added": true
-                },
+                "samsunginternet_android": [
+                  {
+                    "version_added": "1.5"
+                  },
+                  {
+                    "prefix": "-webkit-",
+                    "version_added": "1.0"
+                  }
+                ],
                 "webview_android": [
                   {
                     "version_added": true
@@ -639,7 +651,7 @@
                     "version_added": "12.2"
                   },
                   "samsunginternet_android": {
-                    "version_added": true
+                    "version_added": false
                   },
                   "webview_android": {
                     "version_added": "71"
@@ -687,7 +699,7 @@
                     "version_added": true
                   },
                   "samsunginternet_android": {
-                    "version_added": true
+                    "version_added": "4.0"
                   },
                   "webview_android": {
                     "version_added": "40"
@@ -735,7 +747,7 @@
                     "version_added": true
                   },
                   "samsunginternet_android": {
-                    "version_added": true
+                    "version_added": "1.5"
                   },
                   "webview_android": {
                     "version_added": true
@@ -797,7 +809,7 @@
                     "version_added": true
                   },
                   "samsunginternet_android": {
-                    "version_added": true
+                    "version_added": "1.5"
                   },
                   "webview_android": {
                     "version_added": true
@@ -934,9 +946,15 @@
                 "safari_ios": {
                   "version_added": true
                 },
-                "samsunginternet_android": {
-                  "version_added": true
-                },
+                "samsunginternet_android": [
+                  {
+                    "version_added": "1.5"
+                  },
+                  {
+                    "prefix": "-webkit-",
+                    "version_added": "1.0"
+                  }
+                ],
                 "webview_android": [
                   {
                     "version_added": true
@@ -1031,7 +1049,7 @@
                     "version_added": false
                   },
                   "samsunginternet_android": {
-                    "version_added": true
+                    "version_added": "1.5"
                   },
                   "webview_android": {
                     "version_added": true
@@ -1079,7 +1097,7 @@
                     "version_added": "12.2"
                   },
                   "samsunginternet_android": {
-                    "version_added": true
+                    "version_added": false
                   },
                   "webview_android": {
                     "version_added": "71"
@@ -1127,7 +1145,7 @@
                     "version_added": true
                   },
                   "samsunginternet_android": {
-                    "version_added": true
+                    "version_added": "4.0"
                   },
                   "webview_android": {
                     "version_added": "40"
@@ -1380,9 +1398,15 @@
                 "safari_ios": {
                   "version_added": true
                 },
-                "samsunginternet_android": {
-                  "version_added": true
-                },
+                "samsunginternet_android": [
+                  {
+                    "version_added": "1.5"
+                  },
+                  {
+                    "prefix": "-webkit-",
+                    "version_added": "1.0"
+                  }
+                ],
                 "webview_android": [
                   {
                     "version_added": true
@@ -1435,7 +1459,7 @@
                     "version_added": "12.2"
                   },
                   "samsunginternet_android": {
-                    "version_added": true
+                    "version_added": false
                   },
                   "webview_android": {
                     "version_added": "71"
@@ -1483,7 +1507,7 @@
                     "version_added": true
                   },
                   "samsunginternet_android": {
-                    "version_added": true
+                    "version_added": "4.0"
                   },
                   "webview_android": {
                     "version_added": "40"
@@ -1531,7 +1555,7 @@
                     "version_added": true
                   },
                   "samsunginternet_android": {
-                    "version_added": true
+                    "version_added": "1.5"
                   },
                   "webview_android": {
                     "version_added": true
@@ -1593,7 +1617,7 @@
                     "version_added": true
                   },
                   "samsunginternet_android": {
-                    "version_added": true
+                    "version_added": "1.5"
                   },
                   "webview_android": {
                     "version_added": true
@@ -1729,9 +1753,15 @@
                 "safari_ios": {
                   "version_added": "7.1"
                 },
-                "samsunginternet_android": {
-                  "version_added": true
-                },
+                "samsunginternet_android": [
+                  {
+                    "version_added": "1.5"
+                  },
+                  {
+                    "prefix": "-webkit-",
+                    "version_added": "1.0"
+                  }
+                ],
                 "webview_android": [
                   {
                     "version_added": "4.4"
@@ -1843,7 +1873,7 @@
                     "version_added": false
                   },
                   "samsunginternet_android": {
-                    "version_added": true
+                    "version_added": "1.5"
                   },
                   "webview_android": {
                     "version_added": true
@@ -1891,7 +1921,7 @@
                     "version_added": "12.2"
                   },
                   "samsunginternet_android": {
-                    "version_added": true
+                    "version_added": false
                   },
                   "webview_android": {
                     "version_added": "71"
@@ -1939,7 +1969,7 @@
                     "version_added": true
                   },
                   "samsunginternet_android": {
-                    "version_added": true
+                    "version_added": "4.0"
                   },
                   "webview_android": {
                     "version_added": "40"

--- a/css/types/length-percentage.json
+++ b/css/types/length-percentage.json
@@ -37,7 +37,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -136,7 +136,7 @@
                 "version_added": "7.1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.5"
               },
               "webview_android": {
                 "version_added": true
@@ -426,7 +426,7 @@
                 "version_added": "4"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "2"
@@ -570,7 +570,7 @@
                 "version_added": "6"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.5"
               },
               "webview_android": {
                 "version_added": true
@@ -668,7 +668,7 @@
                 "version_added": "6.1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.5"
               },
               "webview_android": {
                 "version_added": "1.5"
@@ -730,7 +730,7 @@
                 "version_added": "6.1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.5"
               },
               "webview_android": {
                 "version_added": true
@@ -780,7 +780,7 @@
                 "version_added": "6"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.5"
               },
               "webview_android": {
                 "version_added": true

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -37,7 +37,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -136,7 +136,7 @@
                 "version_added": "7.1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.5"
               },
               "webview_android": {
                 "version_added": true
@@ -426,7 +426,7 @@
                 "version_added": "4"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "2"
@@ -572,7 +572,7 @@
                 "version_added": "6"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.5"
               },
               "webview_android": {
                 "version_added": true
@@ -670,7 +670,7 @@
                 "version_added": "6.1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.5"
               },
               "webview_android": {
                 "version_added": "1.5"
@@ -732,7 +732,7 @@
                 "version_added": "6.1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.5"
               },
               "webview_android": {
                 "version_added": true
@@ -782,7 +782,7 @@
                 "version_added": "6"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.5"
               },
               "webview_android": {
                 "version_added": true

--- a/css/types/percentage.json
+++ b/css/types/percentage.json
@@ -37,7 +37,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/types/position.json
+++ b/css/types/position.json
@@ -37,7 +37,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -84,7 +84,7 @@
                 "version_added": "7.1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.5"
               },
               "webview_android": {
                 "version_added": true
@@ -132,7 +132,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true

--- a/css/types/resolution.json
+++ b/css/types/resolution.json
@@ -112,7 +112,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
                 "version_added": true
@@ -172,7 +172,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
                 "version_added": true
@@ -220,7 +220,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
                 "version_added": true

--- a/css/types/shape.json
+++ b/css/types/shape.json
@@ -37,7 +37,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -85,7 +85,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "37"

--- a/css/types/string.json
+++ b/css/types/string.json
@@ -37,7 +37,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -84,7 +84,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true

--- a/css/types/transform-function.json
+++ b/css/types/transform-function.json
@@ -89,7 +89,7 @@
                 "version_added": "3.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "3"

--- a/css/types/url.json
+++ b/css/types/url.json
@@ -37,7 +37,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"


### PR DESCRIPTION
This PR is created by a simple script that mirrors the compatibility data of all APIs from Chrome Android to Samsung Internet when it is set to `null` or `true`. This should help reduce inconsistencies in the browser data.  The script changes values set Samsung Internet values that are `null` or `true` to the appropriate Chrome version based upon the engine mappings in the browser JSON file.

The script itself can be found here: https://github.com/vinyldarkscratch/bcd-toolkit/blob/master/fix.py