### PR TITLE
added devicemotion event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -1285,6 +1285,58 @@
           }
         }
       },
+      "devicemotion_event": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/devicemotion_event",
+          "description": "<code>devicemotion_event</code> event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "6"
+            },
+            "firefox_android": {
+              "version_added": "6"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": "4.2"
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "deviceorientation_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/deviceorientation_event",

--- a/api/Window.json
+++ b/api/Window.json
@@ -1288,7 +1288,7 @@
       "devicemotion_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/devicemotion_event",
-          "description": "<code>devicemotion_event</code> event",
+          "description": "<code>devicemotion</code> event",
           "support": {
             "chrome": {
               "version_added": true


### PR DESCRIPTION
For https://developer.mozilla.org/en-US/docs/Web/API/Window/devicemotion_event
data gleaned from deviceMotionEvent.json
which appears on https://developer.mozilla.org/en-US/docs/Web/API/DeviceMotionEvent
