### PR TITLE
Fix OS notes in css.properties.font-smooth

### DIFF
--- a/css/properties/font-smooth.json
+++ b/css/properties/font-smooth.json
@@ -22,7 +22,7 @@
             "firefox": {
               "version_added": "25",
               "alternative_name": "-moz-osx-font-smoothing",
-              "notes": "Only works on MacOS X / macOS."
+              "notes": "Only works on macOS."
             },
             "firefox_android": {
               "version_added": null
@@ -40,8 +40,7 @@
             },
             "safari": {
               "version_added": "4",
-              "alternative_name": "-webkit-font-smoothing",
-              "notes": "Only works on Mac OS X/macOS."
+              "alternative_name": "-webkit-font-smoothing"
             },
             "safari_ios": {
               "version_added": null


### PR DESCRIPTION
I noticed that the OS-specific notes in the `font-smooth` CSS property were a little off.  This PR fixes them by removing the note on Safari stating "Only available on macOS", as well as updating the note on Firefox to only use the "macOS" name rather than "Mac OS X".