### PR TITLE
CSS: Update Safari from Apple docs (font/text properties)

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -647,10 +647,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": true
+                "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "2"
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/css/properties/-webkit-text-fill-color.json
+++ b/css/properties/-webkit-text-fill-color.json
@@ -60,7 +60,7 @@
               "version_added": "3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/css/properties/-webkit-text-fill-color.json
+++ b/css/properties/-webkit-text-fill-color.json
@@ -57,7 +57,7 @@
               "version_added": "15"
             },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": null

--- a/css/properties/-webkit-text-stroke-color.json
+++ b/css/properties/-webkit-text-stroke-color.json
@@ -57,10 +57,10 @@
               "version_added": "15"
             },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/css/properties/-webkit-text-stroke-color.json
+++ b/css/properties/-webkit-text-stroke-color.json
@@ -60,7 +60,7 @@
               "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "1"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/css/properties/-webkit-text-stroke-width.json
+++ b/css/properties/-webkit-text-stroke-width.json
@@ -60,7 +60,7 @@
               "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "1"
+              "version_added": "2"
             },
             "webview_android": {
               "version_added": "38"

--- a/css/properties/-webkit-text-stroke-width.json
+++ b/css/properties/-webkit-text-stroke-width.json
@@ -57,10 +57,10 @@
               "version_added": "15"
             },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "webview_android": {
               "version_added": "38"

--- a/css/properties/-webkit-text-stroke.json
+++ b/css/properties/-webkit-text-stroke.json
@@ -57,10 +57,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "webview_android": {
               "version_added": "4"

--- a/css/properties/-webkit-text-stroke.json
+++ b/css/properties/-webkit-text-stroke.json
@@ -60,7 +60,7 @@
               "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "1"
+              "version_added": "2"
             },
             "webview_android": {
               "version_added": "4"

--- a/css/properties/font-weight.json
+++ b/css/properties/font-weight.json
@@ -33,10 +33,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "1.0"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/css/properties/font-weight.json
+++ b/css/properties/font-weight.json
@@ -33,10 +33,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "1.0"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "1.0"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/css/properties/line-break.json
+++ b/css/properties/line-break.json
@@ -62,9 +62,17 @@
                 "version_added": true
               }
             ],
-            "safari": {
-              "version_added": true
-            },
+            "safari": [
+              {
+                "version_added": "3",
+                "prefix": "-webkit-"
+              },
+              {
+                "version_added": "2",
+                "version_removed": "3",
+                "prefix": "-khtml-"
+              }
+            ],
             "safari_ios": {
               "version_added": true
             },

--- a/css/properties/line-break.json
+++ b/css/properties/line-break.json
@@ -74,7 +74,8 @@
               }
             ],
             "safari_ios": {
-              "version_added": true
+              "version_added": "1",
+              "prefix": "-webkit-"
             },
             "samsunginternet_android": [
               {

--- a/css/properties/text-size-adjust.json
+++ b/css/properties/text-size-adjust.json
@@ -77,7 +77,7 @@
             ],
             "safari_ios": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/css/properties/word-break.json
+++ b/css/properties/word-break.json
@@ -41,7 +41,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": null

--- a/css/properties/word-break.json
+++ b/css/properties/word-break.json
@@ -44,7 +44,7 @@
               "version_added": "3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/css/properties/word-wrap.json
+++ b/css/properties/word-wrap.json
@@ -74,7 +74,7 @@
                 "version_added": true
               },
               {
-                "version_added": "1"
+                "version_added": "2"
               }
             ],
             "safari_ios": [


### PR DESCRIPTION
Part of five parts to #1774.  This updates all the Safari (and some Safari iOS data) for CSS properties, based upon Apple documentation that @connorshea found.  This conforms BCD's data to said documentation.