### PR TITLE
Add css.at-rules.font-face.font-stretch

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -468,10 +468,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-face/font-stretch",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "62"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "62"
               },
               "edge": {
                 "version_added": "17"
@@ -486,10 +486,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "49"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "41"
               },
               "safari": {
                 "version_added": "10.1"
@@ -498,10 +498,10 @@
                 "version_added": "10.3"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "6.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "62"
               }
             },
             "status": {

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -495,10 +495,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": "11.1"
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": "11.1"
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -476,9 +476,6 @@
               "edge": {
                 "version_added": "17"
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "62"
               },

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -474,16 +474,16 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "17"
               },
               "edge_mobile": {
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": "62"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "62"
               },
               "ie": {
                 "version_added": false
@@ -495,10 +495,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "11.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "11.1"
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -486,7 +486,7 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": true

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -463,6 +463,57 @@
             }
           }
         },
+        "font-stretch": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-face/font-stretch",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "font-style": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-face/font-style",


### PR DESCRIPTION
A part of https://github.com/mdn/sprints/issues/1378 to add basic BCD.  Values were identified via manual testing within SauceLabs.