### PR TITLE
IE compatibility wrongly documented for elementsFromPoint()

### DIFF
--- a/api/DocumentOrShadowRoot.json
+++ b/api/DocumentOrShadowRoot.json
@@ -270,10 +270,10 @@
               "notes": "Before Chrome 66, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
             },
             "edge": {
-              "version_added": true
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "?"
             },
             "firefox": {
               "version_added": "63"
@@ -282,7 +282,7 @@
               "version_added": "63"
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": "40"

--- a/api/DocumentOrShadowRoot.json
+++ b/api/DocumentOrShadowRoot.json
@@ -270,10 +270,10 @@
               "notes": "Before Chrome 66, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": true
             },
             "edge_mobile": {
-              "version_added": "?"
+              "version_added": true
             },
             "firefox": {
               "version_added": "63"
@@ -282,7 +282,8 @@
               "version_added": "63"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10",
+              "notes": "Uses prefixed version <code>document.msElementsFromPoint()</code>"
             },
             "opera": {
               "version_added": "40"


### PR DESCRIPTION
I have tracked down the original commit (#1181) but it did not state source.
This came from my own learnings while working on a project.