### PR TITLE
css.properties.text-decoration.blink: remove has-no-effect notes

### DIFF
--- a/css/properties/text-decoration.json
+++ b/css/properties/text-decoration.json
@@ -56,75 +56,47 @@
             "description": "<code>blink</code>",
             "support": {
               "chrome": {
-                "version_added": "57",
-                "notes": "The <code>blink</code> value does not have any effect."
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": "57",
-                "notes": "The <code>blink</code> value does not have any effect."
+                "version_added": false
               },
               "edge": {
-                "version_added": "12",
-                "notes": "The <code>blink</code> value does not have any effect."
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": true,
-                "notes": "The <code>blink</code> value does not have any effect."
+                "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "23",
-                  "notes": "The <code>blink</code> value does not have any effect."
-                },
-                {
-                  "version_added": "1"
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "23",
-                  "notes": "The <code>blink</code> value does not have any effect."
-                },
-                {
-                  "version_added": "4"
-                }
-              ],
+              "firefox": {
+                "version_added": "1",
+                "version_removed": "23"
+              },
+              "firefox_android": {
+                "version_added": "4",
+                "version_removed": "23"
+              },
               "ie": {
-                "version_added": true,
-                "notes": "The <code>blink</code> value does not have any effect."
+                "version_added": false
               },
-              "opera": [
-                {
-                  "version_added": "15",
-                  "notes": "The <code>blink</code> value does not have any effect."
-                },
-                {
-                  "version_added": "4"
-                }
-              ],
-              "opera_android": [
-                {
-                  "version_added": "14",
-                  "notes": "The <code>blink</code> value does not have any effect."
-                },
-                {
-                  "version_added": "10.1"
-                }
-              ],
+              "opera": {
+                "version_added": "4",
+                "version_removed": "15"
+              },
+              "opera_android": {
+                "version_added": "10.1",
+                "version_removed": "14"
+              },
               "safari": {
-                "version_added": true,
-                "notes": "The <code>blink</code> value does not have any effect."
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": true,
-                "notes": "The <code>blink</code> value does not have any effect."
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "7.0"
               },
               "webview_android": {
-                "version_added": "57",
-                "notes": "The <code>blink</code> value does not have any effect."
+                "version_added": false
               }
             },
             "status": {


### PR DESCRIPTION
We've established that if a property is accepted but has no effect, it is unsupported.  It looks like `text-decoration: blink` had numerous notes that described it as being recognized in browsers, but with no effect.  This PR removes the notes that state the value has no effect, and replaces them with `version_added: false` or `version_removed` statements.