### PR TITLE
Update support for api.Navigator.oscpu

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1502,10 +1502,10 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": true
@@ -1514,22 +1514,22 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
Fixes #4141.  Manually tested in Chrome, Opera, Safari, and Firefox.