### PR TITLE
Refactor test-browsers.js and test-schema.js

### DIFF
--- a/test/test-browsers.js
+++ b/test/test-browsers.js
@@ -127,9 +127,9 @@ function testBrowsers(filename) {
     },
   };
 
-  if (!processData(data, displayBrowsers, requiredBrowsers, category, logger)) {
-    return false;
-  } else {
+  processData(data, displayBrowsers, requiredBrowsers, category, logger);
+
+  if (errors.length) {
     console.error(chalk.red(
       `  Browsers – ${errors.length} ${
         errors.length === 1 ? 'error' : 'errors'
@@ -140,6 +140,7 @@ function testBrowsers(filename) {
     }
     return true;
   }
+  return false;
 }
 
 module.exports = testBrowsers;

--- a/test/test-schema.js
+++ b/test/test-schema.js
@@ -16,9 +16,7 @@ function testSchema(dataFilename, schemaFilename = './../schemas/compat-data.sch
 
   const valid = ajv.validate(schema, data);
 
-  if (valid) {
-    return false;
-  } else {
+  if (!valid) {
     console.error(chalk.red(`  File : ${path.relative(process.cwd(), dataFilename)}`));
     console.error(chalk.red(
       `  JSON schema – ${ajv.errors.length} ${
@@ -32,6 +30,7 @@ function testSchema(dataFilename, schemaFilename = './../schemas/compat-data.sch
     });
     return true;
   }
+  return false;
 }
 
 module.exports = testSchema;


### PR DESCRIPTION
This PR is designed to standardize the browser and schema test files, letting it follow the same function structure as the prefix test with just a few minor changes.  This will help maintain consistency across our code, as well as simply global changes to error reporting that may occur in the future.