### PR TITLE
fix(api): `HTMLMenuElement` is not deprecated

### DIFF
--- a/api/HTMLMenuElement.json
+++ b/api/HTMLMenuElement.json
@@ -42,9 +42,9 @@
           }
         },
         "status": {
-          "experimental": false,
+          "experimental": true,
           "standard_track": true,
-          "deprecated": true
+          "deprecated": false
         }
       },
       "compact": {


### PR DESCRIPTION
I forgot to do this in #3954.