### PR TITLE
Update prefixed Fx support for intrinsic sizing

### DIFF
--- a/css/properties/block-size.json
+++ b/css/properties/block-size.json
@@ -98,7 +98,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "41",
                   "prefix": "-moz-"
                 }
               ],
@@ -107,7 +107,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "41",
                   "prefix": "-moz-"
                 }
               ],
@@ -161,7 +161,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "41",
                   "prefix": "-moz-"
                 }
               ],
@@ -170,7 +170,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "41",
                   "prefix": "-moz-"
                 }
               ],

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -215,7 +215,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "22",
                   "prefix": "-moz-"
                 }
               ],
@@ -224,7 +224,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "22",
                   "prefix": "-moz-"
                 }
               ],
@@ -277,7 +277,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "22",
                   "prefix": "-moz-"
                 }
               ],
@@ -286,7 +286,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "22",
                   "prefix": "-moz-"
                 }
               ],

--- a/css/properties/inline-size.json
+++ b/css/properties/inline-size.json
@@ -98,7 +98,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "41",
                   "prefix": "-moz-"
                 }
               ],
@@ -107,7 +107,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "41",
                   "prefix": "-moz-"
                 }
               ],
@@ -161,7 +161,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "41",
                   "prefix": "-moz-"
                 }
               ],
@@ -170,7 +170,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "41",
                   "prefix": "-moz-"
                 }
               ],

--- a/css/properties/max-block-size.json
+++ b/css/properties/max-block-size.json
@@ -98,7 +98,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "41",
                   "prefix": "-moz-"
                 }
               ],
@@ -107,7 +107,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "41",
                   "prefix": "-moz-"
                 }
               ],
@@ -161,7 +161,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "41",
                   "prefix": "-moz-"
                 }
               ],

--- a/css/properties/max-inline-size.json
+++ b/css/properties/max-inline-size.json
@@ -110,7 +110,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "41",
                   "prefix": "-moz-"
                 }
               ],
@@ -119,7 +119,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "41",
                   "prefix": "-moz-"
                 }
               ],
@@ -173,7 +173,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "41",
                   "prefix": "-moz-"
                 }
               ],
@@ -182,7 +182,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "41",
                   "prefix": "-moz-"
                 }
               ],

--- a/css/properties/min-block-size.json
+++ b/css/properties/min-block-size.json
@@ -98,7 +98,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "41",
                   "prefix": "-moz-"
                 }
               ],
@@ -107,7 +107,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "41",
                   "prefix": "-moz-"
                 }
               ],
@@ -161,7 +161,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "41",
                   "prefix": "-moz-"
                 }
               ],
@@ -170,7 +170,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "41",
                   "prefix": "-moz-"
                 }
               ],

--- a/css/properties/min-inline-size.json
+++ b/css/properties/min-inline-size.json
@@ -98,7 +98,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "41",
                   "prefix": "-moz-"
                 }
               ],
@@ -107,7 +107,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "41",
                   "prefix": "-moz-"
                 }
               ],
@@ -162,7 +162,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "41",
                   "prefix": "-moz-"
                 }
               ],


### PR DESCRIPTION
There is -moz-min-content and -moz-max-content as early as Firefox 3, https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/releases/3/CSS_improvements

When new properties like block-size, flex-basis, inline-size, max-block-size, min-block-size, max-inline-size, min-inline-size were implemented, they got the prefixed -moz-min-content and -moz-max-content values with their initial support, so that's version 41, except for flex-basis where it is 22.