### PR TITLE
Fix Bug 1548460

### DIFF
--- a/javascript/builtins/BigInt.json
+++ b/javascript/builtins/BigInt.json
@@ -18,7 +18,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "67",
+              "version_added": "68",
               "flags": [
                 {
                   "type": "preference",


### PR DESCRIPTION
# Description of fixing Bug 1548460 #

## Background ##

Bug 1548460 managed by Bugzilla is regarded to the invalid response of inputing JavaScript bigint in Firefox console originally. However, the resolution demostrates the feature may be a WONTFIX in Firefox 67 and has been marked as FIXED in Firefox 68 nightly build. (See [the comment 5 of bugzilla discussion](https://bugzilla.mozilla.org/show_bug.cgi?id=1548460#c5) )

## Scope ##

- [JavaScript bigint page, *Browser Compatibility* section](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#Browser_compatibility)

## Purpose ##

- Change the corresponding content in MDN pages to consolidate changes in the genuine release information

## Summary ##

- Change Javascript bigint availability version in Firefox [from Firefox 67 to Firefox 68](https://github.com/mdn/browser-compat-data/pull/4112/files)
- The change [passed](https://travis-ci.org/mdn/browser-compat-data/builds/530159819?utm_source=github_status&utm_medium=notification) CI.

## Reference ##

- *javascript bigint is all null in the console of version 67 after enabled*. updated on 2019-05-09. https://bugzilla.mozilla.org/show_bug.cgi?id=1548460
- *Browser compatibility* section in the page *BigInt* of *MDN JavaScript reference*. last updated on Mar 21, 2019. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#Browser_compatibility

---
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any