### PR TITLE
Add Chrome -webkit- prefix versions for animation properties

### DIFF
--- a/css/properties/animation-delay.json
+++ b/css/properties/animation-delay.json
@@ -11,7 +11,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "3"
               }
             ],
             "chrome_android": [
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "3"
               }
             ],
             "edge": {

--- a/css/properties/animation-delay.json
+++ b/css/properties/animation-delay.json
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "3"
+                "version_added": "18"
               }
             ],
             "edge": {

--- a/css/properties/animation-direction.json
+++ b/css/properties/animation-direction.json
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "3"
+                "version_added": "18"
               }
             ],
             "edge": [

--- a/css/properties/animation-direction.json
+++ b/css/properties/animation-direction.json
@@ -11,7 +11,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "3"
               }
             ],
             "chrome_android": [
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "3"
               }
             ],
             "edge": [

--- a/css/properties/animation-fill-mode.json
+++ b/css/properties/animation-fill-mode.json
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "3"
+                "version_added": "18"
               }
             ],
             "edge": [

--- a/css/properties/animation-fill-mode.json
+++ b/css/properties/animation-fill-mode.json
@@ -11,7 +11,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "3"
               }
             ],
             "chrome_android": [
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "3"
               }
             ],
             "edge": [

--- a/css/properties/animation-iteration-count.json
+++ b/css/properties/animation-iteration-count.json
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "3"
+                "version_added": "18"
               }
             ],
             "edge": [

--- a/css/properties/animation-iteration-count.json
+++ b/css/properties/animation-iteration-count.json
@@ -11,7 +11,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "3"
               }
             ],
             "chrome_android": [
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "3"
               }
             ],
             "edge": [

--- a/css/properties/animation-name.json
+++ b/css/properties/animation-name.json
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "3"
+                "version_added": "18"
               }
             ],
             "edge": [

--- a/css/properties/animation-name.json
+++ b/css/properties/animation-name.json
@@ -11,7 +11,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "3"
               }
             ],
             "chrome_android": [
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "3"
               }
             ],
             "edge": [

--- a/css/properties/animation-play-state.json
+++ b/css/properties/animation-play-state.json
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "3"
+                "version_added": "18"
               }
             ],
             "edge": [

--- a/css/properties/animation-play-state.json
+++ b/css/properties/animation-play-state.json
@@ -11,7 +11,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "3"
               }
             ],
             "chrome_android": [
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "3"
               }
             ],
             "edge": [

--- a/css/properties/animation-timing-function.json
+++ b/css/properties/animation-timing-function.json
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "3"
+                "version_added": "18"
               }
             ],
             "edge": [

--- a/css/properties/animation-timing-function.json
+++ b/css/properties/animation-timing-function.json
@@ -11,7 +11,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "3"
               }
             ],
             "chrome_android": [
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "3"
               }
             ],
             "edge": [

--- a/css/properties/animation.json
+++ b/css/properties/animation.json
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "3"
+                "version_added": "18"
               }
             ],
             "edge": [

--- a/css/properties/animation.json
+++ b/css/properties/animation.json
@@ -11,7 +11,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "3"
               }
             ],
             "chrome_android": [
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "3"
               }
             ],
             "edge": [


### PR DESCRIPTION
The animation-duration property had "3" set for the -webkit- prefix.  This PR mirrors that same version number across all animation properties.
