### PR TITLE
Mark marginwidth as deprecated

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -550,7 +550,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },


### PR DESCRIPTION
Deprecated with marginheight in HTML5

Mentioned in the the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#Deprecated_attributes) for `<iframe/>`

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
