### PR TITLE
Fix `margin-inline-end` Safari iOS alternative

### DIFF
--- a/css/properties/margin-inline-end.json
+++ b/css/properties/margin-inline-end.json
@@ -105,7 +105,7 @@
               },
               {
                 "version_added": "3",
-                "alternative_name": "-webkit-margin-start"
+                "alternative_name": "-webkit-margin-end"
               }
             ],
             "samsunginternet_android": {


### PR DESCRIPTION
I guess this may be a mistake from https://github.com/mdn/browser-compat-data/pull/3930 or am I the one who is mistaken?