### PR TITLE
Update mpadded.json: support of lspace, width, height

### DIFF
--- a/mathml/elements/mpadded.json
+++ b/mathml/elements/mpadded.json
@@ -65,10 +65,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false
@@ -161,10 +161,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false
@@ -353,10 +353,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false

--- a/mathml/elements/mpadded.json
+++ b/mathml/elements/mpadded.json
@@ -221,7 +221,156 @@
                 "version_added": false
               },
               "safari": {
+                "version_added": "10",
+                "partial_implementation": true,
+                "notes": "Relative and pseudo-unit values are not supported, see <a href='https://webkit.org/b/85730'>bug 85730</a>."
+              },
+              "safari_ios": {
                 "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "lspace": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "7"
+              },
+              "firefox_android": {
+                "version_added": "7"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "10",
+                "partial_implementation": true,
+                "notes": "Relative and pseudo-unit values are not supported, see <a href='https://webkit.org/b/85730'>bug 85730</a>."
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "height": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "7"
+              },
+              "firefox_android": {
+                "version_added": "7"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "10",
+                "partial_implementation": true,
+                "notes": "Relative and pseudo-unit values are not supported, see <a href='https://webkit.org/b/85730'>bug 85730</a>."
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "width": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "7"
+              },
+              "firefox_android": {
+                "version_added": "7"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "10",
+                "partial_implementation": true,
+                "notes": "Relative and pseudo-unit values are not supported, see <a href='https://webkit.org/b/85730'>bug 85730</a>."
               },
               "safari_ios": {
                 "version_added": false

--- a/mathml/elements/mpadded.json
+++ b/mathml/elements/mpadded.json
@@ -206,10 +206,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "7"
+                "version_added": true
               },
               "firefox_android": {
-                "version_added": "7"
+                "version_added": true
               },
               "ie": {
                 "version_added": false
@@ -255,10 +255,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "7"
+                "version_added": true
               },
               "firefox_android": {
-                "version_added": "7"
+                "version_added": true
               },
               "ie": {
                 "version_added": false
@@ -353,10 +353,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "7"
+                "version_added": true
               },
               "firefox_android": {
-                "version_added": "7"
+                "version_added": true
               },
               "ie": {
                 "version_added": false

--- a/mathml/elements/mpadded.json
+++ b/mathml/elements/mpadded.json
@@ -49,6 +49,55 @@
             "deprecated": false
           }
         },
+        "height": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "10",
+                "partial_implementation": true,
+                "notes": "Relative and pseudo-unit values are not supported, see <a href='https://webkit.org/b/85730'>bug 85730</a>."
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "href": {
           "__compat": {
             "support": {
@@ -81,6 +130,55 @@
               },
               "safari": {
                 "version_added": "10"
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "lspace": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "10",
+                "partial_implementation": true,
+                "notes": "Relative and pseudo-unit values are not supported, see <a href='https://webkit.org/b/85730'>bug 85730</a>."
               },
               "safari_ios": {
                 "version_added": false
@@ -175,104 +273,6 @@
               },
               "safari": {
                 "version_added": "6"
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "height": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": true
-              },
-              "firefox_android": {
-                "version_added": true
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": "10",
-                "partial_implementation": true,
-                "notes": "Relative and pseudo-unit values are not supported, see <a href='https://webkit.org/b/85730'>bug 85730</a>."
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "lspace": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": true
-              },
-              "firefox_android": {
-                "version_added": true
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": "10",
-                "partial_implementation": true,
-                "notes": "Relative and pseudo-unit values are not supported, see <a href='https://webkit.org/b/85730'>bug 85730</a>."
               },
               "safari_ios": {
                 "version_added": false

--- a/mathml/elements/mpadded.json
+++ b/mathml/elements/mpadded.json
@@ -190,7 +190,7 @@
             }
           }
         },
-        "voffset": {
+        "height": {
           "__compat": {
             "support": {
               "chrome": {
@@ -288,7 +288,7 @@
             }
           }
         },
-        "height": {
+        "voffset": {
           "__compat": {
             "support": {
               "chrome": {


### PR DESCRIPTION
lspace, voffset, width, height has the same support info, so not sure if it is possible to use single row here.

https://bugs.webkit.org/show_bug.cgi?id=155792
https://bugs.webkit.org/show_bug.cgi?id=85730
https://github.com/WebKit/webkit/blob/master/Source/WebCore/rendering/mathml/RenderMathMLPadded.cpp#L98
