### PR TITLE
Update MediaSession.json

### DIFF
--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSession",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "73"
           },
           "chrome_android": {
             "version_added": "57"
@@ -52,7 +52,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSession/metadata",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "73"
             },
             "chrome_android": {
               "version_added": "57"
@@ -100,7 +100,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSession/playbackState",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "73"
             },
             "chrome_android": {
               "version_added": "57"
@@ -148,7 +148,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSession/setActionHandler",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "73"
             },
             "chrome_android": {
               "version_added": "57"


### PR DESCRIPTION
Adds `chrome: "73"` to applicable locations in `api/MediaSession.json`.

Here is the January 17th announcement indicating that Chrome supports `MediaSession` as of M73:
https://groups.google.com/a/chromium.org/forum/#!msg/blink-dev/EQVR9vOrP8o/NkAbV26sDQAJ

LMK if I need to provide any more data! Thanks in advance.
