### PR TITLE
Set Firefox to 53 for api.BaseAudioContext.*

### DIFF
--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -132,10 +132,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
             },
             "ie": {
               "version_added": false
@@ -197,10 +199,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
             },
             "ie": {
               "version_added": false
@@ -262,10 +266,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
             },
             "ie": {
               "version_added": false
@@ -327,10 +333,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
             },
             "ie": {
               "version_added": false
@@ -392,10 +400,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
             },
             "ie": {
               "version_added": false
@@ -457,10 +467,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
             },
             "ie": {
               "version_added": false
@@ -573,10 +585,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
             },
             "ie": {
               "version_added": false
@@ -638,10 +652,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
             },
             "ie": {
               "version_added": false
@@ -703,10 +719,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
             },
             "ie": {
               "version_added": false
@@ -768,10 +786,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
             },
             "ie": {
               "version_added": false
@@ -832,10 +852,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 50."
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 50."
             },
             "ie": {
               "version_added": false
@@ -884,10 +906,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
             },
             "ie": {
               "version_added": false
@@ -949,10 +973,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
             },
             "ie": {
               "version_added": false
@@ -1033,10 +1059,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
             },
             "ie": {
               "version_added": false
@@ -1159,10 +1187,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
             },
             "ie": {
               "version_added": false
@@ -1223,10 +1253,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 37."
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 37."
             },
             "ie": {
               "version_added": false
@@ -1275,10 +1307,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
             },
             "ie": {
               "version_added": false
@@ -1340,10 +1374,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
             },
             "ie": {
               "version_added": false
@@ -1405,10 +1441,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
             },
             "ie": {
               "version_added": false
@@ -1468,10 +1506,12 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "53"
+                "version_added": "53",
+                "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 36."
               },
               "firefox_android": {
-                "version_added": "53"
+                "version_added": "53",
+                "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 36."
               },
               "ie": {
                 "version_added": false
@@ -1521,10 +1561,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
             },
             "ie": {
               "version_added": false
@@ -1650,10 +1692,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 40."
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 40."
             },
             "ie": {
               "version_added": false
@@ -1702,10 +1746,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 25."
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 26."
             },
             "ie": {
               "version_added": false
@@ -1766,10 +1812,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox 40."
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": "Originally implemented on <a href='https://developer.mozilla.org/docs/Web/API/AudioContext'><code>AudioContext</code></a> in Firefox Android 40."
             },
             "ie": {
               "version_added": false

--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -132,10 +132,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "53"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "53"
             },
             "ie": {
               "version_added": false
@@ -197,10 +197,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "53"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "53"
             },
             "ie": {
               "version_added": false
@@ -262,10 +262,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "53"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "53"
             },
             "ie": {
               "version_added": false
@@ -327,10 +327,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "53"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "53"
             },
             "ie": {
               "version_added": false
@@ -392,10 +392,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "53"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "53"
             },
             "ie": {
               "version_added": false
@@ -457,10 +457,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "53"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "53"
             },
             "ie": {
               "version_added": false
@@ -573,10 +573,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "53"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "53"
             },
             "ie": {
               "version_added": false
@@ -638,10 +638,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "53"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "53"
             },
             "ie": {
               "version_added": false
@@ -703,10 +703,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "53"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "53"
             },
             "ie": {
               "version_added": false
@@ -768,10 +768,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "53"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "53"
             },
             "ie": {
               "version_added": false
@@ -832,10 +832,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "50"
+              "version_added": "53"
             },
             "firefox_android": {
-              "version_added": "50"
+              "version_added": "53"
             },
             "ie": {
               "version_added": false
@@ -884,10 +884,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "53"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "53"
             },
             "ie": {
               "version_added": false
@@ -949,10 +949,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "53"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "53"
             },
             "ie": {
               "version_added": false
@@ -1033,10 +1033,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "53"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "53"
             },
             "ie": {
               "version_added": false
@@ -1159,10 +1159,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "53"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "53"
             },
             "ie": {
               "version_added": false
@@ -1223,10 +1223,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "37"
+              "version_added": "53"
             },
             "firefox_android": {
-              "version_added": "37"
+              "version_added": "53"
             },
             "ie": {
               "version_added": false
@@ -1275,10 +1275,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "53"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "53"
             },
             "ie": {
               "version_added": false
@@ -1340,10 +1340,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "53"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "53"
             },
             "ie": {
               "version_added": false
@@ -1405,10 +1405,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "53"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "53"
             },
             "ie": {
               "version_added": false
@@ -1468,10 +1468,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "36"
+                "version_added": "53"
               },
               "firefox_android": {
-                "version_added": "36"
+                "version_added": "53"
               },
               "ie": {
                 "version_added": false
@@ -1521,10 +1521,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "53"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "53"
             },
             "ie": {
               "version_added": false
@@ -1586,10 +1586,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "53"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "53"
             },
             "ie": {
               "version_added": false
@@ -1650,10 +1650,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "40"
+              "version_added": "53"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "53"
             },
             "ie": {
               "version_added": false
@@ -1702,10 +1702,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "53"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "53"
             },
             "ie": {
               "version_added": false
@@ -1766,10 +1766,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "40"
+              "version_added": "53"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "53"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
`BaseAudioContext` has been a weird API in terms of consistency.  It seems that most of the properties were implemented in `AudioContext`.  I have confirmed that `BaseAudioContext` was [implemented in Firefox 53](https://bugzilla.mozilla.org/show_bug.cgi?id=1324352).

This PR sets said version number accordingly, which additionally eliminates version inconsistency.