### PR TITLE
Add IE versions for CSS properties

### DIFF
--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -960,7 +960,7 @@
                 }
               ],
               "ie": {
-                "version_added": null
+                "version_added": "7"
               },
               "opera": {
                 "version_added": null

--- a/css/properties/flex-grow.json
+++ b/css/properties/flex-grow.json
@@ -133,7 +133,7 @@
                 "version_added": "49"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "32",
@@ -144,7 +144,7 @@
                 "notes": "Before Firefox 32, Firefox wasn't able to animate values starting or stopping at <code>0</code>."
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": false

--- a/css/properties/font-variant.json
+++ b/css/properties/font-variant.json
@@ -215,10 +215,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": [
                 {
@@ -253,7 +253,7 @@
                 }
               ],
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null

--- a/css/properties/text-align.json
+++ b/css/properties/text-align.json
@@ -277,10 +277,10 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -289,7 +289,7 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null

--- a/css/properties/text-transform.json
+++ b/css/properties/text-transform.json
@@ -68,10 +68,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "14"
@@ -80,7 +80,7 @@
                 "version_added": "14"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera": {
                 "version_added": true

--- a/css/properties/transition-property.json
+++ b/css/properties/transition-property.json
@@ -174,10 +174,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": true
@@ -186,7 +186,7 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
+                "version_added": "10"
               },
               "opera": {
                 "version_added": true

--- a/css/properties/white-space.json
+++ b/css/properties/white-space.json
@@ -274,10 +274,10 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "36"
@@ -286,7 +286,7 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
+                "version_added": "10"
               },
               "opera": {
                 "version_added": null

--- a/css/types/calc.json
+++ b/css/types/calc.json
@@ -109,10 +109,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "59"
@@ -121,7 +121,7 @@
                 "version_added": "59"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -13,10 +13,10 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -25,7 +25,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
Part of #3801, this PR defines IE and Edge versions for several CSS properties/types, based upon manual testing (unless otherwise specified).  The changes are as follows:

- css.properties.display.ruby_values - true 7 (based upon [spec date](https://www.w3.org/TR/2013/WD-css3-ruby-20130919/#ruby-display), been able to test support in IE 8)
- css.properties.flex-grow.less_than_zero_animate - false (Wondering if this is redundant and can be removed; negative values are disallowed by the spec)
- css.properties.font-variant.css_fonts_shorthand - false
- css.properties.text-align.string - false
- css.properties.text-transform.capitalize - true 3
- css.properties.transition-property.IDENT_value - true 10
- css.properties.white-space.svg_support - true 10
- css.types.calc.color_values - false
- css.types.image - true 10 (in the same spec definition as gradients)