### PR TITLE
Set Opera to false in html.elements.menu

### DIFF
--- a/html/elements/menu.json
+++ b/html/elements/menu.json
@@ -28,14 +28,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Enable Experimental Web Platform Features",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "opera_android": {
               "version_added": false
@@ -136,7 +129,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
                 "version_added": false
@@ -187,7 +180,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": false
               },
               "opera_android": {
                 "version_added": false
@@ -240,7 +233,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": true
+                  "version_added": false
                 },
                 "opera_android": {
                   "version_added": false


### PR DESCRIPTION
I noticed that Opera had a flag saying that the `menu` element was supported by enabling experimental web features.  This was manually confirmed to be false, and this PR updates the data to reflect as such.