### PR TITLE
Set IE/Edge versions for css.properties.clip-path

### DIFF
--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -24,7 +24,7 @@
               }
             ],
             "edge": {
-              "version_added": "15",
+              "version_added": "12",
               "notes": "Edge only supports clip paths defined by <code>url()</code>."
             },
             "edge_mobile": {
@@ -83,7 +83,7 @@
                 "version_added": "55"
               },
               "edge": {
-                "version_added": "15"
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": "12"

--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -38,7 +38,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true,
+              "version_added": "10",
               "notes": "Internet Explorer only supports clip paths defined by <code>url()</code>."
             },
             "opera": {
@@ -95,7 +95,7 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": true
+                "version_added": "10"
               },
               "opera": {
                 "version_added": "42"


### PR DESCRIPTION
This PR does two things regarding IE and Edge:

1. Sets `clip-path` and `clip-path.svg` to IE 10, based upon manual testing.
2. Changes Edge for `clip-path` and `clip-path.svg` from 15 to 12.