### PR TITLE
Add data for toolbar_field_highlight[_text]

### DIFF
--- a/webextensions/manifest/theme.json
+++ b/webextensions/manifest/theme.json
@@ -800,6 +800,48 @@
               }
             }
           },
+          "toolbar_field_highlight": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "67"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "toolbar_field_highlight_text": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "67"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
           "toolbar_field_separator": {
             "__compat": {
               "support": {


### PR DESCRIPTION
These are added in Firefox 67 and set the highlight background
and foreground colors for the fields in the URL bar.

Source: https://bugzilla.mozilla.org/show_bug.cgi?id=1450114
