### PR TITLE
Remove support for File.lastModified in IE/Edge

### DIFF
--- a/api/File.json
+++ b/api/File.json
@@ -127,10 +127,10 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "18"
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": false
             },
             "firefox": {
               "version_added": "15"
@@ -139,7 +139,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
               "version_added": "16"


### PR DESCRIPTION
Fixes #3113.  `File.lastModified` was incorrectly marked as supported in IE and Edge, however they still use the deprecated `File.lastModifiedDate` property.