### PR TITLE
Property pages for logical overflow properties

### DIFF
--- a/css/properties/overflow-block.json
+++ b/css/properties/overflow-block.json
@@ -1,0 +1,57 @@
+{
+  "css": {
+    "properties": {
+      "overflow-block": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overflow-block",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/overflow-inline.json
+++ b/css/properties/overflow-inline.json
@@ -1,0 +1,57 @@
+{
+  "css": {
+    "properties": {
+      "overflow-inline": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overflow-inline",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is the BCD for: https://github.com/mdn/sprints/issues/1005

Spec: https://drafts.csswg.org/css-overflow-3/#logical

I don't think there is any support yet, but adding this so I can do the property pages as they are in the spec.
