### PR TITLE
RTCIceCandidate.usernameFragment added in Firefox 67

### DIFF
--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -782,10 +782,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "67"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "67"
             },
             "ie": {
               "version_added": false

--- a/api/RTCIceCandidateInit.json
+++ b/api/RTCIceCandidateInit.json
@@ -220,10 +220,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": "67"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "67"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Updated for both desktop and mobile.

Source: https://bugzilla.mozilla.org/show_bug.cgi?id=1490658