### PR TITLE
Update Safari 12.1 to be current release

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -104,11 +104,12 @@
         "12": {
           "release_date": "2018-09-24",
           "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_12_release_notes",
-          "status": "current"
+          "status": "retired"
         },
         "12.1": {
+          "release_date": "2019-03-25",
           "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_12_1_release_notes",
-          "status": "beta"
+          "status": "current"
         }
       }
     }


### PR DESCRIPTION
Source: https://en.wikipedia.org/wiki/Safari_version_history#Safari_12