### PR TITLE
adding web audio api event data

### DIFF
--- a/api/OfflineAudioContext.json
+++ b/api/OfflineAudioContext.json
@@ -156,6 +156,58 @@
           }
         }
       },
+      "complete_event": {
+        "__compat": {
+          "description": "<code>complete</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/OfflineAudioContext/complete_event",
+          "support": {
+            "chrome": {
+              "version_added": "14"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "25"
+            },
+            "firefox_android": {
+              "version_added": "26"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OfflineAudioContext/length",

--- a/api/ScriptProcessorNode.json
+++ b/api/ScriptProcessorNode.json
@@ -65,6 +65,73 @@
           "deprecated": true
         }
       },
+      "audioprocess_event": {
+        "__compat": {
+          "description": "<code>audioprocess</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ScriptProcessorNode/audioprocess_event",
+          "support": {
+            "chrome": {
+              "version_added": "14",
+              "prefix": "webkit"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "25"
+            },
+            "firefox_android": {
+              "version_added": "25"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "22"
+              },
+              {
+                "version_added": "14",
+                "prefix": "webkit"
+              }
+            ],
+            "safari": {
+              "version_added": "6",
+              "prefix": "webkit"
+            },
+            "safari_ios": {
+              "version_added": "6",
+              "prefix": "webkit"
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
       "bufferSize": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ScriptProcessorNode/bufferSize",


### PR DESCRIPTION
As per https://github.com/mdn/sprints/issues/1150

I've just copied the event BCD from their associated `on...` properties.