### PR TITLE
Adding Safari support

### DIFF
--- a/css/properties/block-size.json
+++ b/css/properties/block-size.json
@@ -62,7 +62,7 @@
               "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -124,7 +124,7 @@
                 "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -187,7 +187,7 @@
                 "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"

--- a/css/properties/block-size.json
+++ b/css/properties/block-size.json
@@ -59,7 +59,7 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
               "version_added": false
@@ -121,7 +121,7 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": false
+                "version_added": "12.1"
               },
               "safari_ios": {
                 "version_added": false
@@ -184,7 +184,7 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": false
+                "version_added": "12.1"
               },
               "safari_ios": {
                 "version_added": false
@@ -236,10 +236,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": false
+                "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "alternative_name": "-webkit-fill-available",

--- a/css/properties/border-block-end-color.json
+++ b/css/properties/border-block-end-color.json
@@ -56,10 +56,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "webview_android": {
               "version_added": "69"

--- a/css/properties/border-block-end-style.json
+++ b/css/properties/border-block-end-style.json
@@ -56,10 +56,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "webview_android": {
               "version_added": "69"

--- a/css/properties/border-block-end-width.json
+++ b/css/properties/border-block-end-width.json
@@ -56,10 +56,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "webview_android": {
               "version_added": "69"

--- a/css/properties/border-block-end.json
+++ b/css/properties/border-block-end.json
@@ -56,10 +56,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "webview_android": {
               "version_added": "69"

--- a/css/properties/border-block-start-color.json
+++ b/css/properties/border-block-start-color.json
@@ -56,10 +56,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "webview_android": {
               "version_added": "69"

--- a/css/properties/border-block-start-style.json
+++ b/css/properties/border-block-start-style.json
@@ -56,10 +56,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "webview_android": {
               "version_added": "69"

--- a/css/properties/border-block-start-width.json
+++ b/css/properties/border-block-start-width.json
@@ -56,10 +56,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "webview_android": {
               "version_added": "69"

--- a/css/properties/border-block-start.json
+++ b/css/properties/border-block-start.json
@@ -56,10 +56,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "webview_android": {
               "version_added": "69"

--- a/css/properties/border-inline-end-color.json
+++ b/css/properties/border-inline-end-color.json
@@ -64,10 +64,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "webview_android": {
               "version_added": "69"

--- a/css/properties/border-inline-end-style.json
+++ b/css/properties/border-inline-end-style.json
@@ -64,10 +64,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "webview_android": {
               "version_added": "69"

--- a/css/properties/border-inline-end-width.json
+++ b/css/properties/border-inline-end-width.json
@@ -64,10 +64,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "webview_android": {
               "version_added": "69"

--- a/css/properties/border-inline-end.json
+++ b/css/properties/border-inline-end.json
@@ -51,10 +51,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "webview_android": {
               "version_added": "69"

--- a/css/properties/border-inline-start-color.json
+++ b/css/properties/border-inline-start-color.json
@@ -64,10 +64,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "webview_android": {
               "version_added": "69"

--- a/css/properties/border-inline-start-style.json
+++ b/css/properties/border-inline-start-style.json
@@ -64,10 +64,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "webview_android": {
               "version_added": "69"

--- a/css/properties/border-inline-start-width.json
+++ b/css/properties/border-inline-start-width.json
@@ -56,10 +56,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "webview_android": {
               "version_added": "69"

--- a/css/properties/border-inline-start.json
+++ b/css/properties/border-inline-start.json
@@ -51,10 +51,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "webview_android": {
               "version_added": "69"

--- a/css/properties/inline-size.json
+++ b/css/properties/inline-size.json
@@ -62,7 +62,7 @@
               "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -124,7 +124,7 @@
                 "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -187,7 +187,7 @@
                 "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"

--- a/css/properties/inline-size.json
+++ b/css/properties/inline-size.json
@@ -59,7 +59,7 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
               "version_added": false
@@ -121,7 +121,7 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": false
+                "version_added": "12.1"
               },
               "safari_ios": {
                 "version_added": false
@@ -184,7 +184,7 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": false
+                "version_added": "12.1"
               },
               "safari_ios": {
                 "version_added": false
@@ -236,10 +236,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": false
+                "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "alternative_name": "-webkit-fill-available",

--- a/css/properties/margin-block-end.json
+++ b/css/properties/margin-block-end.json
@@ -59,10 +59,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/margin-block-start.json
+++ b/css/properties/margin-block-start.json
@@ -59,10 +59,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/margin-inline-end.json
+++ b/css/properties/margin-inline-end.json
@@ -90,14 +90,24 @@
                 "alternative_name": "-webkit-margin-end"
               }
             ],
-            "safari": {
-              "version_added": "3",
-              "alternative_name": "-webkit-margin-end"
-            },
-            "safari_ios": {
-              "version_added": "3",
-              "alternative_name": "-webkit-margin-end"
-            },
+            "safari": [
+              {
+                "version_added": "12.1"
+              },
+              {
+                "version_added": "3",
+                "alternative_name": "-webkit-margin-end"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "12.2"
+              },
+              {
+                "version_added": "3",
+                "alternative_name": "-webkit-margin-start"
+              }
+            ],
             "samsunginternet_android": {
               "version_added": true,
               "alternative_name": "-webkit-margin-end"

--- a/css/properties/margin-inline-start.json
+++ b/css/properties/margin-inline-start.json
@@ -90,14 +90,24 @@
                 "alternative_name": "-webkit-margin-start"
               }
             ],
-            "safari": {
-              "version_added": "3",
-              "alternative_name": "-webkit-margin-start"
-            },
-            "safari_ios": {
-              "version_added": "3",
-              "alternative_name": "-webkit-margin-start"
-            },
+            "safari": [
+              {
+                "version_added": "12.1"
+              },
+              {
+                "version_added": "3",
+                "alternative_name": "-webkit-margin-start"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "12.2"
+              },
+              {
+                "version_added": "3",
+                "alternative_name": "-webkit-margin-start"
+              }
+            ],
             "samsunginternet_android": {
               "version_added": true,
               "alternative_name": "-webkit-margin-start"

--- a/css/properties/max-block-size.json
+++ b/css/properties/max-block-size.json
@@ -59,10 +59,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -121,10 +121,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": false
+                "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -184,10 +184,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": false
+                "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -235,10 +235,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": false
+                "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "alternative_name": "-webkit-fill-available",

--- a/css/properties/max-inline-size.json
+++ b/css/properties/max-inline-size.json
@@ -58,14 +58,24 @@
             "opera_android": {
               "version_added": "43"
             },
-            "safari": {
-              "prefix": "-webkit-",
-              "version_added": "10.1"
-            },
-            "safari_ios": {
-              "prefix": "-webkit-",
-              "version_added": "10.2"
-            },
+            "safari": [
+              {
+                "prefix": "-webkit-",
+                "version_added": "10.1"
+              },
+              {
+                "version_added": "12.1"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "12.2"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "10.2"
+              }
+            ],
             "samsunginternet_android": {
               "version_added": true
             },
@@ -123,10 +133,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": false
+                "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -241,7 +251,7 @@
                 "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "alternative_name": "-webkit-fill-available",

--- a/css/properties/max-inline-size.json
+++ b/css/properties/max-inline-size.json
@@ -186,7 +186,7 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": false
+                "version_added": "12.1"
               },
               "safari_ios": {
                 "version_added": false
@@ -238,7 +238,7 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": false
+                "version_added": "12.1"
               },
               "safari_ios": {
                 "version_added": false

--- a/css/properties/max-inline-size.json
+++ b/css/properties/max-inline-size.json
@@ -189,7 +189,7 @@
                 "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"

--- a/css/properties/min-block-size.json
+++ b/css/properties/min-block-size.json
@@ -59,10 +59,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -121,10 +121,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": false
+                "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -184,10 +184,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": false
+                "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -235,10 +235,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": false
+                "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "alternative_name": "-webkit-fill-available",

--- a/css/properties/min-inline-size.json
+++ b/css/properties/min-inline-size.json
@@ -59,10 +59,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -122,10 +122,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": false
+                "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -186,10 +186,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": false
+                "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -238,10 +238,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": false
+                "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "alternative_name": "-webkit-fill-available",

--- a/css/properties/padding-block-end.json
+++ b/css/properties/padding-block-end.json
@@ -59,10 +59,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/padding-block-start.json
+++ b/css/properties/padding-block-start.json
@@ -58,11 +58,12 @@
             "opera_android": {
               "version_added": "48"
             },
-            "safari": {
-              "version_added": false
+            "safari":
+            {
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/padding-block-start.json
+++ b/css/properties/padding-block-start.json
@@ -58,8 +58,7 @@
             "opera_android": {
               "version_added": "48"
             },
-            "safari":
-            {
+            "safari": {
               "version_added": "12.1"
             },
             "safari_ios": {

--- a/css/properties/padding-inline-end.json
+++ b/css/properties/padding-inline-end.json
@@ -90,14 +90,24 @@
                 "alternative_name": "-webkit-padding-end"
               }
             ],
-            "safari": {
-              "version_added": "3",
-              "alternative_name": "-webkit-padding-end"
-            },
-            "safari_ios": {
-              "version_added": "3",
-              "alternative_name": "-webkit-padding-end"
-            },
+            "safari": [
+              {
+                "version_added": "12.1"
+              },
+              {
+                "version_added": "3",
+                "alternative_name": "-webkit-padding-end"
+              }
+            ],
+            "safari_ios":  [
+              {
+                "version_added": "12.2"
+              },
+              {
+                "version_added": "3",
+                "alternative_name": "-webkit-padding-end"
+              }
+            ],
             "samsunginternet_android": {
               "version_added": true,
               "alternative_name": "-webkit-padding-end"

--- a/css/properties/padding-inline-end.json
+++ b/css/properties/padding-inline-end.json
@@ -99,7 +99,7 @@
                 "alternative_name": "-webkit-padding-end"
               }
             ],
-            "safari_ios":  [
+            "safari_ios": [
               {
                 "version_added": "12.2"
               },

--- a/css/properties/padding-inline-start.json
+++ b/css/properties/padding-inline-start.json
@@ -99,7 +99,7 @@
                 "alternative_name": "-webkit-padding-start"
               }
             ],
-            "safari_ios":  [
+            "safari_ios": [
               {
                 "version_added": "12.2"
               },

--- a/css/properties/padding-inline-start.json
+++ b/css/properties/padding-inline-start.json
@@ -90,14 +90,24 @@
                 "alternative_name": "-webkit-padding-start"
               }
             ],
-            "safari": {
-              "version_added": "3",
-              "alternative_name": "-webkit-padding-start"
-            },
-            "safari_ios": {
-              "version_added": "3",
-              "alternative_name": "-webkit-padding-start"
-            },
+            "safari": [
+              {
+                "version_added": "12.1"
+              },
+              {
+                "version_added": "3",
+                "alternative_name": "-webkit-padding-start"
+              }
+            ],
+            "safari_ios":  [
+              {
+                "version_added": "12.2"
+              },
+              {
+                "version_added": "3",
+                "alternative_name": "-webkit-padding-start"
+              }
+            ],
             "samsunginternet_android": {
               "version_added": true,
               "alternative_name": "-webkit-padding-start"


### PR DESCRIPTION
Safari 12.1 includes support for the mapped logical properties for size and MBP. I have added this to the various property pages. I don't believe this change includes the new shorthands.

https://github.com/mdn/browser-compat-data/issues/3788
