### PR TITLE
test: Don’t start spinner in CI

### DIFF
--- a/test/lint.js
+++ b/test/lint.js
@@ -49,7 +49,11 @@ function load(...files) {
         const spinner = ora({
           stream: process.stdout,
           text: relativeFilePath
-        }).start();
+        });
+
+        if (!process.env.CI || String(process.env.CI).toLowerCase() !== 'true') {
+          spinner.start();
+        }
 
         const console_error = console.error;
         console.error = (...args) => {


### PR DESCRIPTION
Regressed by #4048.

Without this, file names are double‑printed in CI:
https://travis-ci.org/mdn/browser-compat-data/builds/527677161#L455