### PR TITLE
Add Firefox support for stale-while-revalidate Cache-control response…

### DIFF
--- a/http/headers/cache-control.json
+++ b/http/headers/cache-control.json
@@ -124,7 +124,7 @@
                 "version_added": "68"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "68"
               },
               "ie": {
                 "version_added": false

--- a/http/headers/cache-control.json
+++ b/http/headers/cache-control.json
@@ -121,8 +121,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false,
-                "notes": "See Bugzilla <a href='https://bugzil.la/995651'>bug 995651</a>."
+                "version_added": "68"
               },
               "firefox_android": {
                 "version_added": false
@@ -175,7 +174,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See Bugzilla <a href='https://bugzil.la/995651'>bug 995651</a>."
+                "notes": "See Bugzilla <a href='https://bugzil.la/995651'>bug 995651</a> comment 7."
               },
               "firefox_android": {
                 "version_added": false


### PR DESCRIPTION
- Update Cache-control: stale-while-revalidate Firefox support
- Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1536511

The bug has just landed, it might be good to let it bake few days to confirm it sticks.
