### PR TITLE
Add Chromium versions for several CSS properties

### DIFF
--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -164,10 +164,10 @@
               "description": "<code>first baseline</code> and <code>last baseline</code>",
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": "59"
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": "59"
                 },
                 "edge": {
                   "version_added": false
@@ -185,10 +185,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "46"
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": "43"
                 },
                 "safari": {
                   "version_added": null
@@ -197,10 +197,10 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "webview_android": {
-                  "version_added": null
+                  "version_added": "59"
                 }
               },
               "status": {
@@ -215,10 +215,10 @@
               "description": "<code>start</code> and <code>end</code>",
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": "57"
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": "57"
                 },
                 "edge": {
                   "version_added": false
@@ -236,10 +236,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "44"
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": "43"
                 },
                 "safari": {
                   "version_added": null
@@ -248,10 +248,10 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "webview_android": {
-                  "version_added": null
+                  "version_added": "57"
                 }
               },
               "status": {
@@ -266,10 +266,10 @@
               "description": "<code>left</code> and <code>right</code>",
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "edge": {
                   "version_added": false
@@ -287,10 +287,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "safari": {
                   "version_added": null
@@ -299,10 +299,10 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "webview_android": {
-                  "version_added": null
+                  "version_added": false
                 }
               },
               "status": {

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -155,10 +155,10 @@
               "description": "<code>start</code> and <code>end</code>",
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": "57"
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": "57"
                 },
                 "edge": {
                   "version_added": null
@@ -176,10 +176,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "44"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "43"
                 },
                 "safari": {
                   "version_added": false
@@ -188,10 +188,10 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "webview_android": {
-                  "version_added": null
+                  "version_added": "57"
                 }
               },
               "status": {
@@ -206,10 +206,10 @@
               "description": "<code>left</code> and <code>right</code>",
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "edge": {
                   "version_added": null
@@ -227,7 +227,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "opera_android": {
                   "version_added": false
@@ -239,10 +239,10 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "webview_android": {
-                  "version_added": null
+                  "version_added": false
                 }
               },
               "status": {
@@ -257,10 +257,10 @@
               "description": "<code>baseline</code>",
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": "57"
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": "57"
                 },
                 "edge": {
                   "version_added": null
@@ -278,10 +278,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "44"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "43"
                 },
                 "safari": {
                   "version_added": false
@@ -290,10 +290,10 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "webview_android": {
-                  "version_added": null
+                  "version_added": "57"
                 }
               },
               "status": {
@@ -308,10 +308,10 @@
               "description": "<code>first baseline</code> and <code>last baseline</code>",
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": "57"
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": "57"
                 },
                 "edge": {
                   "version_added": null
@@ -329,10 +329,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "44"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "43"
                 },
                 "safari": {
                   "version_added": false
@@ -344,7 +344,7 @@
                   "version_added": null
                 },
                 "webview_android": {
-                  "version_added": null
+                  "version_added": "57"
                 }
               },
               "status": {
@@ -359,10 +359,10 @@
               "description": "<code>stretch</code>",
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": "57"
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": "57"
                 },
                 "edge": {
                   "version_added": null
@@ -380,10 +380,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "44"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "43"
                 },
                 "safari": {
                   "version_added": false
@@ -392,10 +392,10 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "webview_android": {
-                  "version_added": null
+                  "version_added": "57"
                 }
               },
               "status": {

--- a/css/properties/animation-timing-function.json
+++ b/css/properties/animation-timing-function.json
@@ -176,10 +176,10 @@
             "description": "<code>jump-</code> keywords for <code>steps()</code>",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
                 "version_added": null
@@ -197,10 +197,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": null
@@ -209,10 +209,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
-                "version_added": null
+                "version_added": false
               }
             },
             "status": {

--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -155,7 +155,7 @@
             "description": "optional <code>&lt;border-image-slice&gt;</code>",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "16"
               },
               "edge": {
                 "version_added": "12"
@@ -170,7 +170,7 @@
                 "version_added": "11"
               },
               "opera": {
-                "version_added": null
+                "version_added": "15"
               },
               "safari": {
                 "version_added": null

--- a/css/properties/column-gap.json
+++ b/css/properties/column-gap.json
@@ -8,10 +8,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-gap",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
                 "version_added": null
@@ -29,10 +29,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "qq_android": {
                 "version_added": null
@@ -44,16 +44,16 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "uc_android": {
-                "version_added": null
+                "version_added": false
               },
               "uc_chinese_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
-                "version_added": null
+                "version_added": false
               }
             },
             "status": {

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -916,10 +916,10 @@
             "description": "<code>ruby</code>, <code>ruby-base</code>, <code>ruby-base-container</code>, <code>ruby-text</code>, and <code>ruby-text-container</code>",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
                 "version_added": "12"
@@ -963,10 +963,10 @@
                 "version_added": "7"
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": null
@@ -975,10 +975,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
-                "version_added": null
+                "version_added": false
               }
             },
             "status": {
@@ -1177,10 +1177,10 @@
               "description": "Specific behavior of <a href='https://drafts.csswg.org/css-display/#unbox'>unusual elements</a> when <code>display: contents</code> is applied to them",
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": "58"
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": "58"
                 },
                 "edge": {
                   "version_added": false
@@ -1198,10 +1198,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": "45"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "43"
                 },
                 "safari": {
                   "version_added": false
@@ -1210,10 +1210,10 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": true
                 },
                 "webview_android": {
-                  "version_added": null
+                  "version_added": "58"
                 }
               },
               "status": {

--- a/css/properties/font-variant.json
+++ b/css/properties/font-variant.json
@@ -209,10 +209,10 @@
             "description": "CSS Fonts Module Level 3 shorthand",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "52"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "52"
               },
               "edge": {
                 "version_added": false
@@ -256,10 +256,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": "39"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "41"
               },
               "safari": {
                 "version_added": "9.1"
@@ -268,10 +268,10 @@
                 "version_added": "9.3"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "52"
               }
             },
             "status": {

--- a/css/properties/row-gap.json
+++ b/css/properties/row-gap.json
@@ -8,10 +8,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/row-gap",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
                 "version_added": null
@@ -29,13 +29,13 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "qq_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": false
@@ -44,16 +44,16 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "uc_android": {
-                "version_added": null
+                "version_added": false
               },
               "uc_chinese_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
-                "version_added": null
+                "version_added": false
               }
             },
             "status": {

--- a/css/properties/text-decoration.json
+++ b/css/properties/text-decoration.json
@@ -111,10 +111,10 @@
             "description": "Shorthand",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "57"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "57"
               },
               "edge": {
                 "version_added": false
@@ -144,10 +144,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "44"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "43"
               },
               "safari": {
                 "version_added": true,
@@ -158,10 +158,10 @@
                 "notes": "Safari doesn't support <a href='https://developer.mozilla.org/docs/Web/CSS/text-decoration-style'><code>text-decoration-style</code></a>."
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "57"
               }
             },
             "status": {

--- a/css/properties/text-size-adjust.json
+++ b/css/properties/text-size-adjust.json
@@ -97,10 +97,10 @@
             "description": "<code>&lt;percentage&gt;</code>",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "54"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "54"
               },
               "edge": {
                 "version_added": true
@@ -118,10 +118,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "41"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "41"
               },
               "safari": {
                 "version_added": false
@@ -130,10 +130,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "54"
               }
             },
             "status": {

--- a/css/properties/transition-timing-function.json
+++ b/css/properties/transition-timing-function.json
@@ -168,10 +168,10 @@
             "description": "<code>jump-</code> keywords for <code>steps()</code>",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": false
@@ -189,10 +189,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
                 "version_added": null
@@ -201,10 +201,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
-                "version_added": null
+                "version_added": true
               }
             },
             "status": {

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -56,10 +56,10 @@
             "description": "Animatable",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "26"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "26"
               },
               "edge": {
                 "version_added": "12"
@@ -77,10 +77,10 @@
                 "version_added": "11"
               },
               "opera": {
-                "version_added": null
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "14"
               },
               "safari": {
                 "version_added": null
@@ -89,10 +89,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "4.4"
               }
             },
             "status": {


### PR DESCRIPTION
This adds Chromium versions for all the following properties that were originally null, all based upon manual testing:

- css.properties.align-items.flex_context.first_last_baseline - true 59
- css.properties.align-items.flex_context.start_end - true 57
- css.properties.align-items.flex_context.left_right - false
- css.properties.align-self.flex_context.start_end - true 57
- css.properties.align-self.flex_context.left_right - false
- css.properties.align-self.flex_context.baseline - true 57
- css.properties.align-self.flex_context.first_last_baseline - true 57
- css.properties.align-self.flex_context.stretch - true 57
- css.properties.animation-timing-function.jump - false
- css.properties.border-image.optional_border_image_slice - true 16
- css.properties.column-gap.flex_context - false
- css.properties.display.ruby_values - false
- css.properties.display.contents.contents_unusual - true 58
- css.properties.font-variant.css_fonts_shorthand - true 52
- css.properties.row-gap.flex_context - false
- css.properties.text-decoration.shorthand - true 57
- css.properties.text-size-adjust.percentages - true 54
- css.properties.transition-timing-function.jump - false
- css.properties.width.animatable - true 26