### PR TITLE
added invalid event

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -566,6 +566,58 @@
           }
         }
       },
+      "invalid_event": {
+        "__compat": {
+          "description": "<code>invalid</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLInputElement/invalid_event",
+          "support": {
+            "chrome": {
+              "version_added": "10"
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": "64"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "10"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5"
+            },
+            "safari_ios": {
+              "version_added": "5"
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "4"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "labels": {
         "__compat": {
           "support": {


### PR DESCRIPTION
moved data from HTMLElement to HTMLInputElement for invalid event

BCD for https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/invalid_event
Used caniuse, validitystate, and experience from having tested this in 2014 for numbers/data

While there were bugs with constraint validation in earlier browsers, that was not an issue with the invalid event, rather with the implementation of the constraint validation implementation. The event still worked on features the browser supported.