### PR TITLE
adding browser compat data for the hashbang grammar

### DIFF
--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -232,6 +232,61 @@
           }
         }
       },
+      "hashbang_comments": {
+        "__compat": {
+          "description": "Hashbang (<code>#!</code>) comment syntax",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Hashbang_comments",
+          "support": {
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "67"
+            },
+            "firefox_android": {
+              "version_added": "67"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "74"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "hexadecimal_escape_sequences": {
         "__compat": {
           "description": "Hexadecimal escape sequences (<code>'\\0xA9'</code>)",

--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -274,7 +274,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "74"


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=hashbang, Firefox now supports the hashbang syntax in Fx67 onwards.

In terms of other browser support, I filled in Chrome and friends, as I found https://www.chromestatus.com/features/5134505706782720.

The above link also says that node supports it since 2009, so I've put true for that.

I put null for other browsers. I can't find anny evidence to say that Edge or Webkit supports it (or not), and it is a very new feature, so I'm not sure if we can guarantee that other Chromium-based browsers will have it enabled yet.  