### PR TITLE
Maintain consistency in linter files

### DIFF
--- a/test/lint.js
+++ b/test/lint.js
@@ -7,7 +7,7 @@ const testStyle = require('./test-style');
 const testSchema = require('./test-schema');
 const testVersions = require('./test-versions');
 const testBrowsers = require('./test-browsers');
-const testPrefix = require('./test-prefix.js');
+const testPrefix = require('./test-prefix');
 /** @type {Map<string, string>} */
 const filesWithErrors = new Map();
 

--- a/test/test-prefix.js
+++ b/test/test-prefix.js
@@ -1,5 +1,5 @@
 'use strict';
-path = require('path');
+const path = require('path');
 
 function checkPrefix(data, category, errors, prefix, path="") {
   for (var key in data) {
@@ -16,8 +16,8 @@ function checkPrefix(data, category, errors, prefix, path="") {
       }
     } else {
       if (typeof data[key] === "object") {
-        curr_path = (path.length > 0) ? `${path}.${key}` : key;
-        result = checkPrefix(data[key], category, errors, prefix, curr_path);
+        var curr_path = (path.length > 0) ? `${path}.${key}` : key;
+        var result = checkPrefix(data[key], category, errors, prefix, curr_path);
       }
     }
   }

--- a/test/test-prefix.js
+++ b/test/test-prefix.js
@@ -1,3 +1,4 @@
+'use strict';
 path = require('path');
 
 function checkPrefix(data, category, errors, prefix, path="") {

--- a/test/test-regexes.js
+++ b/test/test-regexes.js
@@ -1,3 +1,4 @@
+'use strict';
 const assert = require('assert');
 
 /**


### PR DESCRIPTION
A couple of small fixes to remove a redundant ".js" from a `require()`, and adding `'use strict';` to the top of every linter file.