### PR TITLE
Mark parent as true when children are truthy in css/*

### DIFF
--- a/css/properties/cursor.json
+++ b/css/properties/cursor.json
@@ -31,7 +31,7 @@
               "version_added": "7"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": "1.2"

--- a/css/properties/hyphens.json
+++ b/css/properties/hyphens.json
@@ -32,7 +32,7 @@
               "notes": "Automatic hyphenation only works for languages with hyphenation dictionaries that are integrated into Internet Explorer."
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": [
               {

--- a/css/properties/image-rendering.json
+++ b/css/properties/image-rendering.json
@@ -30,7 +30,7 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": true

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -130,7 +130,7 @@
                 "version_added": "9"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": true
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/css/properties/mask-clip.json
+++ b/css/properties/mask-clip.json
@@ -40,7 +40,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/css/properties/mask-origin.json
+++ b/css/properties/mask-origin.json
@@ -44,7 +44,7 @@
               "notes": "The <code>margin-box</code> value is unsupported."
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -33,7 +33,7 @@
               "notes": "CSS 2.1 leaves the behavior of <code>max-width</code> with <a href='https://developer.mozilla.org/docs/Web/HTML/Element/table'><code>table</code></a> undefined. Opera supports applying <code>max-width</code> to <code>table</code> elements."
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": "1"

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -34,7 +34,7 @@
               "notes": "CSS 2.1 leaves the behavior of <code>min-height</code> with <a href='https://developer.mozilla.org/docs/Web/HTML/Element/table'><code>table</code></a> undefined. Opera supports applying <code>min-height</code> to <code>table</code> elements."
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": "1.3"

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -33,7 +33,7 @@
               "notes": "CSS 2.1 leaves the behavior of <code>min-width</code> with <a href='https://developer.mozilla.org/docs/Web/HTML/Element/table'><code>table</code></a> undefined. Opera supports applying <code>min-width</code> to <code>table</code> elements."
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": "1"

--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -32,7 +32,7 @@
               "version_added": "7"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": "1"

--- a/css/properties/touch-action.json
+++ b/css/properties/touch-action.json
@@ -70,7 +70,7 @@
               "notes": "See <a href='https://webkit.org/b/133112'>WebKit bug 133112</a>."
             },
             "safari_ios": {
-              "version_added": null,
+              "version_added": true,
               "notes": "See <a href='https://webkit.org/b/133112'>WebKit bug 133112</a>."
             },
             "samsunginternet_android": {

--- a/css/properties/word-break.json
+++ b/css/properties/word-break.json
@@ -38,7 +38,7 @@
               "version_added": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": "3"

--- a/css/selectors/placeholder-shown.json
+++ b/css/selectors/placeholder-shown.json
@@ -48,7 +48,7 @@
               "version_added": "34"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": "9"


### PR DESCRIPTION
This PR marks features as supported if their children contain a true-based value (either "true" or a version number).  NOTE: This should be reviewed with extreme caution, as the data has not been validated for accuracy, only consistency.