### PR TITLE
Mark parent as true when children are truthy in http/* and javascript/*

### DIFF
--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -45,7 +45,7 @@
                 "version_added": "15"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": [
                 {

--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -28,13 +28,13 @@
               "version_added": "11"
             },
             "nodejs": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": "10"
@@ -143,7 +143,7 @@
                 "version_added": "15"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
                 "version_added": "10"
@@ -466,7 +466,7 @@
                 "version_added": "11"
               },
               "nodejs": {
-                "version_added": null
+                "version_added": true
               },
               "opera": {
                 "version_added": "15"

--- a/javascript/builtins/WebAssembly.json
+++ b/javascript/builtins/WebAssembly.json
@@ -42,7 +42,7 @@
               "version_added": "44"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": "11"


### PR DESCRIPTION
This PR marks features as supported if their children contain a true-based value (either "true" or a version number).  NOTE: This should be reviewed with extreme caution, as the data has not been validated for accuracy, only consistency.