### PR TITLE
adding activate and install event data to ServiceWorkerGlobalScope

### DIFF
--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -51,6 +51,59 @@
           "deprecated": false
         }
       },
+      "activate_event": {
+        "__compat": {
+          "description": "<code>activate</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/activate_event",
+          "support": {
+            "chrome": {
+              "version_added": "40"
+            },
+            "chrome_android": {
+              "version_added": "40"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "44",
+              "notes": "Service workers (and Push) have been disabled in the Firefox 45 and 52 Extended Support Releases (ESR)."
+            },
+            "firefox_android": {
+              "version_added": "44"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "24"
+            },
+            "opera_android": {
+              "version_added": "24"
+            },
+            "safari": {
+              "version_added": "11.1"
+            },
+            "safari_ios": {
+              "version_added": "11.1"
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "40"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "clients": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/clients",
@@ -106,6 +159,59 @@
       "caches": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/caches",
+          "support": {
+            "chrome": {
+              "version_added": "40"
+            },
+            "chrome_android": {
+              "version_added": "40"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "44",
+              "notes": "Service workers (and Push) have been disabled in the Firefox 45 and 52 Extended Support Releases (ESR)."
+            },
+            "firefox_android": {
+              "version_added": "44"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "24"
+            },
+            "opera_android": {
+              "version_added": "24"
+            },
+            "safari": {
+              "version_added": "11.1"
+            },
+            "safari_ios": {
+              "version_added": "11.1"
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "40"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "install_event": {
+        "__compat": {
+          "description": "<code>install</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/install_event",
           "support": {
             "chrome": {
               "version_added": "40"


### PR DESCRIPTION
I ended up filing this in response to https://github.com/mdn/sprints/issues/1281. As well as fixing the links, I created new pages for the active and install events, and this is the data to go along with it.

I just copied the data from the `on...` equivalents.