### PR TITLE
Add nodejs version for javascript.builtins.RegExp.dotAll

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -135,9 +135,20 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": true
-              },
+              "nodejs": [
+                {
+                  "version_added": "8.10.0"
+                },
+                {
+                  "version_added": "8.3.0",
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--harmony"
+                    }
+                  ]
+                }
+              ],
               "opera": {
                 "version_added": "49"
               },


### PR DESCRIPTION
Added nodejs version for javascript.builtins.RegExp.dotAll.
Source: https://node.green/#ES2018-features--s--dotAll--flag-for-regular-expressions
Related: #3929 

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
