### PR TITLE
Update matchAll method spec URLs (now in ES spec)

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -1934,7 +1934,7 @@
         "@@matchAll": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@matchAll",
-            "spec_url": "https://tc39.github.io/proposal-string-matchall/#sec-regexp-prototype-matchall",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-regexp-prototype-matchall",
             "support": {
               "chrome": {
                 "version_added": "73"

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -1616,7 +1616,7 @@
         "matchAll": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll",
-            "spec_url": "https://tc39.github.io/proposal-string-matchall/#sec-string-prototype-matchall",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.matchall",
             "support": {
               "chrome": {
                 "version_added": "73"

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -522,7 +522,7 @@
         "matchAll": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/matchAll",
-            "spec_url": "https://tc39.github.io/proposal-string-matchall/#Symbol.matchAll",
+            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.matchall",
             "support": {
               "chrome": {
                 "version_added": "73"


### PR DESCRIPTION
The matchAll methods which had been defined initially in the spec proposal at https://tc39.github.io/proposal-string-matchall/ are now part of the ECMAScript spec itself. So, this change updates the spec_url fields with the ECMAScript spec URLs for the methods.