### PR TITLE
Update current Safari iOS version (12.2)

### DIFF
--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -90,11 +90,11 @@
         "12": {
           "release_date": "2018-09-17",
           "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_12_release_notes",
-          "status": "current"
+          "status": "retired"
         },
         "12.2": {
           "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_12_1_release_notes",
-          "status": "beta"
+          "status": "current"
         }
       }
     }


### PR DESCRIPTION
iOS 12.2 is out of beta.  This PR updates the Safari iOS browser data as such.