### PR TITLE
Remove css.properties.background-image.any_image

### DIFF
--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -391,57 +391,6 @@
               "deprecated": false
             }
           }
-        },
-        "any_image": {
-          "__compat": {
-            "description": "Any <code>&lt;image&gt;</code> value",
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
I was looking through `css.properties.background-image`, and I noticed the `any_image` property added to the compatibility table.  However, upon further inspection, I noticed that it was quite redundant.  All of the possible `<image>` values were listed individually (aside from `url()`, though that is covered by the basic support as it's from the original spec).

This PR removes the redundant property.