### PR TITLE
Add IE support for fr unit

### DIFF
--- a/css/types/flex.json
+++ b/css/types/flex.json
@@ -13,10 +13,10 @@
               "version_added": "29"
             },
             "edge": {
-              "version_added": "16"
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "40"
@@ -25,7 +25,7 @@
               "version_added": "40"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "28"


### PR DESCRIPTION
Support for the `fr` unit was tested in IE 9, 10, and 11.  Confirmed support since IE 10.  Fixes #2355.