### PR TITLE
Add api.Element.DOMMouseScroll_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2289,6 +2289,58 @@
           }
         }
       },
+      "DOMMouseScroll_event": {
+        "__compat": {
+          "description": "<code>DOMMouseScroll</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/DOMMouseScroll_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
       "error_event": {
         "__compat": {
           "description": "<code>error</code> event",


### PR DESCRIPTION
One of the PRs that is intended to complete #1999 once and for all.  This adds https://developer.mozilla.org/en-US/docs/Web/API/Element/DOMMouseScroll_event into the BCD.

_Note: I am not planning on modifying the MDN pages to replace the compatibility table, at least until this PR is merged and a release containing it has been made._