### PR TITLE
Linter: remove redundant array length test

### DIFF
--- a/test/test-versions.js
+++ b/test/test-versions.js
@@ -51,9 +51,9 @@ function testVersions(dataFilename) {
           supportStatements.push(supportData[browser]);
         }
 
-        const validBrowserVersionsString = 'true, false, null, ' + validBrowserVersions[browser].join(', ');
-        const validBrowserVersionsTruthy = 'true, ' + validBrowserVersions[browser].join(', ');
-        
+        const validBrowserVersionsString = `true, false, null, ${validBrowserVersions[browser].join(', ')}`;
+        const validBrowserVersionsTruthy = `true, ${validBrowserVersions[browser].join(', ')}`;
+
         for (const statement of supportStatements) {
           if (!isValidVersion(browser, statement.version_added)) {
             console.error(chalk.red(

--- a/test/test-versions.js
+++ b/test/test-versions.js
@@ -51,16 +51,9 @@ function testVersions(dataFilename) {
           supportStatements.push(supportData[browser]);
         }
 
-        const validBrowserVersionsString =
-          'true, false, null' +
-          (validBrowserVersions[browser].length > 0
-            ? ', ' + validBrowserVersions[browser].join(', ')
-            : '');
-        const validBrowserVersionsTruthy =
-          validBrowserVersions[browser].length > 0
-            ? 'true, ' + validBrowserVersions[browser].join(', ')
-            : 'true';
-
+        const validBrowserVersionsString = 'true, false, null, ' + validBrowserVersions[browser].join(', ');
+        const validBrowserVersionsTruthy = 'true, ' + validBrowserVersions[browser].join(', ');
+        
         for (const statement of supportStatements) {
           if (!isValidVersion(browser, statement.version_added)) {
             console.error(chalk.red(


### PR DESCRIPTION
In the version linter, there were some statements to alter the string if the array of valid browser versions was empty.  However, this check was wrapped within an if() block that checks whether that same array existed and had content.  Thus, one of the two branches will never be called.  This removes that additional, redundant branch.