### PR TITLE
Update Node.js Object.fromEntries version

### DIFF
--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -758,7 +758,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "12.0.0"
               },
               "opera": {
                 "version_added": false


### PR DESCRIPTION
# Changes

Updated the version for Node's support for `Object.fromEntries` from `false` to `"12.0.0"`

# Verification

As can be seen in the photo below, on the latest version of Node 11 (11.15.0), `Object.fromEntries` is logged as `undefined`. And on the first version of Node 12 (12.0.0), `Object.fromEntries` is logged as `[Function: fromEntries]`.

![Node Object fromEntries support](https://user-images.githubusercontent.com/19195374/57578511-36118d80-744b-11e9-886b-6ccadc334581.png)
