### PR TITLE
added input event to HTMLElement

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1135,6 +1135,64 @@
           }
         }
       },
+      "input": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/Input_event",
+          "description": "<code>input</code> event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "not supported on <code>select</code>"
+            },
+            "edge_mobile": {
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "not supported on <code>select</code>"
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": "9",
+              "partial_implementation": true,
+              "notes": "<code>input</code> of type <code>text</code> and <code>password</code> only"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "inputMode": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/inputMode",

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1165,7 +1165,7 @@
             "ie": {
               "version_added": "9",
               "partial_implementation": true,
-              "notes": "<code>input</code> of type <code>text</code> and <code>password</code> only"
+              "notes": "<code>input</code> of type <code>text</code> and <code>password</code> only. Bug in IE10/11: Input event fires on placeholder attribute changes"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
Added the input event for HTMLElement
Note the old BCD info on https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event was outdated. I tested on modern browsers.
mdn/sprints#1284