### PR TITLE
Bug 332175 & 1328138: Remove `XMLDocument.load()` & `XMLDocument.async`

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -658,54 +658,6 @@
           }
         }
       },
-      "async": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/async",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "bgColor": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/bgColor",

--- a/api/XMLDocument.json
+++ b/api/XMLDocument.json
@@ -66,42 +66,16 @@
             "edge_mobile": {
               "version_added": false
             },
-            "firefox": [
-              {
-                "version_added": "68",
-                "flags": [
-                  {
-                    "name": "dom.xmldocument.async.enabled",
-                    "type": "preference",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "See <a href='https://bugzil.la/1546112' title='Remove the code for XMLDocument.load/async if possible'>bug 1546112</a> for complete removal."
-              },
-              {
-                "version_added": "1",
-                "version_removed": "68",
-                "notes": "See <a href='https://bugzil.la/1328138' title='Remove XMLDocument’s async IDL attribute'>bug 1328138</a> for removal."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "68",
-                "flags": [
-                  {
-                    "name": "dom.xmldocument.async.enabled",
-                    "type": "preference",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "See <a href='https://bugzil.la/1546112' title='Remove the code for XMLDocument.load/async if possible'>bug 1546112</a> for complete removal."
-              },
-              {
-                "version_added": "4",
-                "version_removed": "68",
-                "notes": "See <a href='https://bugzil.la/1328138' title='Remove XMLDocument’s async IDL attribute'>bug 1328138</a> for removal."
-              }
-            ],
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "68",
+              "notes": "See <a href='https://bugzil.la/1328138' title='Remove XMLDocument’s async IDL attribute'>bug 1328138</a> for removal."
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "68",
+              "notes": "See <a href='https://bugzil.la/1328138' title='Remove XMLDocument’s async IDL attribute'>bug 1328138</a> for removal."
+            },
             "ie": {
               "version_added": false
             },
@@ -149,17 +123,6 @@
             },
             "firefox": [
               {
-                "version_added": "68",
-                "flags": [
-                  {
-                    "name": "dom.xmldocument.load.enabled",
-                    "type": "preference",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "See <a href='https://bugzil.la/1546112' title='Remove the code for XMLDocument.load/async if possible'>bug 1546112</a> for complete removal."
-              },
-              {
                 "version_added": "3",
                 "version_removed": "68",
                 "notes": "See <a href='https://bugzil.la/332175' title='Drop document.load() support'>bug 332175</a> for removal."
@@ -170,24 +133,11 @@
                 "notes": "Before version 3, Firefox supported cross-origin loads, even in cases where this would violate CORS."
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "68",
-                "flags": [
-                  {
-                    "name": "dom.xmldocument.load.enabled",
-                    "type": "preference",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "See <a href='https://bugzil.la/1546112' title='Remove the code for XMLDocument.load/async if possible'>bug 1546112</a> for complete removal."
-              },
-              {
-                "version_added": "4",
-                "version_removed": "68",
-                "notes": "See <a href='https://bugzil.la/332175' title='Drop document.load() support'>bug 332175</a> for removal."
-              }
-            ],
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "68",
+              "notes": "See <a href='https://bugzil.la/332175' title='Drop document.load() support'>bug 332175</a> for removal."
+            },
             "ie": {
               "version_added": false
             },

--- a/api/XMLDocument.json
+++ b/api/XMLDocument.json
@@ -79,7 +79,7 @@
                 "notes": "See <a href='https://bugzil.la/1546112' title='Remove the code for XMLDocument.load/async if possible'>bug 1546112</a> for complete removal."
               },
               {
-                "version_added": true,
+                "version_added": "1",
                 "version_removed": "68",
                 "notes": "See <a href='https://bugzil.la/1328138' title='Remove XMLDocument’s async IDL attribute'>bug 1328138</a> for removal."
               }
@@ -97,7 +97,7 @@
                 "notes": "See <a href='https://bugzil.la/1546112' title='Remove the code for XMLDocument.load/async if possible'>bug 1546112</a> for complete removal."
               },
               {
-                "version_added": true,
+                "version_added": "4",
                 "notes": "See <a href='https://bugzil.la/1328138' title='Remove XMLDocument’s async IDL attribute'>bug 1328138</a> for removal."
               }
             ],

--- a/api/XMLDocument.json
+++ b/api/XMLDocument.json
@@ -50,6 +50,86 @@
           "deprecated": false
         }
       },
+      "async": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLDocument/async",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": [
+              {
+                "version_added": "68",
+                "flags": [
+                  {
+                    "name": "dom.xmldocument.async.enabled",
+                    "type": "preference",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/1546112' title='Remove the code for XMLDocument.load/async if possible'>bug 1546112</a> for complete removal."
+              },
+              {
+                "version_added": true,
+                "version_removed": "68",
+                "notes": "See <a href='https://bugzil.la/1328138' title='Remove XMLDocument’s async IDL attribute'>bug 1328138</a> for removal."
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "68",
+                "flags": [
+                  {
+                    "name": "dom.xmldocument.async.enabled",
+                    "type": "preference",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/1546112' title='Remove the code for XMLDocument.load/async if possible'>bug 1546112</a> for complete removal."
+              },
+              {
+                "version_added": true,
+                "notes": "See <a href='https://bugzil.la/1328138' title='Remove XMLDocument’s async IDL attribute'>bug 1328138</a> for removal."
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
       "load": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLDocument/load",
@@ -68,7 +148,19 @@
             },
             "firefox": [
               {
+                "version_added": "68",
+                "flags": [
+                  {
+                    "name": "dom.xmldocument.load.enabled",
+                    "type": "preference",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/1546112' title='Remove the code for XMLDocument.load/async if possible'>bug 1546112</a> for complete removal."
+              },
+              {
                 "version_added": "3",
+                "version_removed": "68",
                 "notes": "See <a href='https://bugzil.la/332175' title='Drop document.load() support'>bug 332175</a> for removal."
               },
               {
@@ -77,10 +169,24 @@
                 "notes": "Before version 3, Firefox supported cross-origin loads, even in cases where this would violate CORS."
               }
             ],
-            "firefox_android": {
-              "version_added": "4",
-              "notes": "See <a href='https://bugzil.la/332175' title='Drop document.load() support'>bug 332175</a> for removal."
-            },
+            "firefox_android": [
+              {
+                "version_added": "68",
+                "flags": [
+                  {
+                    "name": "dom.xmldocument.load.enabled",
+                    "type": "preference",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/1546112' title='Remove the code for XMLDocument.load/async if possible'>bug 1546112</a> for complete removal."
+              },
+              {
+                "version_added": "4",
+                "version_removed": "68",
+                "notes": "See <a href='https://bugzil.la/332175' title='Drop document.load() support'>bug 332175</a> for removal."
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/XMLDocument.json
+++ b/api/XMLDocument.json
@@ -98,6 +98,7 @@
               },
               {
                 "version_added": "4",
+                "version_removed": "68",
                 "notes": "See <a href='https://bugzil.la/1328138' title='Remove XMLDocument’s async IDL attribute'>bug 1328138</a> for removal."
               }
             ],

--- a/api/XMLDocument.json
+++ b/api/XMLDocument.json
@@ -69,12 +69,12 @@
             "firefox": {
               "version_added": "1",
               "version_removed": "68",
-              "notes": "See <a href='https://bugzil.la/1328138' title='Remove XMLDocument’s async IDL attribute'>bug 1328138</a> for removal."
+              "notes": "See <a href='https://bugzil.la/1328138'>bug 1328138</a> for removal."
             },
             "firefox_android": {
               "version_added": "4",
               "version_removed": "68",
-              "notes": "See <a href='https://bugzil.la/1328138' title='Remove XMLDocument’s async IDL attribute'>bug 1328138</a> for removal."
+              "notes": "See <a href='https://bugzil.la/1328138'>bug 1328138</a> for removal."
             },
             "ie": {
               "version_added": false
@@ -125,7 +125,7 @@
               {
                 "version_added": "3",
                 "version_removed": "68",
-                "notes": "See <a href='https://bugzil.la/332175' title='Drop document.load() support'>bug 332175</a> for removal."
+                "notes": "See <a href='https://bugzil.la/332175'>bug 332175</a> for removal."
               },
               {
                 "version_added": "1",
@@ -136,7 +136,7 @@
             "firefox_android": {
               "version_added": "4",
               "version_removed": "68",
-              "notes": "See <a href='https://bugzil.la/332175' title='Drop document.load() support'>bug 332175</a> for removal."
+              "notes": "See <a href='https://bugzil.la/332175'>bug 332175</a> for removal."
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
See [bug 332175](https://bugzil.la/332175 "Drop document.load() support"), [bug 1328138](https://bugzil.la/1328138 "Remove XMLDocument’s async IDL attribute") and [bug 1546112](https://bugzil.la/1546112 "Remove the code for XMLDocument.load/async if possible") for details.

review?(@chrisdavidmills)