### PR TITLE
adding data point for external protocol URLs being blocked in iframes

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -304,6 +304,57 @@
             }
           }
         },
+        "external_protocol_urls_blocked": {
+          "__compat": {
+            "description": "External protocol URLs blocked",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "67"
+              },
+              "firefox_android": {
+                "version_added": "67"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
         "frameborder": {
           "__compat": {
             "support": {


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1527882

I couldn't find any data on this concerning other browser's support.