### PR TITLE
Add Chrome flag for webextensions.api.browserAction.openPopup

### DIFF
--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -364,7 +364,14 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/openPopup",
             "support": {
               "chrome": {
-                "version_added": "67"
+                "version_added": "67",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#extension-apis",
+                    "value_to_set": "Enabled"
+                  }
+                ]
               },
               "edge": {
                 "version_added": false


### PR DESCRIPTION
Continuation of #3675 as brought to attention by @brandon1024.  It looks like in Chrome, this feature is not enabled by default and must be enabled via the `Experimental Extension APIs` flag.  Tested in Chrome 73 on macOS.