### PR TITLE
EXT_float_blend not behind a pref on Firefox

### DIFF
--- a/api/EXT_float_blend.json
+++ b/api/EXT_float_blend.json
@@ -17,14 +17,7 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": "67",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "webgl.enable-draft-extensions",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": "67"
           },
           "firefox_android": {
             "version_added": false


### PR DESCRIPTION
The 67 update actually removes the pref that this used to hide
behind, so I've removed that from the data.

Source: https://bugzilla.mozilla.org/show_bug.cgi?id=1535808
