### PR TITLE
CSS: Update Safari from Apple docs (misc. properties)

### DIFF
--- a/css/properties/-webkit-touch-callout.json
+++ b/css/properties/-webkit-touch-callout.json
@@ -33,7 +33,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "4"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": "2"

--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -82,7 +82,7 @@
               "prefix": "-webkit-"
             },
             "safari_ios": {
-              "version_added": "3",
+              "version_added": "1",
               "partial_implementation": true,
               "prefix": "-webkit-"
             },

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -88,7 +88,9 @@
               "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1",
+              "prefix": "-webkit-",
+              "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
             },
             "samsunginternet_android": {
               "version_added": true

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -84,6 +84,7 @@
             ],
             "safari": {
               "version_added": "3",
+              "prefix": "-webkit-",
               "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
             },
             "safari_ios": {

--- a/css/properties/background-origin.json
+++ b/css/properties/background-origin.json
@@ -94,10 +94,10 @@
             ],
             "safari_ios": [
               {
-                "version_added": true
+                "version_added": "1"
               },
               {
-                "version_added": true,
+                "version_added": "1",
                 "prefix": "-webkit-",
                 "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }

--- a/css/properties/background-origin.json
+++ b/css/properties/background-origin.json
@@ -87,7 +87,7 @@
                 "version_added": "3"
               },
               {
-                "version_added": true,
+                "version_added": "3",
                 "prefix": "-webkit-",
                 "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }

--- a/css/properties/column-gap.json
+++ b/css/properties/column-gap.json
@@ -42,7 +42,7 @@
                 "prefix": "-webkit-"
               },
               "safari_ios": {
-                "version_added": "1",
+                "version_added": "2",
                 "prefix": "-webkit-"
               },
               "samsunginternet_android": {

--- a/css/properties/column-gap.json
+++ b/css/properties/column-gap.json
@@ -38,10 +38,12 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": false
+                "version_added": "3",
+                "prefix": "-webkit-"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "1",
+                "prefix": "-webkit-"
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/css/properties/counter-increment.json
+++ b/css/properties/counter-increment.json
@@ -33,10 +33,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/css/properties/counter-reset.json
+++ b/css/properties/counter-reset.json
@@ -33,10 +33,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/css/properties/orphans.json
+++ b/css/properties/orphans.json
@@ -33,10 +33,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": null

--- a/css/properties/pointer-events.json
+++ b/css/properties/pointer-events.json
@@ -33,7 +33,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "3"
+              "version_added": "4"
             },
             "safari_ios": {
               "version_added": true

--- a/css/properties/user-modify.json
+++ b/css/properties/user-modify.json
@@ -49,12 +49,13 @@
             },
             "safari": [
               {
-                "prefix": "-khtml-",
-                "version_added": "2"
+                "version_added": "3",
+                "prefix": "-webkit-"
               },
               {
-                "prefix": "-webkit-",
-                "version_added": "3"
+                "version_added": "2",
+                "version_removed": "3",
+                "prefix": "-khtml-"
               }
             ],
             "safari_ios": {

--- a/css/properties/user-modify.json
+++ b/css/properties/user-modify.json
@@ -59,7 +59,8 @@
               }
             ],
             "safari_ios": {
-              "version_added": null
+              "version_added": "5",
+              "prefix": "-webkit-"
             },
             "samsunginternet_android": {
               "version_added": null

--- a/css/properties/user-select.json
+++ b/css/properties/user-select.json
@@ -97,13 +97,20 @@
               "prefix": "-webkit-",
               "version_added": "14"
             },
-            "safari": {
-              "prefix": "-webkit-",
-              "version_added": "3.1"
-            },
+            "safari": [
+              {
+                "version_added": "3",
+                "prefix": "-webkit-"
+              },
+              {
+                "version_added": "2",
+                "version_removed": "3",
+                "prefix": "-khtml-"
+              }
+            ],
             "safari_ios": {
               "prefix": "-webkit-",
-              "version_added": "3.2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "prefix": "-webkit-",

--- a/css/properties/user-select.json
+++ b/css/properties/user-select.json
@@ -110,7 +110,7 @@
             ],
             "safari_ios": {
               "prefix": "-webkit-",
-              "version_added": "1"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "prefix": "-webkit-",

--- a/css/properties/widows.json
+++ b/css/properties/widows.json
@@ -33,10 +33,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": null


### PR DESCRIPTION
Part of five parts to #1774.  This updates all the Safari (and some Safari iOS data) for CSS properties, based upon Apple documentation that @connorshea found.  This conforms BCD's data to said documentation.