### PR TITLE
Rename crossfade feature to reflect its actual hyphen

### DIFF
--- a/css/types/image.json
+++ b/css/types/image.json
@@ -1915,7 +1915,7 @@
             }
           }
         },
-        "crossfade": {
+        "cross-fade": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/cross-fade",
             "description": "<code>cross-fade()</code>",


### PR DESCRIPTION
The `css.types.image.crossfade` feature is for [`cross-fade()`](https://developer.mozilla.org/en-US/docs/Web/CSS/cross-fade), which has a hyphen in the name. This PR gives the feature name a hyphen too.