### PR TITLE
Set css.properties.display.flex to partial support in IE

### DIFF
--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -531,11 +531,15 @@
               ],
               "ie": [
                 {
-                  "version_added": "11"
+                  "version_added": "11",
+                  "partial_implementation": true,
+                  "notes": "IE incorrectly positions inline block content inside flex containers. See the <a href='https://answers.microsoft.com/en-us/ie/forum/ie11-iewindows_10/inline-block-content-in-a-flex-container-not/deea64e2-933b-4bd2-a98c-62be16d04b57'>discussion on Microsoft Answers</a>."
                 },
                 {
                   "alternative_name": "-ms-flexbox",
-                  "version_added": "8"
+                  "version_added": "8",
+                  "partial_implementation": true,
+                  "notes": "IE incorrectly positions inline block content inside flex containers. See the <a href='https://answers.microsoft.com/en-us/ie/forum/ie11-iewindows_10/inline-block-content-in-a-flex-container-not/deea64e2-933b-4bd2-a98c-62be16d04b57'>discussion on Microsoft Answers</a>."
                 }
               ],
               "opera": [


### PR DESCRIPTION
Fixes #2944.  Confirmed manually in IE 11 on Windows 10.