### PR TITLE
Removed localized MSDev URLs

### DIFF
--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -12,11 +12,11 @@
           },
           "edge": {
             "version_added": false,
-            "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/customelements/'>In Development</a>"
+            "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/customelements/'>In Development</a>"
           },
           "edge_mobile": {
             "version_added": false,
-            "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/customelements/'>In Development</a>"
+            "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/customelements/'>In Development</a>"
           },
           "firefox": [
             {
@@ -245,11 +245,11 @@
             ],
             "edge": {
               "version_added": false,
-              "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/customelements/'>In Development</a>"
+              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/customelements/'>In Development</a>"
             },
             "edge_mobile": {
               "version_added": false,
-              "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/customelements/'>In Development</a>"
+              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/customelements/'>In Development</a>"
             },
             "firefox": [
               {
@@ -394,11 +394,11 @@
             ],
             "edge": {
               "version_added": false,
-              "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/customelements/'>In Development</a>"
+              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/customelements/'>In Development</a>"
             },
             "edge_mobile": {
               "version_added": false,
-              "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/customelements/'>In Development</a>"
+              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/customelements/'>In Development</a>"
             },
             "firefox": [
               {
@@ -594,11 +594,11 @@
             ],
             "edge": {
               "version_added": false,
-              "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/customelements/'>In Development</a>"
+              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/customelements/'>In Development</a>"
             },
             "edge_mobile": {
               "version_added": false,
-              "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/customelements/'>In Development</a>"
+              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/customelements/'>In Development</a>"
             },
             "firefox": [
               {

--- a/api/Element.json
+++ b/api/Element.json
@@ -4986,7 +4986,7 @@
             },
             "edge": {
               "version_added": "12",
-              "notes": "This function doesn't respect boolean attributes' default values.  See <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12087679/'>bug 12087679</a>."
+              "notes": "This function doesn't respect boolean attributes' default values.  See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/12087679/'>bug 12087679</a>."
             },
             "edge_mobile": {
               "version_added": null

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -244,7 +244,7 @@
               },
               "edge": {
                 "version_added": false,
-                "notes": "WebGL 2 is under consideration in Edge, with a roadmap priority of medium. See the <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/webgl20/'></a>Edge Platform status for latest information."
+                "notes": "WebGL 2 is under consideration in Edge, with a roadmap priority of medium. See the <a href='https://developer.microsoft.com/microsoft-edge/platform/status/webgl20/'></a>Edge Platform status for latest information."
               },
               "edge_mobile": {
                 "version_added": null

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2946,13 +2946,13 @@
               {
                 "version_added": true,
                 "partial_implementation": true,
-                "notes": "Returns incorrect value for elements without an explicit tabindex attribute. See <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/4365703/'>issue 4365703</a> for details."
+                "notes": "Returns incorrect value for elements without an explicit tabindex attribute. See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/4365703/'>issue 4365703</a> for details."
               }
             ],
             "edge_mobile": {
               "version_added": true,
               "partial_implementation": true,
-              "notes": "Returns incorrect value for elements without an explicit tabindex attribute. See <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/4365703/'>issue 4365703</a> for details."
+              "notes": "Returns incorrect value for elements without an explicit tabindex attribute. See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/4365703/'>issue 4365703</a> for details."
             },
             "firefox": {
               "version_added": "1"
@@ -2963,7 +2963,7 @@
             "ie": {
               "version_added": "7",
               "partial_implementation": true,
-              "notes": "Returns incorrect value for elements without an explicit tabindex attribute. See <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/4365703/'>issue 4365703</a> for details."
+              "notes": "Returns incorrect value for elements without an explicit tabindex attribute. See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/4365703/'>issue 4365703</a> for details."
             },
             "opera": {
               "version_added": true

--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -304,7 +304,7 @@
             },
             "edge": {
               "version_added": "15",
-              "notes": "Available since <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/intersectionobserver/'>Windows Insider Preview Build 14986</a>"
+              "notes": "Available since <a href='https://developer.microsoft.com/microsoft-edge/platform/status/intersectionobserver/'>Windows Insider Preview Build 14986</a>"
             },
             "edge_mobile": {
               "version_added": true
@@ -418,7 +418,7 @@
             },
             "edge": {
               "version_added": "15",
-              "notes": "Available since <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/intersectionobserver/'>Windows Insider Preview Build 14986</a>"
+              "notes": "Available since <a href='https://developer.microsoft.com/microsoft-edge/platform/status/intersectionobserver/'>Windows Insider Preview Build 14986</a>"
             },
             "edge_mobile": {
               "version_added": true
@@ -474,7 +474,7 @@
             },
             "edge": {
               "version_added": "15",
-              "notes": "Available since <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/intersectionobserver/'>Windows Insider Preview Build 14986</a>"
+              "notes": "Available since <a href='https://developer.microsoft.com/microsoft-edge/platform/status/intersectionobserver/'>Windows Insider Preview Build 14986</a>"
             },
             "edge_mobile": {
               "version_added": true

--- a/api/Path2D.json
+++ b/api/Path2D.json
@@ -63,7 +63,7 @@
             },
             "edge": {
               "version_added": true,
-              "notes": "The constructor for <code>Path2D</code> objects in Edge does not support being invoked with a string consisting of SVG path data. See <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8438884/'>issue 8438884</a> for details."
+              "notes": "The constructor for <code>Path2D</code> objects in Edge does not support being invoked with a string consisting of SVG path data. See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/8438884/'>issue 8438884</a> for details."
             },
             "edge_mobile": {
               "version_added": null

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -12,11 +12,11 @@
           },
           "edge": {
             "version_added": false,
-            "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/shadowdom/?q=web%20components'>In Development</a>"
+            "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/?q=web%20components'>In Development</a>"
           },
           "edge_mobile": {
             "version_added": false,
-            "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/shadowdom/?q=web%20components'>In Development</a>"
+            "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/?q=web%20components'>In Development</a>"
           },
           "firefox": [
             {
@@ -196,11 +196,11 @@
             },
             "edge": {
               "version_added": false,
-              "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/shadowdom/'>In Development</a>"
+              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/'>In Development</a>"
             },
             "edge_mobile": {
               "version_added": false,
-              "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/shadowdom/'>In Development</a>"
+              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/'>In Development</a>"
             },
             "firefox": [
               {
@@ -275,11 +275,11 @@
             },
             "edge": {
               "version_added": false,
-              "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/shadowdom/'>In Development</a>"
+              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/'>In Development</a>"
             },
             "edge_mobile": {
               "version_added": false,
-              "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/shadowdom/'>In Development</a>"
+              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/'>In Development</a>"
             },
             "firefox": [
               {
@@ -354,11 +354,11 @@
             },
             "edge": {
               "version_added": false,
-              "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/shadowdom/'>In Development</a>"
+              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/'>In Development</a>"
             },
             "edge_mobile": {
               "version_added": false,
-              "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/shadowdom/'>In Development</a>"
+              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/'>In Development</a>"
             },
             "firefox": [
               {

--- a/css/selectors/hover.json
+++ b/css/selectors/hover.json
@@ -116,7 +116,7 @@
               },
               "edge": {
                 "version_added": true,
-                "notes": "In Edge, hovering over an element and then scrolling up or down without moving the pointer will leave the element in the <code>:hover</code> state until the pointer is moved. See <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/5381673/'>bug 5381673</a>."
+                "notes": "In Edge, hovering over an element and then scrolling up or down without moving the pointer will leave the element in the <code>:hover</code> state until the pointer is moved. See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/5381673/'>bug 5381673</a>."
               },
               "edge_mobile": {
                 "version_added": null

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -176,8 +176,8 @@
                   "version_added": "13",
                   "partial_implementation": true,
                   "notes": [
-                    "Until Edge 14 (build 14357), attempting to download data URIs caused Edge to crash (<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7160092/'>bug 7160092</a>).",
-                    "Edge 17 or older didn't follow the attributes' value to determine filename (<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7260192/'>bug 7260192</a>)."
+                    "Until Edge 14 (build 14357), attempting to download data URIs caused Edge to crash (<a href='https://developer.microsoft.com/microsoft-edge/platform/issues/7160092/'>bug 7160092</a>).",
+                    "Edge 17 or older didn't follow the attributes' value to determine filename (<a href='https://developer.microsoft.com/microsoft-edge/platform/issues/7260192/'>bug 7260192</a>)."
                   ]
                 }
               ],

--- a/html/elements/applet.json
+++ b/html/elements/applet.json
@@ -15,11 +15,11 @@
             },
             "edge": {
               "version_added": true,
-              "notes": "Removal in Edge is <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11946645/'>under consideration</a>."
+              "notes": "Removal in Edge is <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/11946645/'>under consideration</a>."
             },
             "edge_mobile": {
               "version_added": true,
-              "notes": "Removal in Edge is <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11946645/'>under consideration</a>."
+              "notes": "Removal in Edge is <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/11946645/'>under consideration</a>."
             },
             "firefox": {
               "version_added": true,

--- a/html/elements/details.json
+++ b/html/elements/details.json
@@ -13,7 +13,7 @@
             },
             "edge": {
               "version_added": false,
-              "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/detailssummary?q=details'>Under consideration</a>."
+              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/detailssummary?q=details'>Under consideration</a>."
             },
             "edge_mobile": {
               "version_added": false
@@ -65,7 +65,7 @@
               },
               "edge": {
                 "version_added": false,
-                "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/detailssummary?q=details'>Under consideration</a>."
+                "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/detailssummary?q=details'>Under consideration</a>."
               },
               "edge_mobile": {
                 "version_added": false

--- a/html/elements/summary.json
+++ b/html/elements/summary.json
@@ -13,11 +13,11 @@
             },
             "edge": {
               "version_added": false,
-              "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/detailssummary?filter=f3f0000bf&search=details'>In development</a>."
+              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/detailssummary?filter=f3f0000bf&search=details'>In development</a>."
             },
             "edge_mobile": {
               "version_added": false,
-              "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/detailssummary?filter=f3f0000bf&search=details'>In development</a>."
+              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/detailssummary?filter=f3f0000bf&search=details'>In development</a>."
             },
             "firefox": {
               "version_added": "49"

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -1540,7 +1540,7 @@
               },
               "edge": {
                 "version_added": false,
-                "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/cspupgradeinsecurerequestsdirective'>Under consideration</a> for future release."
+                "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/cspupgradeinsecurerequestsdirective'>Under consideration</a> for future release."
               },
               "edge_mobile": {
                 "version_added": false

--- a/http/headers/origin.json
+++ b/http/headers/origin.json
@@ -13,7 +13,7 @@
             },
             "edge": {
               "version_added": true,
-              "notes": "Not sent with <code>POST</code> requests, see <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/10482384/'>bug 10482384</a>."
+              "notes": "Not sent with <code>POST</code> requests, see <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/10482384/'>bug 10482384</a>."
             },
             "edge_mobile": {
               "version_added": true

--- a/http/headers/public-key-pins-report-only.json
+++ b/http/headers/public-key-pins-report-only.json
@@ -15,7 +15,7 @@
             },
             "edge": {
               "version_added": false,
-              "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/publickeypinningextensionforhttp'>Under consideration</a> for future release."
+              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/publickeypinningextensionforhttp'>Under consideration</a> for future release."
             },
             "edge_mobile": {
               "version_added": null

--- a/http/headers/public-key-pins.json
+++ b/http/headers/public-key-pins.json
@@ -15,7 +15,7 @@
             },
             "edge": {
               "version_added": false,
-              "notes": "<a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/publickeypinningextensionforhttp'>Under consideration</a> for future release."
+              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/publickeypinningextensionforhttp'>Under consideration</a> for future release."
             },
             "edge_mobile": {
               "version_added": null

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1877,7 +1877,7 @@
               },
               "edge": {
                 "version_added": false,
-                "notes": "See <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/status/javascriptmoduleimport/'>development status</a>."
+                "notes": "See <a href='https://developer.microsoft.com/microsoft-edge/platform/status/javascriptmoduleimport/'>development status</a>."
               },
               "edge_mobile": {
                 "version_added": false

--- a/svg/elements/feTurbulence.json
+++ b/svg/elements/feTurbulence.json
@@ -13,11 +13,11 @@
             },
             "edge": {
               "version_added": true,
-              "notes": "Partially supported, see <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12382004/'>bug 12382004</a>."
+              "notes": "Partially supported, see <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/12382004/'>bug 12382004</a>."
             },
             "edge_mobile": {
               "version_added": true,
-              "notes": "Partially supported, see <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12382004/'>bug 12382004</a>."
+              "notes": "Partially supported, see <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/12382004/'>bug 12382004</a>."
             },
             "firefox": {
               "version_added": "4"
@@ -27,7 +27,7 @@
             },
             "ie": {
               "version_added": true,
-              "notes": "Partially supported, see <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12382004/'>bug 12382004</a>."
+              "notes": "Partially supported, see <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/12382004/'>bug 12382004</a>."
             },
             "opera": {
               "version_added": "9"
@@ -62,11 +62,11 @@
               },
               "edge": {
                 "version_added": true,
-                "notes": "Partially supported, see <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12382004/'>bug 12382004</a>."
+                "notes": "Partially supported, see <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/12382004/'>bug 12382004</a>."
               },
               "edge_mobile": {
                 "version_added": true,
-                "notes": "Partially supported, see <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12382004/'>bug 12382004</a>."
+                "notes": "Partially supported, see <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/12382004/'>bug 12382004</a>."
               },
               "firefox": {
                 "version_added": "4"
@@ -76,7 +76,7 @@
               },
               "ie": {
                 "version_added": true,
-                "notes": "Partially supported, see <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12382004/'>bug 12382004</a>."
+                "notes": "Partially supported, see <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/12382004/'>bug 12382004</a>."
               },
               "opera": {
                 "version_added": "9"
@@ -159,11 +159,11 @@
               },
               "edge": {
                 "version_added": true,
-                "notes": "Partially supported, see <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12382004/'>bug 12382004</a>."
+                "notes": "Partially supported, see <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/12382004/'>bug 12382004</a>."
               },
               "edge_mobile": {
                 "version_added": true,
-                "notes": "Partially supported, see <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12382004/'>bug 12382004</a>."
+                "notes": "Partially supported, see <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/12382004/'>bug 12382004</a>."
               },
               "firefox": {
                 "version_added": "4"
@@ -173,7 +173,7 @@
               },
               "ie": {
                 "version_added": true,
-                "notes": "Partially supported, see <a href='https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12382004/'>bug 12382004</a>."
+                "notes": "Partially supported, see <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/12382004/'>bug 12382004</a>."
               },
               "opera": {
                 "version_added": "9"


### PR DESCRIPTION
I noticed that api.ShadowRoot had some localized Microsoft Developer links.  This fixes the URLs in said file, as well as anywhere else I've found a localized URL for https://developer.microsoft.com.