### PR TITLE
Update compat data for input type="color" list attribute

### DIFF
--- a/html/elements/input/color.json
+++ b/html/elements/input/color.json
@@ -84,10 +84,10 @@
                   "version_added": null
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": "12.1"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "12.2"
                 },
                 "webview_android": {
                   "version_added": null
@@ -136,7 +136,7 @@
                   "version_added": null
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": null
                 },
                 "webview_android": {
                   "version_added": null


### PR DESCRIPTION
## Changes
* Adds supported version data for the `list` attribute of html `input` type `color` for Safari and iOS Safari.
* Changed `safari_ios` version data for `autocomplete` attribute to `null` since I cannot verify or find any information on whether it is supported or not.

## Supporting Information
Here are screenshots showing the html and the opened color picker. **Note that the color picker includes a row at the top containing the colors from the `list`.**

### Safari 12.1
<img width="1254" alt="Screen Shot 2019-04-16 at 2 50 36 PM" src="https://user-images.githubusercontent.com/11726925/56240010-faf08a00-6057-11e9-9c4e-8a0da1d44e64.png">

### iOS Safari 12.2
![IMG_2442](https://user-images.githubusercontent.com/11726925/56240035-0b086980-6058-11e9-9205-cee11cbc170f.PNG)
