### PR TITLE
Typo/Styling (style header value stale-if-error within <code/>)

### DIFF
--- a/http/headers/cache-control.json
+++ b/http/headers/cache-control.json
@@ -105,7 +105,7 @@
         },
         "stale-if-error": {
           "__compat": {
-            "description": "stale-if-error",
+            "description": "<code>stale-if-error</code>",
             "support": {
               "chrome": {
                 "version_added": false,


### PR DESCRIPTION
A one-liner typofix to have consistent styling for values listed on https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
There is no actual "data" change.
