### PR TITLE
Update Edge version for classList.replace()

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -1398,7 +1398,7 @@
                 "version_added": "61"
               },
               "edge": {
-                "version_added": null
+                "version_added": "17"
               },
               "edge_mobile": {
                 "version_added": null


### PR DESCRIPTION
## Summary

I've tested the following [JSFiddle](https://jsfiddle.net/xvs30rLe/) in Edge 15, 16, 17 and 18

17, is the earliest version that supports `classList.replace()` and you can see the screenshot from Lambadatest.com, which alerts the result of the new class:

![screeny](https://user-images.githubusercontent.com/2019801/56886986-33389500-6a68-11e9-9500-4f8339ab49e0.png)

Versions 15 and 16 throw an error saying:

> Object doesn't support property or method 'replace'


## Code:

**HTML:**
```
<div id="foo" class="one"></div>
<div id="result"></div>
```

**JS:**
```
document.getElementById('foo').classList.replace('one', 'two');
document.getElementById('result').innerText = foo.classList;
```





