### PR TITLE
adding Fx support data for word-break: break-word

### DIFF
--- a/css/properties/word-break.json
+++ b/css/properties/word-break.json
@@ -127,10 +127,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": "67"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "67"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1296042

We support the `break-word` value of `word-break` in version 67 onwards.