### PR TITLE
Add Node.js for-await-of info

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1024,7 +1024,7 @@
                   }
                 ]
               }
-            ]
+            ],
             
             "opera": {
               "version_added": "50"

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1010,10 +1010,22 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": {
-              "version_added": "10",
-              "notes": "Available in v9.2+ behind --harmony-async-iteration"
-            },
+            "nodejs": [
+              {
+                "version_added": "10.0.0"
+              },
+              {
+                "version_added": "9.2.0",
+                "version_removed": "10.0.0",
+                "flags": [
+                  {
+                    "type": "runtime_flag",
+                    "name": "--harmony-async-iteration"
+                  }
+                ]
+              }
+            ]
+            
             "opera": {
               "version_added": "50"
             },

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1025,7 +1025,6 @@
                 ]
               }
             ],
-            
             "opera": {
               "version_added": "50"
             },

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1015,7 +1015,7 @@
                 "version_added": "10.0.0"
               },
               {
-                "version_added": "9.2.0",
+                "version_added": "8.10.0",
                 "version_removed": "10.0.0",
                 "flags": [
                   {

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1011,7 +1011,8 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": null
+              "version_added": "10",
+              "notes": "Available in v9.2+ behind --harmony-async-iteration"
             },
             "opera": {
               "version_added": "50"


### PR DESCRIPTION
Add Node.js for-await-of info; available as of v10, or v9.2 behind `--harmony-async-iteration`.

