### PR TITLE
Fix indentation in css.properties.max-width/height

### DIFF
--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -53,6 +53,85 @@
             "deprecated": false
           }
         },
+        "fit-content": {
+          "__compat": {
+            "description": "<code>fit-content</code>",
+            "support": {
+              "chrome": [
+                {
+                  "version_added": "46"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "25"
+                }
+              ],
+              "chrome_android": [
+                {
+                  "version_added": "46"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "25"
+                }
+              ],
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "partial_implementation": true,
+                "prefix": "-moz-",
+                "version_added": "3",
+                "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": "43"
+              },
+              "safari": [
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "6.1"
+                },
+                {
+                  "alternative_name": "intrinsic",
+                  "version_added": "2"
+                }
+              ],
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": [
+                {
+                  "version_added": "46"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": true
+                }
+              ]
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "max-content": {
           "__compat": {
             "description": "<code>max-content</code>",
@@ -225,85 +304,6 @@
                 "alternative_name": "-webkit-fill-available",
                 "version_added": "4.4"
               }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "fit-content": {
-          "__compat": {
-            "description": "<code>fit-content</code>",
-            "support": {
-              "chrome": [
-                {
-                  "version_added": "46"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "25"
-                }
-              ],
-              "chrome_android": [
-                {
-                  "version_added": "46"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "25"
-                }
-              ],
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "partial_implementation": true,
-                "prefix": "-moz-",
-                "version_added": "3",
-                "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "44"
-              },
-              "opera_android": {
-                "version_added": "43"
-              },
-              "safari": [
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "6.1"
-                },
-                {
-                  "alternative_name": "intrinsic",
-                  "version_added": "2"
-                }
-              ],
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": "5.0"
-              },
-              "webview_android": [
-                {
-                  "version_added": "46"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": true
-                }
-              ]
             },
             "status": {
               "experimental": true,

--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -231,84 +231,84 @@
               "standard_track": true,
               "deprecated": false
             }
-          },
-          "fit-content": {
-            "__compat": {
-              "description": "<code>fit-content</code>",
-              "support": {
-                "chrome": [
-                  {
-                    "version_added": "46"
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "25"
-                  }
-                ],
-                "chrome_android": [
-                  {
-                    "version_added": "46"
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "25"
-                  }
-                ],
-                "edge": {
-                  "version_added": false
+          }
+        },
+        "fit-content": {
+          "__compat": {
+            "description": "<code>fit-content</code>",
+            "support": {
+              "chrome": [
+                {
+                  "version_added": "46"
                 },
-                "edge_mobile": {
-                  "version_added": false
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "25"
+                }
+              ],
+              "chrome_android": [
+                {
+                  "version_added": "46"
                 },
-                "firefox": {
-                  "partial_implementation": true,
-                  "prefix": "-moz-",
-                  "version_added": "3",
-                  "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "44"
-                },
-                "opera_android": {
-                  "version_added": "43"
-                },
-                "safari": [
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "6.1"
-                  },
-                  {
-                    "alternative_name": "intrinsic",
-                    "version_added": "2"
-                  }
-                ],
-                "safari_ios": {
-                  "version_added": null
-                },
-                "samsunginternet_android": {
-                  "version_added": "5.0"
-                },
-                "webview_android": [
-                  {
-                    "version_added": "46"
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": true
-                  }
-                ]
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "25"
+                }
+              ],
+              "edge": {
+                "version_added": false
               },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "partial_implementation": true,
+                "prefix": "-moz-",
+                "version_added": "3",
+                "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": "43"
+              },
+              "safari": [
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "6.1"
+                },
+                {
+                  "alternative_name": "intrinsic",
+                  "version_added": "2"
+                }
+              ],
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": [
+                {
+                  "version_added": "46"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": true
+                }
+              ]
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -263,78 +263,78 @@
               "standard_track": true,
               "deprecated": false
             }
-          },
-          "fit-content": {
-            "__compat": {
-              "description": "<code>fit-content</code>",
-              "support": {
-                "chrome": [
-                  {
-                    "version_added": "46"
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "25"
-                  }
-                ],
-                "chrome_android": {
+          }
+        },
+        "fit-content": {
+          "__compat": {
+            "description": "<code>fit-content</code>",
+            "support": {
+              "chrome": [
+                {
                   "version_added": "46"
                 },
-                "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "partial_implementation": true,
-                  "prefix": "-moz-",
-                  "version_added": "3",
-                  "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
-                },
-                "firefox_android": {
-                  "version_added": null
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "44"
-                },
-                "opera_android": {
-                  "version_added": "43"
-                },
-                "safari": [
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "6.1"
-                  },
-                  {
-                    "alternative_name": "intrinsic",
-                    "version_added": "2"
-                  }
-                ],
-                "safari_ios": {
-                  "version_added": null
-                },
-                "samsunginternet_android": {
-                  "version_added": "5.0"
-                },
-                "webview_android": [
-                  {
-                    "version_added": "46"
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": true
-                  }
-                ]
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "25"
+                }
+              ],
+              "chrome_android": {
+                "version_added": "46"
               },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "partial_implementation": true,
+                "prefix": "-moz-",
+                "version_added": "3",
+                "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": "43"
+              },
+              "safari": [
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "6.1"
+                },
+                {
+                  "alternative_name": "intrinsic",
+                  "version_added": "2"
+                }
+              ],
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": [
+                {
+                  "version_added": "46"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": true
+                }
+              ]
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -53,6 +53,79 @@
             "deprecated": false
           }
         },
+        "fit-content": {
+          "__compat": {
+            "description": "<code>fit-content</code>",
+            "support": {
+              "chrome": [
+                {
+                  "version_added": "46"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "25"
+                }
+              ],
+              "chrome_android": {
+                "version_added": "46"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "partial_implementation": true,
+                "prefix": "-moz-",
+                "version_added": "3",
+                "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": "43"
+              },
+              "safari": [
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "6.1"
+                },
+                {
+                  "alternative_name": "intrinsic",
+                  "version_added": "2"
+                }
+              ],
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": [
+                {
+                  "version_added": "46"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": true
+                }
+              ]
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "max-content": {
           "__compat": {
             "description": "<code>max-content</code>",
@@ -257,79 +330,6 @@
                 "alternative_name": "-webkit-fill-available",
                 "version_added": "4.4"
               }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "fit-content": {
-          "__compat": {
-            "description": "<code>fit-content</code>",
-            "support": {
-              "chrome": [
-                {
-                  "version_added": "46"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "25"
-                }
-              ],
-              "chrome_android": {
-                "version_added": "46"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "partial_implementation": true,
-                "prefix": "-moz-",
-                "version_added": "3",
-                "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "44"
-              },
-              "opera_android": {
-                "version_added": "43"
-              },
-              "safari": [
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "6.1"
-                },
-                {
-                  "alternative_name": "intrinsic",
-                  "version_added": "2"
-                }
-              ],
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": "5.0"
-              },
-              "webview_android": [
-                {
-                  "version_added": "46"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": true
-                }
-              ]
             },
             "status": {
               "experimental": true,


### PR DESCRIPTION
Looks like `fit-content` was incorrectly placed under `stretch`, based upon what I can tell in the data.  This PR moves them out a level, and in turn fixes consistency.