### PR TITLE
Update @media calc support

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -217,34 +217,34 @@
                 "version_added": "66"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
-                "version_added": true
+                "version_added": "59"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "59"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": "53"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "47"
               },
               "safari": {
-                "version_added": null
+                "version_added": "12"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "12"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": "66"


### PR DESCRIPTION
In Safari 12: https://webkit.org/blog/8088/release-notes-for-safari-technology-preview-49/
In Firefox 59: https://bugzilla.mozilla.org/show_bug.cgi?id=1396057
Not in Edge
Opera values are mirrored from Chrome.