### PR TITLE
Bugfix 1548460 additional request: flag removal

### DIFF
--- a/javascript/builtins/BigInt.json
+++ b/javascript/builtins/BigInt.json
@@ -18,7 +18,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "67",
+              "version_added": "68",
               "flags": [
                 {
                   "type": "preference",

--- a/javascript/builtins/BigInt.json
+++ b/javascript/builtins/BigInt.json
@@ -18,14 +18,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "68",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "javascript.options.bigint",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "68"
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
# Bugfix 1548460 additional request: Flag Removal #

## Background ##

Based on the change (PR #4112 ), it is just acknowledged that the bigint feature would be released as a production-level feature in FF68. It is unecessary to enable the bigint flag in FF68 as the bigint feature would be enabled unintentionally.

## Scope ##

- [JavaScript bigint page, *Browser Compatibility* section](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#Browser_compatibility)

## Purpose ##

- Change the corresponding content in MDN pages to consolidate changes in the genuine release information

## Summary ##

- Remove flag from Firefox version on the bigint page
- The change [passed](https://github.com/mdn/browser-compat-data/pull/4123#partial-pull-merging) CI

## Reference ##

- [Comment 11 on Bug 1548460](https://bugzilla.mozilla.org/show_bug.cgi?id=1548460#c11)
- PR #4112
- Browser compatibility section in the page *BigInt of MDN JavaScript reference*. last updated on 2019-05-09. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#Browser_compatibility

---
A checklist to help your pull request get merged faster:

- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
