### PR TITLE
[Chrome]Additions to #3994.

### DIFF
--- a/api/PaymentResponse.json
+++ b/api/PaymentResponse.json
@@ -254,10 +254,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/onpayerdetailchange",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -292,7 +292,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
@@ -308,10 +308,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/payerdetailchange_event",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -346,7 +346,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {

--- a/api/PaymentResponse.json
+++ b/api/PaymentResponse.json
@@ -277,10 +277,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": null
@@ -331,10 +331,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": null

--- a/api/SharedWorkerGlobalScope.json
+++ b/api/SharedWorkerGlobalScope.json
@@ -107,7 +107,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SharedWorkerGlobalScope/connect_event",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -209,7 +209,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SharedWorkerGlobalScope/onconnect",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"


### PR DESCRIPTION
Adds to #3994:

* `payerdetailchange`/`onpayerdetailchange are not yet available in Chrome.
* `conect`/`onconnect` was [comited a month before Chrome 1 shipped](https://chromium.googlesource.com/chromium/src/+/28acff0e90cdec8c925bc4a963fb4e60458b37fb)
