### PR TITLE
Update CSS selectors "no parent" support

### DIFF
--- a/css/selectors/first-child.json
+++ b/css/selectors/first-child.json
@@ -67,10 +67,10 @@
                 "version_added": "57"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "52"
@@ -79,7 +79,7 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "44"
@@ -88,10 +88,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "7.0"

--- a/css/selectors/last-child.json
+++ b/css/selectors/last-child.json
@@ -63,10 +63,10 @@
                 "version_added": "57"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "52"
@@ -75,7 +75,7 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "44"
@@ -84,10 +84,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "7.0"

--- a/css/selectors/nth-child.json
+++ b/css/selectors/nth-child.json
@@ -118,10 +118,10 @@
                 "version_added": "57"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "52"
@@ -130,7 +130,7 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "44"
@@ -139,10 +139,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "7.0"

--- a/css/selectors/nth-last-child.json
+++ b/css/selectors/nth-last-child.json
@@ -116,10 +116,10 @@
                 "version_added": "57"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "52"
@@ -128,7 +128,7 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "44"
@@ -137,10 +137,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "7.0"

--- a/css/selectors/only-child.json
+++ b/css/selectors/only-child.json
@@ -63,10 +63,10 @@
                 "version_added": "57"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "52"
@@ -75,7 +75,7 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "44"
@@ -84,10 +84,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "7.0"


### PR DESCRIPTION
Manually tested with http://software.hixie.ch/utilities/js/live-dom-viewer/?%3C!DOCTYPE%20html%3E%0A%3Cstyle%3Ehtml%20%7B%20color%3A%20red%3B%20%7D%20html%3Afirst-child%20%7B%20color%3A%20green%3B%20%7D%3C%2Fstyle%3E%0Afoo

Also found here: https://www.chromestatus.com/feature/5705677431373824
Edge: No public signals
Safari:No public signals 