### PR TITLE
adding ended event data for AudioScheduledSourcenode and MediaStreamTrack

### DIFF
--- a/api/AudioScheduledSourceNode.json
+++ b/api/AudioScheduledSourceNode.json
@@ -111,7 +111,7 @@
               {
                 "version_added": "14",
                 "version_removed": "56",
-                "notes": "Before version 57, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "notes": "Before version 57, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
             "chrome_android": [
@@ -121,7 +121,7 @@
               {
                 "version_added": "18",
                 "version_removed": "56",
-                "notes": "Before version 57, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "notes": "Before version 57, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
             "edge": {
@@ -161,7 +161,7 @@
               {
                 "version_added": true,
                 "version_removed": "56",
-                "notes": "Before version 57, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "notes": "Before version 57, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ]
           },
@@ -183,7 +183,7 @@
               {
                 "version_added": "14",
                 "version_removed": "56",
-                "notes": "Before version 57, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "notes": "Before version 57, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
             "chrome_android": [
@@ -193,7 +193,7 @@
               {
                 "version_added": "18",
                 "version_removed": "56",
-                "notes": "Before version 57, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "notes": "Before version 57, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
             "edge": {
@@ -233,7 +233,7 @@
               {
                 "version_added": true,
                 "version_removed": "56",
-                "notes": "Before version 57, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "notes": "Before version 57, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ]
           },
@@ -255,7 +255,7 @@
               {
                 "version_added": "14",
                 "version_removed": "56",
-                "notes": "Before version 57, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "notes": "Before version 57, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
             "chrome_android": [
@@ -265,7 +265,7 @@
               {
                 "version_added": "18",
                 "version_removed": "56",
-                "notes": "Before version 57, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "notes": "Before version 57, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
             "edge": {
@@ -305,7 +305,7 @@
               {
                 "version_added": true,
                 "version_removed": "56",
-                "notes": "Before version 57, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "notes": "Before version 57, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ]
           },
@@ -327,7 +327,7 @@
               {
                 "version_added": "14",
                 "version_removed": "56",
-                "notes": "Before version 57, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "notes": "Before version 57, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
             "chrome_android": [
@@ -337,7 +337,7 @@
               {
                 "version_added": "18",
                 "version_removed": "56",
-                "notes": "Before version 57, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "notes": "Before version 57, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
             "edge": {
@@ -377,7 +377,7 @@
               {
                 "version_added": true,
                 "version_removed": "56",
-                "notes": "Before version 57, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "notes": "Before version 57, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ]
           },

--- a/api/AudioScheduledSourceNode.json
+++ b/api/AudioScheduledSourceNode.json
@@ -99,6 +99,79 @@
           "deprecated": false
         }
       },
+      "ended_event": {
+        "__compat": {
+          "description": "<code>ended</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioScheduledSourceNode/ended_event",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "14",
+                "version_removed": "56",
+                "notes": "Before version 57, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "18",
+                "version_removed": "56",
+                "notes": "Before version 57, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+              }
+            ],
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "25"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": true,
+                "version_removed": "56",
+                "notes": "Before version 57, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+              }
+            ]
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "onended": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioScheduledSourceNode/onended",

--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -254,6 +254,58 @@
           }
         }
       },
+      "ended_event": {
+        "__compat": {
+          "description": "<code>ended</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrack/ended_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "50"
+            },
+            "firefox_android": {
+              "version_added": "50"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getCapabilities": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrack/getCapabilities",


### PR DESCRIPTION
As per https://github.com/mdn/sprints/issues/1151

For the two event data additions, I just copied the data from their associated `on...` properties.