### PR TITLE
Add Safari support for api.Request.destination

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -898,10 +898,10 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
Manual testing in Safari and Safari iOS revealed support for api.Request.destination in 10.1 and above.  This PR reflects said tests, and fixes #3959 in the process.