### PR TITLE
Remove incorrect hyphens from prefixes in api/*

### DIFF
--- a/api/CSSKeyframeRule.json
+++ b/api/CSSKeyframeRule.json
@@ -39,7 +39,7 @@
           },
           "opera": {
             "version_added": "12",
-            "prefix": "-o"
+            "prefix": "o"
           },
           "opera_android": {
             "version_added": true

--- a/api/CSSKeyframesRule.json
+++ b/api/CSSKeyframesRule.json
@@ -39,11 +39,11 @@
           },
           "opera": {
             "version_added": "12",
-            "prefix": "-o"
+            "prefix": "o"
           },
           "opera_android": {
             "version_added": "12",
-            "prefix": "-o"
+            "prefix": "o"
           },
           "safari": {
             "version_added": "4"

--- a/api/Document.json
+++ b/api/Document.json
@@ -5407,7 +5407,7 @@
               {
                 "version_added": "10",
                 "version_removed": "52",
-                "prefix": "-moz-"
+                "prefix": "moz"
               }
             ],
             "firefox_android": [
@@ -5418,7 +5418,7 @@
               {
                 "version_added": "10",
                 "version_removed": "52",
-                "prefix": "-moz-"
+                "prefix": "moz"
               }
             ],
             "ie": {
@@ -9821,7 +9821,7 @@
               {
                 "version_added": "10",
                 "version_removed": "52",
-                "prefix": "-moz-"
+                "prefix": "moz"
               }
             ],
             "firefox_android": [
@@ -9831,7 +9831,7 @@
               {
                 "version_added": "10",
                 "version_removed": "52",
-                "prefix": "-moz-"
+                "prefix": "moz"
               }
             ],
             "ie": {

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2778,7 +2778,7 @@
               "version_added": true
             },
             "firefox": {
-              "prefix": "-moz-",
+              "prefix": "moz",
               "version_added": "20"
             },
             "firefox_android": {

--- a/api/Notification.json
+++ b/api/Notification.json
@@ -28,7 +28,7 @@
               "version_added": "22"
             },
             {
-              "prefix": "-moz-",
+              "prefix": "moz",
               "version_added": "4"
             }
           ],
@@ -523,7 +523,7 @@
                 "version_added": "22"
               },
               {
-                "prefix": "-moz-",
+                "prefix": "moz",
                 "version_added": "4"
               }
             ],
@@ -532,7 +532,7 @@
                 "version_added": "22"
               },
               {
-                "prefix": "-moz-",
+                "prefix": "moz",
                 "version_added": "4"
               }
             ],

--- a/api/RTCSessionDescription.json
+++ b/api/RTCSessionDescription.json
@@ -17,7 +17,7 @@
             "version_added": true
           },
           "firefox": {
-            "prefix": "-moz-",
+            "prefix": "moz",
             "version_added": true
           },
           "firefox_android": {
@@ -68,7 +68,7 @@
               "version_added": true
             },
             "firefox": {
-              "prefix": "-moz-",
+              "prefix": "moz",
               "version_added": true
             },
             "firefox_android": {
@@ -120,7 +120,7 @@
               "version_added": true
             },
             "firefox": {
-              "prefix": "-moz-",
+              "prefix": "moz",
               "version_added": true
             },
             "firefox_android": {
@@ -173,7 +173,7 @@
               "version_added": true
             },
             "firefox": {
-              "prefix": "-moz-",
+              "prefix": "moz",
               "version_added": true
             },
             "firefox_android": {
@@ -225,7 +225,7 @@
               "version_added": true
             },
             "firefox": {
-              "prefix": "-moz-",
+              "prefix": "moz",
               "version_added": true
             },
             "firefox_android": {


### PR DESCRIPTION
Related to #3670.  This removes the inaccuracy of hyphens in prefixes for JavaScript APIs in all remaining browsers.