### PR TITLE
Set BigInt as supported in Firefox Android 68

### DIFF
--- a/javascript/builtins/BigInt.json
+++ b/javascript/builtins/BigInt.json
@@ -21,7 +21,7 @@
               "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Follow-up to #4112 and #4123 that mirrors the data over to Firefox Android.