### PR TITLE
Update Node.js globalThis version

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -70,6 +70,10 @@
         "11.0.0": {
           "release_date": "2018-10-23",
           "release_notes": "https://nodejs.org/en/blog/release/v11.0.0/"
+        },
+        "12.0.0": {
+          "release_date": "2019-04-23",
+          "release_notes": "https://nodejs.org/en/blog/release/v12.0.0/"
         }
       }
     }

--- a/javascript/builtins/globals.json
+++ b/javascript/builtins/globals.json
@@ -468,7 +468,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": false
+              "version_added": "12.0.0"
             },
             "opera": {
               "version_added": false


### PR DESCRIPTION
Fixes #4041 

### Changes
- Updated version when `globalThis` was added in Node.js
- Added v12.0.0 to Node.js versions file

### Verification
I checked on _v11.15.0_ (latest on v11) where `globalThis` doesn't exist. I also checked on _v12.0.0_ (next after v11.15.0) where `globalThis` does exist. I couldn't find information in the changelogs or where the feature was actually introduced in the code but here are some screenshots:

**v11.15.0**
![Screen Shot 2019-05-01 at 3 22 29 PM](https://user-images.githubusercontent.com/19195374/57043645-6ecc8e00-6c25-11e9-8f75-aed91b0e82b9.png)

**v12.0.0**
![Screen Shot 2019-05-01 at 3 27 17 PM](https://user-images.githubusercontent.com/19195374/57043719-a0455980-6c25-11e9-81a3-58ef9d5ec2d3.png)
