### PR TITLE
Update Event.eventPhase for ie

### DIFF
--- a/api/Event.json
+++ b/api/Event.json
@@ -553,7 +553,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": "32"

--- a/api/Event.json
+++ b/api/Event.json
@@ -553,7 +553,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": "32"


### PR DESCRIPTION
I've visited the URL [https://developer.mozilla.org/en-US/docs/Web/API/Event/eventPhase](https://developer.mozilla.org/en-US/docs/Web/API/Event/eventPhase) on internet explorer 11 and executed the given example and it successfully ran which implies that it's supported.
