### PR TITLE
chore: Fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,9 @@
 # See governance.md for more about this repository's owners and this project's
 # governance.
 
-webextensions/ @irenesmith
+/webextensions/ @irenesmith
 
 # Schema, linter and infrastructure changes must be reviewed by an owner:
-test/          @Elchi3 @ddbeck @wbamberg @chrisdavidmills @atopal
-schemas/*.json @Elchi3 @ddbeck @wbamberg @chrisdavidmills @atopal
-.github/       @Elchi3 @ddbeck @wbamberg @chrisdavidmills @atopal
+/test/          @Elchi3 @ddbeck @wbamberg @chrisdavidmills @atopal
+/schemas/*.json @Elchi3 @ddbeck @wbamberg @chrisdavidmills @atopal
+/.github/       @Elchi3 @ddbeck @wbamberg @chrisdavidmills @atopal

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,8 @@
 # governance.
 
 webextensions/ @irenesmith
-!*.json @Elchi3
+
+# Schema, linter and infrastructure changes must be reviewed by an owner:
+test/          @Elchi3 @ddbeck @wbamberg @chrisdavidmills @atopal
+schemas/*.json @Elchi3 @ddbeck @wbamberg @chrisdavidmills @atopal
+.github/       @Elchi3 @ddbeck @wbamberg @chrisdavidmills @atopal

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,10 @@
 /webextensions/ @irenesmith
 
 # Schema, linter and infrastructure changes must be reviewed by an owner:
-/test/          @Elchi3 @ddbeck @wbamberg @chrisdavidmills @atopal
-/schemas/*.json @Elchi3 @ddbeck @wbamberg @chrisdavidmills @atopal
-/.github/       @Elchi3 @ddbeck @wbamberg @chrisdavidmills @atopal
+# ======================================================================
+/test/    @Elchi3
+/schemas/ @Elchi3
+/.github/ @Elchi3
+
+## This pattern will only match files in the root directory:
+/*        @Elchi3


### PR DESCRIPTION
This fixes the `CODEOWNERS` file to correctly request reviews when a schema, linter or infra change is made.

With this, it will be possible to enable required code owner reviews: https://help.github.com/en/articles/enabling-required-reviews-for-pull-requests

---

review?(@Elchi3)