### PR TITLE
Add javascript.builtins.RegExp.dotAll

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -160,7 +160,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         },

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -113,7 +113,6 @@
         "dotAll": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/dotAll",
-            "spec_url": "https://tc39.github.io/proposal-regexp-dotall-flag/",
             "support": {
               "chrome": {
                 "version_added": true

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -115,10 +115,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/dotAll",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "62"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "62"
               },
               "edge": {
                 "version_added": false
@@ -139,22 +139,22 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "49"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "46"
               },
               "safari": {
-                "version_added": true
+                "version_added": "12"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "12"
               },
               "samsunginternet_android": {
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "62"
               }
             },
             "status": {

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -110,6 +110,61 @@
             }
           }
         },
+        "dotAll": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/dotAll",
+            "spec_url": "https://tc39.github.io/proposal-regexp-dotall-flag/",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
         "exec": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec",


### PR DESCRIPTION
Fixes #3423.  All true/false values were identified via manual testing in latest versions of all browsers.  (No version numbers yet; if anyone knows of some I'd be happy to add them in!)