### PR TITLE
[Firefox] Set partial implementation for grid-auto-columns/rows

### DIFF
--- a/css/properties/grid-auto-columns.json
+++ b/css/properties/grid-auto-columns.json
@@ -48,10 +48,14 @@
             },
             "firefox": [
               {
-                "version_added": "52"
+                "version_added": "52",
+                "partial_implementation": true,
+                "notes": "Does not accept multiple track-size values.  See <a href='https://bugzil.la/1339672'>bug 1339672</a>."
               },
               {
                 "version_added": "40",
+                "partial_implementation": true,
+                "notes": "Does not accept multiple track-size values.  See <a href='https://bugzil.la/1339672'>bug 1339672</a>.",
                 "flags": [
                   {
                     "type": "preference",
@@ -63,10 +67,14 @@
             ],
             "firefox_android": [
               {
-                "version_added": "52"
+                "version_added": "52",
+                "partial_implementation": true,
+                "notes": "Does not accept multiple track-size values.  See <a href='https://bugzil.la/1339672'>bug 1339672</a>."
               },
               {
                 "version_added": "40",
+                "partial_implementation": true,
+                "notes": "Does not accept multiple track-size values.  See <a href='https://bugzil.la/1339672'>bug 1339672</a>.",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/grid-auto-columns.json
+++ b/css/properties/grid-auto-columns.json
@@ -50,12 +50,12 @@
               {
                 "version_added": "52",
                 "partial_implementation": true,
-                "notes": "Does not accept multiple track-size values.  See <a href='https://bugzil.la/1339672'>bug 1339672</a>."
+                "notes": "Does not accept multiple track-size values. See <a href='https://bugzil.la/1339672'>bug 1339672</a>."
               },
               {
                 "version_added": "40",
                 "partial_implementation": true,
-                "notes": "Does not accept multiple track-size values.  See <a href='https://bugzil.la/1339672'>bug 1339672</a>.",
+                "notes": "Does not accept multiple track-size values. See <a href='https://bugzil.la/1339672'>bug 1339672</a>.",
                 "flags": [
                   {
                     "type": "preference",
@@ -69,12 +69,12 @@
               {
                 "version_added": "52",
                 "partial_implementation": true,
-                "notes": "Does not accept multiple track-size values.  See <a href='https://bugzil.la/1339672'>bug 1339672</a>."
+                "notes": "Does not accept multiple track-size values. See <a href='https://bugzil.la/1339672'>bug 1339672</a>."
               },
               {
                 "version_added": "40",
                 "partial_implementation": true,
-                "notes": "Does not accept multiple track-size values.  See <a href='https://bugzil.la/1339672'>bug 1339672</a>.",
+                "notes": "Does not accept multiple track-size values. See <a href='https://bugzil.la/1339672'>bug 1339672</a>.",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/grid-auto-rows.json
+++ b/css/properties/grid-auto-rows.json
@@ -48,10 +48,14 @@
             },
             "firefox": [
               {
-                "version_added": "52"
+                "version_added": "52",
+                "partial_implementation": true,
+                "notes": "Does not accept multiple track-size values.  See <a href='https://bugzil.la/1339672'>bug 1339672</a>."
               },
               {
                 "version_added": "40",
+                "partial_implementation": true,
+                "notes": "Does not accept multiple track-size values.  See <a href='https://bugzil.la/1339672'>bug 1339672</a>.",
                 "flags": [
                   {
                     "type": "preference",
@@ -63,10 +67,14 @@
             ],
             "firefox_android": [
               {
-                "version_added": "52"
+                "version_added": "52",
+                "partial_implementation": true,
+                "notes": "Does not accept multiple track-size values.  See <a href='https://bugzil.la/1339672'>bug 1339672</a>."
               },
               {
                 "version_added": "40",
+                "partial_implementation": true,
+                "notes": "Does not accept multiple track-size values.  See <a href='https://bugzil.la/1339672'>bug 1339672</a>.",
                 "flags": [
                   {
                     "type": "preference",


### PR DESCRIPTION
Fixes #2782.  See https://bugzilla.mozilla.org/show_bug.cgi?id=1339672 for more information.  (Confirmed it's still a bug.)