### PR TITLE
Update :-webkit-autofill compat data

### DIFF
--- a/css/selectors/-webkit-autofill.json
+++ b/css/selectors/-webkit-autofill.json
@@ -7,16 +7,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:-webkit-autofill",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -28,22 +28,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
So, I'm trying to wrap my head around how to do archaeology for certain CSS features where we need real values and if it is worth it :) So, here's what I did for this very old feature where we only had true values:

I figured from the name that this is a webkit invention and it must have made its way into the other browsers through engine forking. So, my journey begins at searching https://github.com/WebKit/webkit/ searching for "autofill" and using git blame.

I found https://github.com/WebKit/webkit/commit/174364d6f0463bc7845106935c7d8449ace1536e which in the changelog file says "Added autofill string for "-khtml-autofill" and also other files in the diff give hints that this commit is likely the one that implemented this. This was committed on 13 Apr 2006.

Only 2 days later, 15 Apr 2006, in https://github.com/WebKit/webkit/commit/21d3140fb8ed411bc01cefa0d376f2a6c2db12c5, it was renamed to "-webkit-autofill".

Now I took the date, 15 Apr 2006, and looked up Safari releases in our browser folder and the next one after this date is Safari 3. (`"release_date": "2007-11-14"`). We don't have safari iOS release dates, so I don't know which one it could be.

As Chromium forked from webkit much later (2008), the `true` value can be changed to 1.
Other forks that then happened from Chromium are even later, so I've set their first release version respectively as well.

I'm sure Edge didn't implement this non-standard behavior, so I went from `null` to `false`.