### PR TITLE
Fix Firefox version for webextensions.manifest.incognito.not_allowed

### DIFF
--- a/webextensions/manifest/incognito.json
+++ b/webextensions/manifest/incognito.json
@@ -76,10 +76,10 @@
                 "version_added": "17"
               },
               "firefox": {
-                "version_added": "66"
+                "version_added": "67"
               },
               "firefox_android": {
-                "version_added": "66"
+                "version_added": "67"
               },
               "opera": {
                 "version_added": true


### PR DESCRIPTION
While Firefox 66 had some code supporting `incognito` `not_allowed`, the value isn't permitted in manifest.json until 67.
https://hg.mozilla.org/releases/mozilla-beta/rev/9553d0cc4eea#l20.13

Thanks aswan and robwu_nl on #webextensions for helping me find that.