### PR TITLE
[Chromium] Add versions for WebKit-prefixed CSS properties

### DIFF
--- a/css/properties/-webkit-border-before.json
+++ b/css/properties/-webkit-border-before.json
@@ -6,10 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-border-before",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": false
@@ -27,10 +27,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "15"
             },
             "safari": {
               "version_added": "5.1"
@@ -39,10 +39,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {

--- a/css/properties/-webkit-border-before.json
+++ b/css/properties/-webkit-border-before.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-border-before",
           "support": {
             "chrome": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "chrome_android": {
               "version_added": "18"

--- a/css/properties/-webkit-mask-attachment.json
+++ b/css/properties/-webkit-mask-attachment.json
@@ -6,11 +6,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-attachment",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "24"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "18",
+              "version_removed": "24"
             },
             "edge": {
               "version_added": false
@@ -40,10 +41,11 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "version_removed": true
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {

--- a/css/properties/-webkit-mask-attachment.json
+++ b/css/properties/-webkit-mask-attachment.json
@@ -11,7 +11,7 @@
             },
             "chrome_android": {
               "version_added": "18",
-              "version_removed": "24"
+              "version_removed": "25"
             },
             "edge": {
               "version_added": false

--- a/css/properties/-webkit-mask-repeat-x.json
+++ b/css/properties/-webkit-mask-repeat-x.json
@@ -6,10 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-repeat-x",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "3"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "18"
@@ -27,10 +27,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "15"
             },
             "safari": {
               "version_added": "5"
@@ -39,10 +39,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {

--- a/css/properties/-webkit-mask-repeat-y.json
+++ b/css/properties/-webkit-mask-repeat-y.json
@@ -6,10 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-repeat-y",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "3"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "18"
@@ -27,10 +27,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "15"
             },
             "safari": {
               "version_added": "5"
@@ -39,10 +39,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {

--- a/css/properties/-webkit-print-color-adjust.json
+++ b/css/properties/-webkit-print-color-adjust.json
@@ -6,14 +6,18 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-print-color-adjust",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "16",
               "notes": [
                 "Chrome does not print backgrounds of the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/body'><code>&lt;body&gt;</code></a> element. If this property is set to <code>exact</code> for the <code>&lt;body&gt;</code> element, it will apply only to its descendants.",
                 "Before Chrome 26, if background images are clipped (for example, when using <code>background-image</code> sprites) and <code>-webkit-print-color-adjust</code> is set to <code>exact</code>, then backgrounds will appear distorted when printed. Solid backgrounds and background images that are not clipped (i.e., backgrounds that have narrower and shorter than the element to which they are applied) are printed correctly. See <a href='http://code.google.com/p/chromium/issues/detail?id=131054'>Chromium bug 131054</a>."
               ]
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "16",
+              "notes": [
+                "Chrome does not print backgrounds of the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/body'><code>&lt;body&gt;</code></a> element. If this property is set to <code>exact</code> for the <code>&lt;body&gt;</code> element, it will apply only to its descendants.",
+                "Before Chrome 26, if background images are clipped (for example, when using <code>background-image</code> sprites) and <code>-webkit-print-color-adjust</code> is set to <code>exact</code>, then backgrounds will appear distorted when printed. Solid backgrounds and background images that are not clipped (i.e., backgrounds that have narrower and shorter than the element to which they are applied) are printed correctly. See <a href='http://code.google.com/p/chromium/issues/detail?id=131054'>Chromium bug 131054</a>."
+              ]
             },
             "edge": {
               "version_added": false
@@ -31,10 +35,12 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "15",
+              "notes": "Opera does not print backgrounds of the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/body'><code>&lt;body&gt;</code></a> element. If this property is set to <code>exact</code> for the <code>&lt;body&gt;</code> element, it will apply only to its descendants."
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "15",
+              "notes": "Opera does not print backgrounds of the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/body'><code>&lt;body&gt;</code></a> element. If this property is set to <code>exact</code> for the <code>&lt;body&gt;</code> element, it will apply only to its descendants."
             },
             "safari": {
               "version_added": "6",
@@ -44,10 +50,15 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "notes": [
+                "Samsung Internet does not print backgrounds of the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/body'><code>&lt;body&gt;</code></a> element. If this property is set to <code>exact</code> for the <code>&lt;body&gt;</code> element, it will apply only to its descendants.",
+                "Before Chrome 26, if background images are clipped (for example, when using <code>background-image</code> sprites) and <code>-webkit-print-color-adjust</code> is set to <code>exact</code>, then backgrounds will appear distorted when printed. Solid backgrounds and background images that are not clipped (i.e., backgrounds that have narrower and shorter than the element to which they are applied) are printed correctly. See <a href='http://code.google.com/p/chromium/issues/detail?id=131054'>Chromium bug 131054</a>."
+              ]
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "37",
+              "notes": "WebView does not print backgrounds of the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/body'><code>&lt;body&gt;</code></a> element. If this property is set to <code>exact</code> for the <code>&lt;body&gt;</code> element, it will apply only to its descendants."
             }
           },
           "status": {

--- a/css/properties/-webkit-print-color-adjust.json
+++ b/css/properties/-webkit-print-color-adjust.json
@@ -13,7 +13,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "16",
+              "version_added": "18",
               "notes": [
                 "Chrome does not print backgrounds of the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/body'><code>&lt;body&gt;</code></a> element. If this property is set to <code>exact</code> for the <code>&lt;body&gt;</code> element, it will apply only to its descendants.",
                 "Before Chrome 26, if background images are clipped (for example, when using <code>background-image</code> sprites) and <code>-webkit-print-color-adjust</code> is set to <code>exact</code>, then backgrounds will appear distorted when printed. Solid backgrounds and background images that are not clipped (i.e., backgrounds that have narrower and shorter than the element to which they are applied) are printed correctly. See <a href='http://code.google.com/p/chromium/issues/detail?id=131054'>Chromium bug 131054</a>."

--- a/css/properties/-webkit-print-color-adjust.json
+++ b/css/properties/-webkit-print-color-adjust.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-print-color-adjust",
           "support": {
             "chrome": {
-              "version_added": "16",
+              "version_added": "17",
               "notes": [
                 "Chrome does not print backgrounds of the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/body'><code>&lt;body&gt;</code></a> element. If this property is set to <code>exact</code> for the <code>&lt;body&gt;</code> element, it will apply only to its descendants.",
                 "Before Chrome 26, if background images are clipped (for example, when using <code>background-image</code> sprites) and <code>-webkit-print-color-adjust</code> is set to <code>exact</code>, then backgrounds will appear distorted when printed. Solid backgrounds and background images that are not clipped (i.e., backgrounds that have narrower and shorter than the element to which they are applied) are printed correctly. See <a href='http://code.google.com/p/chromium/issues/detail?id=131054'>Chromium bug 131054</a>."

--- a/css/properties/-webkit-text-fill-color.json
+++ b/css/properties/-webkit-text-fill-color.json
@@ -6,10 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-text-fill-color",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -51,10 +51,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "15"
             },
             "safari": {
               "version_added": true
@@ -63,10 +63,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "37"
             }
           },
           "status": {

--- a/css/properties/-webkit-text-stroke-color.json
+++ b/css/properties/-webkit-text-stroke-color.json
@@ -6,10 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-text-stroke-color",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "15"
@@ -51,10 +51,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "15"
             },
             "safari": {
               "version_added": true
@@ -63,10 +63,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {

--- a/css/properties/-webkit-text-stroke-width.json
+++ b/css/properties/-webkit-text-stroke-width.json
@@ -6,10 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-text-stroke-width",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "15"
@@ -51,10 +51,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "15"
             },
             "safari": {
               "version_added": true
@@ -63,7 +63,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "38"
             }
           },
           "status": {


### PR DESCRIPTION
This PR is for the 2019 Key Result Q2 (#3710) by defining Chromium versions for WebKit-prefixed CSS properties with `version_added: true`.  Looking through the Git repository of Chromium, I've found the following commits (collapsed for convenience) that implement the CSS properties.

<details><summary>Evidence of Use in 1.0</summary><p>

*These commits show the properties being used in or before Chrome 1.0, or date far back enough.*

**css.properties.-webkit-mask-attachment**

```
commit 805c33ce01f0e6bbeb4c900da036a15642a1f194
Author: hyatt@apple.com <hyatt@apple.com@bbb929c8-8fbe-4397-9dbb-9b2b20218538>
Date:   Mon Apr 21 21:59:33 2008 +0000
```

**css.properties.-webkit-text-fill-color, css.properties.-webkit-text-stroke-color, css.properties.-webkit-text-stroke-width**

```
commit b78e73454fac5bfa96ebe29a34dc00de8aac4242
Author: hyatt <hyatt@bbb929c8-8fbe-4397-9dbb-9b2b20218538>
Date:   Wed Dec 20 10:31:33 2006 +0000
```

</p></details>

<details><summary>Estimated by Date</summary><p>

*These commits reveal a property's implementation, but for some reason cannot be tracked down in Chrome's [release finder API](https://storage.googleapis.com/chromium-find-releases-static/index.html).  Their versions have been estimated based upon their date.*

**css.properties.-webkit-border-before**

```
commit c900977d90bba47ddc2c23bbdff3c9fc4d53b224
Author: hyatt@apple.com <hyatt@apple.com@bbb929c8-8fbe-4397-9dbb-9b2b20218538>
Date:   Mon Sep 20 21:03:16 2010 +0000
Ver.?:  8
```

**css.properties.-webkit-mask-repeat-x, css.properties.-webkit-mask-repeat-y**

```
commit 5ea3d8d2563187f1d17ed850a9373a3dda42a606
Author: bdakin@apple.com <bdakin@apple.com@bbb929c8-8fbe-4397-9dbb-9b2b20218538>
Date:   Mon Aug 31 22:05:24 2009 +0000
Ver.?:  3
```

**css.properties.-webkit-print-color-adjust**

```
commit 1e6865bced6ef2adb17f93e94c0b2ea93393aa8e
Author: macpherson@chromium.org <macpherson@chromium.org@bbb929c8-8fbe-4397-9dbb-9b2b20218538>
Date:   Wed Nov 2 01:23:09 2011 +0000
Ver.?:  17
```

</p></details>
