### PR TITLE
Updated CSS transition events for Google Chrome

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -3152,7 +3152,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/transitioncancel_event",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "74"
             },
             "chrome_android": {
               "version_added": false
@@ -3204,7 +3204,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/transitionend_event",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "74"
             },
             "chrome_android": {
               "version_added": false
@@ -3256,7 +3256,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/transitionrun_event",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "74"
             },
             "chrome_android": {
               "version_added": false
@@ -3308,7 +3308,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/transitionstart_event",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "74"
             },
             "chrome_android": {
               "version_added": false

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -3155,7 +3155,7 @@
               "version_added": "74"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "74"
             },
             "edge": {
               "version_added": null
@@ -3188,7 +3188,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "74"
             }
           },
           "status": {
@@ -3207,7 +3207,7 @@
               "version_added": "74"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "74"
             },
             "edge": {
               "version_added": null
@@ -3240,7 +3240,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "74"
             }
           },
           "status": {
@@ -3259,7 +3259,7 @@
               "version_added": "74"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "74"
             },
             "edge": {
               "version_added": null
@@ -3292,7 +3292,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "74"
             }
           },
           "status": {
@@ -3311,7 +3311,7 @@
               "version_added": "74"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "74"
             },
             "edge": {
               "version_added": null
@@ -3344,7 +3344,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "74"
             }
           },
           "status": {


### PR DESCRIPTION
CSS transition events are available since Google Chrome 74.
https://developers.google.com/web/updates/2019/04/nic74#transition-events
