### PR TITLE
Change Opera 59 to Opera 60

### DIFF
--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -963,7 +963,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "59"
+                "version_added": "60"
               },
               "opera_android": {
                 "version_added": null
@@ -1017,7 +1017,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": "59"
+                  "version_added": "60"
                 },
                 "opera_android": {
                   "version_added": null
@@ -1072,7 +1072,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": "59"
+                  "version_added": "60"
                 },
                 "opera_android": {
                   "version_added": null
@@ -1127,7 +1127,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": "59"
+                  "version_added": "60"
                 },
                 "opera_android": {
                   "version_added": null
@@ -1182,7 +1182,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": "59"
+                  "version_added": "60"
                 },
                 "opera_android": {
                   "version_added": null
@@ -1237,7 +1237,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": "59"
+                  "version_added": "60"
                 },
                 "opera_android": {
                   "version_added": null


### PR DESCRIPTION
It's weird, but Opera 59 never shipped. See https://github.com/mdn/browser-compat-data/pull/3874

Fixes the failing build on master as https://github.com/mdn/browser-compat-data/pull/3860 got this wrong.