### PR TITLE
Add IE/Edge data for CSS selectors and types

### DIFF
--- a/css/selectors/hover.json
+++ b/css/selectors/hover.json
@@ -13,10 +13,10 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -171,10 +171,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "28"
@@ -183,7 +183,7 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
+                "version_added": "11"
               },
               "opera": {
                 "version_added": null

--- a/css/selectors/indeterminate.json
+++ b/css/selectors/indeterminate.json
@@ -13,10 +13,10 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "2"
@@ -25,7 +25,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": true
@@ -63,10 +63,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "3.6"
@@ -75,7 +75,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": "9"
+                "version_added": "10"
               },
               "opera": {
                 "version_added": "10.6"
@@ -169,10 +169,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "6"

--- a/css/selectors/visited.json
+++ b/css/selectors/visited.json
@@ -13,10 +13,10 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -25,7 +25,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera": {
               "version_added": "3.5"

--- a/css/types/calc.json
+++ b/css/types/calc.json
@@ -19,10 +19,10 @@
               "version_added": "28"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": [
               {
@@ -205,10 +205,10 @@
                 "version_added": "51"
               },
               "edge": {
-                "version_added": null
+                "version_added": "16"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "16"
               },
               "firefox": {
                 "version_added": "48"
@@ -217,7 +217,7 @@
                 "version_added": "48"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -256,10 +256,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "48"
@@ -268,7 +268,7 @@
                 "version_added": "48"
               },
               "ie": {
-                "version_added": null
+                "version_added": "9"
               },
               "opera": {
                 "version_added": null

--- a/css/types/calc.json
+++ b/css/types/calc.json
@@ -208,7 +208,7 @@
                 "version_added": "16"
               },
               "edge_mobile": {
-                "version_added": "16"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "48"

--- a/css/types/global_keywords.json
+++ b/css/types/global_keywords.json
@@ -24,7 +24,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera": {
               "version_added": true

--- a/css/types/integer.json
+++ b/css/types/integer.json
@@ -13,10 +13,10 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -25,7 +25,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera": {
               "version_added": true

--- a/css/types/length-percentage.json
+++ b/css/types/length-percentage.json
@@ -13,10 +13,10 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -169,10 +169,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": true
@@ -181,7 +181,7 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
+                "version_added": "4"
               },
               "opera": {
                 "version_added": true

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -13,10 +13,10 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -169,10 +169,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": true
@@ -181,7 +181,7 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
+                "version_added": "4"
               },
               "opera": {
                 "version_added": true

--- a/css/types/percentage.json
+++ b/css/types/percentage.json
@@ -13,10 +13,10 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -25,7 +25,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera": {
               "version_added": true

--- a/css/types/string.json
+++ b/css/types/string.json
@@ -13,10 +13,10 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -25,7 +25,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera": {
               "version_added": true
@@ -63,10 +63,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"

--- a/css/types/timing-function.json
+++ b/css/types/timing-function.json
@@ -164,10 +164,10 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "edge_mobile": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "65"
@@ -176,7 +176,7 @@
                   "version_added": "65"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "opera": {
                   "version_added": null


### PR DESCRIPTION
Based upon manual testing (as well as some review of the initial CSS spec), I've found the following IE and Edge versions for selectors and types in CSS:

1. css.selectors.hover.pseudo_elements - true 11
2. css.selectors.indeterminate - true 10
3. css.selectors.visited - true 4
4. css.types.calc.nested - true 16
5. css.types.calc.number_values - true 9
6. css.types.global_keywords - true 3 (part of basic support)
7. css.types.integer - true 3 (part of basic support)
8. css.types.length-percentage.ex - true 4
9. css.types.length.ex - true 4
10. css.types.percentage - true 3 (part of basic support)
11. css.types.string - true 3 (part of basic support)
12. css.types.timing-function.steps.jump - false