### PR TITLE
Updating SetAttribute browser compatibility on IE

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -7165,7 +7165,7 @@
             },
             "ie": {
               "version_added": "6",
-              "notes": "Does not set styles and removes events when you try to set them."
+              "notes": "In IE 6 and earlier, <code>setAttribute</code> does not set styles and removes events when you try to set them."
             },
             "opera": {
               "version_added": true

--- a/api/Element.json
+++ b/api/Element.json
@@ -7164,8 +7164,8 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "5.5",
-              "notes": "IE 5-7 <code>setAttribute</code> doesn't set styles and removes events when you try to set them."
+              "version_added": "5",
+              "notes": "In Internet Explorer 7 and earlier, <code>setAttribute</code> doesn't set styles and removes events when you try to set them."
             },
             "opera": {
               "version_added": true

--- a/api/Element.json
+++ b/api/Element.json
@@ -7164,7 +7164,8 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "6",
+              "notes": "Does not set styles and removes events when you try to set them."
             },
             "opera": {
               "version_added": true

--- a/api/Element.json
+++ b/api/Element.json
@@ -7164,8 +7164,8 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "6",
-              "notes": "In IE 6 and earlier, <code>setAttribute</code> does not set styles and removes events when you try to set them."
+              "version_added": "5.5",
+              "notes": "IE 5-7 <code>setAttribute</code> doesn't set styles and removes events when you try to set them."
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
Per [w3](https://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html) docs... `setAttribute` has been implemented since IE 6

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
