### PR TITLE
Mirror IE -> Edge / Edge Mobile for css/*

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -63,10 +63,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "3.5"
@@ -474,10 +474,10 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "3.5"
@@ -626,10 +626,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "36"

--- a/css/at-rules/import.json
+++ b/css/at-rules/import.json
@@ -13,10 +13,10 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"

--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -25,10 +25,10 @@
               }
             ],
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": [
               {

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -13,10 +13,10 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -165,10 +165,10 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "3.5"
@@ -425,10 +425,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "2"
@@ -477,10 +477,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "2"
@@ -529,10 +529,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "2"
@@ -687,10 +687,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "2"
@@ -893,10 +893,10 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -1048,10 +1048,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "2"
@@ -1351,10 +1351,10 @@
                 "version_added": "29"
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": [
                 {
@@ -1622,10 +1622,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "2"

--- a/css/at-rules/namespace.json
+++ b/css/at-rules/namespace.json
@@ -13,10 +13,10 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"

--- a/css/at-rules/page.json
+++ b/css/at-rules/page.json
@@ -13,10 +13,10 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "19"

--- a/css/at-rules/viewport.json
+++ b/css/at-rules/viewport.json
@@ -25,7 +25,7 @@
             },
             "edge": {
               "prefix": "-ms-",
-              "version_added": true,
+              "version_added": "12",
               "flags": [
                 {
                   "type": "preference",
@@ -35,7 +35,7 @@
             },
             "edge_mobile": {
               "prefix": "-ms-",
-              "version_added": true,
+              "version_added": "12",
               "flags": [
                 {
                   "type": "preference",
@@ -128,10 +128,12 @@
                 "version_added": "29"
               },
               "edge": {
-                "version_added": null
+                "prefix": "-ms-",
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "prefix": "-ms-",
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": false
@@ -193,10 +195,12 @@
                 "version_added": "29"
               },
               "edge": {
-                "version_added": null
+                "prefix": "-ms-",
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "prefix": "-ms-",
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": false
@@ -258,10 +262,12 @@
                 "version_added": "29"
               },
               "edge": {
-                "version_added": null
+                "prefix": "-ms-",
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "prefix": "-ms-",
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": false
@@ -324,11 +330,11 @@
               },
               "edge": {
                 "prefix": "-ms-",
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "prefix": "-ms-",
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": false
@@ -378,10 +384,12 @@
                 "version_added": "29"
               },
               "edge": {
-                "version_added": null
+                "prefix": "-ms-",
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "prefix": "-ms-",
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": false
@@ -443,10 +451,12 @@
                 "version_added": "29"
               },
               "edge": {
-                "version_added": null
+                "prefix": "-ms-",
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "prefix": "-ms-",
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": false
@@ -509,11 +519,11 @@
               },
               "edge": {
                 "prefix": "-ms-",
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "prefix": "-ms-",
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": false
@@ -563,10 +573,12 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "prefix": "-ms-",
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "prefix": "-ms-",
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": false
@@ -619,11 +631,11 @@
               },
               "edge": {
                 "prefix": "-ms-",
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "prefix": "-ms-",
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": false
@@ -710,10 +722,12 @@
                 "version_added": "29"
               },
               "edge": {
-                "version_added": null
+                "prefix": "-ms-",
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "prefix": "-ms-",
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": false
@@ -775,10 +789,12 @@
                 "version_added": "61"
               },
               "edge": {
-                "version_added": null
+                "prefix": "-ms-",
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "prefix": "-ms-",
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": false

--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -158,7 +158,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "15"
@@ -191,7 +191,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "15"
@@ -230,7 +230,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "29"

--- a/css/properties/color.json
+++ b/css/properties/color.json
@@ -324,10 +324,10 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1.5"
@@ -376,10 +376,10 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "3"
@@ -427,10 +427,10 @@
                 "version_added": "38"
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "33"

--- a/css/properties/column-count.json
+++ b/css/properties/column-count.json
@@ -108,10 +108,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "37"

--- a/css/properties/column-width.json
+++ b/css/properties/column-width.json
@@ -147,10 +147,10 @@
                 "version_added": "50"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "37"

--- a/css/properties/columns.json
+++ b/css/properties/columns.json
@@ -109,10 +109,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "37"

--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -114,10 +114,10 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"

--- a/css/properties/hyphens.json
+++ b/css/properties/hyphens.json
@@ -258,10 +258,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "8"
@@ -309,10 +309,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "8"
@@ -360,10 +360,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": false
@@ -513,10 +513,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "8"
@@ -564,10 +564,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "8"
@@ -615,10 +615,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "8"
@@ -666,10 +666,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "8"
@@ -768,10 +768,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "8"
@@ -1074,10 +1074,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "9"
@@ -1329,10 +1329,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "8"
@@ -1380,10 +1380,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "8"
@@ -1431,10 +1431,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "31"
@@ -1482,10 +1482,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "8"
@@ -1533,10 +1533,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "8",
@@ -1585,10 +1585,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "8"
@@ -1687,10 +1687,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "8"
@@ -1738,10 +1738,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "8"
@@ -1789,10 +1789,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "9"
@@ -1993,10 +1993,10 @@
                 "version_added": "55"
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "6",

--- a/css/properties/ime-mode.json
+++ b/css/properties/ime-mode.json
@@ -11,12 +11,24 @@
             "chrome_android": {
               "version_added": false
             },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": true
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "prefix": "-ms-",
+                "version_added": "12"
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": "12"
+              },
+              {
+                "prefix": "-ms-",
+                "version_added": "12"
+              }
+            ],
             "firefox": {
               "version_added": "3"
             },

--- a/css/properties/margin-bottom.json
+++ b/css/properties/margin-bottom.json
@@ -62,10 +62,12 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": null
+                "version_added": "12",
+                "notes": "The <code>auto</code> value is not supported in quirks mode."
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12",
+                "notes": "The <code>auto</code> value is not supported in quirks mode."
               },
               "firefox": {
                 "version_added": "1"

--- a/css/properties/margin-left.json
+++ b/css/properties/margin-left.json
@@ -62,10 +62,12 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": null
+                "version_added": "12",
+                "notes": "The <code>auto</code> value is not supported in quirks mode."
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12",
+                "notes": "The <code>auto</code> value is not supported in quirks mode."
               },
               "firefox": {
                 "version_added": "1"

--- a/css/properties/margin-right.json
+++ b/css/properties/margin-right.json
@@ -62,10 +62,12 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": null
+                "version_added": "12",
+                "notes": "The <code>auto</code> value is not supported in quirks mode."
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12",
+                "notes": "The <code>auto</code> value is not supported in quirks mode."
               },
               "firefox": {
                 "version_added": "1"

--- a/css/properties/margin-top.json
+++ b/css/properties/margin-top.json
@@ -62,10 +62,12 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": null
+                "version_added": "12",
+                "notes": "The <code>auto</code> value is not supported in quirks mode."
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12",
+                "notes": "The <code>auto</code> value is not supported in quirks mode."
               },
               "firefox": {
                 "version_added": "1"

--- a/css/properties/margin.json
+++ b/css/properties/margin.json
@@ -62,10 +62,12 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": null
+                "version_added": "12",
+                "notes": "The <code>auto</code> value is not supported in quirks mode."
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12",
+                "notes": "The <code>auto</code> value is not supported in quirks mode."
               },
               "firefox": {
                 "version_added": "1"

--- a/css/properties/outline-color.json
+++ b/css/properties/outline-color.json
@@ -69,10 +69,10 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_removed": "3",

--- a/css/properties/text-combine-upright.json
+++ b/css/properties/text-combine-upright.json
@@ -162,10 +162,10 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "48",

--- a/css/properties/text-transform.json
+++ b/css/properties/text-transform.json
@@ -68,10 +68,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "14"

--- a/css/properties/text-underline-position.json
+++ b/css/properties/text-underline-position.json
@@ -164,10 +164,10 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": false
@@ -215,10 +215,10 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": false

--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -141,10 +141,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "10"

--- a/css/properties/transition-property.json
+++ b/css/properties/transition-property.json
@@ -174,10 +174,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": true

--- a/css/properties/white-space.json
+++ b/css/properties/white-space.json
@@ -223,10 +223,10 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "36"

--- a/css/properties/word-break.json
+++ b/css/properties/word-break.json
@@ -70,7 +70,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": false

--- a/css/selectors/-ms-browse.json
+++ b/css/selectors/-ms-browse.json
@@ -13,10 +13,10 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": false

--- a/css/selectors/-ms-check.json
+++ b/css/selectors/-ms-check.json
@@ -13,10 +13,10 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": false

--- a/css/selectors/-ms-clear.json
+++ b/css/selectors/-ms-clear.json
@@ -13,10 +13,12 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "12",
+              "notes": "In an <code>&lt;input type='text'&gt;</code> element styled with <code>text-align: right</code>, if the clear button is shown, it will clip off the right edge of the text value of the <code>&lt;input type='text'&gt;</code> element. A workaround is to hide the clear button using <code>display: none</code>."
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12",
+              "notes": "In an <code>&lt;input type='text'&gt;</code> element styled with <code>text-align: right</code>, if the clear button is shown, it will clip off the right edge of the text value of the <code>&lt;input type='text'&gt;</code> element. A workaround is to hide the clear button using <code>display: none</code>."
             },
             "firefox": {
               "version_added": false

--- a/css/selectors/-ms-fill-lower.json
+++ b/css/selectors/-ms-fill-lower.json
@@ -13,10 +13,10 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": false

--- a/css/selectors/-ms-fill-upper.json
+++ b/css/selectors/-ms-fill-upper.json
@@ -13,10 +13,10 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": false

--- a/css/selectors/-ms-fill.json
+++ b/css/selectors/-ms-fill.json
@@ -13,10 +13,10 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": false

--- a/css/selectors/-ms-reveal.json
+++ b/css/selectors/-ms-reveal.json
@@ -13,10 +13,10 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": false

--- a/css/selectors/active.json
+++ b/css/selectors/active.json
@@ -13,10 +13,10 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -63,10 +63,10 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"

--- a/css/selectors/backdrop.json
+++ b/css/selectors/backdrop.json
@@ -31,11 +31,11 @@
             ],
             "edge": {
               "prefix": "-ms-",
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "prefix": "-ms-",
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "47"
@@ -134,10 +134,10 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "47"

--- a/css/selectors/checked.json
+++ b/css/selectors/checked.json
@@ -13,10 +13,10 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"

--- a/css/selectors/disabled.json
+++ b/css/selectors/disabled.json
@@ -13,10 +13,12 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12",
+              "notes": "Edge does not recognize <code>:disabled</code> on the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/fieldset'><code>&lt;fieldset&gt;</code></a> element."
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12",
+              "notes": "Edge does not recognize <code>:disabled</code> on the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/fieldset'><code>&lt;fieldset&gt;</code></a> element."
             },
             "firefox": {
               "version_added": "1"

--- a/css/selectors/empty.json
+++ b/css/selectors/empty.json
@@ -13,10 +13,10 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"

--- a/css/selectors/enabled.json
+++ b/css/selectors/enabled.json
@@ -13,10 +13,10 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"

--- a/css/selectors/first-child.json
+++ b/css/selectors/first-child.json
@@ -13,10 +13,10 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3"

--- a/css/selectors/first-of-type.json
+++ b/css/selectors/first-of-type.json
@@ -13,10 +13,10 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5"

--- a/css/selectors/first.json
+++ b/css/selectors/first.json
@@ -13,10 +13,10 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": false

--- a/css/selectors/focus.json
+++ b/css/selectors/focus.json
@@ -13,10 +13,10 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"

--- a/css/selectors/hover.json
+++ b/css/selectors/hover.json
@@ -64,10 +64,10 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -115,11 +115,12 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true,
+                "version_added": "12",
                 "notes": "In Edge, hovering over an element and then scrolling up or down without moving the pointer will leave the element in the <code>:hover</code> state until the pointer is moved. See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/5381673/'>bug 5381673</a>."
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12",
+                "notes": "In Edge, hovering over an element and then scrolling up or down without moving the pointer will leave the element in the <code>:hover</code> state until the pointer is moved. See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/5381673/'>bug 5381673</a>."
               },
               "firefox": {
                 "version_added": "1"

--- a/css/selectors/lang.json
+++ b/css/selectors/lang.json
@@ -13,10 +13,10 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"

--- a/css/selectors/last-child.json
+++ b/css/selectors/last-child.json
@@ -13,10 +13,10 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"

--- a/css/selectors/last-of-type.json
+++ b/css/selectors/last-of-type.json
@@ -13,10 +13,10 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5"

--- a/css/selectors/left.json
+++ b/css/selectors/left.json
@@ -13,10 +13,10 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": false

--- a/css/selectors/link.json
+++ b/css/selectors/link.json
@@ -13,10 +13,10 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"

--- a/css/selectors/namespace.json
+++ b/css/selectors/namespace.json
@@ -13,10 +13,10 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"

--- a/css/selectors/not.json
+++ b/css/selectors/not.json
@@ -13,10 +13,10 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"

--- a/css/selectors/nth-child.json
+++ b/css/selectors/nth-child.json
@@ -13,10 +13,10 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5"

--- a/css/selectors/nth-last-child.json
+++ b/css/selectors/nth-last-child.json
@@ -13,10 +13,10 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5"

--- a/css/selectors/nth-last-of-type.json
+++ b/css/selectors/nth-last-of-type.json
@@ -13,10 +13,10 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5"

--- a/css/selectors/nth-of-type.json
+++ b/css/selectors/nth-of-type.json
@@ -13,10 +13,10 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5"

--- a/css/selectors/only-child.json
+++ b/css/selectors/only-child.json
@@ -13,10 +13,10 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1.5"

--- a/css/selectors/only-of-type.json
+++ b/css/selectors/only-of-type.json
@@ -13,10 +13,10 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5"

--- a/css/selectors/optional.json
+++ b/css/selectors/optional.json
@@ -13,10 +13,10 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "4"

--- a/css/selectors/required.json
+++ b/css/selectors/required.json
@@ -13,10 +13,10 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "4"

--- a/css/selectors/right.json
+++ b/css/selectors/right.json
@@ -13,10 +13,10 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": false

--- a/css/selectors/root.json
+++ b/css/selectors/root.json
@@ -13,10 +13,10 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": null
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"

--- a/css/selectors/selection.json
+++ b/css/selectors/selection.json
@@ -13,10 +13,10 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": [
               {

--- a/css/selectors/target.json
+++ b/css/selectors/target.json
@@ -13,10 +13,10 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"

--- a/css/selectors/type.json
+++ b/css/selectors/type.json
@@ -63,10 +63,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"

--- a/css/selectors/universal.json
+++ b/css/selectors/universal.json
@@ -63,10 +63,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"

--- a/css/selectors/visited.json
+++ b/css/selectors/visited.json
@@ -63,10 +63,10 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "4"

--- a/css/types/calc.json
+++ b/css/types/calc.json
@@ -160,10 +160,10 @@
                 "version_added": "28"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "19"

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -13,10 +13,10 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -64,10 +64,12 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "prefix": "-ms-",
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "prefix": "-ms-",
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": true,

--- a/css/types/length-percentage.json
+++ b/css/types/length-percentage.json
@@ -730,12 +730,24 @@
               "chrome_android": {
                 "version_added": true
               },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
+              "edge": [
+                {
+                  "version_added": "12"
+                },
+                {
+                  "alternative_name": "vm",
+                  "version_added": "12"
+                }
+              ],
+              "edge_mobile": [
+                {
+                  "version_added": "12"
+                },
+                {
+                  "alternative_name": "vm",
+                  "version_added": "12"
+                }
+              ],
               "firefox": {
                 "version_added": "19"
               },

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -730,12 +730,24 @@
               "chrome_android": {
                 "version_added": true
               },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
+              "edge": [
+                {
+                  "version_added": "12"
+                },
+                {
+                  "alternative_name": "vm",
+                  "version_added": "12"
+                }
+              ],
+              "edge_mobile": [
+                {
+                  "version_added": "12"
+                },
+                {
+                  "alternative_name": "vm",
+                  "version_added": "12"
+                }
+              ],
               "firefox": {
                 "version_added": "19"
               },

--- a/css/types/number.json
+++ b/css/types/number.json
@@ -13,10 +13,10 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -63,10 +63,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "29"

--- a/css/types/ratio.json
+++ b/css/types/ratio.json
@@ -13,10 +13,10 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5"

--- a/css/types/shape.json
+++ b/css/types/shape.json
@@ -13,10 +13,10 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": null
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -63,10 +63,10 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"

--- a/css/types/time-percentage.json
+++ b/css/types/time-percentage.json
@@ -13,10 +13,10 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "4"

--- a/css/types/time.json
+++ b/css/types/time.json
@@ -13,10 +13,10 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "4"

--- a/css/types/timing-function.json
+++ b/css/types/timing-function.json
@@ -13,10 +13,10 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": null
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "4"
@@ -63,10 +63,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "4"

--- a/css/types/transform-function.json
+++ b/css/types/transform-function.json
@@ -13,10 +13,10 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5",
@@ -68,10 +68,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "10"

--- a/css/types/url.json
+++ b/css/types/url.json
@@ -13,10 +13,10 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"


### PR DESCRIPTION
This was a semi-automatic PR made from a script and spot checked afterwards to ensure the validity of the data.

Under the following conditions:
- Edge has `version_added: null` or `version_added: true`
- IE has a `version_added: <true / real value>` statement
- IE does not have a `version_removed` statement

This PR performs the following:
- Mirrors IE data onto Edge (Desktop and Mobile)
- Sets the `version_added` of all the new mirrored data to "12" (since it's continuing the version numbers)

I've gone through and double-checked all the notes, to remove any bad references such as "Edge 7".  This should make it easier for the 2019 KR for Edge.