### PR TITLE
Enable ora spinner

### DIFF
--- a/test/lint.js
+++ b/test/lint.js
@@ -49,7 +49,7 @@ function load(...files) {
         const spinner = ora({
           stream: process.stdout,
           text: relativeFilePath
-        });
+        }).start();
 
         const console_error = console.error;
         console.error = (...args) => {


### PR DESCRIPTION
Seems that although `ora` was imported and required, it was never properly enabled.  `ora`'s constructor creates a spinner object that requires a `.start()` to initialize it.  This adds said `.start()` call.