### PR TITLE
Mark css.properties.text-combine-upright as supported in IE 11

### DIFF
--- a/css/properties/text-combine-upright.json
+++ b/css/properties/text-combine-upright.json
@@ -20,11 +20,11 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": "15",
+              "version_added": "12",
               "alternative_name": "-ms-text-combine-horizontal"
             },
             "edge_mobile": {
-              "version_added": true,
+              "version_added": "12",
               "alternative_name": "-ms-text-combine-horizontal"
             },
             "firefox": [
@@ -106,7 +106,8 @@
               }
             ],
             "ie": {
-              "version_added": false
+              "version_added": "11",
+              "alternative_name": "-ms-text-combine-horizontal"
             },
             "opera": [
               {
@@ -191,7 +192,7 @@
                 "notes": "Firefox recognizes this value but does not yet implement layout support for tate-chū-yoko (see <a href='https://bugzil.la/1258635'>bug 1258635</a>)."
               },
               "ie": {
-                "version_added": false
+                "version_added": "11"
               },
               "opera": {
                 "version_added": false

--- a/css/properties/text-combine-upright.json
+++ b/css/properties/text-combine-upright.json
@@ -20,10 +20,12 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": "15"
+              "version_added": "15",
+              "alternative_name": "-ms-text-combine-horizontal"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": true,
+              "alternative_name": "-ms-text-combine-horizontal"
             },
             "firefox": [
               {
@@ -104,8 +106,7 @@
               }
             ],
             "ie": {
-              "version_added": "11",
-              "alternative_name": "-ms-text-combine-horizontal"
+              "version_added": false
             },
             "opera": [
               {
@@ -190,7 +191,7 @@
                 "notes": "Firefox recognizes this value but does not yet implement layout support for tate-chū-yoko (see <a href='https://bugzil.la/1258635'>bug 1258635</a>)."
               },
               "ie": {
-                "version_added": true
+                "version_added": false
               },
               "opera": {
                 "version_added": false


### PR DESCRIPTION
Internet Explorer doesn't recognize the property or its specified alternative name, however Edge does.  (This was determined based upon manual testing.)