### PR TITLE
updates to individual transform properties

### DIFF
--- a/css/properties/rotate.json
+++ b/css/properties/rotate.json
@@ -6,10 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/rotate",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": false
@@ -56,7 +56,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": true
+              "version_added": false
             }
           },
           "status": {
@@ -70,10 +70,10 @@
             "description": "x, y, or z axis name plus angle value",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": false
               },
               "edge": {
                 "version_added": false
@@ -120,7 +120,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": true
+                "version_added": false
               }
             },
             "status": {

--- a/css/properties/scale.json
+++ b/css/properties/scale.json
@@ -6,10 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scale",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": false
@@ -53,10 +53,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
-              "version_added": true
+              "version_added": false
             }
           },
           "status": {

--- a/css/properties/translate.json
+++ b/css/properties/translate.json
@@ -6,10 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/translate",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": false
@@ -53,10 +53,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
-              "version_added": true
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
Individual CSS transform properties are only supported in FF and only behind a flag.
They include:
   * rotate
   * scale
   * translate
The do NOT include:
   * skew

This was noticed in https://github.com/mdn/sprints/issues/1131
Chrome/Blink not yet supporting https://www.chromestatus.com/features/5705698193178624
which lists Edge as supporting, but edge documentation does not indicate support.