### PR TITLE
adding note to the firefox connect event data

### DIFF
--- a/api/SharedWorkerGlobalScope.json
+++ b/api/SharedWorkerGlobalScope.json
@@ -119,10 +119,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "29"
+              "version_added": "29",
+              "notes": "Before version 65 the <code>data</code> property of the event object was <code>null</code>; it is now initialized to an empty string, as per spec."
             },
             "firefox_android": {
-              "version_added": "29"
+              "version_added": "29",
+              "notes": "Before version 65 the <code>data</code> property of the event object was <code>null</code>; it is now initialized to an empty string, as per spec."
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
In https://developer.mozilla.org/en-US/docs/Web/API/SharedWorkerGlobalScope/connect_event, there was a note contained in the page that @wbamberg pointed out would probably be better off living in the BCD itself.

This PR adds that note.