### PR TITLE
Add missing "webkit" prefix in api.PerformanceEntry

### DIFF
--- a/api/PerformanceEntry.json
+++ b/api/PerformanceEntry.json
@@ -9,7 +9,8 @@
               "version_added": "46"
             },
             {
-              "version_added": "25"
+              "version_added": "25",
+              "prefix": "webkit"
             }
           ],
           "chrome_android": [


### PR DESCRIPTION
Seems like this was a bad import from the original table.  Chrome had a "webkit" prefix specified for version 25 in the original BCD, but it was only copied over for Chrome Android and Webview Android.

Sub-PR of #3526 for the data itself.
