### PR TITLE
Update css.properties.font.font_stretch_support

### DIFF
--- a/css/properties/font.json
+++ b/css/properties/font.json
@@ -104,19 +104,19 @@
         },
         "font_stretch_support": {
           "__compat": {
-            "description": "Support for <code>font-stretch</code> values",
+            "description": "Support for <code>font-stretch</code> values in shorthand",
             "support": {
               "chrome": {
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "43"
@@ -125,25 +125,25 @@
                 "version_added": "43"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
-                "version_added": null
+                "version_added": true
               }
             },
             "status": {


### PR DESCRIPTION
This PR does two things:

1) Updates all the data with manual testing in each browser (and also mirroring Chromium onto Opera, et. al.).
2) Updates the description of the property a little bit, clarifying it's referring to inclusion in the shorthand, rather than the `font-stretch` property.