### PR TITLE
Fix missing </code> tags

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -2267,11 +2267,11 @@
             },
             "firefox": {
               "version_added": false,
-              "notes": "Firefox implements the <code>PromiseRejectionEvent</code> interface if you go to <code>about:config and set the <code>dom.promise_rejection_events.enabled</code> pref to <code>true</code>. However, Firefox doesn't yet actually send the <code>unhandledrejection</code> or understand <code>rejectionhandled</code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+              "notes": "Firefox implements the <code>PromiseRejectionEvent</code> interface if you go to <code>about:config</code> and set the <code>dom.promise_rejection_events.enabled</code> pref to <code>true</code>. However, Firefox doesn't yet actually send the <code>unhandledrejection</code> or understand <code>rejectionhandled</code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
             },
             "firefox_android": {
               "version_added": false,
-              "notes": "Firefox implements the <code>PromiseRejectionEvent</code> interface if you go to about:config and set the <code>dom.promise_rejection_events.enabled</code> pref to <code>true</code>. However, Firefox doesn't yet actually send the <code>unhandledrejection</code> or understand <code>rejectionhandled</code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+              "notes": "Firefox implements the <code>PromiseRejectionEvent</code> interface if you go to <code>about:config</code> and set the <code>dom.promise_rejection_events.enabled</code> pref to <code>true</code>. However, Firefox doesn't yet actually send the <code>unhandledrejection</code> or understand <code>rejectionhandled</code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
             },
             "ie": {
               "version_added": false
@@ -6788,11 +6788,11 @@
             },
             "firefox": {
               "version_added": false,
-              "notes": "Firefox implements the <code>PromiseRejectionEvent</code> interface if you go to <code>about:config and set the <code>dom.promise_rejection_events.enabled</code> pref to <code>true</code>. However, Firefox doesn't yet actually send the <code>unhandledrejection</code> or understand <code>rejectionhandled</code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+              "notes": "Firefox implements the <code>PromiseRejectionEvent</code> interface if you go to <code>about:config</code> and set the <code>dom.promise_rejection_events.enabled</code> pref to <code>true</code>. However, Firefox doesn't yet actually send the <code>unhandledrejection</code> or understand <code>rejectionhandled</code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
             },
             "firefox_android": {
               "version_added": false,
-              "notes": "Firefox implements the <code>PromiseRejectionEvent</code> interface if you go to about:config and set the <code>dom.promise_rejection_events.enabled</code> pref to <code>true</code>. However, Firefox doesn't yet actually send the <code>unhandledrejection</code> or understand <code>rejectionhandled</code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+              "notes": "Firefox implements the <code>PromiseRejectionEvent</code> interface if you go to <code>about:config</code> and set the <code>dom.promise_rejection_events.enabled</code> pref to <code>true</code>. However, Firefox doesn't yet actually send the <code>unhandledrejection</code> or understand <code>rejectionhandled</code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Fixed a few missing `</code>` tags as well as adding a couple of `<code>` blocks on things that were missing it. This should *finally* finish issue #1124 at last.