### PR TITLE
SetConfiguration is unsupported in Firefox

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -3953,10 +3953,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1253706'>bug 1253706</a>."
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1253706'>bug 1253706</a>."
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Misleading information in the documentation that it is supported since Version 22: https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/setConfiguration
SetConfiguration is not supported in Firefox since three years: https://bugzil.la/1253706
Error message: "setConfiguration is not a function" on PC and Android.

Because of this bug, Firefox does not fit in our new security concept where the WebRTC user gets an generated username and password for a TURN server, which are just valid for the current call and expire after few seconds. Our web app, which has few thousands visitors each day (mainly with Chrome and IOS Safari), is removing support for Firefox completely till it gets fixed.
