### PR TITLE
Add release dates for Node.js 0.10 and 0.12

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -4,9 +4,11 @@
       "name": "Node.js",
       "releases": {
         "0.10": {
+          "release_date": "2013-03-11",
           "release_notes": "https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V010.md"
         },
         "0.12": {
+          "release_date": "2015-02-06",
           "release_notes": "https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V012.md"
         },
         "4.0.0": {


### PR DESCRIPTION
Found the release dates for Node.js 0.10 and 0.12 on https://nodejs.org/en/download/releases/.  This PR adds them in.