### PR TITLE
Remove IE 1.5

### DIFF
--- a/browsers/ie.json
+++ b/browsers/ie.json
@@ -7,9 +7,6 @@
           "release_date": "1995-08-16",
           "status": "retired"
         },
-        "1.5": {
-          "status": "retired"
-        },
         "2": {
           "release_date": "1995-11-22",
           "status": "retired"


### PR DESCRIPTION
Follow-up to #3879.  Since IE 1.5 isn't actually used anywhere, and it seems to not provide any new features other than possibly Windows NT compatibility (plus it had a release date AFTER version 2.0), it was thought to be better to simply remove it.