### PR TITLE
Update Safari compatibility for HTMLCanvasElement.toBlob

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -733,8 +733,7 @@
               "version_added": "37"
             },
             "safari": {
-              "version_added": true,
-              "notes": "See <a href='https://webkit.org/b/71270'>WebKit bug 71270</a>."
+              "version_added": "10.1"
             },
             "safari_ios": {
               "version_added": false

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -733,7 +733,7 @@
               "version_added": "37"
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": "11"
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
I can see that the issue was solved in March 2017: https://bugs.webkit.org/show_bug.cgi?id=148878
A comment there refers to this changeset: https://trac.webkit.org/changeset/213437

I assume the Safari version where it was released is 10.1 because the `213437` changeset was listed in [Release notes for Safari Technology Preview 25](https://webkit.org/blog/7432/release-notes-for-safari-technology-preview-25/) in full [revisions list](https://trac.webkit.org/log/webkit/?stop_rev=212356&rev=213542&limit=1270). And 10.1 Safari was released after STP 26