### PR TITLE
Add Samsung Internet 8.0-9.2 info

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -73,7 +73,7 @@
         },
         "7.4": {
           "release_date": "2018-09-12",
-          "status": "current"
+          "status": "retired"
         },
         "8.2": {
           "release_date": "2018-12-21",

--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -75,8 +75,16 @@
           "release_date": "2018-09-12",
           "status": "retired"
         },
+        "8.0": {
+          "release_date": "2018-07-18",
+          "status": "retired"
+        },
         "8.2": {
           "release_date": "2018-12-21",
+          "status": "retired"
+        },
+        "9.0": {
+          "release_date": "2018-09-15",
           "status": "retired"
         },
         "9.2": {

--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -78,6 +78,10 @@
         "8.2": {
           "release_date": "2018-12-21",
           "status": "current"
+        },
+        "9.2": {
+          "release_date": "2019-04-02",
+          "status": "current"
         }
       }
     }

--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -77,7 +77,7 @@
         },
         "8.2": {
           "release_date": "2018-12-21",
-          "status": "current"
+          "status": "retired"
         },
         "9.2": {
           "release_date": "2019-04-02",

--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -76,7 +76,8 @@
           "status": "current"
         },
         "8.2": {
-          "status": "beta"
+          "release_date": "2018-12-21",
+          "status": "current"
         }
       }
     }


### PR DESCRIPTION
Samsung Internet 9.2 is released.  This adds the release date of 8.2, as well as adding 8.0, 9.0, and 9.2 into the browser data.

Sources:
https://www.apkmirror.com/uploads/?q=samsung-internet-for-android
https://gist.github.com/poshaughnessy/5718717a04db20a02e9fdb3fc16e2258
https://medium.com/samsung-internet-dev/hello-samsung-internet-8-2-beta-521e4b215fb3
https://medium.com/samsung-internet-dev/8-2-stable-release-is-out-the-door-122cba80b788