### PR TITLE
Migrate api.Window.deviceorientation_event from MDN table

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -1285,7 +1285,7 @@
           }
         }
       },
-      "deviceorientation": {
+      "deviceorientation_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/deviceorientation_event",
           "description": "<code>deviceorientation</code> event",
@@ -1327,7 +1327,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "3.0"
+              "version_added": "3"
             }
           },
           "status": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -1285,6 +1285,58 @@
           }
         }
       },
+      "deviceorientation": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/deviceorientation_event",
+          "description": "<code>deviceorientation</code> event",
+          "support": {
+            "chrome": {
+              "version_added": "7"
+            },
+            "chrome_android": {
+              "version_added": "59"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.6"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": "4.2"
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "error_event": {
         "__compat": {
           "description": "<code>error</code> event",

--- a/api/Window.json
+++ b/api/Window.json
@@ -1294,7 +1294,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": "59"
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -1303,10 +1303,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "3.6"
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "6"
             },
             "ie": {
               "version_added": null
@@ -1318,7 +1318,7 @@
               "version_added": "12"
             },
             "safari": {
-              "version_added": true
+              "version_added": "4.1"
             },
             "safari_ios": {
               "version_added": "4.2"
@@ -1327,7 +1327,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "3.0"
             }
           },
           "status": {


### PR DESCRIPTION
Supersedes #3811.  This adds all of the data from the MDN table for api.Window.deviceorientation_event, and corrects some of the inconsistencies determined within it.