### PR TITLE
Add Firefox versions to list-style-types

### DIFF
--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -73,7 +73,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "4"
+                  "version_added": "1"
                 }
               ],
               "firefox_android": [
@@ -187,7 +187,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "4"
+                  "version_added": "1"
                 }
               ],
               "firefox_android": [
@@ -301,7 +301,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "4"
+                  "version_added": "1"
                 }
               ],
               "firefox_android": [
@@ -364,7 +364,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "4"
+                  "version_added": "1"
                 }
               ],
               "firefox_android": [
@@ -543,7 +543,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "4"
+                  "version_added": "1"
                 }
               ],
               "firefox_android": [
@@ -709,7 +709,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "4"
+                  "version_added": "1"
                 }
               ],
               "firefox_android": [
@@ -824,7 +824,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "4"
+                  "version_added": "1"
                 }
               ],
               "firefox_android": [
@@ -887,7 +887,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "4"
+                  "version_added": "1"
                 }
               ],
               "firefox_android": [
@@ -1259,7 +1259,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "4"
+                  "version_added": "1"
                 }
               ],
               "firefox_android": [
@@ -1452,7 +1452,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "4"
+                  "version_added": "1"
                 }
               ],
               "firefox_android": [
@@ -1668,7 +1668,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "4"
+                  "version_added": "1"
                 }
               ],
               "firefox_android": [
@@ -1833,7 +1833,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "4"
+                  "version_added": "1"
                 }
               ],
               "firefox_android": [
@@ -1947,7 +1947,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "4"
+                  "version_added": "1"
                 }
               ],
               "firefox_android": [
@@ -2010,7 +2010,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "4"
+                  "version_added": "1"
                 }
               ],
               "firefox_android": [
@@ -2073,7 +2073,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "4"
+                  "version_added": "1"
                 }
               ],
               "firefox_android": [
@@ -2250,7 +2250,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "4"
+                  "version_added": "1"
                 }
               ],
               "firefox_android": [
@@ -2313,7 +2313,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "4"
+                  "version_added": "1"
                 }
               ],
               "firefox_android": [
@@ -2376,7 +2376,7 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "version_added": "4"
+                  "version_added": "1"
                 }
               ],
               "firefox_android": [

--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -67,9 +67,15 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": true
-              },
+              "firefox": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4"
+                }
+              ],
               "firefox_android": [
                 {
                   "version_added": "33"
@@ -175,9 +181,15 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": true
-              },
+              "firefox": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4"
+                }
+              ],
               "firefox_android": [
                 {
                   "version_added": "33"
@@ -283,9 +295,15 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": true
-              },
+              "firefox": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4"
+                }
+              ],
               "firefox_android": [
                 {
                   "version_added": "33"
@@ -340,9 +358,15 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": true
-              },
+              "firefox": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4"
+                }
+              ],
               "firefox_android": [
                 {
                   "version_added": "33"
@@ -513,9 +537,15 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": true
-              },
+              "firefox": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4"
+                }
+              ],
               "firefox_android": [
                 {
                   "version_added": "33"
@@ -672,9 +702,16 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": true
-              },
+              "firefox": [
+                {
+                  "version_added": "33",
+                  "notes": "Before Firefox 38, Firefox added a dot as suffix of the number for <code>ethiopic-numeric</code> (for example, ፫. instead of ፫). The specification later defined the absence of a suffix, which Firefox 38 followed."
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4"
+                }
+              ],
               "firefox_android": [
                 {
                   "version_added": "33",
@@ -781,9 +818,15 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": true
-              },
+              "firefox": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4"
+                }
+              ],
               "firefox_android": [
                 {
                   "version_added": "33"
@@ -838,9 +881,15 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": true
-              },
+              "firefox": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4"
+                }
+              ],
               "firefox_android": [
                 {
                   "version_added": "33"
@@ -1204,9 +1253,15 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": true
-              },
+              "firefox": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4"
+                }
+              ],
               "firefox_android": [
                 {
                   "version_added": "33"
@@ -1391,9 +1446,15 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": true
-              },
+              "firefox": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4"
+                }
+              ],
               "firefox_android": [
                 {
                   "version_added": "33"
@@ -1601,9 +1662,15 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": true
-              },
+              "firefox": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4"
+                }
+              ],
               "firefox_android": [
                 {
                   "version_added": "33"
@@ -1760,9 +1827,15 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": true
-              },
+              "firefox": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4"
+                }
+              ],
               "firefox_android": [
                 {
                   "version_added": "33"
@@ -1868,9 +1941,15 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": true
-              },
+              "firefox": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4"
+                }
+              ],
               "firefox_android": [
                 {
                   "version_added": "33"
@@ -1925,9 +2004,15 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": true
-              },
+              "firefox": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4"
+                }
+              ],
               "firefox_android": [
                 {
                   "version_added": "33"
@@ -1982,9 +2067,15 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": true
-              },
+              "firefox": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4"
+                }
+              ],
               "firefox_android": [
                 {
                   "version_added": "33"
@@ -2153,9 +2244,15 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": true
-              },
+              "firefox": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4"
+                }
+              ],
               "firefox_android": [
                 {
                   "version_added": "33"
@@ -2210,9 +2307,15 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": true
-              },
+              "firefox": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4"
+                }
+              ],
               "firefox_android": [
                 {
                   "version_added": "33"
@@ -2267,9 +2370,15 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": true
-              },
+              "firefox": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4"
+                }
+              ],
               "firefox_android": [
                 {
                   "version_added": "33"


### PR DESCRIPTION
I think this wasn't migrated quite properly form the legacy tables.
See https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-type$revision/1321999

I think it was implemented (or unprefixed rather) in this bug https://bugzilla.mozilla.org/show_bug.cgi?id=1063856

See also the Firefox 33 release notes: https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/33#CSS

This PR updates:
css.properties.list-style-type.arabic-indic
css.properties.list-style-type.bengali
css.properties.list-style-type.cjk-earthly-branch
css.properties.list-style-type.cjk-heavenly-stem
css.properties.list-style-type.devanagari
css.properties.list-style-type.ethiopic-numeric
css.properties.list-style-type.gujarati
css.properties.list-style-type.gurmukhi
css.properties.list-style-type.kannada
css.properties.list-style-type.khmer
css.properties.list-style-type.lao
css.properties.list-style-type.malayalam
css.properties.list-style-type.myanmar
css.properties.list-style-type.oriya
css.properties.list-style-type.persian
css.properties.list-style-type.tamil
css.properties.list-style-type.telugu
css.properties.list-style-type.thai