### PR TITLE
Add subfeature for non-shift secondary modifier

### DIFF
--- a/webextensions/manifest/commands.json
+++ b/webextensions/manifest/commands.json
@@ -184,6 +184,28 @@
               }
             }
           }
+        },
+        "MoreSecondaryModifiers": {
+          "__compat": {
+            "description": "Secondary modifier other than <kbd>Shift</kbd>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "63"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Firefox supports keys other than <kbd>Shift</kbd> as secondary modifier.

Bug that added this to Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1364784. There is no evidence that any other browser supports this.