### PR TITLE
feat(api, html): Complete Firefox and Edge/IE support for HTML <menu>s

### DIFF
--- a/api/HTMLMenuElement.json
+++ b/api/HTMLMenuElement.json
@@ -11,19 +11,19 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "12"
           },
           "edge_mobile": {
-            "version_added": null
+            "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "8"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "8"
           },
           "ie": {
-            "version_added": null
+            "version_added": true
           },
           "opera": {
             "version_added": true
@@ -43,7 +43,7 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": false,
+          "standard_track": true,
           "deprecated": true
         }
       },
@@ -61,16 +61,16 @@
               "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "8"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "8"
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": true
@@ -90,7 +90,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": true
           }
         }
@@ -112,13 +112,14 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": "8"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "8",
+              "notes": "Nested menus are not supported."
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -138,7 +139,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": true
           }
         }
@@ -154,19 +155,21 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "version_removed": true
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": "12",
+              "version_removed": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": "8"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "8"
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": false
@@ -186,7 +189,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": true
           }
         }

--- a/api/HTMLMenuItemElement.json
+++ b/api/HTMLMenuItemElement.json
@@ -11,19 +11,19 @@
             "version_added": false
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "edge_mobile": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
-            "version_added": true
+            "version_added": "8"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "8"
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": false
@@ -32,18 +32,18 @@
             "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
-            "version_added": null
+            "version_added": false
           }
         },
         "status": {
           "experimental": false,
-          "standard_track": false,
+          "standard_track": true,
           "deprecated": true
         }
       },
@@ -58,19 +58,19 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "8"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "8"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -79,18 +79,66 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "command": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMenuItemElement/command",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
             "deprecated": true
           }
         }
@@ -106,19 +154,21 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": true,
+              "alternative_name": "defaultChecked"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": true,
+              "alternative_name": "defaultChecked"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -127,18 +177,18 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": true
           }
         }
@@ -154,19 +204,19 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "8"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "8"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -175,18 +225,18 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": true
           }
         }
@@ -202,19 +252,19 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "8"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "8"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -223,18 +273,18 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": true
           }
         }
@@ -250,19 +300,19 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "8"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "8"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -271,18 +321,18 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": true
           }
         }
@@ -298,19 +348,19 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "8"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "8"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -319,18 +369,18 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": true
           }
         }
@@ -346,19 +396,19 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "8"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "8"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -367,18 +417,18 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": true
           }
         }

--- a/html/elements/menu.json
+++ b/html/elements/menu.json
@@ -21,7 +21,7 @@
               "version_added": "8"
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "8",
               "notes": "Nested menus are not supported."
             },
             "ie": {
@@ -171,16 +171,16 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": true
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8"
               },
               "firefox_android": {
-                "version_added": true,
+                "version_added": "8",
                 "notes": "Nested menus are not supported."
               },
               "ie": {
@@ -233,7 +233,7 @@
                   "version_added": "8"
                 },
                 "firefox_android": {
-                  "version_added": true,
+                  "version_added": "8",
                   "notes": "Nested menus are not supported."
                 },
                 "ie": {

--- a/html/elements/menuitem.json
+++ b/html/elements/menuitem.json
@@ -12,10 +12,10 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": false
             },
             "firefox": {
               "version_added": "8",
@@ -55,7 +55,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": true
           }
         },
@@ -69,24 +69,16 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": true
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": false
               },
               "firefox": {
-                "version_added": "8",
-                "notes": [
-                  "Only works for <code>&lt;menuitem&gt;</code> elements defined within a <code>&lt;menu&gt;</code> element assigned to an element via the <code>contextmenu</code> attribute.",
-                  "The <code>&lt;menuitem&gt;</code> element requires a closing tag."
-                ]
+                "version_added": "8"
               },
               "firefox_android": {
-                "version_added": "8",
-                "notes": [
-                  "Only works for <code>&lt;menuitem&gt;</code> elements defined within a <code>&lt;menu&gt;</code> element assigned to an element via the <code>contextmenu</code> attribute.",
-                  "The <code>&lt;menuitem&gt;</code> element requires a closing tag."
-                ]
+                "version_added": "8"
               },
               "ie": {
                 "version_added": false
@@ -112,7 +104,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": true
             }
           }
@@ -127,24 +119,16 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": true
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": false
               },
               "firefox": {
-                "version_added": "8",
-                "notes": [
-                  "Only works for <code>&lt;menuitem&gt;</code> elements defined within a <code>&lt;menu&gt;</code> element assigned to an element via the <code>contextmenu</code> attribute.",
-                  "The <code>&lt;menuitem&gt;</code> element requires a closing tag."
-                ]
+                "version_added": "8"
               },
               "firefox_android": {
-                "version_added": "8",
-                "notes": [
-                  "Only works for <code>&lt;menuitem&gt;</code> elements defined within a <code>&lt;menu&gt;</code> element assigned to an element via the <code>contextmenu</code> attribute.",
-                  "The <code>&lt;menuitem&gt;</code> element requires a closing tag."
-                ]
+                "version_added": "8"
               },
               "ie": {
                 "version_added": false
@@ -170,7 +154,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": true
             }
           }
@@ -185,24 +169,16 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": true
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": false
               },
               "firefox": {
-                "version_added": "8",
-                "notes": [
-                  "Only works for <code>&lt;menuitem&gt;</code> elements defined within a <code>&lt;menu&gt;</code> element assigned to an element via the <code>contextmenu</code> attribute.",
-                  "The <code>&lt;menuitem&gt;</code> element requires a closing tag."
-                ]
+                "version_added": "8"
               },
               "firefox_android": {
-                "version_added": "8",
-                "notes": [
-                  "Only works for <code>&lt;menuitem&gt;</code> elements defined within a <code>&lt;menu&gt;</code> element assigned to an element via the <code>contextmenu</code> attribute.",
-                  "The <code>&lt;menuitem&gt;</code> element requires a closing tag."
-                ]
+                "version_added": "8"
               },
               "ie": {
                 "version_added": false
@@ -228,7 +204,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": true
             }
           }
@@ -243,24 +219,16 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": true
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": false
               },
               "firefox": {
-                "version_added": "8",
-                "notes": [
-                  "Only works for <code>&lt;menuitem&gt;</code> elements defined within a <code>&lt;menu&gt;</code> element assigned to an element via the <code>contextmenu</code> attribute.",
-                  "The <code>&lt;menuitem&gt;</code> element requires a closing tag."
-                ]
+                "version_added": "8"
               },
               "firefox_android": {
-                "version_added": "8",
-                "notes": [
-                  "Only works for <code>&lt;menuitem&gt;</code> elements defined within a <code>&lt;menu&gt;</code> element assigned to an element via the <code>contextmenu</code> attribute.",
-                  "The <code>&lt;menuitem&gt;</code> element requires a closing tag."
-                ]
+                "version_added": "8"
               },
               "ie": {
                 "version_added": false
@@ -286,7 +254,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": true
             }
           }
@@ -301,24 +269,16 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": true
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": false
               },
               "firefox": {
-                "version_added": "8",
-                "notes": [
-                  "Only works for <code>&lt;menuitem&gt;</code> elements defined within a <code>&lt;menu&gt;</code> element assigned to an element via the <code>contextmenu</code> attribute.",
-                  "The <code>&lt;menuitem&gt;</code> element requires a closing tag."
-                ]
+                "version_added": "8"
               },
               "firefox_android": {
-                "version_added": "8",
-                "notes": [
-                  "Only works for <code>&lt;menuitem&gt;</code> elements defined within a <code>&lt;menu&gt;</code> element assigned to an element via the <code>contextmenu</code> attribute.",
-                  "The <code>&lt;menuitem&gt;</code> element requires a closing tag."
-                ]
+                "version_added": "8"
               },
               "ie": {
                 "version_added": false
@@ -344,7 +304,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": true
             }
           }
@@ -359,24 +319,16 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": true
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": false
               },
               "firefox": {
-                "version_added": "8",
-                "notes": [
-                  "Only works for <code>&lt;menuitem&gt;</code> elements defined within a <code>&lt;menu&gt;</code> element assigned to an element via the <code>contextmenu</code> attribute.",
-                  "The <code>&lt;menuitem&gt;</code> element requires a closing tag."
-                ]
+                "version_added": "8"
               },
               "firefox_android": {
-                "version_added": "8",
-                "notes": [
-                  "Only works for <code>&lt;menuitem&gt;</code> elements defined within a <code>&lt;menu&gt;</code> element assigned to an element via the <code>contextmenu</code> attribute.",
-                  "The <code>&lt;menuitem&gt;</code> element requires a closing tag."
-                ]
+                "version_added": "8"
               },
               "ie": {
                 "version_added": false
@@ -402,7 +354,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": true
             }
           }
@@ -417,24 +369,16 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": true
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": false
               },
               "firefox": {
-                "version_added": "8",
-                "notes": [
-                  "Only works for <code>&lt;menuitem&gt;</code> elements defined within a <code>&lt;menu&gt;</code> element assigned to an element via the <code>contextmenu</code> attribute.",
-                  "The <code>&lt;menuitem&gt;</code> element requires a closing tag."
-                ]
+                "version_added": "8"
               },
               "firefox_android": {
-                "version_added": "8",
-                "notes": [
-                  "Only works for <code>&lt;menuitem&gt;</code> elements defined within a <code>&lt;menu&gt;</code> element assigned to an element via the <code>contextmenu</code> attribute.",
-                  "The <code>&lt;menuitem&gt;</code> element requires a closing tag."
-                ]
+                "version_added": "8"
               },
               "ie": {
                 "version_added": false
@@ -460,7 +404,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": true
             }
           }


### PR DESCRIPTION
I’ve manually tested **IE 11**, **Edge 18** and **Firefox Nightly**.

review?(@Elchi3, @irenesmith, @vinyldarkscratch)