### PR TITLE
updating Fx data for InputEvent data and dataTransfer

### DIFF
--- a/api/InputEvent.json
+++ b/api/InputEvent.json
@@ -119,10 +119,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "67"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "67"
             },
             "ie": {
               "version_added": false
@@ -170,10 +170,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "67"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "67"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=998941

We support `InputEvent.data` and `InputEvent.dataTransfer` as of Fx67. 