### PR TITLE
updating fx compat data for dynamic imports

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1894,28 +1894,38 @@
               "edge_mobile": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "66",
-                "flags": [
-                  {
-                    "name": "javascript.options.dynamicImport",
-                    "type": "preference",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "See <a href='https://bugzil.la/1517546'>bug 1517546</a>. This flag is enabled by default on nightly builds from Nightly 67. See <a href='https://bugzil.la/1522491'>bug 1522491</a>."
-              },
-              "firefox_android": {
-                "version_added": "66",
-                "flags": [
-                  {
-                    "name": "javascript.options.dynamicImport",
-                    "type": "preference",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "See <a href='https://bugzil.la/1517546'>bug 1517546</a>. This flag is enabled by default on nightly builds from Nightly 67. See <a href='https://bugzil.la/1522491'>bug 1522491</a>."
-              },
+              "firefox": [
+                {
+                  "version_added": "67"
+                },
+                {
+                  "version_added": "66",
+                  "version_removed": "67",
+                  "flags": [
+                    {
+                      "name": "javascript.options.dynamicImport",
+                      "type": "preference",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "67"
+                },
+                {
+                  "version_added": "66",
+                  "version_removed": "67",
+                  "flags": [
+                    {
+                      "name": "javascript.options.dynamicImport",
+                      "type": "preference",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1517546, Firefox 67 now supports dynamic imports by default.