### PR TITLE
Add number input html compat data for Edge

### DIFF
--- a/html/elements/input/number.json
+++ b/html/elements/input/number.json
@@ -14,7 +14,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": null

--- a/html/elements/input/number.json
+++ b/html/elements/input/number.json
@@ -14,7 +14,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": true
               },
               "edge_mobile": {
                 "version_added": null


### PR DESCRIPTION
Despite lack of increment/decrement arrows in the UI, Edge has supported `<input type="number">` since it was created. A more detailed test of the compatibility can be seen here: https://quirksmode.org/html5/inputs/#t08
