### PR TITLE
Update Opera versions

### DIFF
--- a/api/FetchEvent.json
+++ b/api/FetchEvent.json
@@ -600,7 +600,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "59"
+              "version_added": "60"
             },
             "opera_android": {
               "version_added": "50"

--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -349,9 +349,6 @@
           "release_notes": "https://dev.opera.com/blog/opera-58/",
           "status": "retired"
         },
-        "59": {
-          "status": "retired"
-        },
         "60": {
           "release_date": "2019-04-09",
           "release_notes": "https://blogs.opera.com/desktop/2019/04/opera-60-reborn-3-web-3-0-vpn-ad-blocker/",

--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -345,16 +345,21 @@
           "status": "current"
         },
         "58": {
-          "status": "beta"
+          "release_date": "2019-01-23",
+          "release_notes": "https://dev.opera.com/blog/opera-58/",
+          "status": "retired"
         },
         "59": {
-          "status": "nightly"
+          "status": "retired"
         },
         "60": {
-          "status": "planned"
+          "status": "current"
         },
         "61": {
-          "status": "planned"
+          "status": "beta"
+        },
+        "62": {
+          "status": "nightly"
         }
       }
     }

--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -353,6 +353,8 @@
           "status": "retired"
         },
         "60": {
+          "release_date": "2019-04-09",
+          "release_notes": "https://blogs.opera.com/desktop/2019/04/opera-60-reborn-3-web-3-0-vpn-ad-blocker/",
           "status": "current"
         },
         "61": {

--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -1106,7 +1106,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "59",
+                "version_added": "60",
                 "flags": [
                   {
                     "type": "preference",
@@ -1410,7 +1410,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "59",
+                "version_added": "60",
                 "flags": [
                   {
                     "type": "preference",

--- a/javascript/builtins/JSON.json
+++ b/javascript/builtins/JSON.json
@@ -193,7 +193,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": "59"
+                  "version_added": "60"
                 },
                 "opera_android": {
                   "version_added": "50"


### PR DESCRIPTION
This PR updates Opera releases to match latest updates.  Based upon https://help.opera.com/en/opera-version-history/, it looks like version 59 never left beta before they released version 60, codenamed "Reborn 3".  Thus, no release notes or release date was actually made for Opera 59.