### PR TITLE
Firefox 67 releases on 2019-05-21

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -495,7 +495,7 @@
           "engine_version": "66"
         },
         "67": {
-          "release_date": "2019-05-14",
+          "release_date": "2019-05-21",
           "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/67",
           "status": "beta",
           "engine": "Gecko",

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -425,7 +425,7 @@
           "engine_version": "66"
         },
         "67": {
-          "release_date": "2019-05-14",
+          "release_date": "2019-05-21",
           "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/67",
           "status": "beta",
           "engine": "Gecko",


### PR DESCRIPTION
Firefox 67 release was delayed for a week.
https://wiki.mozilla.org/Release_Management/Calendar