### PR TITLE
Update navigator.getUserMedia().

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -966,8 +966,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "53",
-                "notes": "Unprefixed version."
+                "version_added": "53"
               },
               {
                 "version_added": "21",
@@ -977,8 +976,7 @@
             ],
             "chrome_android": [
               {
-                "version_added": "53",
-                "notes": "Unprefixed version."
+                "version_added": "53"
               },
               {
                 "version_added": "25",
@@ -1032,15 +1030,14 @@
             },
             "webview_android": [
               {
-                "version_added": "53",
-                "notes": "Unprefixed version."
+                "version_added": "53"
               },
               {
                 "version_added": "40",
                 "prefix": "webkit",
                 "notes": "An outdated constraint syntax is still in use, but the syntax described here is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
               }
-            ],
+            ]
           },
           "status": {
             "experimental": false,

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -964,14 +964,28 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/getUserMedia",
           "support": {
-            "chrome": {
-              "version_added": "21",
-              "prefix": "webkit",
-              "notes": "Later versions of Chrome support the unprefixed <code>MediaDevices.getUserMedia()</code> which replaced this deprecated method."
-            },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome": [
+              {
+                "version_added": "53",
+                "notes": "Unprefixed version."
+              },
+              {
+                "version_added": "21",
+                "prefix": "webkit",
+                "notes": "An outdated constraint syntax is still in use, but the syntax described here is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "53",
+                "notes": "Unprefixed version."
+              },
+              {
+                "version_added": "25",
+                "prefix": "webkit",
+                "notes": "An outdated constraint syntax is still in use, but the syntax described here is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+              }
+            ],
             "edge": {
               "version_added": "12"
             },
@@ -1016,11 +1030,17 @@
             "samsunginternet_android": {
               "version_added": false
             },
-            "webview_android": {
-              "version_added": "40",
-              "prefix": "webkit",
-              "notes": "An outdated constraint syntax is still in use, but the syntax described here is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
-            }
+            "webview_android": [
+              {
+                "version_added": "53",
+                "notes": "Unprefixed version."
+              },
+              {
+                "version_added": "40",
+                "prefix": "webkit",
+                "notes": "An outdated constraint syntax is still in use, but the syntax described here is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+              }
+            ],
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
Unprefixed `navigator.getUserMedia` [in Chrome 53](https://storage.googleapis.com/chromium-find-releases-static/489.html#489f502a4d2d39665eb58158dc5df313ee2dbf15) 