### PR TITLE
Fix version numbers in api/AudioScheduledSourceNode

### DIFF
--- a/api/AudioScheduledSourceNode.json
+++ b/api/AudioScheduledSourceNode.json
@@ -138,12 +138,26 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "15"
-            },
-            "opera_android": {
-              "version_added": "14"
-            },
+            "opera": [
+              {
+                "version_added": "44"
+              },
+              {
+                "version_added": "15",
+                "version_removed": "44",
+                "notes": "Before version 44, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "44"
+              },
+              {
+                "version_added": "14",
+                "version_removed": "44",
+                "notes": "Before version 44, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+              }
+            ],
             "safari": {
               "version_added": null
             },
@@ -210,12 +224,26 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "15"
-            },
-            "opera_android": {
-              "version_added": "14"
-            },
+            "opera": [
+              {
+                "version_added": "44"
+              },
+              {
+                "version_added": "15",
+                "version_removed": "44",
+                "notes": "Before version 44, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "44"
+              },
+              {
+                "version_added": "14",
+                "version_removed": "44",
+                "notes": "Before version 44, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+              }
+            ],
             "safari": {
               "version_added": null
             },
@@ -282,12 +310,26 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "15"
-            },
-            "opera_android": {
-              "version_added": "14"
-            },
+            "opera": [
+              {
+                "version_added": "44"
+              },
+              {
+                "version_added": "15",
+                "version_removed": "44",
+                "notes": "Before version 44, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "44"
+              },
+              {
+                "version_added": "14",
+                "version_removed": "44",
+                "notes": "Before version 44, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+              }
+            ],
             "safari": {
               "version_added": null
             },

--- a/api/AudioScheduledSourceNode.json
+++ b/api/AudioScheduledSourceNode.json
@@ -146,7 +146,7 @@
               {
                 "version_added": "15",
                 "version_removed": "44",
-                "notes": "Before version 44, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "notes": "Before version 44, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
             "opera_android": [
@@ -156,7 +156,7 @@
               {
                 "version_added": "14",
                 "version_removed": "44",
-                "notes": "Before version 44, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "notes": "Before version 44, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
             "safari": {
@@ -232,7 +232,7 @@
               {
                 "version_added": "15",
                 "version_removed": "44",
-                "notes": "Before version 44, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "notes": "Before version 44, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
             "opera_android": [
@@ -242,7 +242,7 @@
               {
                 "version_added": "14",
                 "version_removed": "44",
-                "notes": "Before version 44, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "notes": "Before version 44, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
             "safari": {
@@ -318,7 +318,7 @@
               {
                 "version_added": "15",
                 "version_removed": "44",
-                "notes": "Before version 44, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "notes": "Before version 44, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
             "opera_android": [
@@ -328,7 +328,7 @@
               {
                 "version_added": "14",
                 "version_removed": "44",
-                "notes": "Before version 44, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "notes": "Before version 44, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
             "safari": {
@@ -404,7 +404,7 @@
               {
                 "version_added": "15",
                 "version_removed": "44",
-                "notes": "Before version 44, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "notes": "Before version 44, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
             "opera_android": [
@@ -414,7 +414,7 @@
               {
                 "version_added": "14",
                 "version_removed": "44",
-                "notes": "Before version 44, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "notes": "Before version 44, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
             "safari": {

--- a/api/AudioScheduledSourceNode.json
+++ b/api/AudioScheduledSourceNode.json
@@ -10,7 +10,7 @@
             },
             {
               "version_added": "14",
-              "version_removed": "56",
+              "version_removed": "57",
               "alternative_name": "AudioSourceNode"
             }
           ],
@@ -20,7 +20,7 @@
             },
             {
               "version_added": "18",
-              "version_removed": "56",
+              "version_removed": "57",
               "alternative_name": "AudioSourceNode"
             }
           ],
@@ -36,7 +36,7 @@
             },
             {
               "version_added": "25",
-              "version_removed": "52",
+              "version_removed": "53",
               "alternative_name": "AudioSourceNode"
             }
           ],
@@ -46,7 +46,7 @@
             },
             {
               "version_added": "25",
-              "version_removed": "52",
+              "version_removed": "53",
               "alternative_name": "AudioSourceNode"
             }
           ],
@@ -59,17 +59,17 @@
             },
             {
               "version_added": "15",
-              "version_removed": "43",
+              "version_removed": "44",
               "alternative_name": "AudioSourceNode"
             }
           ],
           "opera_android": [
             {
-              "version_added": "43"
+              "version_added": "44"
             },
             {
               "version_added": "14",
-              "version_removed": "43",
+              "version_removed": "44",
               "alternative_name": "AudioSourceNode"
             }
           ],
@@ -88,7 +88,7 @@
             },
             {
               "version_added": true,
-              "version_removed": "56",
+              "version_removed": "57",
               "alternative_name": "AudioSourceNode"
             }
           ]
@@ -109,7 +109,7 @@
               },
               {
                 "version_added": "14",
-                "version_removed": "56",
+                "version_removed": "57",
                 "notes": "Before version 57, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
@@ -119,7 +119,7 @@
               },
               {
                 "version_added": "18",
-                "version_removed": "56",
+                "version_removed": "57",
                 "notes": "Before version 57, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
@@ -159,7 +159,7 @@
               },
               {
                 "version_added": true,
-                "version_removed": "56",
+                "version_removed": "57",
                 "notes": "Before version 57, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ]
@@ -181,7 +181,7 @@
               },
               {
                 "version_added": "14",
-                "version_removed": "56",
+                "version_removed": "57",
                 "notes": "Before version 57, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
@@ -191,7 +191,7 @@
               },
               {
                 "version_added": "18",
-                "version_removed": "56",
+                "version_removed": "57",
                 "notes": "Before version 57, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
@@ -231,7 +231,7 @@
               },
               {
                 "version_added": true,
-                "version_removed": "56",
+                "version_removed": "57",
                 "notes": "Before version 57, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ]
@@ -253,7 +253,7 @@
               },
               {
                 "version_added": "14",
-                "version_removed": "56",
+                "version_removed": "57",
                 "notes": "Before version 57, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
@@ -263,7 +263,7 @@
               },
               {
                 "version_added": "18",
-                "version_removed": "56",
+                "version_removed": "57",
                 "notes": "Before version 57, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
@@ -303,7 +303,7 @@
               },
               {
                 "version_added": true,
-                "version_removed": "56",
+                "version_removed": "57",
                 "notes": "Before version 57, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ]

--- a/api/AudioScheduledSourceNode.json
+++ b/api/AudioScheduledSourceNode.json
@@ -110,7 +110,7 @@
               },
               {
                 "version_added": "14",
-                "version_removed": "56",
+                "version_removed": "57",
                 "notes": "Before version 57, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
@@ -120,7 +120,7 @@
               },
               {
                 "version_added": "18",
-                "version_removed": "56",
+                "version_removed": "57",
                 "notes": "Before version 57, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
@@ -139,12 +139,26 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "15"
-            },
-            "opera_android": {
-              "version_added": "14"
-            },
+            "opera": [
+              {
+                "version_added": "44"
+              },
+              {
+                "version_added": "15",
+                "version_removed": "44",
+                "notes": "Before version 44, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "44"
+              },
+              {
+                "version_added": "14",
+                "version_removed": "44",
+                "notes": "Before version 44, this event was implemented on  AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+              }
+            ],
             "safari": {
               "version_added": null
             },
@@ -160,7 +174,7 @@
               },
               {
                 "version_added": true,
-                "version_removed": "56",
+                "version_removed": "57",
                 "notes": "Before version 57, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ]


### PR DESCRIPTION
I noticed that the version numbers in api/AudioScheduledSourceNode were a little off.  There was a `version_removed` set to "53" with notes, but then a `version_added` set to "54" with no notes, meaning there seemed to be a single-version gap in between.  This didn't make sense.  Furthermore, it appeared that the Opera data didn't mirror the Chrome data well enough.  This PR fixes both of those issues.