### PR TITLE
Update :-webkit-file-upload-button compat data

### DIFF
--- a/css/selectors/-webkit-file-upload-button.json
+++ b/css/selectors/-webkit-file-upload-button.json
@@ -7,10 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-webkit-file-upload-button",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": false
@@ -28,19 +28,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
More archeology! :smile: 

The commit for WebKit is https://github.com/WebKit/webkit/commit/004104aff678b7876acc78b8491cfe6ce7935caf, thus it is Safari 3 (given the commit date).

Chromiums are derived from webkit, so I've set the versions to their first releases.