### PR TITLE
Bump minimum Node.js version to 8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "extend": "3.0.2"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #3509.  It's May 1st, a day after we said we'd raise the minimum Node.js version.  So, here we are!