### PR TITLE
Update CSS IE data

### DIFF
--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -184,7 +184,7 @@
                 "version_added": "19"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -229,7 +229,7 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -437,7 +437,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": null
+                "version_added": "9"
               },
               "opera": {
                 "version_added": null
@@ -489,7 +489,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": null
+                "version_added": "9"
               },
               "opera": {
                 "version_added": null
@@ -541,7 +541,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": null
+                "version_added": "9"
               },
               "opera": {
                 "version_added": null
@@ -595,7 +595,7 @@
                 "notes": "Firefox 47 and later support <code>display-mode</code> values <code>fullscreen</code> and <code>browser</code>. Firefox 57 added support for <code>minimal-ui</code> and <code>standalone</code> values."
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -1059,7 +1059,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": null
+                "version_added": "9"
               },
               "opera": {
                 "version_added": true
@@ -1215,7 +1215,7 @@
                 "version_added": "64"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "28"
@@ -1369,7 +1369,7 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
+                "version_added": "9"
               },
               "opera": {
                 "version_added": true
@@ -1685,7 +1685,7 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -1737,7 +1737,7 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -2091,7 +2091,7 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": true
@@ -2143,7 +2143,7 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": true

--- a/css/at-rules/page.json
+++ b/css/at-rules/page.json
@@ -76,7 +76,7 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -128,7 +128,7 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -180,7 +180,7 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null

--- a/css/at-rules/viewport.json
+++ b/css/at-rules/viewport.json
@@ -679,7 +679,7 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -388,7 +388,7 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "44"

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -173,7 +173,7 @@
                   "version_added": "45"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "opera": {
                   "version_added": null
@@ -224,7 +224,7 @@
                   "version_added": "52"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "opera": {
                   "version_added": null
@@ -275,7 +275,7 @@
                   "version_added": "45"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "opera": {
                   "version_added": null
@@ -326,7 +326,7 @@
                   "version_added": "52"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "opera": {
                   "version_added": null
@@ -377,7 +377,7 @@
                   "version_added": "52"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "opera": {
                   "version_added": null

--- a/css/properties/animation-timing-function.json
+++ b/css/properties/animation-timing-function.json
@@ -194,7 +194,7 @@
                 "version_added": "65"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null

--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -354,7 +354,7 @@
                 "notes": "See <a href='https://bugzil.la/1107646'>bug 1107646</a>."
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "prefix": "-webkit-",

--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -161,7 +161,7 @@
                 "version_added": "15"
               },
               "ie": {
-                "version_added": null
+                "version_added": "11"
               },
               "opera": {
                 "version_added": null
@@ -194,7 +194,7 @@
                 "version_added": "15"
               },
               "ie": {
-                "version_added": null
+                "version_added": "11"
               },
               "opera": {
                 "version_added": null
@@ -233,7 +233,7 @@
                 "version_added": "29"
               },
               "ie": {
-                "version_added": true
+                "version_added": "10"
               },
               "opera": {
                 "version_added": true

--- a/css/properties/border-radius.json
+++ b/css/properties/border-radius.json
@@ -122,7 +122,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "9"
               },
               "opera": {
                 "version_added": true
@@ -168,7 +168,7 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
+                "version_added": "9"
               },
               "opera": {
                 "version_added": true
@@ -215,7 +215,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "9"
               },
               "opera": {
                 "version_added": "11.5",

--- a/css/properties/box-lines.json
+++ b/css/properties/box-lines.json
@@ -28,7 +28,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true,

--- a/css/properties/color.json
+++ b/css/properties/color.json
@@ -24,7 +24,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera": {
               "version_added": true
@@ -504,7 +504,7 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "39",
@@ -561,7 +561,7 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "52"
@@ -612,7 +612,7 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "53"

--- a/css/properties/column-count.json
+++ b/css/properties/column-count.json
@@ -120,7 +120,7 @@
                 "version_added": "37"
               },
               "ie": {
-                "version_added": true
+                "version_added": "10"
               },
               "opera": {
                 "version_added": true

--- a/css/properties/column-fill.json
+++ b/css/properties/column-fill.json
@@ -36,7 +36,7 @@
               }
             ],
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": null

--- a/css/properties/column-width.json
+++ b/css/properties/column-width.json
@@ -159,7 +159,7 @@
                 "version_added": "37"
               },
               "ie": {
-                "version_added": true
+                "version_added": "10"
               },
               "opera": {
                 "version_added": true

--- a/css/properties/columns.json
+++ b/css/properties/columns.json
@@ -121,7 +121,7 @@
                 "version_added": "37"
               },
               "ie": {
-                "version_added": true
+                "version_added": "10"
               },
               "opera": {
                 "version_added": true

--- a/css/properties/contain.json
+++ b/css/properties/contain.json
@@ -40,7 +40,7 @@
               "notes": "See <a href='https://bugzil.la/1150081'>bug 1150081</a> for the overall implementation status."
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "40"

--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -74,7 +74,7 @@
                 "version_added": "63"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": true

--- a/css/properties/line-height-step.json
+++ b/css/properties/line-height-step.json
@@ -36,7 +36,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "47",

--- a/css/properties/mask-origin.json
+++ b/css/properties/mask-origin.json
@@ -26,7 +26,7 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "prefix": "-webkit-",

--- a/css/properties/mask-position.json
+++ b/css/properties/mask-position.json
@@ -25,7 +25,7 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null

--- a/css/properties/mask-repeat.json
+++ b/css/properties/mask-repeat.json
@@ -25,7 +25,7 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null

--- a/css/properties/mask-size.json
+++ b/css/properties/mask-size.json
@@ -24,7 +24,7 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null

--- a/css/properties/mask-type.json
+++ b/css/properties/mask-type.json
@@ -50,7 +50,7 @@
               }
             ],
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null

--- a/css/properties/offset-distance.json
+++ b/css/properties/offset-distance.json
@@ -36,7 +36,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null

--- a/css/properties/offset-path.json
+++ b/css/properties/offset-path.json
@@ -54,7 +54,7 @@
               ]
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": [
               {
@@ -125,7 +125,7 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "51"

--- a/css/properties/offset-rotate.json
+++ b/css/properties/offset-rotate.json
@@ -44,7 +44,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null

--- a/css/properties/offset.json
+++ b/css/properties/offset.json
@@ -36,7 +36,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null

--- a/css/properties/place-items.json
+++ b/css/properties/place-items.json
@@ -26,7 +26,7 @@
                 "version_added": "45"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -78,7 +78,7 @@
                 "version_added": "45"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null

--- a/css/properties/place-self.json
+++ b/css/properties/place-self.json
@@ -26,7 +26,7 @@
                 "version_added": "45"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -78,7 +78,7 @@
                 "version_added": "45"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null

--- a/css/selectors/-moz-focusring.json
+++ b/css/selectors/-moz-focusring.json
@@ -25,7 +25,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null

--- a/css/selectors/-ms-fill-lower.json
+++ b/css/selectors/-ms-fill-lower.json
@@ -25,7 +25,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": false

--- a/css/selectors/-ms-fill-upper.json
+++ b/css/selectors/-ms-fill-upper.json
@@ -25,7 +25,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": false

--- a/css/selectors/-webkit-autofill.json
+++ b/css/selectors/-webkit-autofill.json
@@ -25,7 +25,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null

--- a/css/selectors/-webkit-inner-spin-button.json
+++ b/css/selectors/-webkit-inner-spin-button.json
@@ -25,7 +25,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true

--- a/css/selectors/-webkit-outer-spin-button.json
+++ b/css/selectors/-webkit-outer-spin-button.json
@@ -25,7 +25,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true

--- a/css/selectors/-webkit-search-cancel-button.json
+++ b/css/selectors/-webkit-search-cancel-button.json
@@ -25,7 +25,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null

--- a/css/selectors/-webkit-search-results-button.json
+++ b/css/selectors/-webkit-search-results-button.json
@@ -25,7 +25,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null

--- a/css/selectors/class.json
+++ b/css/selectors/class.json
@@ -25,7 +25,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera": {
               "version_added": true

--- a/css/selectors/descendant.json
+++ b/css/selectors/descendant.json
@@ -37,7 +37,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera": {
               "version_added": true

--- a/css/selectors/id.json
+++ b/css/selectors/id.json
@@ -25,7 +25,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera": {
               "version_added": true

--- a/css/selectors/type.json
+++ b/css/selectors/type.json
@@ -25,7 +25,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera": {
               "version_added": true

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -1852,7 +1852,7 @@
                 "notes": "See <a href='https://bugzil.la/1107646'>bug 1107646</a>."
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "prefix": "-webkit-",

--- a/css/types/resolution.json
+++ b/css/types/resolution.json
@@ -140,7 +140,7 @@
                 "version_added": "62"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null


### PR DESCRIPTION
First part for https://github.com/mdn/browser-compat-data/issues/3801

1. `css.at.rules.keyframes.ignore_important_declarations`: changed to false (manual testing)
2. `css.at-rules.media.calc`: changed to false (manual testing)
3. `css.at-rules.media.device-aspect-ratio`: changed to 9 (part of initial media query support)
4. `css.at-rules.media.device-height`: changed to 9 (part of initial media query support)
5. `css.at-rules.media.device-width`: changed to 9 (part of initial media query support)
6. `css.at-rules.media.display-mode`: changed to false (manual testing)
7. `css.at-rules.media.orientation`: changed to 9 (part of initial media query support)
8. `css.at-rules.media.pointer`: changed to false (manual testing)
9. `css.at-rules.media.resolution`: changed to 9 (part of initial media query support)
10. `css.at-rules.media.-moz-device-pixel-ratio`: changed to false (moz specific only)
11. `css.at-rules.media.-webkit-animation`: changed to false (webkit specific only)
12. `css.at-rules.media.-webkit-transform-3d`: changed to false (webkit specific only)
13. `css.at-rules.media.-webkit-transition`: changed to false (webkit specific only)
14. `css.at-rules.page.bleed`: changed to false (manual testing)
15. `css.at-rules.page.marks`: changed to false (manual testing)
16. `css.at-rules.page.size`: changed to false (manual testing)
17. `css.at-rules.viewport.viewport-fit`: changed to false (manual testing)
18. `css.properties.align-items.grid_context`: changed to false (too new for IE)
19. `css.properties.align-items.flex_context.start_end`: changed to false (too new for IE)
20. `css.properties.align-self.flex_context.left_right`: changed to false (too new for IE)
21. `css.properties.align-self.flex_context.baseline`: changed to false (too new for IE)
22. `css.properties.align-self.flex_context.first_last_baseline`: changed to false (too new for IE)
23. `css.properties.align-self.flex_context.stretch`: changed to false (too new for IE)
24. `css.properties.animation-timing-function.jump`: changed to false (too new for IE)
25. `css.properties.background-image.image-set`: changed to false (manual testing)
26. `css.properties.border-image.optional_border_image_slice`: changed to 11 (manual testing)
27. `css.properties.border-image.fill_keyword`: changed to 11 (manual testing)
28. `css.properties.border-image.gradient`: changed to 10 (manual testing, landed together with rest of gradient support)
29. `css.properties.border-radius.elliptical_borders`: changed to 9 (manual testing)
30. `css.properties.border-radius.4_values_for_4_corners`: changed to 9 (manual testing)
31. `css.properties.border-radius.percentages`: changed to 9 (manual testing)
32. `css.properties.properties.box-lines`: changed to false (safari only)
33. `css.properties.properties.color`: changed to 3 (IE 3 first had CSS support, this is a basic feature)
34. `css.properties.color.alpha_hexadecimal_notation`: changed to false (too new for IE)
35. `css.properties.color.space_separated_functional_notation`: changed to false (too new for IE)
36. `css.properties.color.floats_in_rgb_rgba`: changed to false (too new for IE)
37. `css.properties.column-count.on_display_table_caption`: changed to 10 (manual testing, landed together with initial column support)
38. `css.properties.column-fill`: changed to 10 manual testing, landed together with initial column support)
39. `css.properties.column-width.on_display_table_caption`: changed to 10 manual testing, landed together with initial column support)
40. `css.properties.columns.on_display_table_caption`: changed to 10 manual testing, landed together with initial column support)
41. `css.properties.contain`: changed to false (too new for IE)
42. `css.properties.content.element_replacement`: changed to false (manual testing=
43. `css.properties.line-height-step`: changed to false (too new for IE)
44. `css.properties.mask-origin`: changed to false (too new for IE)
45. `css.properties.mask-position`: changed to false (too new for IE)
46. `css.properties.mask-repeat`: changed to false (too new for IE)
47. `css.properties.mask-size`: changed to false (too new for IE)
48. `css.properties.mask-type`: changed to false (too new for IE)
49. `css.properties.offset-distance`: changed to false (too new for IE)
50. `css.properties.offset-path`: changed to false (too new for IE)
51. `css.properties.offset-path.path-support`: changed to false (too new for IE)
52. `css.properties.offset-rotate`: changed to false (too new for IE)
53. `css.properties.offset`: changed to false (too new for IE)
54. `css.properties.place-items.flex_context`: changed to false (too new for IE)
55. `css.properties.place-items.grid_context`: changed to false (too new for IE)
56. `css.properties.place-self.flex_context`: changed to false (too new for IE)
57. `css.properties.place-self.grid_context`: changed to false (too new for IE)
58. `css.selectors.-moz-focusring`: changed to false (moz specific)
59. `css.selectors.-ms-fill-lower`: changed to 10 (input type=ranges supported in IE 10)
60. `css.selectors.-ms-fill-upper`: changed to 10 (input type=ranges supported in IE 10)
61. `css.selectors.-webkit-autofill`: changed to false (webkit specific)
62. `css.selectors.-webkit-inner-spin-button`: changed to false (webkit specific)
63. `css.selectors.-webkit-outer-spin-button`: changed to false (webkit specific)
64. `css.selectors.-webkit-search-cancel-button`: changed to false (webkit specific)
65. `css.selectors.-webkit-search-results-button`: changed to false (webkit specific)
66. `css.selectors.class`: changed to 3 (IE 3 first had CSS support, this is a basic feature)
67. `css.selectors.descendant`: changed to 3 (IE 3 first had CSS support, this is a basic feature)
68. `css.selectors.id`: changed to 3 (IE 3 first had CSS support, this is a basic feature)
69. `css.selectors.type`: changed to 3 (IE 3 first had CSS support, this is a basic feature)
70. `css.types.image.image-set`: changed to false (manual testing)
71. `css.types.resolution.x`: changed to false (manual testing)