### PR TITLE
Update Edge/IE support for CSS hyphens

### DIFF
--- a/css/properties/hyphens.json
+++ b/css/properties/hyphens.json
@@ -29,10 +29,14 @@
             "edge": {
               "prefix": "-ms-",
               "version_added": "12",
-              "notes": "Automatic hyphenation only works for languages with hyphenation dictionaries that are integrated into Internet Explorer."
+              "partial_implementation": true,
+              "notes": "Only works if the specified language is the same as the language of the underlying OS."
             },
             "edge_mobile": {
-              "version_added": null
+              "prefix": "-ms-",
+              "version_added": "12",
+              "partial_implementation": true,
+              "notes": "Only works if the specified language is the same as the language of the underlying OS."
             },
             "firefox": [
               {
@@ -57,7 +61,8 @@
             "ie": {
               "prefix": "-ms-",
               "version_added": "10",
-              "notes": "Automatic hyphenation only works for languages with hyphenation dictionaries that are integrated into Internet Explorer."
+              "partial_implementation": true,
+              "notes": "Only works if the specified language is the same as the language of the underlying OS."
             },
             "opera": {
               "version_added": "44",
@@ -105,10 +110,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8"
@@ -156,10 +161,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8"
@@ -207,10 +212,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8"
@@ -258,10 +263,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8"
@@ -270,7 +275,7 @@
                 "version_added": "8"
               },
               "ie": {
-                "version_added": "10"
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -309,10 +314,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8"
@@ -321,7 +326,7 @@
                 "version_added": "8"
               },
               "ie": {
-                "version_added": "10"
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -360,10 +365,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -372,7 +377,7 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": "10"
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -411,10 +416,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8"
@@ -462,10 +467,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8"
@@ -513,10 +518,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8"
@@ -525,7 +530,7 @@
                 "version_added": "8"
               },
               "ie": {
-                "version_added": "10"
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -564,10 +569,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8"
@@ -576,7 +581,7 @@
                 "version_added": "8"
               },
               "ie": {
-                "version_added": "10"
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -615,10 +620,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8"
@@ -627,7 +632,7 @@
                 "version_added": "8"
               },
               "ie": {
-                "version_added": "10"
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -666,10 +671,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8"
@@ -678,7 +683,7 @@
                 "version_added": "8"
               },
               "ie": {
-                "version_added": "10"
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -717,10 +722,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "9"
@@ -768,10 +773,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8"
@@ -780,7 +785,7 @@
                 "version_added": "8"
               },
               "ie": {
-                "version_added": "10"
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -819,10 +824,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8"
@@ -831,7 +836,7 @@
                 "version_added": "8"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -870,10 +875,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8"
@@ -882,7 +887,7 @@
                 "version_added": "8"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -921,10 +926,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "9"
@@ -972,10 +977,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8"
@@ -1023,10 +1028,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8"
@@ -1074,10 +1079,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "9"
@@ -1086,7 +1091,7 @@
                 "version_added": "9"
               },
               "ie": {
-                "version_added": "10"
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -1125,10 +1130,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8"
@@ -1176,10 +1181,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8"
@@ -1227,10 +1232,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8"
@@ -1278,10 +1283,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8"
@@ -1329,10 +1334,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8"
@@ -1341,7 +1346,7 @@
                 "version_added": "8"
               },
               "ie": {
-                "version_added": "10"
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -1380,10 +1385,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8"
@@ -1392,7 +1397,7 @@
                 "version_added": "8"
               },
               "ie": {
-                "version_added": "10"
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -1431,10 +1436,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "31"
@@ -1443,7 +1448,7 @@
                 "version_added": "31"
               },
               "ie": {
-                "version_added": "10"
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -1482,10 +1487,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8"
@@ -1494,7 +1499,7 @@
                 "version_added": "8"
               },
               "ie": {
-                "version_added": "10"
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -1533,10 +1538,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8",
@@ -1547,7 +1552,7 @@
                 "notes": "For Brazilian Portuguese, Firefox uses a Portuguese dictionary."
               },
               "ie": {
-                "version_added": "10"
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -1586,10 +1591,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8"
@@ -1598,7 +1603,7 @@
                 "version_added": "8"
               },
               "ie": {
-                "version_added": "10"
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -1637,10 +1642,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8"
@@ -1688,10 +1693,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8"
@@ -1700,7 +1705,7 @@
                 "version_added": "8"
               },
               "ie": {
-                "version_added": "10"
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -1739,10 +1744,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8"
@@ -1751,7 +1756,7 @@
                 "version_added": "8"
               },
               "ie": {
-                "version_added": "10"
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -1790,10 +1795,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "9"
@@ -1802,7 +1807,7 @@
                 "version_added": "9"
               },
               "ie": {
-                "version_added": "10"
+                "version_added": false
               },
               "opera": {
                 "version_added": null
@@ -1841,10 +1846,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "9"
@@ -1892,10 +1897,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8"
@@ -1943,10 +1948,10 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "8"


### PR DESCRIPTION
I've been trying to research this, but I can't find evidence that these two are supported in IE.
In this test code it doesn't work in IE for me: https://jsfiddle.net/xrtd60qc/3/

I think we should go with `false` until someone proofs otherwise.