### PR TITLE
Add Chromium versions for several selectors/types

### DIFF
--- a/css/selectors/-moz-focusring.json
+++ b/css/selectors/-moz-focusring.json
@@ -7,10 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:-moz-focusring",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -28,10 +28,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": null
@@ -40,10 +40,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {

--- a/css/selectors/first.json
+++ b/css/selectors/first.json
@@ -7,10 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:first",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "18"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -31,7 +31,7 @@
               "version_added": "9.2"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "9.2"
             },
             "safari": {
               "version_added": null
@@ -40,10 +40,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "4.3"
             }
           },
           "status": {

--- a/css/selectors/first.json
+++ b/css/selectors/first.json
@@ -31,7 +31,7 @@
               "version_added": "9.2"
             },
             "opera_android": {
-              "version_added": "9.2"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": null
@@ -43,7 +43,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "4.3"
+              "version_added": "4.4"
             }
           },
           "status": {

--- a/css/selectors/left.json
+++ b/css/selectors/left.json
@@ -32,7 +32,7 @@
               "version_removed": "15"
             },
             "opera_android": {
-              "version_added": "9.2",
+              "version_added": "10.1",
               "version_removed": "14"
             },
             "safari": {

--- a/css/selectors/left.json
+++ b/css/selectors/left.json
@@ -7,10 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:left",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": "12"
@@ -28,10 +28,12 @@
               "version_added": "8"
             },
             "opera": {
-              "version_added": "9.2"
+              "version_added": "9.2",
+              "version_removed": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "9.2",
+              "version_removed": "14"
             },
             "safari": {
               "version_added": null
@@ -40,10 +42,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {

--- a/css/selectors/placeholder-shown.json
+++ b/css/selectors/placeholder-shown.json
@@ -74,10 +74,10 @@
             "description": "Support on non-<code>type=&quot;text&quot;</code> elements (such as <code>type=&quot;number&quot;</code> or <code>type=&quot;time&quot;</code>)",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "47"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "47"
               },
               "edge": {
                 "version_added": false
@@ -95,10 +95,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": "34"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "34"
               },
               "safari": {
                 "version_added": true
@@ -107,10 +107,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "47"
               }
             },
             "status": {

--- a/css/selectors/right.json
+++ b/css/selectors/right.json
@@ -32,7 +32,7 @@
               "version_removed": "15"
             },
             "opera_android": {
-              "version_added": "9.2",
+              "version_added": "10.1",
               "version_removed": "14"
             },
             "safari": {

--- a/css/selectors/right.json
+++ b/css/selectors/right.json
@@ -7,10 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:right",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": "12"
@@ -28,10 +28,12 @@
               "version_added": "8"
             },
             "opera": {
-              "version_added": "9.2"
+              "version_added": "9.2",
+              "version_removed": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "9.2",
+              "version_removed": "14"
             },
             "safari": {
               "version_added": null
@@ -40,10 +42,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {

--- a/css/types/calc.json
+++ b/css/types/calc.json
@@ -103,10 +103,10 @@
             "description": "<code>&lt;color&gt;</code> value support",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
                 "version_added": false
@@ -124,10 +124,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": null
@@ -136,10 +136,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
-                "version_added": null
+                "version_added": false
               }
             },
             "status": {
@@ -256,10 +256,10 @@
             "description": "<code>&lt;number&gt;</code> value support",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "31"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "31"
               },
               "edge": {
                 "version_added": "12"
@@ -277,10 +277,10 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": null
+                "version_added": "18"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "safari": {
                 "version_added": null
@@ -289,10 +289,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "4.4.3"
               }
             },
             "status": {

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -1801,10 +1801,10 @@
             "description": "<code>image()</code>",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
                 "version_added": null
@@ -1824,10 +1824,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": null
@@ -1836,10 +1836,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
-                "version_added": null
+                "version_added": false
               }
             },
             "status": {

--- a/css/types/resolution.json
+++ b/css/types/resolution.json
@@ -122,10 +122,10 @@
             "description": "<code>x</code> units",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
                 "version_added": null
@@ -143,10 +143,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": null
@@ -155,7 +155,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": false

--- a/css/types/timing-function.json
+++ b/css/types/timing-function.json
@@ -158,10 +158,10 @@
               "description": "<code>jump-</code> keywords for <code>steps()</code>",
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "edge": {
                   "version_added": false
@@ -179,10 +179,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "safari": {
                   "version_added": null
@@ -191,10 +191,10 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "webview_android": {
-                  "version_added": null
+                  "version_added": false
                 }
               },
               "status": {


### PR DESCRIPTION
This sets the Chromium versions for a variety of selectors and types, based upon manual testing.  They are as follows:

- css.selectors.-moz-focusring - false
- css.selectors.first - true 18
- css.selectors.placeholder-shown.non_text_types - true 47
- css.selectors.left - false
- css.selectors.right - false
- css.types.calc.color_values - false
- css.types.calc.number_values - true 31
- css.types.image.image - false
- css.types.resolution.x - false
- css.types.timing-function.steps.jump - false