### PR TITLE
Update compat data for webkit-spin-button selectors

### DIFF
--- a/css/selectors/-webkit-inner-spin-button.json
+++ b/css/selectors/-webkit-inner-spin-button.json
@@ -7,16 +7,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-webkit-inner-spin-button",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -28,22 +28,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "4.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {

--- a/css/selectors/-webkit-outer-spin-button.json
+++ b/css/selectors/-webkit-outer-spin-button.json
@@ -7,16 +7,17 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-webkit-outer-spin-button",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "6",
+              "version_removed": "13"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -28,22 +29,24 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "4.1",
+              "version_removed": "5.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "4.2",
+              "version_removed": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": true
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
webkit-inner-spin-button
Added in Safari 4.1 https://github.com/WebKit/webkit/commit/7395818ba1980f26237bed4e54be832a0aa6421f

webkit-outer-spin-button
Added in Safari 4.1 https://github.com/WebKit/webkit/commit/7395818ba1980f26237bed4e54be832a0aa6421f
Removed in Safari 5.1 https://github.com/WebKit/webkit/commit/2d7871b1f4bc92d8c4a1f9884ac868639d0bfc89

Chromium numbers are derived from the Safari versions as they both had the webkit engine back then. The others are assumed false, as this is a non-standard webkit feature.