### PR TITLE
Fix test-prefix

### DIFF
--- a/test/lint.js
+++ b/test/lint.js
@@ -43,7 +43,7 @@ function load(...files) {
           hasStyleErrors = false,
           hasBrowserErrors = false,
           hasVersionErrors = false,
-          hasApiErrors = false;
+          hasPrefixErrors = false;
         const relativeFilePath = path.relative(process.cwd(), file);
 
         const spinner = ora({
@@ -71,13 +71,13 @@ function load(...files) {
             hasStyleErrors = testStyle(file);
             hasBrowserErrors = testBrowsers(file);
             hasVersionErrors = testVersions(file);
-            hasApiErrors = testPrefix(file);
+            hasPrefixErrors = testPrefix(file);
           }
         } catch (e) {
           hasSyntaxErrors = true;
           console.error(e);
         }
-        if (hasSyntaxErrors || hasSchemaErrors || hasStyleErrors || hasBrowserErrors || hasVersionErrors || hasApiErrors) {
+        if (hasSyntaxErrors || hasSchemaErrors || hasStyleErrors || hasBrowserErrors || hasVersionErrors || hasPrefixErrors) {
           hasErrors = true;
           filesWithErrors.set(relativeFilePath, file);
         } else {
@@ -129,6 +129,7 @@ if (hasErrors) {
         testStyle(file);
         testVersions(file);
         testBrowsers(file);
+        testPrefix(file);
       }
     } catch (e) {
       console.error(e);

--- a/test/test-prefix.js
+++ b/test/test-prefix.js
@@ -5,7 +5,7 @@ function checkPrefix(data, category, errors, prefix, path="") {
   for (var key in data) {
     if (key === "prefix" && typeof(data[key]) === "string") {
       if (data[key].includes(prefix)) {
-        var error = `${prefix} prefix is wrong for key: ${path}`;
+        var error = `\x1b[31m${prefix} prefix is wrong for key: ${path}\x1b[0m`;
         var rules = [
           category == "api" && !data[key].startsWith(prefix),
           category == "css" && !data[key].startsWith(`-${prefix}`)


### PR DESCRIPTION
I noticed that the prefix test had a couple of little issues.  This PR fixes them.

1) The output didn't show up at the end of the file, as the function wasn't called.
2) The error variable, "hasApiErrors", was improperly named.  This sets it to "hasPrefixErrors".
3) A little bit of styling and formatting goes a long way!