### PR TITLE
Add Chrome version for css.properties.border-radius.percentages

### DIFF
--- a/css/properties/border-radius.json
+++ b/css/properties/border-radius.json
@@ -207,11 +207,10 @@
             "description": "Percentages",
             "support": {
               "chrome": {
-                "version_added": true,
-                "notes": "<code>&lt;percentage&gt;</code> values are not supported in older Chrome and Safari versions (it was <a href='http://trac.webkit.org/changeset/66615'>fixed in Sepember 2010</a>)."
+                "version_added": "8"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "8"
               },
               "edge": {
                 "version_added": "12"
@@ -237,19 +236,16 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": "5.1",
-                "notes": "<code>&lt;percentage&gt;</code> values are not supported in older Chrome and Safari versions (it was <a href='http://trac.webkit.org/changeset/66615'>fixed in Sepember 2010</a>)."
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": true,
-                "notes": "<code>&lt;percentage&gt;</code> values are not supported in older Chrome and Safari versions (it was <a href='http://trac.webkit.org/changeset/66615'>fixed in Sepember 2010</a>)."
+                "version_added": true
               },
               "samsunginternet_android": {
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true,
-                "notes": "<code>&lt;percentage&gt;</code> values are not supported in older Chrome and Safari versions (it was <a href='http://trac.webkit.org/changeset/66615'>fixed in Sepember 2010</a>)."
+                "version_added": true
               }
             },
             "status": {

--- a/css/properties/border-radius.json
+++ b/css/properties/border-radius.json
@@ -210,7 +210,7 @@
                 "version_added": "8"
               },
               "chrome_android": {
-                "version_added": "8"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -233,7 +233,7 @@
                 "notes": "The implementation of <code>&lt;percentage&gt;</code> values was buggy in Opera prior to 11.50."
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "11.5"
               },
               "safari": {
                 "version_added": "5.1"


### PR DESCRIPTION
Chrome version was based upon date of https://trac.webkit.org/changeset/66615/webkit and Chrome feature freeze spreadsheet shared by Joe Medley.
