### PR TITLE
adding data point about strict mime checks on importScripts

### DIFF
--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -795,7 +795,7 @@
                 "version_added": "58"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "50"
               },
               "safari": {
                 "version_added": false

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -765,6 +765,57 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "mime_checks": {
+          "__compat": {
+            "description": "Strict MIME type checks for <code>importScripts()</code>",
+            "support": {
+              "chrome": {
+                "version_added": "71"
+              },
+              "chrome_android": {
+                "version_added": "71"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "67"
+              },
+              "firefox_android": {
+                "version_added": "67"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": "71"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "onclose": {

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -792,7 +792,7 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": true
+                "version_added": "58"
               },
               "opera_android": {
                 "version_added": true


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1514680

As for the other browser compat data:

* https://chromium-review.googlesource.com/c/chromium/src/+/1206270 suggests that Chrome shipped it in v71.
* Since Chrome has it, I reckon other Chromiums probably have it too, so I set them to true.
* I set Safari/iOS to false, as https://bugs.webkit.org/show_bug.cgi?id=192749 shows that it was reported but no movemet has happened yet.
* I left Edge/IE as null, as I really have no idea. 