### PR TITLE
updates to border-radius properties

### DIFF
--- a/css/properties/border-bottom-left-radius.json
+++ b/css/properties/border-bottom-left-radius.json
@@ -14,6 +14,9 @@
                 "version_added": "1"
               }
             ],
+            "chrome_android": {
+              "version_added": true
+            },
             "edge": [
               {
                 "version_added": "12"
@@ -110,9 +113,6 @@
             },
             "webview_android": {
               "version_added": true
-            },
-            "chrome_android": {
-              "version_added": true
             }
           },
           "status": {
@@ -127,6 +127,9 @@
             "support": {
               "chrome": {
                 "version_added": "4"
+              },
+              "chrome_android": {
+                "version_added": true
               },
               "edge": {
                 "version_added": "12"
@@ -166,9 +169,6 @@
               },
               "webview_android": {
                 "version_added": true
-              },
-              "chrome_android": {
-                "version_added": true
               }
             },
             "status": {
@@ -184,6 +184,9 @@
             "support": {
               "chrome": {
                 "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": true
               },
               "edge": {
                 "version_added": "12"
@@ -216,9 +219,6 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
-              },
-              "chrome_android": {
                 "version_added": true
               }
             },

--- a/css/properties/border-bottom-left-radius.json
+++ b/css/properties/border-bottom-left-radius.json
@@ -15,7 +15,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": [
               {
@@ -129,7 +129,7 @@
                 "version_added": "4"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -186,7 +186,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"

--- a/css/properties/border-bottom-left-radius.json
+++ b/css/properties/border-bottom-left-radius.json
@@ -90,6 +90,9 @@
             "opera": {
               "version_added": "10.5"
             },
+            "opera_android": {
+              "version_added": true
+            },
             "safari": [
               {
                 "version_added": "5"
@@ -98,7 +101,19 @@
                 "prefix": "-webkit-",
                 "version_added": "3"
               }
-            ]
+            ],
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -137,8 +152,23 @@
               "opera": {
                 "version_added": "10.5"
               },
+              "opera_android": {
+                "version_added": true
+              },
               "safari": {
                 "version_added": "5"
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
               }
             },
             "status": {
@@ -148,9 +178,9 @@
             }
           }
         },
-        "ellipitcal_corners": {
+        "elliptical_corners": {
           "__compat": {
-            "description": "Ellipitcal corners",
+            "description": "Elliptical corners",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -173,8 +203,23 @@
               "opera": {
                 "version_added": "10.5"
               },
+              "opera_android": {
+                "version_added": true
+              },
               "safari": {
                 "version_added": "3"
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
               }
             },
             "status": {

--- a/css/properties/border-bottom-right-radius.json
+++ b/css/properties/border-bottom-right-radius.json
@@ -14,6 +14,9 @@
                 "version_added": "1"
               }
             ],
+            "chrome_android": {
+              "version_added": true
+            },
             "edge": [
               {
                 "version_added": "12"
@@ -110,9 +113,6 @@
             },
             "webview_android": {
               "version_added": true
-            },
-            "chrome_android": {
-              "version_added": true
             }
           },
           "status": {
@@ -127,6 +127,9 @@
             "support": {
               "chrome": {
                 "version_added": "4"
+              },
+              "chrome_android": {
+                "version_added": true
               },
               "edge": {
                 "version_added": "12"
@@ -166,9 +169,6 @@
               },
               "webview_android": {
                 "version_added": true
-              },
-              "chrome_android": {
-                "version_added": true
               }
             },
             "status": {
@@ -184,6 +184,9 @@
             "support": {
               "chrome": {
                 "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": true
               },
               "edge": {
                 "version_added": "12"
@@ -216,9 +219,6 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
-              },
-              "chrome_android": {
                 "version_added": true
               }
             },

--- a/css/properties/border-bottom-right-radius.json
+++ b/css/properties/border-bottom-right-radius.json
@@ -15,7 +15,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": [
               {
@@ -129,7 +129,7 @@
                 "version_added": "4"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -186,7 +186,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"

--- a/css/properties/border-bottom-right-radius.json
+++ b/css/properties/border-bottom-right-radius.json
@@ -90,6 +90,9 @@
             "opera": {
               "version_added": "10.5"
             },
+            "opera_android": {
+              "version_added": true
+            },
             "safari": [
               {
                 "version_added": "5"
@@ -98,7 +101,19 @@
                 "prefix": "-webkit-",
                 "version_added": "3"
               }
-            ]
+            ],
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -137,8 +152,23 @@
               "opera": {
                 "version_added": "10.5"
               },
+              "opera_android": {
+                "version_added": true
+              },
               "safari": {
                 "version_added": "5"
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
               }
             },
             "status": {
@@ -148,9 +178,9 @@
             }
           }
         },
-        "ellipitcal_corners": {
+        "elliptical_corners": {
           "__compat": {
-            "description": "Ellipitcal corners",
+            "description": "Elliptical corners",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -173,8 +203,23 @@
               "opera": {
                 "version_added": "10.5"
               },
+              "opera_android": {
+                "version_added": true
+              },
               "safari": {
                 "version_added": "3"
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
               }
             },
             "status": {

--- a/css/properties/border-radius.json
+++ b/css/properties/border-radius.json
@@ -122,19 +122,25 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "9"
               },
               "opera": {
                 "version_added": true
               },
               "opera_android": {
-                "version_added": false
+                "version_added": true
               },
               "safari": {
                 "version_added": true,
                 "notes": "Prior to Safari 4.1, the slash <code>/</code> notation is unsupported. If two values are specified, an elliptical border is drawn on all four corners. <code>-webkit-border-radius: 40px 10px;</code> is equivalent to <code>border-radius: 40px/10px;</code>."
               },
+              "safari_ios": {
+                "version_added": true
+              },
               "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
                 "version_added": true
               }
             },
@@ -168,18 +174,24 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
+                "version_added": "9"
               },
               "opera": {
                 "version_added": true
               },
               "opera_android": {
-                "version_added": false
+                "version_added": true
               },
               "safari": {
                 "version_added": "5"
               },
+              "safari_ios": {
+                "version_added": true
+              },
               "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
                 "version_added": true
               }
             },
@@ -215,14 +227,14 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "9"
               },
               "opera": {
                 "version_added": "11.5",
                 "notes": "The implementation of <code>&lt;percentage&gt;</code> values was buggy in Opera prior to 11.50."
               },
               "opera_android": {
-                "version_added": false
+                "version_added": true
               },
               "safari": {
                 "version_added": "5.1",

--- a/css/properties/border-top-left-radius.json
+++ b/css/properties/border-top-left-radius.json
@@ -14,6 +14,9 @@
                 "version_added": "1"
               }
             ],
+            "chrome_android": {
+              "version_added": true
+            },
             "edge": [
               {
                 "version_added": "12"
@@ -110,9 +113,6 @@
             },
             "webview_android": {
               "version_added": true
-            },
-            "chrome_android": {
-              "version_added": true
             }
           },
           "status": {
@@ -127,6 +127,9 @@
             "support": {
               "chrome": {
                 "version_added": "4"
+              },
+              "chrome_android": {
+                "version_added": true
               },
               "edge": {
                 "version_added": "12"
@@ -166,9 +169,6 @@
               },
               "webview_android": {
                 "version_added": true
-              },
-              "chrome_android": {
-                "version_added": true
               }
             },
             "status": {
@@ -184,6 +184,9 @@
             "support": {
               "chrome": {
                 "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": true
               },
               "edge": {
                 "version_added": "12"
@@ -216,9 +219,6 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
-              },
-              "chrome_android": {
                 "version_added": true
               }
             },

--- a/css/properties/border-top-left-radius.json
+++ b/css/properties/border-top-left-radius.json
@@ -15,7 +15,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": [
               {
@@ -129,7 +129,7 @@
                 "version_added": "4"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -186,7 +186,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"

--- a/css/properties/border-top-left-radius.json
+++ b/css/properties/border-top-left-radius.json
@@ -90,6 +90,9 @@
             "opera": {
               "version_added": "10.5"
             },
+            "opera_android": {
+              "version_added": true
+            },
             "safari": [
               {
                 "version_added": "5"
@@ -98,7 +101,19 @@
                 "prefix": "-webkit-",
                 "version_added": "3"
               }
-            ]
+            ],
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -137,8 +152,23 @@
               "opera": {
                 "version_added": "10.5"
               },
+              "opera_android": {
+                "version_added": true
+              },
               "safari": {
                 "version_added": "5"
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
               }
             },
             "status": {
@@ -148,9 +178,9 @@
             }
           }
         },
-        "ellipitcal_corners": {
+        "elliptical_corners": {
           "__compat": {
-            "description": "Ellipitcal corners",
+            "description": "Elliptical corners",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -173,8 +203,23 @@
               "opera": {
                 "version_added": "10.5"
               },
+              "opera_android": {
+                "version_added": true
+              },
               "safari": {
                 "version_added": "3"
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
               }
             },
             "status": {

--- a/css/properties/border-top-right-radius.json
+++ b/css/properties/border-top-right-radius.json
@@ -14,6 +14,9 @@
                 "version_added": "1"
               }
             ],
+            "chrome_android": {
+              "version_added": true
+            },
             "edge": [
               {
                 "version_added": "12"
@@ -110,9 +113,6 @@
             },
             "webview_android": {
               "version_added": true
-            },
-            "chrome_android": {
-              "version_added": true
             }
           },
           "status": {
@@ -127,6 +127,9 @@
             "support": {
               "chrome": {
                 "version_added": "4"
+              },
+              "chrome_android": {
+                "version_added": true
               },
               "edge": {
                 "version_added": "12"
@@ -166,9 +169,6 @@
               },
               "webview_android": {
                 "version_added": true
-              },
-              "chrome_android": {
-                "version_added": true
               }
             },
             "status": {
@@ -184,6 +184,9 @@
             "support": {
               "chrome": {
                 "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": true
               },
               "edge": {
                 "version_added": "12"
@@ -216,9 +219,6 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
-              },
-              "chrome_android": {
                 "version_added": true
               }
             },

--- a/css/properties/border-top-right-radius.json
+++ b/css/properties/border-top-right-radius.json
@@ -15,7 +15,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": [
               {
@@ -129,7 +129,7 @@
                 "version_added": "4"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -186,7 +186,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"

--- a/css/properties/border-top-right-radius.json
+++ b/css/properties/border-top-right-radius.json
@@ -90,6 +90,9 @@
             "opera": {
               "version_added": "10.5"
             },
+            "opera_android": {
+              "version_added": true
+            },
             "safari": [
               {
                 "version_added": "5"
@@ -98,7 +101,19 @@
                 "prefix": "-webkit-",
                 "version_added": "3"
               }
-            ]
+            ],
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            }
           },
           "status": {
             "experimental": false,
@@ -137,8 +152,23 @@
               "opera": {
                 "version_added": "10.5"
               },
+              "opera_android": {
+                "version_added": true
+              },
               "safari": {
                 "version_added": "5"
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
               }
             },
             "status": {
@@ -148,9 +178,9 @@
             }
           }
         },
-        "ellipitcal_corners": {
+        "elliptical_corners": {
           "__compat": {
-            "description": "Ellipitcal corners",
+            "description": "Elliptical corners",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -173,8 +203,23 @@
               "opera": {
                 "version_added": "10.5"
               },
+              "opera_android": {
+                "version_added": true
+              },
               "safari": {
                 "version_added": "3"
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
               }
             },
             "status": {


### PR DESCRIPTION
I was writing some stuff that deals with border-radius and noticed we were missing some data points for various mobile browsers which all support these properties.

I don't have detailed version history but given the properties have been supported for a long time I thought marking them true would be better than a null value.

Also Elliptical was spelled incorrectly in the longhand properties so I fixed that.
