### PR TITLE
Set api.window.print to false for Firefox Android

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -6632,7 +6632,8 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1247609'>bug 1247609</a>."
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
Fixes #3131.  See issue for more details.