### PR TITLE
IE/Edge Mobile: CSS, null to false

### DIFF
--- a/css/properties/box-lines.json
+++ b/css/properties/box-lines.json
@@ -19,7 +19,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -28,7 +28,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true,

--- a/css/properties/column-fill.json
+++ b/css/properties/column-fill.json
@@ -36,7 +36,7 @@
               }
             ],
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null

--- a/css/properties/contain.json
+++ b/css/properties/contain.json
@@ -15,7 +15,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "41",
@@ -40,7 +40,7 @@
               "notes": "See <a href='https://bugzil.la/1150081'>bug 1150081</a> for the overall implementation status."
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "40"

--- a/css/properties/line-height-step.json
+++ b/css/properties/line-height-step.json
@@ -27,7 +27,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -36,7 +36,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "47",

--- a/css/properties/offset-distance.json
+++ b/css/properties/offset-distance.json
@@ -27,7 +27,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -36,7 +36,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null

--- a/css/properties/offset-path.json
+++ b/css/properties/offset-path.json
@@ -54,7 +54,7 @@
               ]
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": [
               {
@@ -125,7 +125,7 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "51"

--- a/css/properties/offset-rotate.json
+++ b/css/properties/offset-rotate.json
@@ -35,7 +35,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -44,7 +44,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null

--- a/css/properties/offset.json
+++ b/css/properties/offset.json
@@ -27,7 +27,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -36,7 +36,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null


### PR DESCRIPTION
Based upon manual testing, I've found various properties set to `null` that were unsupported in IE (and Edge Mobile).  This PR updates the BCD to reflect said tests.