### PR TITLE
Update <basic-shape> data for Firefox

### DIFF
--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -19,24 +19,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.shape-outside.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "54"
             },
             "firefox_android": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.shape-outside.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "54"
             },
             "ie": {
               "version_added": false
@@ -84,24 +70,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "61",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.shape-outside.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "54"
               },
               "firefox_android": {
-                "version_added": "61",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.shape-outside.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "54"
               },
               "ie": {
                 "version_added": false
@@ -150,24 +122,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "61",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.shape-outside.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "54"
               },
               "firefox_android": {
-                "version_added": "61",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.shape-outside.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "54"
               },
               "ie": {
                 "version_added": false
@@ -216,24 +174,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "61",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.shape-outside.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "54"
               },
               "firefox_android": {
-                "version_added": "61",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.shape-outside.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "54"
               },
               "ie": {
                 "version_added": false
@@ -364,24 +308,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "61",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.shape-outside.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "54"
               },
               "firefox_android": {
-                "version_added": "61",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.shape-outside.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "54"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
Fixes #2418.

> [Bug 1247229](https://bugzilla.mozilla.org/show_bug.cgi?id=1247229) suggests that `<basic-shape>` is supported in `clip-path` from Firefox 54, and the `clip-path` compat data says the same thing: https://github.com/mdn/browser-compat-data/blob/master/css/properties/clip-path.json#L146-L149.

The bug implies that this CSS type existed in Firefox 54.  This PR reflects said implications.