### PR TITLE
CSS cursor: Firefox 32x32 px limit & no Firefox Android support

### DIFF
--- a/css/properties/cursor.json
+++ b/css/properties/cursor.json
@@ -22,7 +22,7 @@
               "notes": "Starting in Firefox 67, the maximum size allowed for custom cursors is 32x32 pixels due to cursors being misused by certain malicious sites."
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": false
             },
             "ie": {
               "version_added": "4",
@@ -73,7 +73,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": false
               },
               "ie": {
                 "version_added": "4"
@@ -124,7 +124,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": false
               },
               "ie": {
                 "version_added": "4"
@@ -175,7 +175,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": false
               },
               "ie": {
                 "version_added": "8"
@@ -226,7 +226,7 @@
                 "version_added": "3"
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": false
               },
               "ie": {
                 "version_added": "9"
@@ -280,8 +280,7 @@
                 "notes": "This cursor is only supported on macOS and Linux."
               },
               "firefox_android": {
-                "version_added": "4",
-                "notes": "This cursor is only supported on macOS and Linux."
+                "version_added": false
               },
               "ie": {
                 "version_added": "10"
@@ -332,7 +331,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": false
               },
               "ie": {
                 "version_added": "4"
@@ -383,7 +382,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": false
               },
               "ie": {
                 "version_added": "6"
@@ -434,7 +433,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": false
               },
               "ie": {
                 "version_added": "6"
@@ -485,7 +484,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": false
               },
               "ie": {
                 "version_added": "4"
@@ -536,7 +535,7 @@
                 "version_added": "1.5"
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": false
               },
               "ie": {
                 "version_added": "10"
@@ -587,7 +586,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": false
               },
               "ie": {
                 "version_added": "4"
@@ -638,7 +637,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": false
               },
               "ie": {
                 "version_added": "4"
@@ -689,7 +688,7 @@
                 "version_added": "1.5"
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": false
               },
               "ie": {
                 "version_added": false
@@ -740,7 +739,7 @@
                 "version_added": "1.5"
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": false
               },
               "ie": {
                 "version_added": "10"
@@ -791,7 +790,7 @@
                 "version_added": "1.5"
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": false
               },
               "ie": {
                 "version_added": "10"
@@ -842,7 +841,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": false
               },
               "ie": {
                 "version_added": "4"
@@ -893,7 +892,7 @@
                 "version_added": "1.5"
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": false
               },
               "ie": {
                 "version_added": "6"
@@ -944,7 +943,7 @@
                 "version_added": "1.5"
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": false
               },
               "ie": {
                 "version_added": "6"
@@ -995,7 +994,7 @@
                 "version_added": "1.5"
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": false
               },
               "ie": {
                 "version_added": "6"
@@ -1046,7 +1045,7 @@
                 "version_added": "1.5"
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": false
               },
               "ie": {
                 "version_added": "6"
@@ -1097,7 +1096,7 @@
                 "version_added": "1.5"
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": false
               },
               "ie": {
                 "version_added": "6"
@@ -1148,7 +1147,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": false
               },
               "ie": {
                 "version_added": "4"
@@ -1199,7 +1198,7 @@
                 "version_added": "1.5"
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": false
               },
               "ie": {
                 "version_added": "10"
@@ -1267,15 +1266,9 @@
                   "version_added": "1"
                 }
               ],
-              "firefox_android": [
-                {
-                  "version_added": "24"
-                },
-                {
-                  "prefix": "-moz-",
-                  "version_added": "4"
-                }
-              ],
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -1366,15 +1359,9 @@
                   "version_added": "1.5"
                 }
               ],
-              "firefox_android": [
-                {
-                  "version_added": "27"
-                },
-                {
-                  "prefix": "-moz-",
-                  "version_added": "4"
-                }
-              ],
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -1439,8 +1426,7 @@
                 "notes": "Firefox 4 added macOS support."
               },
               "firefox_android": {
-                "version_added": "4",
-                "notes": "Firefox 4 added macOS support."
+                "version_added": false
               },
               "ie": {
                 "version_added": "6"
@@ -1492,8 +1478,7 @@
                 "notes": "Firefox 4 added macOS support."
               },
               "firefox_android": {
-                "version_added": "4",
-                "notes": "Firefox 4 added macOS support."
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/css/properties/cursor.json
+++ b/css/properties/cursor.json
@@ -18,7 +18,8 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "Starting in Firefox 67, the maximum size allowed for custom cursors is 32x32 pixels due to cursors being misused by certain malicious sites."
             },
             "firefox_android": {
               "version_added": "4"


### PR DESCRIPTION
This adds a note that Firefox 67 and later limit cursors to no larger
than 32x32 pixels. In addition, some version numbers are corrected;
most notably, because  the `cursor` property does nothing on Firefox
for Android, I've changed every entry to say `false` for `version_added`
there.

Source: https://bugzilla.mozilla.org/show_bug.cgi?id=1445844

Also, KWierso plugged a mouse into his phone and tested that neither
Focus nor Firefox for Android support the `cursor` property.