### PR TITLE
Update css.properties.user-select[.contain]

### DIFF
--- a/css/properties/user-select.json
+++ b/css/properties/user-select.json
@@ -86,6 +86,7 @@
               }
             ],
             "ie": {
+              "prefix": "-ms-",
               "version_added": "10"
             },
             "opera": {
@@ -351,39 +352,24 @@
               "chrome_android": {
                 "version_added": false
               },
-              "edge": [
-                {
-                  "version_added": "12"
-                },
-                {
-                  "alternative_name": "element",
-                  "version_added": "12"
-                }
-              ],
-              "edge_mobile": [
-                {
-                  "version_added": "12"
-                },
-                {
-                  "alternative_name": "element",
-                  "version_added": "12"
-                }
-              ],
+              "edge": {
+                "alternative_name": "element",
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "alternative_name": "element",
+                "version_added": "12"
+              },
               "firefox": {
                 "version_added": false
               },
               "firefox_android": {
                 "version_added": false
               },
-              "ie": [
-                {
-                  "version_added": true
-                },
-                {
-                  "alternative_name": "element",
-                  "version_added": "10"
-                }
-              ],
+              "ie": {
+                "alternative_name": "element",
+                "version_added": "10"
+              },
               "opera": {
                 "version_added": false
               },


### PR DESCRIPTION
This PR updates the `user-select` property by adding the prefix for IE and updating the `contain` property to remove the `version_added: true` statements (which were disproven; IE and Edge only support it via the alternative name of "element").