### PR TITLE
Update css.properties.font-variant/text-transform

### DIFF
--- a/css/properties/font-variant.json
+++ b/css/properties/font-variant.json
@@ -30,13 +30,13 @@
               "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "3.5"
             },
             "safari": {
               "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -56,10 +56,10 @@
             "description": "<code>ß</code> → <code>SS</code>",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": false
@@ -71,28 +71,28 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "4"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
-                "version_added": false
+                "version_added": true
               }
             },
             "status": {
@@ -107,16 +107,16 @@
             "description": "<code>i</code> → <code>İ</code> and <code>ı</code> → <code>I</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "14"
@@ -125,25 +125,25 @@
                 "version_added": "14"
               },
               "ie": {
-                "version_added": null
+                "version_added": true
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": false
+                "version_added": true
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": true
               },
               "webview_android": {
-                "version_added": false
+                "version_added": true
               }
             },
             "status": {
@@ -158,43 +158,44 @@
             "description": "Greek accented characters",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "12",
+                "version_removed": "18"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "15"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "15"
               },
               "ie": {
-                "version_added": false
+                "version_added": true
               },
               "opera": {
-                "version_added": false
+                "version_added": true
               },
               "opera_android": {
-                "version_added": false
+                "version_added": true
               },
               "safari": {
-                "version_added": false
+                "version_added": true
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": true
               },
               "webview_android": {
-                "version_added": false
+                "version_added": true
               }
             },
             "status": {

--- a/css/properties/text-transform.json
+++ b/css/properties/text-transform.json
@@ -115,13 +115,13 @@
                 "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "19"
@@ -169,10 +169,10 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "64"
@@ -181,22 +181,22 @@
                 "version_added": "64"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": false
@@ -217,13 +217,13 @@
                 "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "14"
@@ -268,40 +268,40 @@
                 "version_added": "30"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "30"
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "15"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "15"
               },
               "ie": {
-                "version_added": false
+                "version_added": true
               },
               "opera": {
-                "version_added": false
+                "version_added": "17"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "17"
               },
               "safari": {
-                "version_added": false
+                "version_added": true
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "4.4"
               }
             },
             "status": {
@@ -319,13 +319,13 @@
                 "version_added": "30"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "30"
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "14"
@@ -334,25 +334,25 @@
                 "version_added": "14"
               },
               "ie": {
-                "version_added": false
+                "version_added": true
               },
               "opera": {
-                "version_added": false
+                "version_added": "17"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "17"
               },
               "safari": {
                 "version_added": "6"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "6"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "4.4"
               }
             },
             "status": {
@@ -367,16 +367,16 @@
             "description": "<code>i</code> → <code>İ</code> and <code>ı</code> → <code>I</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "14"
@@ -385,25 +385,25 @@
                 "version_added": "14"
               },
               "ie": {
-                "version_added": null
+                "version_added": true
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": false
+                "version_added": true
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": true
               },
               "webview_android": {
-                "version_added": false
+                "version_added": true
               }
             },
             "status": {
@@ -418,16 +418,16 @@
             "description": "<code>ß</code> → <code>SS</code>",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": true
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": true
               },
               "firefox": {
                 "version_added": "1"
@@ -436,25 +436,25 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
-                "version_added": null
+                "version_added": false
               }
             },
             "status": {


### PR DESCRIPTION
While testing the compatibility data for the 2019 Key Result in determining version numbers, I noticed inaccuracies in the data of `font-variant` and `text-transform`, where they were set to `false` when they should have been `true`.  This PR updates all of the language-based pieces of both properties, based upon manual testing in the following browsers:

- Chrome 73 (macOS)
- Firefox 66 (macOS)
- Safari 12.1 (macOS)
- IE 11 (Windows 10)
- Edge 15-18 (Windows 10)
- Firefox Android 66