### PR TITLE
Linter: remove redundant "File: XXX" console logging

### DIFF
--- a/test/test-schema.js
+++ b/test/test-schema.js
@@ -19,7 +19,6 @@ function testSchema(dataFilename, schemaFilename = './../schemas/compat-data.sch
   if (valid) {
     return false;
   } else {
-    console.error(chalk.red(`  File : ${path.relative(process.cwd(), dataFilename)}`));
     console.error(chalk.red(
       `  JSON schema – ${ajv.errors.length} ${
         ajv.errors.length === 1 ? 'error' : 'errors'

--- a/test/test-versions.js
+++ b/test/test-versions.js
@@ -122,7 +122,6 @@ function testVersions(dataFilename) {
   findSupport(data);
 
   if (hasErrors) {
-    console.error(chalk.red(`  File : ${path.relative(process.cwd(), dataFilename)}`));
     console.error(chalk.red('  Browser version error(s)'));
     return true;
   } else {


### PR DESCRIPTION
Two linters had statements that let us know what files they were coming from, however this is redundant as we're already logging the file name right above:

<img width="280" alt="Screen Shot 2019-05-07 at 16 40 09" src="https://user-images.githubusercontent.com/5179191/57339640-43dfaf80-70e7-11e9-9a1a-2541565c50ed.png">

This PR removes those statements.

(P.S. The styling looks different in this screenshot than a local test will reveal.  I found this out while working on a PR to update styling.  :wink:)