### PR TITLE
Fix typo in PushSubscription.toJSON description

### DIFF
--- a/api/PushSubscription.json
+++ b/api/PushSubscription.json
@@ -313,7 +313,7 @@
       "toJSON": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushSubscription/toJSON",
-          "description": "<code.toJSON()</code>",
+          "description": "<code>toJSON()</code>",
           "support": {
             "chrome": {
               "version_added": "42"


### PR DESCRIPTION
I don't know why this description is needed, but it has a typo.

See the rendering: https://developer.mozilla.org/en-US/docs/Web/API/PushSubscription#Browser_compatibility