### PR TITLE
Remove doubled version_added: true in api.AnimationEvent

### DIFF
--- a/api/AnimationEvent.json
+++ b/api/AnimationEvent.json
@@ -100,22 +100,12 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AnimationEvent/AnimationEvent",
           "support": {
-            "chrome": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": true
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": true
-              }
-            ],
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": {
+              "version_added": "43"
+            },
             "edge": {
               "version_added": null
             },
@@ -146,14 +136,9 @@
             "samsunginternet_android": {
               "version_added": "4.0"
             },
-            "webview_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": true
-              }
-            ]
+            "webview_android": {
+              "version_added": "43"
+            }
           },
           "status": {
             "experimental": true,
@@ -166,22 +151,12 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AnimationEvent/animationName",
           "support": {
-            "chrome": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": true
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": true
-              }
-            ],
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": {
+              "version_added": "43"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -212,14 +187,9 @@
             "samsunginternet_android": {
               "version_added": "4.0"
             },
-            "webview_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "version_added": true
-              }
-            ]
+            "webview_android": {
+              "version_added": "43"
+            }
           },
           "status": {
             "experimental": true,


### PR DESCRIPTION
This removes the redundant "version_added: true" statements in an array with "version_added: VERSION".

Sub-PR of #3526 for the data itself.