### PR TITLE
Edge and Firefox getUserMedia not secure

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -532,13 +532,13 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": null

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -541,7 +541,7 @@
                 "version_added": "68"
               },
               "firefox_android": {
-                 "version_added": "68"
+                "version_added": "68"
               },
               "ie": {
                 "version_added": false

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -541,7 +541,7 @@
                 "version_added": "68"
               },
               "firefox_android": {
-                "version_added": null
+                 "version_added": "68"
               },
               "ie": {
                 "version_added": false

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -538,7 +538,7 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": false
+                "version_added": "68"
               },
               "firefox_android": {
                 "version_added": null


### PR DESCRIPTION
Edge and Firefox desktop do not require secure context for getUserMedia to be accessed.

Testing: 

- First I tried running `navigator.mediaDevices.getUserMedia()` in DevTools; Chrome gave an insecure warning, Edge and Firefox granted access.
- Then I tried running my insecure HTTP server; Edge and Firefox granted access, Chrome gave a warning.