### PR TITLE
Add compat data for the last 3 proprietary events

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -4178,6 +4178,58 @@
           }
         }
       },
+      "msContentZoom_event": {
+        "__compat": {
+          "description": "<code>msContentZoom</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/msContentZoom_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "name": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/name",
@@ -4512,6 +4564,58 @@
           "status": {
             "experimental": false,
             "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "overflow_event": {
+        "__compat": {
+          "description": "<code>overflow</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/overflow_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
             "deprecated": false
           }
         }
@@ -7003,6 +7107,58 @@
           "status": {
             "experimental": false,
             "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "underflow_event": {
+        "__compat": {
+          "description": "<code>underflow</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/underflow_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
             "deprecated": false
           }
         }


### PR DESCRIPTION
This is part of https://github.com/mdn/sprints/issues/1102 and is the follow-up to https://github.com/mdn/browser-compat-data/pull/3825.

It adds compat data for:

https://developer.mozilla.org/en-US/docs/Web/Events/msContentZoom
https://developer.mozilla.org/en-US/docs/Web/Events/overflow
https://developer.mozilla.org/en-US/docs/Web/Events/underflow

These events are each supported by only a single underlying browser engine, and I don't have specific numbers.