### PR TITLE
CSS: Update Safari from Apple docs (box properties)

### DIFF
--- a/css/properties/box-align.json
+++ b/css/properties/box-align.json
@@ -63,7 +63,7 @@
               },
               {
                 "version_added": "1.1",
-                "version_removed": true,
+                "version_removed": "3",
                 "prefix": "-khtml-"
               }
             ],

--- a/css/properties/box-align.json
+++ b/css/properties/box-align.json
@@ -68,7 +68,8 @@
               }
             ],
             "safari_ios": {
-              "version_added": null
+              "version_added": "1",
+              "prefix": "-webkit-"
             },
             "samsunginternet_android": {
               "version_added": null

--- a/css/properties/box-direction.json
+++ b/css/properties/box-direction.json
@@ -80,7 +80,8 @@
               },
               {
                 "prefix": "-khtml-",
-                "version_added": "1.1"
+                "version_added": "1.1",
+                "version_removed": "3"
               }
             ],
             "safari_ios": {

--- a/css/properties/box-flex-group.json
+++ b/css/properties/box-flex-group.json
@@ -47,6 +47,7 @@
               },
               {
                 "version_added": "1.1",
+                "version_removed": "3",
                 "prefix": "-khtml-"
               }
             ],

--- a/css/properties/box-flex.json
+++ b/css/properties/box-flex.json
@@ -80,7 +80,8 @@
               },
               {
                 "prefix": "-khtml-",
-                "version_added": "1.1"
+                "version_added": "1.1",
+                "version_removed": "3"
               }
             ],
             "safari_ios": {

--- a/css/properties/box-lines.json
+++ b/css/properties/box-lines.json
@@ -47,6 +47,7 @@
               },
               {
                 "version_added": "1.1",
+                "version_removed": "3",
                 "prefix": "-khtml-"
               }
             ],

--- a/css/properties/box-ordinal-group.json
+++ b/css/properties/box-ordinal-group.json
@@ -62,6 +62,7 @@
               },
               {
                 "version_added": "1.1",
+                "version_removed": "3",
                 "prefix": "-khtml-"
               }
             ],

--- a/css/properties/box-orient.json
+++ b/css/properties/box-orient.json
@@ -80,7 +80,8 @@
               },
               {
                 "prefix": "-khtml-",
-                "version_added": "1.1"
+                "version_added": "1.1",
+                "version_removed": "3"
               }
             ],
             "safari_ios": {

--- a/css/properties/box-pack.json
+++ b/css/properties/box-pack.json
@@ -80,7 +80,8 @@
               },
               {
                 "prefix": "-khtml-",
-                "version_added": "1.1"
+                "version_added": "1.1",
+                "version_removed": "3"
               }
             ],
             "safari_ios": {


### PR DESCRIPTION
Part of five parts to #1774.  This updates all the Safari (and some Safari iOS data) for CSS properties, based upon Apple documentation that @connorshea found.  This conforms BCD's data to said documentation.