### PR TITLE
CSS: absolute/sticky positioning within tables

### DIFF
--- a/css/properties/position.json
+++ b/css/properties/position.json
@@ -175,16 +175,16 @@
             "description": "Table elements as <code>absolute</code> positioning containers",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "30",
@@ -195,25 +195,25 @@
                 "notes": "Firefox helps developers transition to the new behavior and detect any rendering issues it may cause on their sites by printing the following warning to the JavaScript console: &quot;Absolute positioning of table rows and row groups is now supported. This site may need to be updated because it may depend on this feature having no effect.&quot;"
               },
               "ie": {
-                "version_added": null
+                "version_added": "4"
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
-                "version_added": null
+                "version_added": true
               }
             },
             "status": {

--- a/css/properties/position.json
+++ b/css/properties/position.json
@@ -228,16 +228,16 @@
             "description": "Table elements as <code>sticky</code> positioning containers",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": true
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "16"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "59"
@@ -246,25 +246,25 @@
                 "version_added": "59"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": true
               },
               "opera_android": {
-                "version_added": false
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": true
               },
               "webview_android": {
-                "version_added": false
+                "version_added": true
               }
             },
             "status": {


### PR DESCRIPTION
This adds compatibility data for absolute and sticky positioning, using table elements as containers.  All data was manually tested using LambdaTest.