### PR TITLE
notification.onclick is working in Firefox

### DIFF
--- a/api/Notification.json
+++ b/api/Notification.json
@@ -735,7 +735,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": true
             },
             "firefox_android": {
               "version_added": false

--- a/api/Notification.json
+++ b/api/Notification.json
@@ -735,7 +735,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": "22"
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
A simple test on FF 66:

`var notification = new Notification("test"); notification.onclick = () => console.log("working");`

