### PR TITLE
Fix grammar in api.PaymentRequest

### DIFF
--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -28,7 +28,7 @@
               {
                 "name": "dom.payments.request.supportedRegions",
                 "type": "preference",
-                "value_to_set": "A comma-delineated list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>."
+                "value_to_set": "A comma-delineated list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>)."
               }
             ]
           },
@@ -44,7 +44,7 @@
               {
                 "name": "dom.payments.request.supportedRegions",
                 "type": "preference",
-                "value_to_set": "A comma-delineated list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>."
+                "value_to_set": "A comma-delineated list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>)."
               }
             ]
           },


### PR DESCRIPTION
Small, grammatical change is all.  Adds a closing parenthesis into the preference flag.