### PR TITLE
adding data for straggler events

### DIFF
--- a/api/HTMLDetailsElement.json
+++ b/api/HTMLDetailsElement.json
@@ -100,6 +100,58 @@
             "deprecated": false
           }
         }
+      },
+      "toggle_event": {
+        "__compat": {
+          "description": "<code>toggle</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLDetailsElement/toggle_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -396,6 +396,58 @@
           }
         }
       },
+      "beforeinput_event": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/beforeinput_event",
+          "description": "<code>beforeinput</code> event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "blur": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/blur",

--- a/api/PaymentResponse.json
+++ b/api/PaymentResponse.json
@@ -249,6 +249,113 @@
           }
         }
       },
+      "onpayerdetailchange": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/onpayerdetailchange",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "64",
+              "notes": "Available only in nightly builds."
+            },
+            "firefox_android": {
+              "version_added": "64",
+              "notes": "Available only in nightly builds."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "payerdetailchange_event": {
+        "__compat": {
+          "description": "<code>payerdetailchange</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/payerdetailchange_event",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "64",
+              "notes": "Available only in nightly builds."
+            },
+            "firefox_android": {
+              "version_added": "64",
+              "notes": "Available only in nightly builds."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "payerEmail": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/payerEmail",

--- a/api/SharedWorkerGlobalScope.json
+++ b/api/SharedWorkerGlobalScope.json
@@ -101,6 +101,58 @@
           }
         }
       },
+      "connect_event": {
+        "__compat": {
+          "description": "<code>connect</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SharedWorkerGlobalScope/connect_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "29"
+            },
+            "firefox_android": {
+              "version_added": "29"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "10.6"
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "name": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SharedWorkerGlobalScope/name",

--- a/api/Window.json
+++ b/api/Window.json
@@ -876,6 +876,58 @@
           }
         }
       },
+      "clipboardchange_event": {
+        "__compat": {
+          "description": "<code>clipboardchange</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/clipboardchange_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "confirm": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/confirm",


### PR DESCRIPTION
As per https://github.com/mdn/sprints/issues/1318

Some of these were difficult to find much about. An explanation of each follows:

* api.HTMLDetails​Element.toggle_event — this has no associated ontoggle property to copy off, so I ended up just copying the data for the `HTMLDetailsElement` as a whole. I did some local testing on macOS, and the event seemed to work in all the places I tested.
* api.PaymentResponse.payerdetailchange_event — this had an old-style compat table left over in the event page, so I used that data (the old style table is still there, hidden using `<div class=hidden></div>`), also copying the data over to `onpayerdetailchange` and creating that data point too.
* api.SharedWorkerGlobalScope.connect_event — easy; I just copied this from the available `onconnect` data
* api.Window.clipboardchange — this is a very new event. There is no equivalent `onclipboardchange` handler specified at present, afaict, and it doesn't seem to work anywhere (I tested it in Chrome/Fx/Safari/Opera). So I put all the data as `false`.
* api.HTMLElement.beforeinput_event — this is also very new, and does not appear to have an equivalent `on...` handler property. I tested it, and it didn't work in Firefox, but did in Chrome/Safari/Opera, so I have filled those in as `true` and guessed a bit at the mobile equivalents.