### PR TITLE
Chromium supports prefers-color-scheme media query

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1247,10 +1247,10 @@
             "description": "<code>prefers-color-scheme</code> media feature",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "76"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "76"
               },
               "edge": {
                 "version_added": false
@@ -1280,7 +1280,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "76"
               }
             },
             "status": {


### PR DESCRIPTION
## Summary
As per Chrome Platform status, Chrome for desktop and Android and Android WebView support
media query prefers-color-scheme:
https://www.chromestatus.com/feature/5109758977638400

## Data
### Chrome Platform status
https://www.chromestatus.com/feature/5109758977638400

### Tests with Chrome Dev build on Windows 10
Version:
> Version 76.0.3788.1 (Official Build) dev (64-bit)

Looked at the MDN prefers-color-scheme page demo:
https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme and 

and saw this (Chrome 76.0.3788.1 on the top, Firefox 67.0b19 on the bottom; left column is "light" mode, right is "dark" mode): 
![chrome](https://user-images.githubusercontent.com/45960703/57747538-90089200-769b-11e9-926b-6647a2b93369.png)


## Related issues
The media query is officially enabled for stable release only in upcoming version 76, but some parts of it were implement earlier and enabled in developer builds (see [Chromium bug # 889087](https://bugs.chromium.org/p/chromium/issues/detail?id=889087)). Also, there were some bugs with the pre-76 implementation (e.g., see [Chromium bug # 962156](https://bugs.chromium.org/p/chromium/issues/detail?id=962156)).

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
