### PR TITLE
Update compat data for of syntax of css nth selectors

### DIFF
--- a/css/selectors/nth-child.json
+++ b/css/selectors/nth-child.json
@@ -59,16 +59,17 @@
             "description": "<code>of &lt;selector&gt;</code> syntax",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/304163'>bug 304163</a>."
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false,
@@ -79,13 +80,13 @@
                 "notes": "See <a href='https://bugzil.la/854148'>bug 854148</a>."
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": "9"
@@ -97,7 +98,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": null
+                "version_added": false
               }
             },
             "status": {

--- a/css/selectors/nth-last-child.json
+++ b/css/selectors/nth-last-child.json
@@ -57,16 +57,17 @@
             "description": "<code>of &lt;selector&gt;</code> syntax",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/304163'>bug 304163</a>."
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false,
@@ -77,13 +78,13 @@
                 "notes": "See <a href='https://bugzil.la/854148'>bug 854148</a>."
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": "9"
@@ -95,7 +96,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": null
+                "version_added": false
               }
             },
             "status": {


### PR DESCRIPTION
Test code: https://output.jsbin.com/meliga/quiet

This is only supported in Safari.