### PR TITLE
Fix Firefox versions for api.DOMPointReadOnly.toJSON

### DIFF
--- a/api/DOMPointReadOnly.json
+++ b/api/DOMPointReadOnly.json
@@ -401,10 +401,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "31"
+              "version_added": "62"
             },
             "firefox_android": {
-              "version_added": "31"
+              "version_added": "62"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Fixes #3398.  Review of the history revealed a bad initial import of the Firefox versions.