### PR TITLE
Add estimated release date for IE 1.5

### DIFF
--- a/browsers/ie.json
+++ b/browsers/ie.json
@@ -8,6 +8,7 @@
           "status": "retired"
         },
         "1.5": {
+          "release_date": "1996-01-16",
           "status": "retired"
         },
         "2": {


### PR DESCRIPTION
The Wikipedia article puts the release of IE 1.5 at January 1996, but doesn't specify a date.  I don't think we'll be able to narrow down the exact release date since it's so long ago, so I would say it's good enough?  I'd love to know if other people think we should try to find more accurate data.
