### PR TITLE
Fix Chrome Android version numbers during mirroring

### DIFF
--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -2703,7 +2703,7 @@
                   "version_added": "24"
                 },
                 "chrome_android": {
-                  "version_added": "26"
+                  "version_added": "25"
                 },
                 "edge": {
                   "version_added": "14"
@@ -2977,7 +2977,7 @@
                   "version_added": "24"
                 },
                 "chrome_android": {
-                  "version_added": "26"
+                  "version_added": "25"
                 },
                 "edge": {
                   "version_added": "14"
@@ -3195,7 +3195,7 @@
                   "version_added": "24"
                 },
                 "chrome_android": {
-                  "version_added": "26"
+                  "version_added": "25"
                 },
                 "edge": {
                   "version_added": "14"


### PR DESCRIPTION
Follow-up to [@jpmedley's comment](https://github.com/mdn/browser-compat-data/pull/3830/files/bdc4f6ae74d20532832744a42b74eada3706fc06#r279031667) on #3830.