### PR TITLE
test: Prefer template literals over string concatenation for logging

### DIFF
--- a/test/lint.js
+++ b/test/lint.js
@@ -113,8 +113,12 @@ if (argv.files) {
 }
 
 if (hasErrors) {
-  console.warn("");
-  console.warn(`Problems in ${filesWithErrors.size} file${filesWithErrors.size > 1 ? 's' : ''}:`);
+  console.warn('');
+  console.warn(
+    `Problems in ${filesWithErrors.size} ${
+      filesWithErrors.size === 1 ? 'file' : 'files'
+    }:`,
+  );
   for (const [fileName, file] of filesWithErrors) {
     console.warn(fileName);
     try {

--- a/test/test-browsers.js
+++ b/test/test-browsers.js
@@ -46,7 +46,7 @@ const browsers = {
  * @param {string[]} displayBrowsers
  * @param {string[]} requiredBrowsers
  * @param {string} category
- * @param {{error:function(string):void}} logger
+ * @param {{error:function(...unknown):void}} logger
  * @param {string} [path]
  * @returns {boolean}
  */
@@ -66,7 +66,16 @@ function processData(data, displayBrowsers, requiredBrowsers, category, logger, 
   }
   for (const key in data) {
     if (key === "__compat") continue;
-    hasErrors |= processData(data[key], displayBrowsers, requiredBrowsers, category, logger, (path && path.length > 0) ? `${path}.${key}` : key);
+    hasErrors = processData(
+      data[key],
+      displayBrowsers,
+      requiredBrowsers,
+      category,
+      logger,
+      (path && path.length > 0)
+        ? `${path}.${key}`
+        : key
+    ) || hasErrors;
   }
   return hasErrors;
 }
@@ -104,15 +113,23 @@ function testBrowsers(filename) {
   /** @type {string[]} */
   const errors = [];
   const logger = {
-    error: (message) => {errors.push(message);}
-  }
+    /** @param {...unknown} message */
+    error: (...message) => {
+      errors.push(message.join(' '));
+    },
+  };
 
   if (!processData(data, displayBrowsers, requiredBrowsers, category, logger)) {
     return false;
   } else {
-    console.error('\x1b[31m  Browsers –', errors.length, 'error(s):\x1b[0m');
-    for (let error of errors)
+    console.error(
+      `\x1b[  Browsers – ${errors.length} ${
+        errors.length === 1 ? 'error' : 'errors'
+      }:`,
+    );
+    for (const error of errors) {
       console.error(`    ${error}`);
+    }
     return true;
   }
 }

--- a/test/test-prefix.js
+++ b/test/test-prefix.js
@@ -1,4 +1,5 @@
-path = require('path');
+'use strict';
+const path = require('path');
 
 function checkPrefix(data, category, errors, prefix, path="") {
   for (var key in data) {
@@ -15,8 +16,8 @@ function checkPrefix(data, category, errors, prefix, path="") {
       }
     } else {
       if (typeof data[key] === "object") {
-        curr_path = (path.length > 0) ? `${path}.${key}` : key;
-        result = checkPrefix(data[key], category, errors, prefix, curr_path);
+        const curr_path = (path.length > 0) ? `${path}.${key}` : key;
+        checkPrefix(data[key], category, errors, prefix, curr_path);
       }
     }
   }

--- a/test/test-prefix.js
+++ b/test/test-prefix.js
@@ -48,8 +48,10 @@ function testPrefix(filename) {
   var errors = processData(data, category);
 
   if (errors.length) {
-    console.error('\x1b[31m  Prefix –', errors.length, 'error(s):\x1b[0m');
-    for (let error of errors) {
+    console.error(`\x1b[31m  Prefix – ${errors.length} ${
+      errors.length === 1 ? 'error' : 'errors'
+    }:`);
+    for (const error of errors) {
       console.error(`    ${error}`);
     }
     return true;

--- a/test/test-regexes.js
+++ b/test/test-regexes.js
@@ -1,3 +1,4 @@
+'use strict';
 const assert = require('assert');
 
 /**

--- a/test/test-schema.js
+++ b/test/test-schema.js
@@ -18,8 +18,14 @@ function testSchema(dataFilename, schemaFilename = './../schemas/compat-data.sch
   if (valid) {
     return false;
   } else {
-    console.error('\x1b[31m  File : ' + path.relative(process.cwd(), dataFilename));
-    console.error('\x1b[31m  JSON schema – ' + ajv.errors.length + ' error(s)\x1b[0m');
+    console.error(`\x1b[31m  File : ${path.relative(process.cwd(), dataFilename)}`);
+    console.error(
+      `\x1b[31m  JSON schema – ${ajv.errors.length} ${
+        ajv.errors.length === 1 ? 'error' : 'errors'
+      }:\x1b[0m`,
+    );
+    // Output messages by one since better-ajv-errors wrongly joins messages
+    // (see https://github.com/atlassian/better-ajv-errors/pull/21)
     ajv.errors.forEach(e => {
       console.error(betterAjvErrors(schema, data, [e], {indent: 2}));
     });

--- a/test/test-style.js
+++ b/test/test-style.js
@@ -55,7 +55,7 @@ function escapeInvisibles(str) {
  * @param {number} index
  * @return {[number, number] | [null, null]}
  */
-function indexToPos(str, index) {
+function indexToPosRaw(str, index) {
   let line = 1, col = 1;
   let prevChar = null;
 
@@ -88,6 +88,18 @@ function indexToPos(str, index) {
   }
 
   return [line, col];
+}
+
+/**
+ * Gets the row and column matching the index in a string and formats it.
+ *
+ * @param {string} str
+ * @param {number} index
+ * @return {string} The line and column in the form of: `"(Ln <ln>, Col <col>)"`
+ */
+function indexToPos(str, index) {
+  const [line, col] = indexToPosRaw(str, index);
+  return `(Ln ${line}, Col ${col})`;
 }
 
 /**
@@ -142,9 +154,12 @@ function testStyle(filename) {
     // use https://bugzil.la/1000000 instead
     hasErrors = true;
     console.error(
-      '\x1b[33m  Style – Use shortenable URL (%s → https://bugzil.la/%s).\x1b[0m',
-      bugzillaMatch[0],
-      bugzillaMatch[1],
+      `\x1b[33m  Style ${indexToPos(
+        actual,
+        bugzillaMatch.index,
+      )} – Use shortenable URL (${
+        bugzillaMatch[0]
+      } → https://bugzil.la/${bugzillaMatch[1]}).\x1b[0m`,
     );
   }
 

--- a/test/test-style.js
+++ b/test/test-style.js
@@ -166,9 +166,10 @@ function testStyle(filename) {
 
         if (protocol !== 'https') {
           hasErrors = true;
-          console.error(`\x1b[33m  Style ${
-            indexToPos(actual, match.index)
-          } – Use HTTPS URL (http://${domain}/${bugId} → https://${domain}/${bugId}).\x1b[0m`);
+          console.error(`\x1b[33m  Style ${indexToPos(
+            actual,
+            match.index,
+          )} – Use HTTPS URL (http://${domain}/${bugId} → https://${domain}/${bugId}).\x1b[0m`);
         }
 
         if (domain !== 'bugzil.la') {
@@ -177,21 +178,24 @@ function testStyle(filename) {
 
         if (/^bug $/.test(before)) {
           hasErrors = true;
-          console.error(`\x1b[33m  Style ${
-            indexToPos(actual, match.index)
-          } – Move word "bug" into link text ("${before}<a href='...'>${linkText}</a>" → "<a href='...'>${before}${bugId}</a>").\x1b[0m`);
+          console.error(`\x1b[33m  Style ${indexToPos(
+            actual,
+            match.index,
+          )} – Move word "bug" into link text ("${before}<a href='...'>${linkText}</a>" → "<a href='...'>${before}${bugId}</a>").\x1b[0m`);
         } else if (linkText === `Bug ${bugId}`) {
           if (!/(\. |")$/.test(before)) {
             hasErrors = true;
-            console.error(`\x1b[33m  Style ${
-              indexToPos(actual, match.index)
-            } – Use lowercase "bug" word within sentence ("Bug ${bugId}" → "bug ${bugId}").\x1b[0m`);
+            console.error(`\x1b[33m  Style ${indexToPos(
+              actual,
+              match.index,
+            )} – Use lowercase "bug" word within sentence ("Bug ${bugId}" → "bug ${bugId}").\x1b[0m`);
           }
         } else if (linkText !== `bug ${bugId}`) {
           hasErrors = true;
-          console.error(`\x1b[33m  Style ${
-            indexToPos(actual, match.index)
-          } – Use standard link text ("${linkText}" → "bug ${bugId}").\x1b[0m`);
+          console.error(`\x1b[33m  Style ${indexToPos(
+            actual,
+            match.index,
+          )} – Use standard link text ("${linkText}" → "bug ${bugId}").\x1b[0m`);
         }
       }
     } while (match != null);
@@ -202,10 +206,12 @@ function testStyle(filename) {
     // use https://crbug.com/100000 instead
     hasErrors = true;
     console.error(
-      '\x1b[33m  Style %s – Use shortenable URL (%s → https://crbug.com/%s).\x1b[0m',
-      indexToPos(actual, crbugMatch.index),
-      crbugMatch[0],
-      crbugMatch[1],
+      `\x1b[33m  Style ${indexToPos(
+        actual,
+        crbugMatch.index,
+      )} – Use shortenable URL (${
+        crbugMatch[0]
+      } → https://crbug.com/${crbugMatch[1]}).\x1b[0m`,
     );
   }
 
@@ -214,10 +220,12 @@ function testStyle(filename) {
     // use https://webkit.org/b/100000 instead
     hasErrors = true;
     console.error(
-      '\x1b[33m  Style %s – Use shortenable URL (%s → https://webkit.org/b/%s).\x1b[0m',
-      indexToPos(actual, webkitMatch.index),
-      webkitMatch[0],
-      webkitMatch[1],
+      `\x1b[33m  Style ${indexToPos(
+        actual,
+        webkitMatch.index,
+      )} – Use shortenable URL (${
+        webkitMatch[0]
+      } → https://webkit.org/b/${webkitMatch[1]}).\x1b[0m`,
     );
   }
 
@@ -225,10 +233,12 @@ function testStyle(filename) {
   if (mdnUrlMatch) {
     hasErrors = true;
     console.error(
-      '\x1b[33m  Style %s – Use non-localized MDN URL (%s → https://developer.mozilla.org/%s).\x1b[0m',
-      indexToPos(actual, mdnUrlMatch.index),
-      mdnUrlMatch[0],
-      mdnUrlMatch[2],
+      `\x1b[33m  Style ${indexToPos(
+        actual,
+        mdnUrlMatch.index,
+      )} – Use non-localized MDN URL (${
+        mdnUrlMatch[0]
+      } → https://developer.mozilla.org/${mdnUrlMatch[2]}).\x1b[0m`,
     );
   }
 
@@ -236,10 +246,12 @@ function testStyle(filename) {
   if (msdevUrlMatch) {
     hasErrors = true;
     console.error(
-      '\x1b[33m  Style %s – Use non-localized Microsoft Developer URL (%s → https://developer.microsoft.com/%s).\x1b[0m',
-      indexToPos(actual, msdevUrlMatch.index),
-      msdevUrlMatch[0],
-      msdevUrlMatch[2],
+      `\x1b[33m  Style ${indexToPos(
+        actual,
+        msdevUrlMatch.index,
+      )} – Use non-localized Microsoft Developer URL (${
+        msdevUrlMatch[0]
+      } → https://developer.microsoft.com${msdevUrlMatch[2]}).\x1b[0m`,
     );
   }
 
@@ -247,10 +259,12 @@ function testStyle(filename) {
   if (constructorMatch) {
     hasErrors = true;
     console.error(
-      '\x1b[33m  Style %s – Use parentheses in constructor description: %s → %s()\x1b[0m',
-      indexToPos(actual, constructorMatch.index),
-      constructorMatch[1],
-      constructorMatch[1],
+      `\x1b[33m  Style ${indexToPos(
+        actual,
+        constructorMatch.index,
+      )} – Use parentheses in constructor description: ${
+        constructorMatch[1]
+      } → ${constructorMatch[1]}()\x1b[0m`,
     );
   }
 
@@ -259,17 +273,19 @@ function testStyle(filename) {
     console.error('\x1b[33m  Style – Found \\" but expected \' for <a href>.\x1b[0m');
   }
 
-  const regexp = new RegExp("<a href='([^'>]+)'>((?:.(?!\<\/a\>))*.)</a>", 'g');
+  const regexp = new RegExp(String.raw`<a href='([^'>]+)'>((?:.(?!</a>))*.)</a>`, 'g');
   let match = regexp.exec(actual);
   if (match) {
     var a_url = url.parse(match[1]);
     if (a_url.hostname === null) {
       hasErrors = true;
       console.error(
-        '\x1b[33m  Style %s – Include hostname in URL: %s → https://developer.mozilla.org/%s\x1b[0m',
-        indexToPos(actual, match.index),
-        match[1],
-        match[1],
+        `\x1b[33m  Style ${indexToPos(
+          actual,
+          match.index,
+        )} – Include hostname in URL: ${
+          match[1]
+        } → https://developer.mozilla.org/${match[1]}\x1b[0m`,
       );
     }
   }

--- a/test/test-style.js
+++ b/test/test-style.js
@@ -80,23 +80,26 @@ function testStyle(filename) {
 
   if (actual !== expected) {
     hasErrors = true;
-    console.error('\x1b[31m  File : ' + path.relative(process.cwd(), filename));
-    console.error('\x1b[31m  Style – Error on line ' + jsonDiff(actual, expected));
+    console.error(`\x1b[31m  File : ${path.relative(process.cwd(), filename)}`);
+    console.error(`\x1b[31m  Style – Error on line ${jsonDiff(actual, expected)}`);
   }
 
   let expectedSorting = JSON.stringify(JSON.parse(actual), orderSupportBlock, 2);
   if (actual !== expectedSorting) {
     hasErrors = true;
-    console.error('\x1b[31m  File : ' + path.relative(process.cwd(), filename));
-    console.error('\x1b[31m  Browser name sorting – Error on line ' + jsonDiff(actual, expectedSorting));
+    console.error(`\x1b[31m  File : ${path.relative(process.cwd(), filename)}`);
+    console.error(`\x1b[31m  Browser name sorting – Error on line ${jsonDiff(actual, expected)}`);
   }
 
   const bugzillaMatch = actual.match(String.raw`https?://bugzilla\.mozilla\.org/show_bug\.cgi\?id=(\d+)`);
   if (bugzillaMatch) {
     // use https://bugzil.la/1000000 instead
     hasErrors = true;
-    console.error('\x1b[33m  Style – Use shortenable URL (%s → https://bugzil.la/%s).\x1b[0m', bugzillaMatch[0],
-      bugzillaMatch[1]);
+    console.error(
+      '\x1b[33m  Style – Use shortenable URL (%s → https://bugzil.la/%s).\x1b[0m',
+      bugzillaMatch[0],
+      bugzillaMatch[1],
+    );
   }
 
   {
@@ -144,16 +147,22 @@ function testStyle(filename) {
   if (crbugMatch) {
     // use https://crbug.com/100000 instead
     hasErrors = true;
-    console.error('\x1b[33m  Style – Use shortenable URL (%s → https://crbug.com/%s).\x1b[0m', crbugMatch[0],
-      crbugMatch[1]);
+    console.error(
+      '\x1b[33m  Style – Use shortenable URL (%s → https://crbug.com/%s).\x1b[0m',
+      crbugMatch[0],
+      crbugMatch[1],
+    );
   }
 
   const webkitMatch = actual.match(String.raw`https?://bugs\.webkit\.org/show_bug\.cgi\?id=(\d+)`);
   if (webkitMatch) {
     // use https://webkit.org/b/100000 instead
     hasErrors = true;
-    console.error('\x1b[33m  Style – Use shortenable URL (%s → https://webkit.org/b/%s).\x1b[0m', webkitMatch[0],
-      webkitMatch[1]);
+    console.error(
+      '\x1b[33m  Style – Use shortenable URL (%s → https://webkit.org/b/%s).\x1b[0m',
+      webkitMatch[0],
+      webkitMatch[1],
+    );
   }
 
   const mdnUrlMatch = actual.match(String.raw`https?://developer.mozilla.org/(\w\w-\w\w)/(.*?)(?=["'\s])`);
@@ -162,7 +171,8 @@ function testStyle(filename) {
     console.error(
       '\x1b[33m  Style – Use non-localized MDN URL (%s → https://developer.mozilla.org/%s).\x1b[0m',
       mdnUrlMatch[0],
-      mdnUrlMatch[2]);
+      mdnUrlMatch[2],
+    );
   }
 
   const msdevUrlMatch = actual.match(String.raw`https?://developer.microsoft.com/(\w\w-\w\w)/(.*?)(?=["'\s])`);
@@ -171,7 +181,8 @@ function testStyle(filename) {
     console.error(
       '\x1b[33m  Style – Use non-localized Microsoft Developer URL (%s → https://developer.microsoft.com/%s).\x1b[0m',
       msdevUrlMatch[0],
-      msdevUrlMatch[2]);
+      msdevUrlMatch[2],
+    );
   }
 
   let constructorMatch = actual.match(String.raw`"<code>([^)]*?)</code> constructor"`)
@@ -180,7 +191,7 @@ function testStyle(filename) {
     console.error(
       '\x1b[33m  Style – Use parentheses in constructor description: %s → %s()\x1b[0m',
       constructorMatch[1],
-      constructorMatch[1]
+      constructorMatch[1],
     );
   }
 
@@ -196,7 +207,9 @@ function testStyle(filename) {
     if (a_url.hostname === null) {
       hasErrors = true;
       console.error(
-        '\x1b[33m  Style – Include hostname in URL: %s → https://developer.mozilla.org/%s\x1b[0m', match[1], match[1]
+        '\x1b[33m  Style – Include hostname in URL: %s → https://developer.mozilla.org/%s\x1b[0m',
+        match[1],
+        match[1],
       );
     }
   }

--- a/test/test-style.js
+++ b/test/test-style.js
@@ -25,7 +25,11 @@ function orderSupportBlock(key, value) {
   return value;
 }
 
+/**
+ * @param {string} str
+ */
 function escapeInvisibles(str) {
+  /** @type {Array<[string, string]>} */
   const invisibles = [
     ['\b', '\\b'],
     ['\f', '\\f'],
@@ -88,7 +92,7 @@ function testStyle(filename) {
   if (actual !== expectedSorting) {
     hasErrors = true;
     console.error(`\x1b[31m  File : ${path.relative(process.cwd(), filename)}`);
-    console.error(`\x1b[31m  Browser name sorting – Error on line ${jsonDiff(actual, expected)}`);
+    console.error(`\x1b[31m  Browser name sorting – Error on line ${jsonDiff(actual, expectedSorting)}`);
   }
 
   const bugzillaMatch = actual.match(String.raw`https?://bugzilla\.mozilla\.org/show_bug\.cgi\?id=(\d+)`);

--- a/test/test-versions.js
+++ b/test/test-versions.js
@@ -20,7 +20,7 @@ for (const browser of Object.keys(browsers)) {
  * @param {VersionValue} version
  */
 function isValidVersion(browserIdentifier, version) {
-  if (typeof version === "string") {
+  if (typeof version === 'string') {
     return validBrowserVersions[browserIdentifier].includes(version);
   } else {
     return true;
@@ -49,24 +49,59 @@ function testVersions(dataFilename) {
           supportStatements.push(supportData[browser]);
         }
 
+        const validBrowserVersionsString =
+          'true, false, null' +
+          (validBrowserVersions[browser].length > 0
+            ? ', ' + validBrowserVersions[browser].join(', ')
+            : '');
+        const validBrowserVersionsTruthy =
+          validBrowserVersions[browser].length > 0
+            ? 'true, ' + validBrowserVersions[browser].join(', ')
+            : 'true';
+
         for (const statement of supportStatements) {
           if (!isValidVersion(browser, statement.version_added)) {
-            console.error('\x1b[31m  version_added: "' + statement.version_added + '" is not a valid version number for ' + browser);
-            console.error('  Valid ' + browser + ' versions are: ' + validBrowserVersions[browser].join(', '));
+            console.error(
+              `\x1b[31m  version_added: "${
+                statement.version_added
+              }" is not a valid version number for ${browser}`,
+            );
+            console.error(`\x1b[31m  Valid ${browser} versions are: ${validBrowserVersionsString}`);
             hasErrors = true;
           }
           if (!isValidVersion(browser, statement.version_removed)) {
-            console.error('\x1b[31m  version_removed: "' + statement.version_removed + '" is not a valid version number for ' + browser);
-            console.error('  Valid ' + browser + ' versions are: ' + validBrowserVersions[browser].join(', '));
+            console.error(
+              `\x1b[31m  version_removed: "${
+                statement.version_removed
+              }" is not a valid version number for ${browser}`,
+            );
+            console.error(`\x1b[31m  Valid ${browser} versions are: ${validBrowserVersionsString}`);
             hasErrors = true;
           }
-          if ("version_removed" in statement && "version_added" in statement) {
-            if (typeof statement.version_added !== "string" && statement.version_added !== true) {
-              console.error('\x1b[31m  version_added: "' + statement.version_added + '" is not a valid version number when version_removed is present');
-              console.error('  Valid', browser, 'versions are:', validBrowserVersions[browser].length > 0 ? 'true, ' + validBrowserVersions[browser].join(', ') : 'true');
+          if ('version_removed' in statement && 'version_added' in statement) {
+            if (
+              typeof statement.version_added !== 'string' &&
+              statement.version_added !== true
+            ) {
+              console.error(
+                `\x1b[31m  version_added: "${
+                  statement.version_added
+                }" is not a valid version number when version_removed is present`,
+              );
+              console.error(`\x1b[31m  Valid ${browser} versions are: ${validBrowserVersionsTruthy}`);
               hasErrors = true;
-            } else if (typeof statement.version_added === "string" && typeof statement.version_removed === "string" && compareVersions(statement.version_added, statement.version_removed) >= 0) {
-              console.error('\x1b[31m  version_removed: "' + statement.version_removed + '" must be greater than version_added: "' + statement.version_added + '"');
+            } else if (
+              typeof statement.version_added === 'string' &&
+              typeof statement.version_removed === 'string' &&
+              compareVersions(statement.version_added, statement.version_removed) >= 0
+            ) {
+              console.error(
+                `\x1b[31m  version_removed: "${
+                  statement.version_removed
+                }" must be greater than version_added: "${
+                  statement.version_added
+                }"`,
+              );
               hasErrors = true;
             }
           }
@@ -84,7 +119,7 @@ function testVersions(dataFilename) {
         checkVersions(data[prop].support);
       }
       const sub = data[prop];
-      if (typeof(sub) === "object") {
+      if (typeof sub === 'object') {
         findSupport(sub);
       }
     }
@@ -92,7 +127,7 @@ function testVersions(dataFilename) {
   findSupport(data);
 
   if (hasErrors) {
-    console.error('\x1b[31m  File : ' + path.relative(process.cwd(), dataFilename));
+    console.error(`\x1b[31m  File : ${path.relative(process.cwd(), dataFilename)}`);
     console.error('\x1b[31m  Browser version error(s)\x1b[0m');
     return true;
   } else {


### PR DESCRIPTION
This refactors the tests to prefer template literals over string concatenation for logging purposes.

Extracted from #4015.

---

review?(@Elchi3)