### PR TITLE
Fixed names of promise rejection events

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -6717,7 +6717,7 @@
           }
         }
       },
-      "rejectionhandled": {
+      "rejectionhandled_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/rejectionhandled_event",
           "description": "<code>rejectionhandled</code> event",
@@ -9475,7 +9475,7 @@
           }
         }
       },
-      "unhandledrejection": {
+      "unhandledrejection_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/unhandledrejection_event",
           "description": "<code>unhandledrejection</code> event",


### PR DESCRIPTION
These were labeled without the "_event" part by mistake. This should finish the last details for issue #1124.