### PR TITLE
Fix indentation in css.properties.appearance

### DIFF
--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -284,7 +284,7 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": true

--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -210,160 +210,160 @@
               "standard_track": true,
               "deprecated": false
             }
-          },
-          "button": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                },
-                "samsunginternet_android": {
-                  "version_added": true
-                },
-                "webview_android": {
-                  "version_added": true
-                }
+          }
+        },
+        "button": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
               },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "textfield": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
-                  "version_added": true
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                },
-                "samsunginternet_android": {
-                  "version_added": true
-                },
-                "webview_android": {
-                  "version_added": true
-                }
+          }
+        },
+        "textfield": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
               },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "compat": {
-            "__compat": {
-              "description": "<code>&lt;compat&gt;</code> (compatibility values <code>searchfield</code>, <code>textarea</code>, <code>push-button</code>, <code>button-bevel</code>, <code>slider-horizontal</code>, <code>checkbox</code>, <code>radio</code>, <code>square-button</code>, <code>menulist</code>, <code>menulist-button</code>, <code>listbox</code>, <code>meter</code>, <code>progress-bar</code>)",
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true,
-                  "partial_implementation": true
-                },
-                "edge_mobile": {
-                  "version_added": true,
-                  "partial_implementation": true
-                },
-                "firefox": {
-                  "version_added": true,
-                  "partial_implementation": true
-                },
-                "firefox_android": {
-                  "version_added": false,
-                  "partial_implementation": true
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": {
-                  "version_added": true
-                },
-                "samsunginternet_android": {
-                  "version_added": true
-                },
-                "webview_android": {
-                  "version_added": true
-                }
+          }
+        },
+        "compat": {
+          "__compat": {
+            "description": "<code>&lt;compat&gt;</code> (compatibility values <code>searchfield</code>, <code>textarea</code>, <code>push-button</code>, <code>button-bevel</code>, <code>slider-horizontal</code>, <code>checkbox</code>, <code>radio</code>, <code>square-button</code>, <code>menulist</code>, <code>menulist-button</code>, <code>listbox</code>, <code>meter</code>, <code>progress-bar</code>)",
+            "support": {
+              "chrome": {
+                "version_added": true
               },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": true,
+                "partial_implementation": true
+              },
+              "edge_mobile": {
+                "version_added": true,
+                "partial_implementation": true
+              },
+              "firefox": {
+                "version_added": true,
+                "partial_implementation": true
+              },
+              "firefox_android": {
+                "version_added": false,
+                "partial_implementation": true
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }


### PR DESCRIPTION
Looks like when these new properties were added, they were added in on the wrong indentation level.  This repairs that, thus aiding consistency.