### PR TITLE
Remove future Firefox Android (Fennec) releases

### DIFF
--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -313,21 +313,6 @@
           "release_date": "2019-07-09",
           "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/68",
           "status": "nightly"
-        },
-        "69": {
-          "release_date": "2019-09-03",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/69",
-          "status": "planned"
-        },
-        "70": {
-          "release_date": "2019-10-22",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/70",
-          "status": "planned"
-        },
-        "71": {
-          "release_date": "2019-12-10",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/71",
-          "status": "planned"
         }
       }
     }


### PR DESCRIPTION
See https://groups.google.com/forum/#!topic/mozilla.dev.platform/k-irJtmCcqg

The fennec project is EOL'ed, so there will be no `firefox_android` that follows Firefox desktop releases. 68 is the last fennec version which will be an ESR release that won't get new web platform features in the future.

We will need to see when Mozilla ships https://github.com/mozilla-mobile/fenix to end-users and how we want to continue with `firefox_android` browser compat data and versions at that point.