### PR TITLE
Part of the touch event API was removed on Firefox Desktop 67

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -1940,7 +1940,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/createEvent",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "From version 70, creating touch events using this method is no longer supported."
             },
             "chrome_android": {
               "version_added": true
@@ -1952,7 +1953,8 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "notes": "From version 67, creating touch events using this method is no longer supported."
             },
             "firefox_android": {
               "version_added": true
@@ -2302,7 +2304,8 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "18"
+              "version_added": "18",
+              "version_removed": "67"
             },
             "firefox_android": {
               "version_added": "6"
@@ -2361,7 +2364,8 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "18"
+              "version_added": "18",
+              "version_removed": "67"
             },
             "firefox_android": {
               "version_added": "6"

--- a/api/Document.json
+++ b/api/Document.json
@@ -1940,8 +1940,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/createEvent",
           "support": {
             "chrome": {
-              "version_added": "1",
-              "notes": "From version 70, creating touch events using this method is no longer supported."
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": true

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -4355,7 +4355,8 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true,
+              "version_removed": "67"
             },
             "firefox_android": {
               "version_added": null
@@ -4406,7 +4407,8 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true,
+              "version_removed": "67"
             },
             "firefox_android": {
               "version_added": null
@@ -4457,7 +4459,8 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true,
+              "version_removed": "67"
             },
             "firefox_android": {
               "version_added": null
@@ -4508,7 +4511,8 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true,
+              "version_removed": "67"
             },
             "firefox_android": {
               "version_added": null


### PR DESCRIPTION
This update is for [bug 1412485](https://bugzilla.mozilla.org/show_bug.cgi?id=1412485), which removes part of the touch event API in Firefox Desktop only, version 67.

Specifically: https://bugzilla.mozilla.org/show_bug.cgi?id=1412485#c14:

> Hiding document.createEvent("TouchEvent"), document.createTouch, document.createTouchList and ontouch* event handlers on desktop with touchscreen

...tracking the same change in Chrome: https://groups.google.com/a/chromium.org/forum/#!msg/blink-dev/KV6kqDJpYiE/YFM28ZNBBAAJ.

Note that the `addEventListener('touch*')` version is not affected by this, which makes me feel good about our decision to have separate BCD for `on-*` properties and for `addEventListener`.

******

I've only updated the Firefox data here but we should update Chrome too. From what I can understand of https://chromium-review.googlesource.com/c/chromium/src/+/729220, this change landed in Chrome v70. Currently:

* the data for `GlobalEventHandlers.ontouch*` has these properties still supported in Chrome, (e.g. https://github.com/mdn/browser-compat-data/blob/master/api/GlobalEventHandlers.json#L4346)
* the data for `document.createTouch` and `document.createTouchList` say it was removed in Chrome [66](https://github.com/mdn/browser-compat-data/blob/master/api/Document.json#L2281) and [69](https://github.com/mdn/browser-compat-data/blob/master/api/Document.json#L2351) respectively, and that they were removed in Chrome Android too, which seems wrong to me.

But I'd like to hear what @jpmedley thinks :).
