### PR TITLE
Update Opera versions of Date.toLocaleString.*

### DIFF
--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -2894,7 +2894,7 @@
                   "version_added": "15"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "safari": {
                   "version_added": "10"
@@ -2947,7 +2947,7 @@
                   "version_added": "15"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "14"
                 },
                 "safari": {
                   "version_added": "10"
@@ -2998,7 +2998,7 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "15"
                 },
                 "opera_android": {
                   "version_added": null


### PR DESCRIPTION
Fixes #2039 by mirroring the Chrome Android values in Date.toLocaleString.* onto Opera Android, and Chrome Desktop onto Opera Desktop where needed.