### PR TITLE
Clean up Firefox grid preferences, notes, and versions

### DIFF
--- a/css/properties/column-gap.json
+++ b/css/properties/column-gap.json
@@ -128,6 +128,7 @@
                 },
                 {
                   "version_added": "40",
+                  "version_removed": "59",
                   "alternative_name": "grid-gap",
                   "flags": [
                     {
@@ -148,6 +149,7 @@
                 },
                 {
                   "version_added": "40",
+                  "version_removed": "59",
                   "alternative_name": "grid-gap",
                   "flags": [
                     {

--- a/css/properties/gap.json
+++ b/css/properties/gap.json
@@ -128,6 +128,7 @@
                 },
                 {
                   "version_added": "40",
+                  "version_removed": "59",
                   "alternative_name": "grid-gap",
                   "flags": [
                     {
@@ -148,6 +149,7 @@
                 },
                 {
                   "version_added": "40",
+                  "version_removed": "59",
                   "alternative_name": "grid-gap",
                   "flags": [
                     {

--- a/css/properties/grid-area.json
+++ b/css/properties/grid-area.json
@@ -45,6 +45,7 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "59",
                 "flags": [
                   {
                     "type": "preference",
@@ -60,6 +61,7 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "59",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/grid-auto-columns.json
+++ b/css/properties/grid-auto-columns.json
@@ -52,6 +52,7 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "59",
                 "flags": [
                   {
                     "type": "preference",
@@ -67,6 +68,7 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "59",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/grid-auto-flow.json
+++ b/css/properties/grid-auto-flow.json
@@ -45,6 +45,7 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "59",
                 "flags": [
                   {
                     "type": "preference",
@@ -60,6 +61,7 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "59",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/grid-auto-rows.json
+++ b/css/properties/grid-auto-rows.json
@@ -52,6 +52,7 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "59",
                 "flags": [
                   {
                     "type": "preference",
@@ -67,6 +68,7 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "59",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/grid-column-end.json
+++ b/css/properties/grid-column-end.json
@@ -45,6 +45,7 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "59",
                 "flags": [
                   {
                     "type": "preference",
@@ -60,6 +61,7 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "59",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/grid-column-start.json
+++ b/css/properties/grid-column-start.json
@@ -45,6 +45,7 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "59",
                 "flags": [
                   {
                     "type": "preference",
@@ -60,6 +61,7 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "59",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/grid-column.json
+++ b/css/properties/grid-column.json
@@ -45,6 +45,7 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "59",
                 "flags": [
                   {
                     "type": "preference",
@@ -60,6 +61,7 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "59",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/grid-row-end.json
+++ b/css/properties/grid-row-end.json
@@ -45,6 +45,7 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "59",
                 "flags": [
                   {
                     "type": "preference",
@@ -60,6 +61,7 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "59",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/grid-row-start.json
+++ b/css/properties/grid-row-start.json
@@ -45,6 +45,7 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "59",
                 "flags": [
                   {
                     "type": "preference",
@@ -60,6 +61,7 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "59",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/grid-row.json
+++ b/css/properties/grid-row.json
@@ -45,6 +45,7 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "59",
                 "flags": [
                   {
                     "type": "preference",
@@ -60,6 +61,7 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "59",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/grid-template-areas.json
+++ b/css/properties/grid-template-areas.json
@@ -45,6 +45,7 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "59",
                 "flags": [
                   {
                     "type": "preference",
@@ -60,6 +61,7 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "59",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -45,6 +45,7 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "59",
                 "flags": [
                   {
                     "type": "preference",
@@ -60,6 +61,7 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "59",
                 "flags": [
                   {
                     "type": "preference",
@@ -153,6 +155,7 @@
                 },
                 {
                   "version_added": "40",
+                  "version_removed": "59",
                   "flags": [
                     {
                       "type": "preference",
@@ -168,6 +171,7 @@
                 },
                 {
                   "version_added": "40",
+                  "version_removed": "59",
                   "flags": [
                     {
                       "type": "preference",

--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -284,11 +284,11 @@
               ],
               "firefox_android": [
                 {
-                  "version_added": "57"
+                  "version_added": "60"
                 },
                 {
                   "version_added": "52",
-                  "version_removed": "57",
+                  "version_removed": "60",
                   "notes": "<a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> doesn't work in <code>repeat()</code> (see <a href='https://bugzil.la/1350069'>bug 1350069</a>).",
                   "partial_implementation": true
                 },

--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -271,7 +271,7 @@
                   "partial_implementation": true
                 },
                 {
-                  "version_added": true,
+                  "version_added": "31",
                   "version_removed": "52",
                   "flags": [
                     {
@@ -293,7 +293,7 @@
                   "partial_implementation": true
                 },
                 {
-                  "version_added": true,
+                  "version_added": "31",
                   "version_removed": "52",
                   "flags": [
                     {

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -45,6 +45,7 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "59",
                 "flags": [
                   {
                     "type": "preference",
@@ -60,6 +61,7 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "59",
                 "flags": [
                   {
                     "type": "preference",
@@ -153,6 +155,7 @@
                 },
                 {
                   "version_added": "40",
+                  "version_removed": "59",
                   "flags": [
                     {
                       "type": "preference",
@@ -168,6 +171,7 @@
                 },
                 {
                   "version_added": "40",
+                  "version_removed": "59",
                   "flags": [
                     {
                       "type": "preference",
@@ -263,6 +267,7 @@
                 },
                 {
                   "version_added": true,
+                  "version_removed": "59",
                   "flags": [
                     {
                       "type": "preference",
@@ -279,6 +284,7 @@
                 },
                 {
                   "version_added": true,
+                  "version_removed": "59",
                   "flags": [
                     {
                       "type": "preference",

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -266,7 +266,7 @@
                   "notes": "<a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> doesn't work in <code>repeat()</code> (see <a href='https://bugzil.la/1350069'>bug 1350069</a>)."
                 },
                 {
-                  "version_added": true,
+                  "version_added": "31",
                   "version_removed": "59",
                   "flags": [
                     {
@@ -283,7 +283,7 @@
                   "notes": "<a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> doesn't work in <code>repeat()</code> (see <a href='https://bugzil.la/1350069'>bug 1350069</a>)."
                 },
                 {
-                  "version_added": true,
+                  "version_added": "31",
                   "version_removed": "59",
                   "flags": [
                     {

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -262,8 +262,13 @@
               },
               "firefox": [
                 {
+                  "version_added": "57"
+                },
+                {
                   "version_added": "52",
-                  "notes": "<a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> doesn't work in <code>repeat()</code> (see <a href='https://bugzil.la/1350069'>bug 1350069</a>)."
+                  "version_removed": "57",
+                  "notes": "<a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> doesn't work in <code>repeat()</code> (see <a href='https://bugzil.la/1350069'>bug 1350069</a>).",
+                  "partial_implementation": true
                 },
                 {
                   "version_added": "31",
@@ -279,8 +284,13 @@
               ],
               "firefox_android": [
                 {
+                  "version_added": "60"
+                },
+                {
                   "version_added": "52",
-                  "notes": "<a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> doesn't work in <code>repeat()</code> (see <a href='https://bugzil.la/1350069'>bug 1350069</a>)."
+                  "version_removed": "60",
+                  "notes": "<a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> doesn't work in <code>repeat()</code> (see <a href='https://bugzil.la/1350069'>bug 1350069</a>).",
+                  "partial_implementation": true
                 },
                 {
                   "version_added": "31",

--- a/css/properties/grid-template.json
+++ b/css/properties/grid-template.json
@@ -45,10 +45,12 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "59",
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "Enable experimental Web Platform features"
+                    "name": "layout.css.grid.enabled",
+                    "value_to_set": "true"
                   }
                 ]
               }
@@ -59,6 +61,7 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "59",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/grid.json
+++ b/css/properties/grid.json
@@ -45,6 +45,7 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "59",
                 "flags": [
                   {
                     "type": "preference",
@@ -60,6 +61,7 @@
               },
               {
                 "version_added": "40",
+                "version_removed": "59",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/row-gap.json
+++ b/css/properties/row-gap.json
@@ -127,6 +127,7 @@
                 },
                 {
                   "version_added": "40",
+                  "version_removed": "59",
                   "alternative_name": "grid-row-gap",
                   "flags": [
                     {
@@ -147,6 +148,7 @@
                 },
                 {
                   "version_added": "40",
+                  "version_removed": "59",
                   "alternative_name": "grid-row-gap",
                   "flags": [
                     {


### PR DESCRIPTION
This fixes up a few miscellaneous issues I spotted in some of the grid data:

*  The [`layout.css.grid.enabled` pref was removed in Firefox 59](https://bugzilla.mozilla.org/show_bug.cgi?id=1398492)
* [`repeat()` first shipped in Firefox 31](https://bugzilla.mozilla.org/show_bug.cgi?id=978478) (replacing a `true` value)
* A bug involving `repeat()` used with `calc()` [was fixed with Stylo](https://bugzilla.mozilla.org/show_bug.cgi?id=1350069) (producing a few odd inconsistencies between properties and between desktop and Android)