### PR TITLE
Update css.text-transform based upon manual testing

### DIFF
--- a/css/properties/text-transform.json
+++ b/css/properties/text-transform.json
@@ -10,7 +10,7 @@
               "notes": "The <code>text-transform</code> property does not work for <code>::first-line</code> pseudo-elements (nor for the one-colon syntax). See <a href='https://crbug.com/129669'>Chromium bug 129669</a>."
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -32,7 +32,7 @@
               "notes": "Since Opera 15, the <code>text-transform</code> property does not work for <code>::first-line</code> pseudo-elements (nor for the one-colon syntax). See <a href='https://crbug.com/129669'>Chromium bug 129669</a>."
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "7"
             },
             "safari": {
               "version_added": "1",
@@ -43,7 +43,7 @@
               "notes": "The <code>text-transform</code> property does not work for <code>::first-line</code> pseudo-elements (also not for the old one-colon syntax). See <a href='https://webkit.org/b/3409'>WebKit bug 3409</a>."
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "1",
@@ -61,16 +61,16 @@
             "description": "<code>capitalize</code> as defined by CSS level 3",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": true
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": true
               },
               "firefox": {
                 "version_added": "14"
@@ -79,25 +79,25 @@
                 "version_added": "14"
               },
               "ie": {
-                "version_added": null
+                "version_added": true
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
-                "version_added": null
+                "version_added": true
               }
             },
             "status": {
@@ -115,13 +115,13 @@
                 "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "19"
@@ -169,10 +169,10 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "64"
@@ -181,22 +181,22 @@
                 "version_added": "64"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": false
@@ -217,7 +217,7 @@
                 "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
                 "version_added": null
@@ -268,7 +268,7 @@
                 "version_added": "30"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "30"
               },
               "edge": {
                 "version_added": null
@@ -286,10 +286,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "17"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "17"
               },
               "safari": {
                 "version_added": false
@@ -298,10 +298,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "4.4"
               }
             },
             "status": {
@@ -319,7 +319,7 @@
                 "version_added": "30"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "30"
               },
               "edge": {
                 "version_added": null
@@ -337,10 +337,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "17"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "17"
               },
               "safari": {
                 "version_added": "6"
@@ -349,10 +349,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "4.4"
               }
             },
             "status": {
@@ -367,10 +367,10 @@
             "description": "<code>i</code> → <code>İ</code> and <code>ı</code> → <code>I</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": null
@@ -388,10 +388,10 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
                 "version_added": false
@@ -400,10 +400,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": true
               },
               "webview_android": {
-                "version_added": false
+                "version_added": true
               }
             },
             "status": {
@@ -418,10 +418,10 @@
             "description": "<code>ß</code> → <code>SS</code>",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": null
@@ -439,10 +439,10 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
                 "version_added": null
@@ -451,10 +451,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
-                "version_added": null
+                "version_added": true
               }
             },
             "status": {

--- a/css/properties/text-transform.json
+++ b/css/properties/text-transform.json
@@ -32,7 +32,7 @@
               "notes": "Since Opera 15, the <code>text-transform</code> property does not work for <code>::first-line</code> pseudo-elements (nor for the one-colon syntax). See <a href='https://crbug.com/129669'>Chromium bug 129669</a>."
             },
             "opera_android": {
-              "version_added": "7"
+              "version_added": "11"
             },
             "safari": {
               "version_added": "1",
@@ -289,7 +289,7 @@
                 "version_added": "17"
               },
               "opera_android": {
-                "version_added": "17"
+                "version_added": "18"
               },
               "safari": {
                 "version_added": false
@@ -340,7 +340,7 @@
                 "version_added": "17"
               },
               "opera_android": {
-                "version_added": "17"
+                "version_added": "18"
               },
               "safari": {
                 "version_added": "6"


### PR DESCRIPTION
Fixes #3076 and adds more properties' compatibility information based upon both manual testing and consistency review.