### PR TITLE
Finish migration of CSS :scope

### DIFF
--- a/css/selectors/scope.json
+++ b/css/selectors/scope.json
@@ -20,10 +20,12 @@
             },
             "firefox": [
               {
-                "version_added": "32"
+                "version_added": "32",
+                "notes": "Firefox 55 removes support for <code>&lt;style scoped&gt;</code> but not for the <code>:scope</code> pseudo-class, which is still supported. <code>&lt;style scoped&gt;</code> made it possible to explicitly set up element scopes, but ongoing discussions about the design of this feature as well as lack of other implementations resulted in the decision to remove it."
               },
               {
                 "version_added": "20",
+                "version_removed": "32",
                 "flags": [
                   {
                     "type": "preference",
@@ -35,7 +37,8 @@
             ],
             "firefox_android": [
               {
-                "version_added": "32"
+                "version_added": "32",
+                "notes": "Firefox 55 removes support for <code>&lt;style scoped&gt;</code> but not for the <code>:scope</code> pseudo-class, which is still supported. <code>&lt;style scoped&gt;</code> made it possible to explicitly set up element scopes, but ongoing discussions about the design of this feature as well as lack of other implementations resulted in the decision to remove it."
               },
               {
                 "version_added": "20",


### PR DESCRIPTION
Fixes #2911 by migrating some of the missing data in the CSS `:scope` selector.