### PR TITLE
Add api.Document.selectionchange_event

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -6795,56 +6795,67 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/onselectionchange",
           "support": {
             "chrome": {
-              "version_added": "49"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": "49"
+              "version_added": true
             },
             "edge": {
-              "version_added": "12"
-            },
-            "edge_mobile": {
-              "version_added": true
-            },
-            "firefox": {
-              "version_added": "45",
-              "notes": "Flag not necessary on Nightly",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.select_events.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "firefox_android": {
-              "version_added": "45",
-              "notes": "Flag not necessary on Nightly",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.select_events.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "ie": {
               "version_added": null
             },
-            "opera": {
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "43",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.select_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "52"
+              },
+              {
+                "version_added": "43",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.select_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "ie": {
               "version_added": true
+            },
+            "opera": {
+              "version_added": null
             },
             "opera_android": {
-              "version_added": true
+              "version_added": null
             },
             "safari": {
-              "version_added": true
+              "version_added": "1.3"
             },
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": null
+            },
             "webview_android": {
-              "version_added": "49"
+              "version_added": true
             }
           },
           "status": {

--- a/api/Document.json
+++ b/api/Document.json
@@ -9127,6 +9127,71 @@
           }
         }
       },
+      "selectionchange_event": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/selectionchange_event",
+          "description": "<code>selectionchange</code> event",
+          "support": {
+            "chrome": {
+              "version_added": "49"
+            },
+            "chrome_android": {
+              "version_added": "49"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "45",
+              "notes": "Flag not necessary on Nightly",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.select_events.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "45",
+              "notes": "Flag not necessary on Nightly",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.select_events.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "49"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "styleSheetSets": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/styleSheetSets",


### PR DESCRIPTION
One of the PRs that is intended to complete #1999 once and for all.  When browsing through the list of remaining old tables, I found this one was flat-out missing.  This creates `selectionchange_event` by copying `onselectionchange`.