### PR TITLE
Firefox 67 implements MediaDeviceInfo.groupId

### DIFF
--- a/api/MediaDeviceInfo.json
+++ b/api/MediaDeviceInfo.json
@@ -28,12 +28,12 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true,
-            "notes": "This interface is available in Opera through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+            "version_added": false,
+            "notes": "This interface can be used in Opera by using the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
           },
           "opera_android": {
-            "version_added": true,
-            "notes": "This interface is available in Opera through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+            "version_added": false,
+            "notes": "This interface can be used in Opera by using the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
           },
           "safari": {
             "version_added": false
@@ -83,12 +83,12 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
-              "notes": "This interface is available in Opera through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+              "version_added": false,
+              "notes": "This property can be used in Opera by using the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
             },
             "opera_android": {
-              "version_added": true,
-              "notes": "This interface is available in Opera through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+              "version_added": false,
+              "notes": "This property can be used in Opera by using the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
             },
             "safari": {
               "version_added": false
@@ -129,36 +129,24 @@
             "edge_mobile": {
               "version_added": true
             },
-            "firefox": [
-              {
-                "version_added": "67",
-                "notes": "Starting in Firefox 67, related devices are actually grouped together by <code>groupId</code>."
-              },
-              {
-                "version_added": "39",
-                "notes": "Although added in Firefox 39, <code>groupId</code> does not actually associate related devices together."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "67",
-                "notes": "Starting in Firefox 67, related devices are actually grouped together by <code>groupId</code>."
-              },
-              {
-                "version_added": "39",
-                "notes": "Although added in Firefox 39, <code>groupId</code> does not actually associate related devices together."
-              }
-            ],
+            "firefox": {
+              "version_added": "39",
+              "notes": "Prior to Firefox 67, related devices are not actually grouped together by <code>groupId</code>."
+            },
+            "firefox_android": {
+              "version_added": "39",
+              "notes": "Prior to Firefox 67, related devices are not actually grouped together by <code>groupId</code>."
+            },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": true,
-              "notes": "This interface is available in Opera through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+              "version_added": false,
+              "notes": "This property can be used in Opera by using the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
             },
             "opera_android": {
-              "version_added": true,
-              "notes": "This interface is available in Opera through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+              "version_added": false,
+              "notes": "This property can be used in Opera by using the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
             },
             "safari": {
               "version_added": false
@@ -209,12 +197,12 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
-              "notes": "This interface is available in Opera through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+              "version_added": false,
+              "notes": "This property can be used in Opera by using the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
             },
             "opera_android": {
-              "version_added": true,
-              "notes": "This interface is available in Opera through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+              "version_added": false,
+              "notes": "This property can be used in Opera by using the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
             },
             "safari": {
               "version_added": false
@@ -265,12 +253,12 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
-              "notes": "This interface is available in Opera through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+              "version_added": false,
+              "notes": "This property can be used in Opera by using the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
             },
             "opera_android": {
-              "version_added": true,
-              "notes": "This interface is available in Opera through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+              "version_added": false,
+              "notes": "This property can be used in Opera by using the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
             },
             "safari": {
               "version_added": false
@@ -296,6 +284,7 @@
       "toJSON": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDeviceInfo/toJSON",
+          "description": "<code>toJSON()</code>",
           "support": {
             "chrome": {
               "version_added": true
@@ -319,10 +308,12 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": false,
+              "notes": "For earlier versions, this method is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": false,
+              "notes": "For earlier versions, this method is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
             },
             "safari": {
               "version_added": false

--- a/api/MediaDeviceInfo.json
+++ b/api/MediaDeviceInfo.json
@@ -129,12 +129,26 @@
             "edge_mobile": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "67"
-            },
-            "firefox_android": {
-              "version_added": "67"
-            },
+            "firefox": [
+              {
+                "version_added": "67",
+                "notes": "Starting in Firefox 67, related devices are actually grouped together by <code>groupId</code>."
+              },
+              {
+                "version_added": "39",
+                "notes": "Although added in Firefox 39, <code>groupId</code> does not actually associate related devices together."
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "67",
+                "notes": "Starting in Firefox 67, related devices are actually grouped together by <code>groupId</code>."
+              },
+              {
+                "version_added": "39",
+                "notes": "Although added in Firefox 39, <code>groupId</code> does not actually associate related devices together."
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/MediaDeviceInfo.json
+++ b/api/MediaDeviceInfo.json
@@ -130,10 +130,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "39"
+              "version_added": "67"
             },
             "firefox_android": {
-              "version_added": "39"
+              "version_added": "67"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Fix MediaDeviceInfo.groupId to be more detailed
Turns out that groupId was added in Firefox 39 but didn't actually
use the same value for related devices until 67. This commit
corrects the data to reflect that.
