### PR TITLE
test(style): Enforce HTTPS for all bug tracker domains

### DIFF
--- a/api/NavigatorOnLine.json
+++ b/api/NavigatorOnLine.json
@@ -101,7 +101,7 @@
           "support": {
             "chrome": {
               "version_added": true,
-              "notes": "Earlier versions of Chrome incorrectly return true when a tab is first opened, but it starts reporting the correct connectivity status after the first network event. Windows: 11, Mac: 14, Chrome OS: 13, Linux: Always returns <code>true</code>. For history, see <a href='http://crbug.com/7469'>crbug.com/7469</a>."
+              "notes": "Earlier versions of Chrome incorrectly return true when a tab is first opened, but it starts reporting the correct connectivity status after the first network event. Windows: 11, Mac: 14, Chrome OS: 13, Linux: Always returns <code>true</code>. For history, see <a href='https://crbug.com/7469'>crbug.com/7469</a>."
             },
             "chrome_android": {
               "version_added": true

--- a/css/properties/text-rendering.json
+++ b/css/properties/text-rendering.json
@@ -9,7 +9,7 @@
               "version_added": "4",
               "notes": [
                 "This property is only supported on Windows and Linux.",
-                "Initial versions had bugs on Windows and Linux that broke <a href='http://crbug.com/114719'>font substitition</a>, <a href='http://crbug.com/51973'>small-caps</a>, <a href='http://crbug.com/55458'>letter-spacing</a> or caused <a href='http://crbug.com/149548'>text to overlap</a>."
+                "Initial versions had bugs on Windows and Linux that broke <a href='https://crbug.com/114719'>font substitition</a>, <a href='https://crbug.com/51973'>small-caps</a>, <a href='https://crbug.com/55458'>letter-spacing</a> or caused <a href='https://crbug.com/149548'>text to overlap</a>."
               ]
             },
             "chrome_android": {

--- a/test/test-style.js
+++ b/test/test-style.js
@@ -101,19 +101,27 @@ function testStyle(filename) {
 
   {
     // Bugzil.la links should use HTTPS and have "bug ###" as link text ("Bug ###" only at the begin of notes/sentences).
-    const regexp = new RegExp("(....)<a href='(https?)://bugzil.la/(\\d+)'>(.*?)</a>", 'g');
+    const regexp = new RegExp(String.raw`(....)<a href='(https?)://(bugzil\.la|crbug\.com|webkit\.org/b)/(\d+)'>(.*?)</a>`, 'g');
+    /** @type {RegExpExecArray} */
     let match;
     do {
       match = regexp.exec(actual);
       if (match) {
-        const before = match[1];
-        const protocol = match[2];
-        const bugId = match[3];
-        const linkText = match[4];
+        const [,
+          before,
+          protocol,
+          domain,
+          bugId,
+          linkText,
+        ] = match;
 
         if (protocol !== 'https') {
           hasErrors = true;
-          console.error(`\x1b[33m  Style – Use HTTPS URL (http://bugzil.la/${bugId} → https://bugzil.la/${bugId}).\x1b[0m`);
+          console.error(`\x1b[33m  Style – Use HTTPS URL (http://${domain}/${bugId} → https://${domain}/${bugId}).\x1b[0m`);
+        }
+
+        if (domain !== 'bugzil.la') {
+          continue;
         }
 
         if (/^bug $/.test(before)) {


### PR DESCRIPTION
This enforces that all&nbsp;known bug&nbsp;tracker domains use&nbsp;HTTPS.

review?(@Elchi3, @vinyldarkscratch)