### PR TITLE
api.Performance.getEntriesByType: mirror Chrome onto Opera

### DIFF
--- a/api/Performance.json
+++ b/api/Performance.json
@@ -420,7 +420,7 @@
               {
                 "prefix": "webkit",
                 "version_added": "14",
-                "version_removed": "23"
+                "version_removed": "24"
               }
             ],
             "safari": {

--- a/api/Performance.json
+++ b/api/Performance.json
@@ -403,12 +403,26 @@
             "ie": {
               "version_added": true
             },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": [
+              {
+                "version_added": "15"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "15",
+                "version_removed": "23"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "15"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "14",
+                "version_removed": "23"
+              }
+            ],
             "safari": {
               "version_added": "11"
             },


### PR DESCRIPTION
Fixes #4053.