### PR TITLE
Update list-style-type part 5 (S to T)

### DIFF
--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -2114,6 +2114,63 @@
             }
           }
         },
+        "sidama": {
+          "__compat": {
+            "description": "<code>sidama</code>",
+            "support": {
+              "chrome": {
+                "version_added": "6",
+                "version_removed": "45"
+              },
+              "chrome_android": {
+                "version_added": "18",
+                "version_removed": "45"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15",
+                "version_removed": "32"
+              },
+              "opera_android": {
+                "version_added": "14",
+                "version_removed": "32"
+              },
+              "safari": {
+                "version_added": "4.1"
+              },
+              "safari_ios": {
+                "version_added": "4.2"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0",
+                "version_removed": "5.0"
+              },
+              "webview_android": {
+                "version_added": "1",
+                "version_removed": "45"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "simp-chinese-formal": {
           "__compat": {
             "description": "<code>simp-chinese-formal</code>",
@@ -2139,9 +2196,15 @@
                   "version_added": "1"
                 }
               ],
-              "firefox_android": {
-                "version_added": true
-              },
+              "firefox_android": [
+                {
+                  "version_added": "28"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -2196,9 +2259,15 @@
                   "version_added": "1"
                 }
               ],
-              "firefox_android": {
-                "version_added": true
-              },
+              "firefox_android": [
+                {
+                  "version_added": "28"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -2223,6 +2292,114 @@
             },
             "status": {
               "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "somali": {
+          "__compat": {
+            "description": "<code>somali</code>",
+            "support": {
+              "chrome": {
+                "version_added": "6",
+                "version_removed": "45"
+              },
+              "chrome_android": {
+                "version_added": "18",
+                "version_removed": "45"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15",
+                "version_removed": "32"
+              },
+              "opera_android": {
+                "version_added": "14",
+                "version_removed": "32"
+              },
+              "safari": {
+                "version_added": "4.1"
+              },
+              "safari_ios": {
+                "version_added": "4.2"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0",
+                "version_removed": "5.0"
+              },
+              "webview_android": {
+                "version_added": "1",
+                "version_removed": "45"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "square": {
+          "__compat": {
+            "description": "<code>square</code>",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": "18"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "4"
+              },
+              "opera": {
+                "version_added": "3.5"
+              },
+              "opera_android": {
+                "version_added": "10.1"
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": "1"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0"
+              },
+              "webview_android": {
+                "version_added": "1"
+              }
+            },
+            "status": {
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -2296,10 +2473,10 @@
             "description": "<code>telugu</code>",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "6"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": false
@@ -2329,22 +2506,22 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "14"
               },
               "safari": {
-                "version_added": true
+                "version_added": "4.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -2359,10 +2536,10 @@
             "description": "<code>thai</code>",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "6"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": false
@@ -2392,26 +2569,362 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "14"
               },
               "safari": {
-                "version_added": true
+                "version_added": "4.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
               "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "tibetan": {
+          "__compat": {
+            "description": "<code>tibetan</code>",
+            "support": {
+              "chrome": {
+                "version_added": "6"
+              },
+              "chrome_android": {
+                "version_added": "18"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "33"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": "14"
+              },
+              "safari": {
+                "version_added": "4.1"
+              },
+              "safari_ios": {
+                "version_added": "4.2"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0"
+              },
+              "webview_android": {
+                "version_added": "1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "tigre": {
+          "__compat": {
+            "description": "<code>tigre</code>",
+            "support": {
+              "chrome": {
+                "version_added": "6",
+                "version_removed": "45"
+              },
+              "chrome_android": {
+                "version_added": "18",
+                "version_removed": "45"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15",
+                "version_removed": "32"
+              },
+              "opera_android": {
+                "version_added": "14",
+                "version_removed": "32"
+              },
+              "safari": {
+                "version_added": "4.1"
+              },
+              "safari_ios": {
+                "version_added": "4.2"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0",
+                "version_removed": "5.0"
+              },
+              "webview_android": {
+                "version_added": "1",
+                "version_removed": "45"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "tigrinya-er": {
+          "__compat": {
+            "description": "<code>tigrinya-er</code>",
+            "support": {
+              "chrome": {
+                "version_added": "6",
+                "version_removed": "45"
+              },
+              "chrome_android": {
+                "version_added": "18",
+                "version_removed": "45"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15",
+                "version_removed": "32"
+              },
+              "opera_android": {
+                "version_added": "14",
+                "version_removed": "32"
+              },
+              "safari": {
+                "version_added": "4.1"
+              },
+              "safari_ios": {
+                "version_added": "4.2"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0",
+                "version_removed": "5.0"
+              },
+              "webview_android": {
+                "version_added": "1",
+                "version_removed": "45"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "tigrinya-er-abegede": {
+          "__compat": {
+            "description": "<code>tigrinya-er-abegede</code>",
+            "support": {
+              "chrome": {
+                "version_added": "6",
+                "version_removed": "45"
+              },
+              "chrome_android": {
+                "version_added": "18",
+                "version_removed": "45"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15",
+                "version_removed": "32"
+              },
+              "opera_android": {
+                "version_added": "14",
+                "version_removed": "32"
+              },
+              "safari": {
+                "version_added": "4.1"
+              },
+              "safari_ios": {
+                "version_added": "4.2"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0",
+                "version_removed": "5.0"
+              },
+              "webview_android": {
+                "version_added": "1",
+                "version_removed": "45"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "tigrinya-et": {
+          "__compat": {
+            "description": "<code>tigrinya-et</code>",
+            "support": {
+              "chrome": {
+                "version_added": "6",
+                "version_removed": "45"
+              },
+              "chrome_android": {
+                "version_added": "18",
+                "version_removed": "45"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15",
+                "version_removed": "32"
+              },
+              "opera_android": {
+                "version_added": "14",
+                "version_removed": "32"
+              },
+              "safari": {
+                "version_added": "4.1"
+              },
+              "safari_ios": {
+                "version_added": "4.2"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0",
+                "version_removed": "5.0"
+              },
+              "webview_android": {
+                "version_added": "1",
+                "version_removed": "45"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "tigrinya-et-abegede": {
+          "__compat": {
+            "description": "<code>tigrinya-et-abegede</code>",
+            "support": {
+              "chrome": {
+                "version_added": "6",
+                "version_removed": "45"
+              },
+              "chrome_android": {
+                "version_added": "18",
+                "version_removed": "45"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15",
+                "version_removed": "32"
+              },
+              "opera_android": {
+                "version_added": "14",
+                "version_removed": "32"
+              },
+              "safari": {
+                "version_added": "4.1"
+              },
+              "safari_ios": {
+                "version_added": "4.2"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0",
+                "version_removed": "5.0"
+              },
+              "webview_android": {
+                "version_added": "1",
+                "version_removed": "45"
+              }
+            },
+            "status": {
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -2442,9 +2955,15 @@
                   "version_added": "1"
                 }
               ],
-              "firefox_android": {
-                "version_added": true
-              },
+              "firefox_android": [
+                {
+                  "version_added": "28"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -2499,9 +3018,15 @@
                   "version_added": "1"
                 }
               ],
-              "firefox_android": {
-                "version_added": true
-              },
+              "firefox_android": [
+                {
+                  "version_added": "28"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4"
+                }
+              ],
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
Please see #4148 for the research that went into this and where the version numbers come from.

This PR is for list-style-type types letters S to T.

For Chromiums I was unable to find versions for the 4 types below. They aren't in WebKit / Safari and I have no idea when they were added to blink.

simp-chinese-formal
simp-chinese-informal
trad-chinese-formal
trad-chinese-informal