### PR TITLE
CSS viewport lengths: Move Firefox specific details into notes

### DIFF
--- a/css/types/length-percentage.json
+++ b/css/types/length-percentage.json
@@ -687,10 +687,12 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "19"
+                "version_added": "19",
+                "notes": "Starting with version 21, viewport-percentage lengths are invalid in <code>@page</code>."
               },
               "firefox_android": {
-                "version_added": "19"
+                "version_added": "19",
+                "notes": "Starting with version 21, viewport-percentage lengths are invalid in <code>@page</code>."
               },
               "ie": {
                 "version_added": false
@@ -750,10 +752,12 @@
                 }
               ],
               "firefox": {
-                "version_added": "19"
+                "version_added": "19",
+                "notes": "Starting with version 21, viewport-percentage lengths are invalid in <code>@page</code>."
               },
               "firefox_android": {
-                "version_added": "19"
+                "version_added": "19",
+                "notes": "Starting with version 21, viewport-percentage lengths are invalid in <code>@page</code>."
               },
               "ie": [
                 {
@@ -807,10 +811,12 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "19"
+                "version_added": "19",
+                "notes": "Starting with version 21, viewport-percentage lengths are invalid in <code>@page</code>."
               },
               "firefox_android": {
-                "version_added": "19"
+                "version_added": "19",
+                "notes": "Starting with version 21, viewport-percentage lengths are invalid in <code>@page</code>."
               },
               "ie": {
                 "version_added": "9"
@@ -832,57 +838,6 @@
               },
               "webview_android": {
                 "version_added": true
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "viewport_lengths_invalid_in_paged_media": {
-          "__compat": {
-            "description": "Viewport-percentage lengths invalid in <code>@page</code>",
-            "support": {
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": "21"
-              },
-              "firefox_android": {
-                "version_added": "21"
-              },
-              "ie": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": null
-              },
-              "webview_android": {
-                "version_added": null
               }
             },
             "status": {

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -585,10 +585,12 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "19"
+                "version_added": "19",
+                "notes": "Starting with version 21, viewport-percentage lengths are invalid in <code>@page</code>."
               },
               "firefox_android": {
-                "version_added": "19"
+                "version_added": "19",
+                "notes": "Starting with version 21, viewport-percentage lengths are invalid in <code>@page</code>."
               },
               "ie": {
                 "version_added": "9"
@@ -687,10 +689,12 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": "19"
+                "version_added": "19",
+                "notes": "Starting with version 21, viewport-percentage lengths are invalid in <code>@page</code>."
               },
               "firefox_android": {
-                "version_added": "19"
+                "version_added": "19",
+                "notes": "Starting with version 21, viewport-percentage lengths are invalid in <code>@page</code>."
               },
               "ie": {
                 "version_added": false
@@ -750,10 +754,12 @@
                 }
               ],
               "firefox": {
-                "version_added": "19"
+                "version_added": "19",
+                "notes": "Starting with version 21, viewport-percentage lengths are invalid in <code>@page</code>."
               },
               "firefox_android": {
-                "version_added": "19"
+                "version_added": "19",
+                "notes": "Starting with version 21, viewport-percentage lengths are invalid in <code>@page</code>."
               },
               "ie": [
                 {
@@ -807,10 +813,12 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "19"
+                "version_added": "19",
+                "notes": "Starting with version 21, viewport-percentage lengths are invalid in <code>@page</code>."
               },
               "firefox_android": {
-                "version_added": "19"
+                "version_added": "19",
+                "notes": "Starting with version 21, viewport-percentage lengths are invalid in <code>@page</code>."
               },
               "ie": {
                 "version_added": "9"
@@ -832,57 +840,6 @@
               },
               "webview_android": {
                 "version_added": true
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "viewport_lengths_invalid_in_paged_media": {
-          "__compat": {
-            "description": "Viewport-percentage lengths invalid in <code>@page</code>",
-            "support": {
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": "21"
-              },
-              "firefox_android": {
-                "version_added": "21"
-              },
-              "ie": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": null
-              },
-              "webview_android": {
-                "version_added": null
               }
             },
             "status": {


### PR DESCRIPTION
See these two pages / compat tables where we only have Firefox info for "Viewport-percentage lengths invalid in @page"
https://developer.mozilla.org/en-US/docs/Web/CSS/length
https://developer.mozilla.org/en-US/docs/Web/CSS/length-percentage

I don't believe we need a separate row for this specific aspect. I would rather treat it as a note to the Firefox implementation. Thoughts?