### PR TITLE
IE does not support Object.assign

### DIFF
--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -412,7 +412,7 @@
                 "version_added": "34"
               },
               "ie": {
-                "version_added": "10"
+                "version_added": false
               },
               "nodejs": {
                 "version_added": "4.0.0"


### PR DESCRIPTION
This reverts https://github.com/mdn/browser-compat-data/pull/3965.

I believe the author of the PR was testing `Object.assign` on a site that had set up a polyfill. The same test does not work on a website such as example.com.

Here is an example of `console.log(Object.assign)` on a website that has a polyfill and website that does not:

![Screenshot of two websites](https://user-images.githubusercontent.com/916038/56987801-48362680-6b43-11e9-8ca2-d41084b9c6ee.png)

Here is `Object.assign` on `compat-table`:

![Screenshot of a table showing IE doesn't support Object.assign](https://user-images.githubusercontent.com/916038/56987934-a3681900-6b43-11e9-91ef-6c191db4b883.png)

***

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any

***
cc: @vinyldarkscratch, @metric152

Shout-out to @komatsu for pointing this out to me.