### PR TITLE
Linter: remove redundant newlines

### DIFF
--- a/test/test-browsers.js
+++ b/test/test-browsers.js
@@ -130,11 +130,7 @@ function testBrowsers(filename) {
   if (!processData(data, displayBrowsers, requiredBrowsers, category, logger)) {
     return false;
   } else {
-    console.error(chalk.red(
-      `  Browsers – ${errors.length} ${
-        errors.length === 1 ? 'error' : 'errors'
-      }:`,
-    ));
+    console.error(chalk.red(`  Browsers – ${errors.length} ${errors.length === 1 ? 'error' : 'errors'}:`));
     for (const error of errors) {
       console.error(`    ${error}`);
     }

--- a/test/test-prefix.js
+++ b/test/test-prefix.js
@@ -49,11 +49,7 @@ function testPrefix(filename) {
   var errors = processData(data, category);
 
   if (errors.length) {
-    console.error(chalk.red(
-      `  Prefix – ${errors.length} ${
-        errors.length === 1 ? 'error' : 'errors'
-      }:`
-    ));
+    console.error(chalk.red(`  Prefix – ${errors.length} ${errors.length === 1 ? 'error' : 'errors'}:`));
     for (const error of errors) {
       console.error(`    ${error}`);
     }

--- a/test/test-schema.js
+++ b/test/test-schema.js
@@ -20,11 +20,7 @@ function testSchema(dataFilename, schemaFilename = './../schemas/compat-data.sch
     return false;
   } else {
     console.error(chalk.red(`  File : ${path.relative(process.cwd(), dataFilename)}`));
-    console.error(chalk.red(
-      `  JSON schema – ${ajv.errors.length} ${
-        ajv.errors.length === 1 ? 'error' : 'errors'
-      }:`,
-    ));
+    console.error(chalk.red(`  JSON schema – ${ajv.errors.length} ${ajv.errors.length === 1 ? 'error' : 'errors'}:`));
     // Output messages by one since better-ajv-errors wrongly joins messages
     // (see https://github.com/atlassian/better-ajv-errors/pull/21)
     ajv.errors.forEach(e => {

--- a/test/test-style.js
+++ b/test/test-style.js
@@ -190,10 +190,9 @@ function testStyle(filename) {
 
         if (protocol !== 'https') {
           hasErrors = true;
-          console.error(chalk.yellow(`  Style ${indexToPos(
-            actual,
-            match.index,
-          )} – Use HTTPS URL (http://${domain}/${bugId} → https://${domain}/${bugId}).`));
+          console.error(chalk.yellow(`  Style ${
+            indexToPos(actual, match.index)
+          } – Use HTTPS URL (http://${domain}/${bugId} → https://${domain}/${bugId}).`));
         }
 
         if (domain !== 'bugzil.la') {
@@ -202,24 +201,21 @@ function testStyle(filename) {
 
         if (/^bug $/.test(before)) {
           hasErrors = true;
-          console.error(chalk.yellow(`  Style ${indexToPos(
-            actual,
-            match.index,
-          )} – Move word "bug" into link text ("${before}<a href='...'>${linkText}</a>" → "<a href='...'>${before}${bugId}</a>").`));
+          console.error(chalk.yellow(`  Style ${
+            indexToPos(actual, match.index)
+          } – Move word "bug" into link text ("${before}<a href='...'>${linkText}</a>" → "<a href='...'>${before}${bugId}</a>").`));
         } else if (linkText === `Bug ${bugId}`) {
           if (!/(\. |")$/.test(before)) {
             hasErrors = true;
-            console.error(chalk.yellow(`  Style ${indexToPos(
-              actual,
-              match.index,
-            )} – Use lowercase "bug" word within sentence ("Bug ${bugId}" → "bug ${bugId}").`));
+            console.error(chalk.yellow(`  Style ${
+              indexToPos(actual, match.index)
+            } – Use lowercase "bug" word within sentence ("Bug ${bugId}" → "bug ${bugId}").`));
           }
         } else if (linkText !== `bug ${bugId}`) {
           hasErrors = true;
-          console.error(chalk.yellow(`  Style ${indexToPos(
-            actual,
-            match.index,
-          )} – Use standard link text ("${linkText}" → "bug ${bugId}").`));
+          console.error(chalk.yellow(`  Style ${
+            indexToPos(actual, match.index)
+          } – Use standard link text ("${linkText}" → "bug ${bugId}").`));
         }
       }
     } while (match != null);
@@ -230,10 +226,9 @@ function testStyle(filename) {
     // use https://crbug.com/100000 instead
     hasErrors = true;
     console.error(chalk.yellow(
-      `  Style ${indexToPos(
-        actual,
-        crbugMatch.index,
-      )} – Use shortenable URL (${
+      `  Style ${
+        indexToPos(actual, crbugMatch.index)
+      } – Use shortenable URL (${
         crbugMatch[0]
       } → https://crbug.com/${crbugMatch[1]}).`,
     ));
@@ -244,10 +239,9 @@ function testStyle(filename) {
     // use https://webkit.org/b/100000 instead
     hasErrors = true;
     console.error(chalk.yellow(
-      `  Style ${indexToPos(
-        actual,
-        webkitMatch.index,
-      )} – Use shortenable URL (${
+      `  Style ${
+        indexToPos(actual, webkitMatch.index)
+      } – Use shortenable URL (${
         webkitMatch[0]
       } → https://webkit.org/b/${webkitMatch[1]}).`,
     ));
@@ -257,10 +251,9 @@ function testStyle(filename) {
   if (mdnUrlMatch) {
     hasErrors = true;
     console.error(chalk.yellow(
-      `  Style ${indexToPos(
-        actual,
-        mdnUrlMatch.index,
-      )} – Use non-localized MDN URL (${
+      `  Style ${
+        indexToPos(actual, mdnUrlMatch.index)
+      } – Use non-localized MDN URL (${
         mdnUrlMatch[0]
       } → https://developer.mozilla.org/${mdnUrlMatch[2]}).`,
     ));
@@ -270,10 +263,9 @@ function testStyle(filename) {
   if (msdevUrlMatch) {
     hasErrors = true;
     console.error(chalk.yellow(
-      `  Style ${indexToPos(
-        actual,
-        msdevUrlMatch.index,
-      )} – Use non-localized Microsoft Developer URL (${
+      `  Style ${
+        indexToPos(actual, msdevUrlMatch.index)
+      } – Use non-localized Microsoft Developer URL (${
         msdevUrlMatch[0]
       } → https://developer.microsoft.com${msdevUrlMatch[2]}).`,
     ));
@@ -283,10 +275,9 @@ function testStyle(filename) {
   if (constructorMatch) {
     hasErrors = true;
     console.error(chalk.yellow(
-      `  Style ${indexToPos(
-        actual,
-        constructorMatch.index,
-      )} – Use parentheses in constructor description: ${
+      `  Style ${
+        indexToPos(actual, constructorMatch.index)
+      } – Use parentheses in constructor description: ${
         constructorMatch[1]
       } → ${constructorMatch[1]}()`,
     ));
@@ -304,10 +295,9 @@ function testStyle(filename) {
     if (a_url.hostname === null) {
       hasErrors = true;
       console.error(chalk.yellow(
-        `  Style ${indexToPos(
-          actual,
-          match.index,
-        )} – Include hostname in URL: ${
+        `  Style ${
+          indexToPos(actual, match.index)
+        } – Include hostname in URL: ${
           match[1]
         } → https://developer.mozilla.org/${match[1]}`,
       ));

--- a/test/test-versions.js
+++ b/test/test-versions.js
@@ -63,47 +63,25 @@ function testVersions(dataFilename) {
 
         for (const statement of supportStatements) {
           if (!isValidVersion(browser, statement.version_added)) {
-            console.error(chalk.red(
-              `  version_added: "${
-                statement.version_added
-              }" is not a valid version number for ${browser}`,
-            ));
+            console.error(chalk.red(`  version_added: "${statement.version_added}" is not a valid version number for ${browser}`));
             console.error(chalk.red(`  Valid ${browser} versions are: ${validBrowserVersionsString}`));
             hasErrors = true;
           }
           if (!isValidVersion(browser, statement.version_removed)) {
-            console.error(chalk.red(
-              `  version_removed: "${
-                statement.version_removed
-              }" is not a valid version number for ${browser}`,
-            ));
+            console.error(chalk.red(`  version_removed: "${statement.version_removed}" is not a valid version number for ${browser}`));
             console.error(chalk.red(`  Valid ${browser} versions are: ${validBrowserVersionsString}`));
             hasErrors = true;
           }
           if ('version_removed' in statement && 'version_added' in statement) {
-            if (
-              typeof statement.version_added !== 'string' &&
-              statement.version_added !== true
-            ) {
-              console.error(chalk.red(
-                `  version_added: "${
-                  statement.version_added
-                }" is not a valid version number when version_removed is present`,
-              ));
+            if (typeof statement.version_added !== 'string' && statement.version_added !== true) {
+              console.error(chalk.red(`  version_added: "${statement.version_added}" is not a valid version number when version_removed is present`));
               console.error(chalk.red(`  Valid ${browser} versions are: ${validBrowserVersionsTruthy}`));
               hasErrors = true;
-            } else if (
-              typeof statement.version_added === 'string' &&
+            } else if (typeof statement.version_added === 'string' &&
               typeof statement.version_removed === 'string' &&
               compareVersions(statement.version_added, statement.version_removed) >= 0
             ) {
-              console.error(chalk.red(
-                `  version_removed: "${
-                  statement.version_removed
-                }" must be greater than version_added: "${
-                  statement.version_added
-                }"`,
-              ));
+              console.error(chalk.red(`  version_removed: "${statement.version_removed}" must be greater than version_added: "${statement.version_added}"`));
               hasErrors = true;
             }
           }


### PR DESCRIPTION
I noticed that there were a series of newlines added to the linters that were somewhat redundant, as we have lines that span far larger than them already there.  (This should be enforced by a code styling formula.)  This PR removes those redundant newlines.