### PR TITLE
[MIXED] Corrections, mostly from confluence.

### DIFF
--- a/api/External.json
+++ b/api/External.json
@@ -52,7 +52,7 @@
               "version_added": "54"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "54"
             },
             "edge": {
               "version_added": null
@@ -70,7 +70,7 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "41"
             },
             "safari": {
               "version_added": null
@@ -79,7 +79,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "54"
             }
           },
           "status": {
@@ -115,7 +115,7 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "41"
             },
             "safari": {
               "version_added": null

--- a/api/External.json
+++ b/api/External.json
@@ -49,7 +49,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/External/AddSearchProvider",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "54"
             },
             "chrome_android": {
               "version_added": true
@@ -94,10 +94,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/External/IsSearchProviderInstalled",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "54"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "54"
             },
             "edge": {
               "version_added": null
@@ -124,7 +124,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "54"
             }
           },
           "status": {

--- a/api/HTMLAllCollection.json
+++ b/api/HTMLAllCollection.json
@@ -52,10 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAllCollection/length",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "44"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "edge": {
               "version_added": "14"
@@ -79,13 +79,13 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "44"
             }
           },
           "status": {
@@ -127,7 +127,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": true
@@ -175,7 +175,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": true

--- a/api/HTMLAllCollection.json
+++ b/api/HTMLAllCollection.json
@@ -73,10 +73,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "31"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "safari": {
               "version_added": "10"

--- a/api/HTMLAllCollection.json
+++ b/api/HTMLAllCollection.json
@@ -76,7 +76,7 @@
               "version_added": "31"
             },
             "opera_android": {
-              "version_added": "31"
+              "version_added": "32"
             },
             "safari": {
               "version_added": "10"

--- a/api/HTMLFrameElement.json
+++ b/api/HTMLFrameElement.json
@@ -52,10 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFrameElement/contentDocument",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -79,7 +79,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
               "version_added": true
@@ -100,10 +100,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFrameElement/contentWindow",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -127,7 +127,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": true
@@ -148,10 +148,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFrameElement/frameBorder",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -175,7 +175,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": true
@@ -196,10 +196,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFrameElement/longDesc",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -223,7 +223,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": true
@@ -244,10 +244,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFrameElement/marginHeight",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -271,7 +271,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": true
@@ -292,10 +292,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFrameElement/marginWidth",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -319,7 +319,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": true
@@ -340,10 +340,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFrameElement/name",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -367,7 +367,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": true
@@ -388,10 +388,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFrameElement/noResize",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -415,7 +415,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": true
@@ -436,10 +436,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFrameElement/scrolling",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -463,7 +463,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": true
@@ -484,10 +484,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFrameElement/src",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -511,7 +511,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": true

--- a/api/InputDeviceInfo.json
+++ b/api/InputDeviceInfo.json
@@ -79,7 +79,7 @@
               "version_added": "54"
             },
             "opera_android": {
-              "version_added": "54"
+              "version_added": "48"
             },
             "safari": {
               "version_added": null

--- a/api/InputDeviceInfo.json
+++ b/api/InputDeviceInfo.json
@@ -55,10 +55,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/InputDeviceInfo/getCapabilities",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "67"
             },
             "edge": {
               "version_added": null
@@ -91,7 +91,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "67"
             }
           },
           "status": {

--- a/api/InputDeviceInfo.json
+++ b/api/InputDeviceInfo.json
@@ -76,10 +76,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": "54"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "54"
             },
             "safari": {
               "version_added": null

--- a/api/MediaEncryptedEvent.json
+++ b/api/MediaEncryptedEvent.json
@@ -113,13 +113,13 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": null
+              "version_added": "13"
             },
             "edge_mobile": {
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
               "version_added": null
@@ -164,13 +164,13 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": null
+              "version_added": "13"
             },
             "edge_mobile": {
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
               "version_added": null

--- a/api/TextTrackList.json
+++ b/api/TextTrackList.json
@@ -232,7 +232,7 @@
               "version_added": "31"
             },
             "opera_android": {
-              "version_added": "31"
+              "version_added": "32"
             },
             "safari": {
               "version_added": "10"

--- a/api/TextTrackList.json
+++ b/api/TextTrackList.json
@@ -229,10 +229,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "31"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "31"
             },
             "safari": {
               "version_added": "10"

--- a/api/TextTrackList.json
+++ b/api/TextTrackList.json
@@ -163,13 +163,13 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": "18"
             },
             "edge_mobile": {
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
               "version_added": null
@@ -184,7 +184,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": null
@@ -208,19 +208,19 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackList/length",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "44"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
               "version_added": null
@@ -235,7 +235,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
               "version_added": null
@@ -244,7 +244,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "44"
             }
           },
           "status": {


### PR DESCRIPTION
Here's what I did. After running my weekly of what Chrome APIs are missing from MDN, I extracted all of the interface names and pass them to confluence. These six files are what I got back. In reviewing them, I found that `HTMLFrameElement` had some false positives for Chrome 43. I changed that data to Chrome 1/Android 18 based on these change lists:
* `contentDocument`, `frameBorder`, `longDesc`, `marginHeight`, `marginWidth`, `name`,`noResize`,`scrolling`, and `src` [in Chrome 1](https://chromium.googlesource.com/chromium/src/+/9aae9c4e971747c2bb9dd7bc0fed3b416f6f8b19/third_party/WebKit/WebCore/html/HTMLFrameElement.idl)
* `contentWindow` [also Chrome 1 by different commit](https://chromium.googlesource.com/chromium/src/+/2c826854e0f530e415da10c8bf0b96353e16b8d7/third_party/WebKit/WebCore/html/HTMLFrameElement.idl)
