### PR TITLE
fix(html): Correct `SourceMap` header data

### DIFF
--- a/http/headers/sourcemap.json
+++ b/http/headers/sourcemap.json
@@ -7,16 +7,22 @@
           "support": {
             "chrome": [
               {
-                "prefix": "X-",
                 "version_added": true
               },
               {
+                "prefix": "X-",
                 "version_added": true
               }
             ],
-            "chrome_android": {
-              "version_added": null
-            },
+            "chrome_android": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "X-",
+                "version_added": true
+              }
+            ],
             "edge": {
               "version_added": null
             },
@@ -25,49 +31,79 @@
             },
             "firefox": [
               {
-                "prefix": "X-",
-                "version_added": "27"
+                "version_added": "55"
               },
               {
-                "version_added": "55"
+                "prefix": "X-",
+                "version_added": "27"
               }
             ],
             "firefox_android": [
               {
-                "prefix": "X-",
-                "version_added": "27"
+                "version_added": "55"
               },
               {
-                "version_added": "55"
+                "prefix": "X-",
+                "version_added": "27"
               }
             ],
             "ie": {
               "version_added": null
             },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": [
+            "opera": [
               {
-                "prefix": "X-",
                 "version_added": true
               },
               {
+                "prefix": "X-",
                 "version_added": true
               }
             ],
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": null
-            },
-            "webview_android": {
-              "version_added": null
-            }
+            "opera_android": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "X-",
+                "version_added": true
+              }
+            ],
+            "safari": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "X-",
+                "version_added": true
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "X-",
+                "version_added": true
+              }
+            ],
+            "samsunginternet_android": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "X-",
+                "version_added": true
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "X-",
+                "version_added": true
+              }
+            ]
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
This corrects the order of support statements in the support statement array so that the prefixed variant comes after the un‑prefixed one.

review?(@Elchi3)