### PR TITLE
Add a test-real-values.js linter

### DIFF
--- a/test/lint.js
+++ b/test/lint.js
@@ -7,6 +7,7 @@ const chalk = require('chalk');
 const testStyle = require('./test-style');
 const testSchema = require('./test-schema');
 const testVersions = require('./test-versions');
+const testRealValues = require('./test-real-values');
 const testBrowsers = require('./test-browsers');
 const testPrefix = require('./test-prefix');
 /** @type {Map<string, string>} */
@@ -45,6 +46,7 @@ function load(...files) {
           hasStyleErrors = false,
           hasBrowserErrors = false,
           hasVersionErrors = false,
+          hasRealValueErrors = false,
           hasPrefixErrors = false;
         const relativeFilePath = path.relative(process.cwd(), file);
 
@@ -73,6 +75,7 @@ function load(...files) {
             hasStyleErrors = testStyle(file);
             hasBrowserErrors = testBrowsers(file);
             hasVersionErrors = testVersions(file);
+            hasRealValueErrors = testRealValues(file);
             hasPrefixErrors = testPrefix(file);
           }
         } catch (e) {
@@ -86,6 +89,7 @@ function load(...files) {
           hasStyleErrors,
           hasBrowserErrors,
           hasVersionErrors,
+          hasRealValueErrors,
           hasPrefixErrors,
         ].some(x => !!x);
 
@@ -139,6 +143,7 @@ if (hasErrors) {
         testSchema(file);
         testStyle(file);
         testVersions(file);
+        testRealValues(file);
         testBrowsers(file);
         testPrefix(file);
       }

--- a/test/test-real-values.js
+++ b/test/test-real-values.js
@@ -1,6 +1,5 @@
 'use strict';
 const path = require('path');
-const compareVersions = require('compare-versions');
 const chalk = require('chalk');
 
 /** @type {Record<string, string[]>} */

--- a/test/test-real-values.js
+++ b/test/test-real-values.js
@@ -87,7 +87,7 @@ function testRealValues(filename) {
       }
     }
   }
-  findSupport(data, "");
+  findSupport(data);
 
   if (errors.length) {
     console.error(chalk`{red   Real values – }{red.bold ${errors.length}}{red  ${errors.length === 1 ? 'error' : 'errors'}:}`);

--- a/test/test-real-values.js
+++ b/test/test-real-values.js
@@ -2,6 +2,22 @@
 const path = require('path');
 const chalk = require('chalk');
 
+/** @type {string[]} */
+const blockMany = [
+  'chrome',
+  'chrome_android',
+  'edge',
+  'edge_mobile',
+  'firefox',
+  'firefox_android',
+  'ie',
+  'opera',
+  'opera_android',
+  'safari',
+  'safari_ios',
+  'webview_android'
+];
+
 /** @type {Record<string, string[]>} */
 const blockList = {
   api: [],
@@ -10,8 +26,8 @@ const blockList = {
   http: [],
   svg: [],
   javascript: [],
-  mathml: [],
-  webdriver: [],
+  mathml: blockMany,
+  webdriver: blockMany.concat(['samsunginternet_android']),
   webextensions: [],
   xpath: [],
   xslt: []

--- a/test/test-real-values.js
+++ b/test/test-real-values.js
@@ -1,0 +1,98 @@
+'use strict';
+const path = require('path');
+const compareVersions = require('compare-versions');
+const chalk = require('chalk');
+
+/** @type {Record<string, string[]>} */
+const browsers = {
+  api: [],
+  css: ['ie'],
+  html: [],
+  http: [],
+  svg: [],
+  javascript: [],
+  mathml: [],
+  webdriver: [],
+  webextensions: [],
+  xpath: [],
+  xslt: []
+};
+
+/**
+ * @param {SupportBlock} supportData
+ * @param {{error:function(...unknown):void}} logger
+ */
+function checkRealValues(supportData, browsers, logger) {
+  let hasErrors = false;
+  const browsersToCheck = Object.keys(supportData);
+  for (const browser of browsersToCheck) {
+    if (browsers.includes(browser)) {
+      /** @type {SimpleSupportStatement[]} */
+      const supportStatements = [];
+      if (Array.isArray(supportData[browser])) {
+        Array.prototype.push.apply(supportStatements, supportData[browser]);
+      } else {
+        supportStatements.push(supportData[browser]);
+      }
+
+      for (const statement of supportStatements) {
+        if ([true, null].includes(statement.version_added)) {
+          logger.error(chalk`{red.bold ${browser}} {red no longer accepts} {red.bold ${statement.version_added}} {red as a value}`);
+          hasErrors = true;
+        }
+        if ([true, null].includes(statement.version_removed)) {
+          logger.error(chalk`{red.bold ${browser}} {red no longer accepts} {red.bold ${statement.version_removed}} {red as a value}`);
+          hasErrors = true;
+        }
+      }
+    }
+  }
+
+  return hasErrors;
+}
+
+/**
+ * @param {string} filename
+ */
+function testRealValues(filename) {
+  const relativePath = path.relative(path.resolve(__dirname, '..'), filename);
+  const category = relativePath.includes(path.sep) && relativePath.split(path.sep)[0];
+  /** @type {Identifier} */
+  const data = require(filename);
+
+  /** @type {string[]} */
+  const errors = [];
+  const logger = {
+    /** @param {...unknown} message */
+    error: (...message) => {
+      errors.push(message.join(' '));
+    },
+  };
+
+  /**
+   * @param {Identifier} data
+   */
+  function findSupport(data) {
+    for (const prop in data) {
+      if (prop === '__compat' && data[prop].support) {
+        if (browsers[category] && browsers[category].length > 0) checkRealValues(data[prop].support, browsers[category], logger);
+      }
+      const sub = data[prop];
+      if (typeof sub === 'object') {
+        findSupport(sub);
+      }
+    }
+  }
+  findSupport(data);
+
+  if (errors.length) {
+    console.error(chalk`{red   Real values – }{red.bold ${errors.length}}{red  ${errors.length === 1 ? 'error' : 'errors'}:}`);
+    for (const error of errors) {
+      console.error(`    ${error}`);
+    }
+    return true;
+  }
+  return false;
+}
+
+module.exports = testRealValues;

--- a/test/test-real-values.js
+++ b/test/test-real-values.js
@@ -20,9 +20,10 @@ const blockList = {
 /**
  * @param {SupportBlock} supportData
  * @param {string[]} blockList
+ * @param {string} relPath
  * @param {{error:function(...unknown):void}} logger
  */
-function checkRealValues(supportData, blockList, logger) {
+function checkRealValues(supportData, blockList, relPath, logger) {
   let hasErrors = false;
   for (const browser of blockList) {
     /** @type {SimpleSupportStatement[]} */
@@ -35,15 +36,15 @@ function checkRealValues(supportData, blockList, logger) {
 
     for (const statement of supportStatements) {
       if (statement === undefined) {
-        logger.error(chalk`{red.bold ${browser}} {red must be defined for} {red.bold XXX}`);
+        logger.error(chalk`{red.bold ${browser}} {red must be defined for} {red.bold ${relPath}}`);
           hasErrors = true;
       } else {
         if ([true, null].includes(statement.version_added)) {
-          logger.error(chalk`{red.bold ${browser}} {red no longer accepts} {red.bold ${statement.version_added}} {red as a value}`);
+          logger.error(chalk`{red.bold ${relPath}} {red -} {red.bold ${browser}} {red no longer accepts} {red.bold ${statement.version_added}} {red as a value}`);
           hasErrors = true;
         }
         if ([true, null].includes(statement.version_removed)) {
-          logger.error(chalk`{red.bold ${browser}} {red no longer accepts} {red.bold ${statement.version_removed}} {red as a value}`);
+          logger.error(chalk`{red.bold ${relPath}} {red -} {red.bold ${browser}} {red no longer accepts} {red.bold ${statement.version_removed}} {red as a value}`);
           hasErrors = true;
         }
       }
@@ -73,19 +74,20 @@ function testRealValues(filename) {
 
   /**
    * @param {Identifier} data
+   * @param {string} relPath
    */
-  function findSupport(data) {
+  function findSupport(data, relPath) {
     for (const prop in data) {
       if (prop === '__compat' && data[prop].support) {
-        if (blockList[category] && blockList[category].length > 0) checkRealValues(data[prop].support, blockList[category], logger);
+        if (blockList[category] && blockList[category].length > 0) checkRealValues(data[prop].support, blockList[category], relPath, logger);
       }
       const sub = data[prop];
       if (typeof sub === 'object') {
-        findSupport(sub);
+        findSupport(sub, relPath ? `${relPath}.${prop}` : `${prop}`);
       }
     }
   }
-  findSupport(data);
+  findSupport(data, "");
 
   if (errors.length) {
     console.error(chalk`{red   Real values – }{red.bold ${errors.length}}{red  ${errors.length === 1 ? 'error' : 'errors'}:}`);


### PR DESCRIPTION
This PR adds a linter that prevents the use of `true` and `null` values in specified browsers for specified categories.  Currently, it's configured to disallow IE CSS values.  This fixes #4121.