### PR TITLE
Fix changes in #3735

### DIFF
--- a/api/RTCDtlsTransport.json
+++ b/api/RTCDtlsTransport.json
@@ -28,7 +28,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "59"
+            "version_added": "60"
           },
           "opera_android": {
             "version_added": "50"
@@ -80,7 +80,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "59"
+              "version_added": "60"
             },
             "opera_android": {
               "version_added": "50"
@@ -135,7 +135,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "59"
+              "version_added": "60"
             },
             "opera_android": {
               "version_added": "50"
@@ -188,7 +188,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "59"
+              "version_added": "60"
             },
             "opera_android": {
               "version_added": "50"
@@ -243,7 +243,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "59"
+              "version_added": "60"
             },
             "opera_android": {
               "version_added": "50"
@@ -296,7 +296,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "59"
+              "version_added": "60"
             },
             "opera_android": {
               "version_added": "50"
@@ -352,7 +352,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "59"
+              "version_added": "60"
             },
             "opera_android": {
               "version_added": "50"


### PR DESCRIPTION
`master` is failing due to a faulty change in #3735 that was not caught by the updated browser and linter data (since it wasn't merged into the branch).  This PR fixes the changes, allowing for working tests once again.