### PR TITLE
Add IE versions for CSS properties

### DIFF
--- a/css/properties/height.json
+++ b/css/properties/height.json
@@ -190,10 +190,10 @@
                 "version_added": "28"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": null
@@ -202,7 +202,7 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -202,7 +202,8 @@
                   "version_added": "45"
                 },
                 "ie": {
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "opera": {
                   "version_added": false,

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -246,7 +246,7 @@
                   "version_added": false
                 },
                 "edge_mobile": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "52"
@@ -255,8 +255,7 @@
                   "version_added": "52"
                 },
                 "ie": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": false
                 },
                 "opera": {
                   "version_added": false,

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -202,8 +202,7 @@
                   "version_added": "45"
                 },
                 "ie": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": false
                 },
                 "opera": {
                   "version_added": false,
@@ -256,7 +255,8 @@
                   "version_added": "52"
                 },
                 "ie": {
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "opera": {
                   "version_added": false,

--- a/css/properties/letter-spacing.json
+++ b/css/properties/letter-spacing.json
@@ -62,10 +62,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": false
@@ -74,7 +74,7 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
+                "version_added": "10"
               },
               "opera": {
                 "version_added": true

--- a/css/properties/outline-style.json
+++ b/css/properties/outline-style.json
@@ -81,7 +81,7 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null

--- a/css/properties/overflow-wrap.json
+++ b/css/properties/overflow-wrap.json
@@ -169,10 +169,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "65"
@@ -181,7 +181,7 @@
                 "version_added": "65"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null

--- a/css/properties/text-align-last.json
+++ b/css/properties/text-align-last.json
@@ -41,7 +41,7 @@
               "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": [
               {
@@ -64,7 +64,7 @@
               }
             ],
             "ie": {
-              "version_added": true,
+              "version_added": "5.5",
               "partial_implementation": true,
               "notes": [
                 "IE only supports <code>text-align-last</code> when <code>text-align</code> is set to <code>justify</code>.",

--- a/css/properties/transition-timing-function.json
+++ b/css/properties/transition-timing-function.json
@@ -174,10 +174,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "65"
@@ -186,7 +186,7 @@
                 "version_added": "65"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null

--- a/css/properties/visibility.json
+++ b/css/properties/visibility.json
@@ -77,7 +77,7 @@
                 "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1",
@@ -88,7 +88,7 @@
                 "notes": "Firefox doesn't hide borders when hiding <a href='https://developer.mozilla.org/docs/Web/HTML/Element/col'><code>&lt;col&gt;</code></a> and <a href='https://developer.mozilla.org/docs/Web/HTML/Element/colgroup'><code>&lt;colgroup&gt;</code></a> elements if <code>border-collapse: collapse</code> is set."
               },
               "ie": {
-                "version_added": true
+                "version_added": "10"
               },
               "opera": {
                 "version_added": true,

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -62,10 +62,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "16"
@@ -74,7 +74,7 @@
                 "version_added": "16"
               },
               "ie": {
-                "version_added": null
+                "version_added": "11"
               },
               "opera": {
                 "version_added": null
@@ -278,7 +278,7 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -499,7 +499,7 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null


### PR DESCRIPTION
Part of #3801.  This provides 11 new CSS properties that have been manually tested using LambdaTest and virtual machines.

1. css.properties.height.stretch - false
2. css.properties.justify-content.flex_context.left_right - false
3. css.properties.letter-spacing.svg - 10
4. css.properties.outline-style.auto - false
5. css.properties.overflow-wrap.anywhere - false
6. css.properties.text-align-last - 5.5
7. css.properties.transition-timing-function.jump - false
8. css.properties.visibility.collapse - 10
9. css.properties.width.animatable - 11
10. css.properties.width.stretch - false
11. css.properties.width.fill - false
