### PR TITLE
Add Chromium versions for CSS selectors

### DIFF
--- a/css/selectors/defined.json
+++ b/css/selectors/defined.json
@@ -7,10 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:defined",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "54"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "54"
             },
             "edge": {
               "version_added": false
@@ -28,10 +28,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "41"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": true
@@ -43,7 +43,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "54"
             }
           },
           "status": {

--- a/css/selectors/host-context.json
+++ b/css/selectors/host-context.json
@@ -7,10 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:host-context()",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "54"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "54"
             },
             "edge": {
               "version_added": false
@@ -30,10 +30,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "41"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": false
@@ -45,7 +45,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "54"
             }
           },
           "status": {

--- a/css/selectors/host.json
+++ b/css/selectors/host.json
@@ -7,10 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:host",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "54"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "54"
             },
             "edge": {
               "version_added": false,
@@ -56,10 +56,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "41"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": true
@@ -71,7 +71,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "54"
             }
           },
           "status": {

--- a/css/selectors/hostfunction.json
+++ b/css/selectors/hostfunction.json
@@ -7,10 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:host()",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "54"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "54"
             },
             "edge": {
               "version_added": false,
@@ -56,10 +56,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "41"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": false
@@ -71,7 +71,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "54"
             }
           },
           "status": {

--- a/css/selectors/invalid.json
+++ b/css/selectors/invalid.json
@@ -57,10 +57,10 @@
             "description": "Applies to <a href='https://developer.mozilla.org/docs/Web/HTML/Element/form'>&lt;form&gt;</a> elements",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "40"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "40"
               },
               "edge": {
                 "version_added": false
@@ -78,10 +78,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "27"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "27"
               },
               "safari": {
                 "version_added": null
@@ -90,10 +90,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "40"
               }
             },
             "status": {

--- a/css/selectors/valid.json
+++ b/css/selectors/valid.json
@@ -57,10 +57,10 @@
             "description": "Applies to <a href='https://developer.mozilla.org/docs/Web/HTML/Element/form'>&lt;form&gt;</a> elements",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "40"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "40"
               },
               "edge": {
                 "version_added": false
@@ -78,10 +78,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "27"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "27"
               },
               "safari": {
                 "version_added": null
@@ -90,10 +90,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "40"
               }
             },
             "status": {


### PR DESCRIPTION
Based upon manual testing, I have identified the following support:

css.selectors.defined - true 54
css.selectors.host - true 54
css.selectors.host-context - true 54
css.selectors.hostfunction - true 54
css.selectors.invalid.form - true 40
css.selectors.valid.form - true 40
