### PR TITLE
adding BCD for events mixed bag part 2

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -9191,6 +9191,58 @@
           }
         }
       },
+      "scroll_event": {
+        "__compat": {
+          "description": "<code>scroll</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/scroll_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "scrollingElement": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/scrollingElement",
@@ -10328,6 +10380,58 @@
           },
           "status": {
             "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "wheel_event": {
+        "__compat": {
+          "description": "<code>wheel</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/wheel_event",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Element.json
+++ b/api/Element.json
@@ -7065,7 +7065,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/api/Element.json
+++ b/api/Element.json
@@ -5909,6 +5909,58 @@
           }
         }
       },
+      "scroll_event": {
+        "__compat": {
+          "description": "<code>scroll</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/scroll_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "scrollIntoView": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/scrollIntoView",
@@ -6495,6 +6547,58 @@
           }
         }
       },
+      "select_event": {
+        "__compat": {
+          "description": "<code>select</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/select_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "setAttribute": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/setAttribute",
@@ -6904,6 +7008,58 @@
             },
             "webview_android": {
               "version_added": "43"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "show_event": {
+        "__compat": {
+          "description": "<code>show</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/show_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": false
             }
           },
           "status": {
@@ -7373,6 +7529,58 @@
           "status": {
             "experimental": false,
             "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
+      "wheel_event": {
+        "__compat": {
+          "description": "<code>wheel</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/wheel_event",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/HTMLSlotElement.json
+++ b/api/HTMLSlotElement.json
@@ -382,6 +382,116 @@
             "deprecated": false
           }
         }
+      },
+      "slotchange_event": {
+        "__compat": {
+          "description": "<code>slotchange</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSlotElement/slotchange_event",
+          "support": {
+            "chrome": {
+              "version_added": "53"
+            },
+            "chrome_android": {
+              "version_added": "53"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": [
+              {
+                "version_added": "63"
+              },
+              {
+                "version_added": "59",
+                "version_removed": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": true,
+                "version_removed": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.enabled",
+                    "value_to_set": "true"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "63"
+              },
+              {
+                "version_added": "59",
+                "version_removed": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": true,
+                "version_removed": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.enabled",
+                    "value_to_set": "true"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.shadowdom.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "40"
+            },
+            "opera_android": {
+              "version_added": "41"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.1"
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": "53"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/Performance.json
+++ b/api/Performance.json
@@ -777,6 +777,73 @@
           }
         }
       },
+      "resourcetimingbufferfull_event": {
+        "__compat": {
+          "description": "<code>resourcetimingbufferfull</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Performance/resourcetimingbufferfull_event",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "46"
+              },
+              {
+                "version_added": "22",
+                "version_removed": "57",
+                "alternative_name": "webkitresourcetimingbufferfull"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "46"
+              },
+              {
+                "version_added": "25",
+                "version_removed": "57",
+                "alternative_name": "webkitresourcetimingbufferfull"
+              }
+            ],
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "webview_android": [
+              {
+                "version_added": "46"
+              },
+              {
+                "version_added": true,
+                "version_removed": "57",
+                "alternative_name": "webkitresourcetimingbufferfull"
+              }
+            ]
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "setResourceTimingBufferSize": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Performance/setResourceTimingBufferSize",

--- a/api/Window.json
+++ b/api/Window.json
@@ -7569,11 +7569,11 @@
             },
             "firefox": {
               "version_added": true,
-              "notes": "Firefox emits a <code>resize</code> event on page load, but it will soon stop doing so (see <a href='https://bugzil.la/1528052'>bug 1528052</a>)."
+              "notes": "Firefox emits a <code>resize</code> event on page load."
             },
             "firefox_android": {
               "version_added": true,
-              "notes": "Firefox emits a <code>resize</code> event on page load, but it will soon stop doing so (see <a href='https://bugzil.la/1528052'>bug 1528052</a>)."
+              "notes": "Firefox emits a <code>resize</code> event on page load."
             },
             "ie": {
               "version_added": true

--- a/api/Window.json
+++ b/api/Window.json
@@ -6816,6 +6816,55 @@
           }
         }
       },
+      "popstate_event": {
+        "__compat": {
+          "description": "<code>popstate</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/popstate_event",
+          "support": {
+            "chrome": {
+              "version_added": "5"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "11.5"
+            },
+            "opera_android": {
+              "version_added": "11.5"
+            },
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "5.1"
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "postMessage": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/postMessage",
@@ -7484,6 +7533,58 @@
             },
             "webview_android": {
               "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "resize_event": {
+        "__compat": {
+          "description": "<code>resize</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/resize_event",
+          "support": {
+            "chrome": {
+              "version_added": "45"
+            },
+            "chrome_android": {
+              "version_added": "45"
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "32"
+            },
+            "opera_android": {
+              "version_added": "32"
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "45"
             }
           },
           "status": {
@@ -9495,6 +9596,55 @@
             },
             "webview_android": {
               "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "storage_event": {
+        "__compat": {
+          "description": "<code>storage</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/storage_event",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": {
+              "version_added": "45"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": false
             }
           },
           "status": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -6822,10 +6822,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/popstate_event",
           "support": {
             "chrome": {
-              "version_added": "5"
+              "version_added": "5",
+              "notes": "Chrome used to incorrectly emit a <code>popstate</code> event on page load, but since version 34 no longer does."
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "18",
+              "notes": "Chrome used to incorrectly emit a <code>popstate</code> event on page load, but since version 34 no longer does."
             },
             "edge": {
               "version_added": "12"
@@ -6849,13 +6851,15 @@
               "version_added": "11.5"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "6",
+              "notes": "Safari used to incorrectly emit a <code>popstate</code> event on page load, but since version 10.0 no longer does."
             },
             "safari_ios": {
-              "version_added": "5.1"
+              "version_added": "5.1",
+              "notes": "Safari used to incorrectly emit a <code>popstate</code> event on page load, but since version 10.0 no longer does."
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -9611,7 +9615,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/storage_event",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
               "version_added": false

--- a/api/Window.json
+++ b/api/Window.json
@@ -6823,11 +6823,11 @@
           "support": {
             "chrome": {
               "version_added": "5",
-              "notes": "Chrome used to incorrectly emit a <code>popstate</code> event on page load, but since version 34 no longer does."
+              "notes": "Chrome used to emit a <code>popstate</code> event on page load, but since version 34 no longer does."
             },
             "chrome_android": {
               "version_added": "18",
-              "notes": "Chrome used to incorrectly emit a <code>popstate</code> event on page load, but since version 34 no longer does."
+              "notes": "Chrome used to emit a <code>popstate</code> event on page load, but since version 34 no longer does."
             },
             "edge": {
               "version_added": "12"
@@ -6836,10 +6836,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "4",
+              "notes": "Firefox emits a <code>popstate</code> event on page load."
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "4",
+              "notes": "Firefox emits a <code>popstate</code> event on page load."
             },
             "ie": {
               "version_added": "10"
@@ -6852,11 +6854,11 @@
             },
             "safari": {
               "version_added": "6",
-              "notes": "Safari used to incorrectly emit a <code>popstate</code> event on page load, but since version 10.0 no longer does."
+              "notes": "Safari used to emit a <code>popstate</code> event on page load, but since version 10.0 no longer does."
             },
             "safari_ios": {
               "version_added": "5.1",
-              "notes": "Safari used to incorrectly emit a <code>popstate</code> event on page load, but since version 10.0 no longer does."
+              "notes": "Safari used to emit a <code>popstate</code> event on page load, but since version 10.0 no longer does."
             },
             "webview_android": {
               "version_added": true
@@ -7552,10 +7554,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/resize_event",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "45",
+              "notes": "Chrome does not emit a <code>resize</code> event on page load."
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "45",
+              "notes": "Chrome does not emit a <code>resize</code> event on page load."
             },
             "edge": {
               "version_added": true
@@ -7564,19 +7568,23 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Firefox emits a <code>resize</code> event on page load, but it will soon stop doing so (see <a href='https://bugzil.la/1528052'>bug 1528052</a>)."
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Firefox emits a <code>resize</code> event on page load, but it will soon stop doing so (see <a href='https://bugzil.la/1528052'>bug 1528052</a>)."
             },
             "ie": {
               "version_added": true
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "32",
+              "notes": "Opera does not emit a <code>resize</code> event on page load."
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "32",
+              "notes": "Opera does not emit a <code>resize</code> event on page load."
             },
             "safari": {
               "version_added": true
@@ -7588,7 +7596,8 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "45",
+              "notes": "Webview does not emit a <code>resize</code> event on page load."
             }
           },
           "status": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -6859,7 +6859,7 @@
               "notes": "Safari used to incorrectly emit a <code>popstate</code> event on page load, but since version 10.0 no longer does."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {

--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -1904,6 +1904,58 @@
           }
         }
       },
+      "timeout_event": {
+        "__compat": {
+          "description": "<code>timeout</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/timeout_event",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "upload": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/upload",


### PR DESCRIPTION
As per https://github.com/mdn/sprints/issues/1126#issuecomment-487053382

The following is a list describing where the data comes from, for each addition.

* api.XMLHttpRequest.timeout_event: Copied from api.XMLHttpRequestEventTarget.ontimeout.
* api.HTMLSlotElement.slotchange_event: Copied from api.HTMLSlotElement.assignedNodes, as I remember this stuff being supported at roughly the same time, although it would be very hard to find out definitively. There is no onslotchange to copy from; the property doesn't exist.
* api.Element.select_event: Copied from api.GlobalEventHandlers.onselect.
* api.Element.show_event: Copied from api.GlobalEventHandlers.onshow.
* api.Performance.resourcetimingbufferfull_event: Copied from api.Performance.onresourcetimingbufferfull.
* api.Document.scroll_event and api.Element.scroll_event: Copied from api.GlobalEventHandlers.onscroll.
* api.Document.wheel_event and api.Element.wheel_event: Copied from api.GlobalEventHandlers.onwheel.
* api.Window.resize_event: Copied from api.GlobalEventHandlers.onresize.
* api.Window.storage_event: Copied from api.WindowEventHandlers.onstorage.
* api.Window.popstate_event: Copied from api.WindowEventHandlers.onpopstate.