### PR TITLE
Update compatibility for css.properties.font-stretch

### DIFF
--- a/css/properties/font-stretch.json
+++ b/css/properties/font-stretch.json
@@ -6,10 +6,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-stretch",
           "support": {
             "chrome": {
-              "version_added": "60"
+              "version_added": "60",
+              "notes": "A <code>font-stretch</code> definition must be added to the <code>@font-face</code> before this property will function."
             },
             "chrome_android": {
-              "version_added": "60"
+              "version_added": "60",
+              "notes": "A <code>font-stretch</code> definition must be added to the <code>@font-face</code> before this property will function."
             },
             "edge": {
               "version_added": "12"
@@ -27,22 +29,26 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": "47"
+              "version_added": "47",
+              "notes": "A <code>font-stretch</code> definition must be added to the <code>@font-face</code> before this property will function."
             },
             "opera_android": {
-              "version_added": "44"
+              "version_added": "44",
+              "notes": "A <code>font-stretch</code> definition must be added to the <code>@font-face</code> before this property will function."
             },
             "safari": {
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "notes": "A <code>font-stretch</code> definition must be added to the <code>@font-face</code> before this property will function."
             },
             "webview_android": {
-              "version_added": "60"
+              "version_added": "60",
+              "notes": "A <code>font-stretch</code> definition must be added to the <code>@font-face</code> before this property will function."
             }
           },
           "status": {
@@ -56,16 +62,16 @@
             "description": "<code>&lt;percentage&gt;</code> syntax",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "62"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "62"
               },
               "edge": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "61"
@@ -77,22 +83,22 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": "49"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "46"
               },
               "safari": {
-                "version_added": null
+                "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "62"
               }
             },
             "status": {


### PR DESCRIPTION
This PR updates the `font-stretch` property based upon manual testing.  A summary of the changes:

- Chromium requires a `font-stretch` value defined on the `@font-face`.  This has been [stated by a Chromium developer](https://bugs.chromium.org/p/chromium/issues/detail?id=331119#c20).
- Safari iOS supports `font-stretch`.
- Percentage-based values are supported since Chromium 62 and Edge 18.  This has been manually tested in LambdaTest.
- Percentage-based values are supported in Safari.  This has been manually tested on my local machine (Safari 12.1, macOS 10.14.4).