### PR TITLE
CSS: Update Safari from Apple docs (animation properties)

### DIFF
--- a/css/properties/animation-fill-mode.json
+++ b/css/properties/animation-fill-mode.json
@@ -143,7 +143,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "4"
               }
             ],
             "samsunginternet_android": [

--- a/css/properties/animation-fill-mode.json
+++ b/css/properties/animation-fill-mode.json
@@ -134,7 +134,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "4"
+                "version_added": "5"
               }
             ],
             "safari_ios": [

--- a/css/properties/animation-play-state.json
+++ b/css/properties/animation-play-state.json
@@ -143,7 +143,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "2"
               }
             ],
             "samsunginternet_android": [

--- a/css/properties/animation-play-state.json
+++ b/css/properties/animation-play-state.json
@@ -134,7 +134,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "4"
               }
             ],
             "safari_ios": [

--- a/css/properties/mask-clip.json
+++ b/css/properties/mask-clip.json
@@ -37,7 +37,7 @@
             },
             "safari": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "4"
             },
             "safari_ios": {
               "version_added": null

--- a/css/properties/mask-origin.json
+++ b/css/properties/mask-origin.json
@@ -40,7 +40,7 @@
             },
             "safari": {
               "prefix": "-webkit-",
-              "version_added": true,
+              "version_added": "4",
               "notes": "The <code>margin-box</code> value is unsupported."
             },
             "safari_ios": {

--- a/css/properties/mask-size.json
+++ b/css/properties/mask-size.json
@@ -33,10 +33,12 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "4",
+              "prefix": "-webkit"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "3",
+              "prefix": "-webkit"
             },
             "samsunginternet_android": {
               "version_added": null

--- a/css/properties/mask-size.json
+++ b/css/properties/mask-size.json
@@ -37,7 +37,7 @@
               "prefix": "-webkit"
             },
             "safari_ios": {
-              "version_added": "3",
+              "version_added": "2",
               "prefix": "-webkit"
             },
             "samsunginternet_android": {

--- a/css/properties/mask.json
+++ b/css/properties/mask.json
@@ -78,7 +78,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true,
+                "version_added": "4",
                 "notes": "The prefixed property can be used with SVG and HTML with a slightly different syntax, which allows setting the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-attachment'><code>-webkit-mask-attachment</code></a> property."
               }
             ],

--- a/css/properties/perspective-origin.json
+++ b/css/properties/perspective-origin.json
@@ -96,7 +96,7 @@
             },
             "safari_ios": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": null

--- a/css/properties/perspective-origin.json
+++ b/css/properties/perspective-origin.json
@@ -92,7 +92,7 @@
             },
             "safari": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "4"
             },
             "safari_ios": {
               "prefix": "-webkit-",

--- a/css/properties/perspective.json
+++ b/css/properties/perspective.json
@@ -102,7 +102,7 @@
             },
             "safari": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "4"
             },
             "safari_ios": {
               "prefix": "-webkit-",

--- a/css/properties/perspective.json
+++ b/css/properties/perspective.json
@@ -106,7 +106,7 @@
             },
             "safari_ios": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": null

--- a/css/properties/transform-style.json
+++ b/css/properties/transform-style.json
@@ -96,7 +96,7 @@
             },
             "safari_ios": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": null

--- a/css/properties/transform-style.json
+++ b/css/properties/transform-style.json
@@ -92,7 +92,7 @@
             },
             "safari": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "4"
             },
             "safari_ios": {
               "prefix": "-webkit-",

--- a/css/properties/transition-delay.json
+++ b/css/properties/transition-delay.json
@@ -126,7 +126,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "3"
+                "version_added": "4"
               }
             ],
             "safari_ios": [
@@ -135,7 +135,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "3.2"
+                "version_added": "3"
               }
             ],
             "samsunginternet_android": [

--- a/css/properties/transition-delay.json
+++ b/css/properties/transition-delay.json
@@ -135,7 +135,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "3"
+                "version_added": "2"
               }
             ],
             "samsunginternet_android": [

--- a/css/properties/transition-duration.json
+++ b/css/properties/transition-duration.json
@@ -126,7 +126,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "3"
+                "version_added": "3.1"
               }
             ],
             "safari_ios": [
@@ -135,7 +135,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "3.2"
+                "version_added": "4"
               }
             ],
             "samsunginternet_android": [

--- a/css/properties/transition-duration.json
+++ b/css/properties/transition-duration.json
@@ -135,7 +135,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "4"
+                "version_added": "2"
               }
             ],
             "samsunginternet_android": [

--- a/css/properties/transition-property.json
+++ b/css/properties/transition-property.json
@@ -144,7 +144,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "2"
               }
             ],
             "webview_android": [

--- a/css/properties/transition-property.json
+++ b/css/properties/transition-property.json
@@ -135,7 +135,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "3.1"
               }
             ],
             "samsunginternet_android": [

--- a/css/properties/transition-property.json
+++ b/css/properties/transition-property.json
@@ -135,7 +135,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "3.1"
+                "version_added": "2"
               }
             ],
             "samsunginternet_android": [
@@ -144,7 +144,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "2"
+                "version_added": true
               }
             ],
             "webview_android": [

--- a/css/properties/transition-timing-function.json
+++ b/css/properties/transition-timing-function.json
@@ -135,7 +135,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "2"
               }
             ],
             "samsunginternet_android": [

--- a/css/properties/transition-timing-function.json
+++ b/css/properties/transition-timing-function.json
@@ -126,7 +126,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "3.1"
               }
             ],
             "safari_ios": [

--- a/css/properties/transition.json
+++ b/css/properties/transition.json
@@ -136,7 +136,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "3"
+                "version_added": "3.1"
               }
             ],
             "safari_ios": [
@@ -145,7 +145,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "3.2"
+                "version_added": "2"
               }
             ],
             "samsunginternet_android": [


### PR DESCRIPTION
Part of five parts to #1774.  This updates all the Safari (and some Safari iOS data) for CSS properties, based upon Apple documentation that @connorshea found.  This conforms BCD's data to said documentation.