### PR TITLE
updating -moz-binding data to show that it has been removed

### DIFF
--- a/css/properties/-moz-binding.json
+++ b/css/properties/-moz-binding.json
@@ -19,10 +19,16 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": "XBL is deprecated and being removed. See <a href='https://bugzil.la/1397874'>bug 1397874</a>."
+              "version_removed": "67",
+              "notes": [
+                "XBL is deprecated and being removed. See <a href='https://bugzil.la/1397874'>bug 1397874</a>.",
+                "Available only in chrome and UA style sheets."
+              ]
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "4",
+              "version_removed": "67",
+              "notes": "Available only in chrome and UA style sheets."
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1523712, `-moz-binding` has been removed from the web in Fx67,  and is now available only in chrome and UA style sheets.