### PR TITLE
Safari supports `allow-top-navigation-by-user-activation`

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -1036,7 +1036,8 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": null
+                "version_added": "11.1",
+                "notes": "Not initially available in 11.1, but added in sub-version 13605.1.33.1.2. Also backported to version 10.13.4 on MacOS High Sierra."
               },
               "safari_ios": {
                 "version_added": null

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -1037,7 +1037,7 @@
               },
               "safari": {
                 "version_added": "11.1",
-                "notes": "Not initially available in 11.1, but added in sub-version 13605.1.33.1.2. Also backported to version 10.13.4 on MacOS High Sierra."
+                "notes": "Not initially available in 11.1, but added in sub-version 13605.1.33.1.2."
               },
               "safari_ios": {
                 "version_added": null


### PR DESCRIPTION
i.e., `<iframe sandbox="allow-top-navigation-by-user-activation">`

See https://bugs.webkit.org/show_bug.cgi?id=171327