### PR TITLE
[Chrome, Opera]Improve AudioScheduledSourceNode

### DIFF
--- a/api/AudioScheduledSourceNode.json
+++ b/api/AudioScheduledSourceNode.json
@@ -104,24 +104,12 @@
           "description": "<code>ended</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioScheduledSourceNode/ended_event",
           "support": {
-            "chrome": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "14",
-                "version_removed": "58"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "18",
-                "version_removed": "58"
-              }
-            ],
+            "chrome": {
+              "version_added": "14"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": null
             },
@@ -137,24 +125,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "44"
-              },
-              {
-                "version_added": "15",
-                "version_removed": "45"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "44"
-              },
-              {
-                "version_added": "14",
-                "version_removed": "45"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": null
             },
@@ -164,15 +140,9 @@
             "samsunginternet_android": {
               "version_added": true
             },
-            "webview_android": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": true,
-                "version_removed": "58"
-              }
-            ]
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -185,24 +155,12 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioScheduledSourceNode/onended",
           "support": {
-            "chrome": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "14",
-                "version_removed": "58"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "18",
-                "version_removed": "58"
-              }
-            ],
+            "chrome": {
+              "version_added": "14"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": null
             },
@@ -218,24 +176,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "44"
-              },
-              {
-                "version_added": "15",
-                "version_removed": "45"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "44"
-              },
-              {
-                "version_added": "14",
-                "version_removed": "45"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": null
             },
@@ -245,15 +191,9 @@
             "samsunginternet_android": {
               "version_added": true
             },
-            "webview_android": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": true,
-                "version_removed": "58"
-              }
-            ]
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -266,24 +206,12 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioScheduledSourceNode/start",
           "support": {
-            "chrome": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "14",
-                "version_removed": "58"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "18",
-                "version_removed": "58"
-              }
-            ],
+            "chrome": {
+              "version_added": "14"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": null
             },
@@ -299,24 +227,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "44"
-              },
-              {
-                "version_added": "15",
-                "version_removed": "45"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "44"
-              },
-              {
-                "version_added": "14",
-                "version_removed": "45"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": null
             },
@@ -326,15 +242,9 @@
             "samsunginternet_android": {
               "version_added": true
             },
-            "webview_android": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": true,
-                "version_removed": "58"
-              }
-            ]
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -347,24 +257,12 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioScheduledSourceNode/stop",
           "support": {
-            "chrome": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "14",
-                "version_removed": "58"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "18",
-                "version_removed": "58"
-              }
-            ],
+            "chrome": {
+              "version_added": "14"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": null
             },
@@ -380,24 +278,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "44"
-              },
-              {
-                "version_added": "15",
-                "version_removed": "45"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "44"
-              },
-              {
-                "version_added": "14",
-                "version_removed": "45"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": null
             },
@@ -407,15 +293,9 @@
             "samsunginternet_android": {
               "version_added": true
             },
-            "webview_android": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": true,
-                "version_removed": "58"
-              }
-            ]
+            "webview_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,

--- a/api/AudioScheduledSourceNode.json
+++ b/api/AudioScheduledSourceNode.json
@@ -110,8 +110,7 @@
               },
               {
                 "version_added": "14",
-                "version_removed": "58",
-                "notes": "Before version 58, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "58"
               }
             ],
             "chrome_android": [
@@ -120,8 +119,7 @@
               },
               {
                 "version_added": "18",
-                "version_removed": "58",
-                "notes": "Before version 58, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "58"
               }
             ],
             "edge": {
@@ -145,8 +143,7 @@
               },
               {
                 "version_added": "15",
-                "version_removed": "44",
-                "notes": "Before version 44, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "45"
               }
             ],
             "opera_android": [
@@ -155,8 +152,7 @@
               },
               {
                 "version_added": "14",
-                "version_removed": "44",
-                "notes": "Before version 44, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "45"
               }
             ],
             "safari": {
@@ -174,8 +170,7 @@
               },
               {
                 "version_added": true,
-                "version_removed": "58",
-                "notes": "Before version 58, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "58"
               }
             ]
           },
@@ -196,8 +191,7 @@
               },
               {
                 "version_added": "14",
-                "version_removed": "58",
-                "notes": "Before version 58, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "58"
               }
             ],
             "chrome_android": [
@@ -206,8 +200,7 @@
               },
               {
                 "version_added": "18",
-                "version_removed": "58",
-                "notes": "Before version 58, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "58"
               }
             ],
             "edge": {
@@ -231,8 +224,7 @@
               },
               {
                 "version_added": "15",
-                "version_removed": "44",
-                "notes": "Before version 44, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "45"
               }
             ],
             "opera_android": [
@@ -241,8 +233,7 @@
               },
               {
                 "version_added": "14",
-                "version_removed": "44",
-                "notes": "Before version 44, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "45"
               }
             ],
             "safari": {
@@ -260,8 +251,7 @@
               },
               {
                 "version_added": true,
-                "version_removed": "58",
-                "notes": "Before version 58, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "58"
               }
             ]
           },
@@ -282,8 +272,7 @@
               },
               {
                 "version_added": "14",
-                "version_removed": "58",
-                "notes": "Before version 58, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "58"
               }
             ],
             "chrome_android": [
@@ -292,8 +281,7 @@
               },
               {
                 "version_added": "18",
-                "version_removed": "58",
-                "notes": "Before version 58, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "58"
               }
             ],
             "edge": {
@@ -317,8 +305,7 @@
               },
               {
                 "version_added": "15",
-                "version_removed": "44",
-                "notes": "Before version 44, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "45"
               }
             ],
             "opera_android": [
@@ -327,8 +314,7 @@
               },
               {
                 "version_added": "14",
-                "version_removed": "44",
-                "notes": "Before version 44, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "45"
               }
             ],
             "safari": {
@@ -346,8 +332,7 @@
               },
               {
                 "version_added": true,
-                "version_removed": "58",
-                "notes": "Before version 58, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "58"
               }
             ]
           },
@@ -368,8 +353,7 @@
               },
               {
                 "version_added": "14",
-                "version_removed": "58",
-                "notes": "Before version 58, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "58"
               }
             ],
             "chrome_android": [
@@ -378,8 +362,7 @@
               },
               {
                 "version_added": "18",
-                "version_removed": "58",
-                "notes": "Before version 58, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "58"
               }
             ],
             "edge": {
@@ -403,8 +386,7 @@
               },
               {
                 "version_added": "15",
-                "version_removed": "44",
-                "notes": "Before version 44, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "45"
               }
             ],
             "opera_android": [
@@ -413,8 +395,7 @@
               },
               {
                 "version_added": "14",
-                "version_removed": "44",
-                "notes": "Before version 44, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "45"
               }
             ],
             "safari": {
@@ -432,8 +413,7 @@
               },
               {
                 "version_added": true,
-                "version_removed": "58",
-                "notes": "Before version 58, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "58"
               }
             ]
           },

--- a/api/AudioScheduledSourceNode.json
+++ b/api/AudioScheduledSourceNode.json
@@ -10,7 +10,7 @@
             },
             {
               "version_added": "14",
-              "version_removed": "57",
+              "version_removed": "58",
               "alternative_name": "AudioSourceNode"
             }
           ],
@@ -20,7 +20,7 @@
             },
             {
               "version_added": "18",
-              "version_removed": "57",
+              "version_removed": "58",
               "alternative_name": "AudioSourceNode"
             }
           ],
@@ -88,7 +88,7 @@
             },
             {
               "version_added": true,
-              "version_removed": "57",
+              "version_removed": "58",
               "alternative_name": "AudioSourceNode"
             }
           ]
@@ -110,8 +110,8 @@
               },
               {
                 "version_added": "14",
-                "version_removed": "57",
-                "notes": "Before version 57, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "58",
+                "notes": "Before version 58, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
             "chrome_android": [
@@ -120,8 +120,8 @@
               },
               {
                 "version_added": "18",
-                "version_removed": "57",
-                "notes": "Before version 57, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "58",
+                "notes": "Before version 58, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
             "edge": {
@@ -174,8 +174,8 @@
               },
               {
                 "version_added": true,
-                "version_removed": "57",
-                "notes": "Before version 57, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "58",
+                "notes": "Before version 58, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ]
           },
@@ -196,8 +196,8 @@
               },
               {
                 "version_added": "14",
-                "version_removed": "57",
-                "notes": "Before version 57, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "58",
+                "notes": "Before version 58, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
             "chrome_android": [
@@ -206,8 +206,8 @@
               },
               {
                 "version_added": "18",
-                "version_removed": "57",
-                "notes": "Before version 57, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "58",
+                "notes": "Before version 58, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
             "edge": {
@@ -260,8 +260,8 @@
               },
               {
                 "version_added": true,
-                "version_removed": "57",
-                "notes": "Before version 57, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "58",
+                "notes": "Before version 58, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ]
           },
@@ -282,8 +282,8 @@
               },
               {
                 "version_added": "14",
-                "version_removed": "57",
-                "notes": "Before version 57, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "58",
+                "notes": "Before version 58, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
             "chrome_android": [
@@ -292,8 +292,8 @@
               },
               {
                 "version_added": "18",
-                "version_removed": "57",
-                "notes": "Before version 57, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "58",
+                "notes": "Before version 58, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
             "edge": {
@@ -346,8 +346,8 @@
               },
               {
                 "version_added": true,
-                "version_removed": "57",
-                "notes": "Before version 57, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "58",
+                "notes": "Before version 58, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ]
           },
@@ -368,8 +368,8 @@
               },
               {
                 "version_added": "14",
-                "version_removed": "57",
-                "notes": "Before version 57, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "58",
+                "notes": "Before version 58, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
             "chrome_android": [
@@ -378,8 +378,8 @@
               },
               {
                 "version_added": "18",
-                "version_removed": "57",
-                "notes": "Before version 57, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "58",
+                "notes": "Before version 58, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ],
             "edge": {
@@ -432,8 +432,8 @@
               },
               {
                 "version_added": true,
-                "version_removed": "57",
-                "notes": "Before version 57, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
+                "version_removed": "58",
+                "notes": "Before version 58, this event was implemented on AudioBufferSourceNode, OscillatorNode, and ConstantSourceNode, which are now children of this class."
               }
             ]
           },


### PR DESCRIPTION
Improves on #3894 

Removal of `AudioSourceNode` [occurred in 58, not 56](https://storage.googleapis.com/chromium-find-releases-static/717.html#717012126c57dfe596b6562f9ad17f2a7e537a5b)

Regarding removing this: “Before version 57, this event was implemented on `AudioBufferSourceNode`, `OscillatorNode`, and `ConstantSourceNode`, which are now children of this class.”

This isn't helpful. From a web developer’s point of view, from the point of view of an actual script, these interfaces appear identical both before and after the change.

For what it’s worth, I’ve confirmed that this change [actually was in 57](https://storage.googleapis.com/chromium-find-releases-static/009.html#00971f38908388728f49cd5127b9c6c6761d035f)

