### PR TITLE
Update scroll-snap data

### DIFF
--- a/css/properties/scroll-margin-block-end.json
+++ b/css/properties/scroll-margin-block-end.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-margin-block-start.json
+++ b/css/properties/scroll-margin-block-start.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-margin-block.json
+++ b/css/properties/scroll-margin-block.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-margin-bottom.json
+++ b/css/properties/scroll-margin-bottom.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-margin-inline-end.json
+++ b/css/properties/scroll-margin-inline-end.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-margin-inline-start.json
+++ b/css/properties/scroll-margin-inline-start.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-margin-inline.json
+++ b/css/properties/scroll-margin-inline.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-margin-left.json
+++ b/css/properties/scroll-margin-left.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-margin-right.json
+++ b/css/properties/scroll-margin-right.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-margin-top.json
+++ b/css/properties/scroll-margin-top.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-margin.json
+++ b/css/properties/scroll-margin.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-padding-block-end.json
+++ b/css/properties/scroll-padding-block-end.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-padding-block-start.json
+++ b/css/properties/scroll-padding-block-start.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-padding-block.json
+++ b/css/properties/scroll-padding-block.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-padding-bottom.json
+++ b/css/properties/scroll-padding-bottom.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-padding-inline-end.json
+++ b/css/properties/scroll-padding-inline-end.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-padding-inline-start.json
+++ b/css/properties/scroll-padding-inline-start.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-padding-inline.json
+++ b/css/properties/scroll-padding-inline.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-padding-left.json
+++ b/css/properties/scroll-padding-left.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-padding-right.json
+++ b/css/properties/scroll-padding-right.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-padding-top.json
+++ b/css/properties/scroll-padding-top.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-padding.json
+++ b/css/properties/scroll-padding.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-snap-align.json
+++ b/css/properties/scroll-snap-align.json
@@ -18,10 +18,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-snap-coordinate.json
+++ b/css/properties/scroll-snap-coordinate.json
@@ -18,12 +18,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "39",
-              "version_removed": "68"
+              "version_removed": "68",
+              "version_added": "39"
             },
             "firefox_android": {
-              "version_added": "46",
-              "version_removed": "68"
+              "version_removed": "68",
+              "version_added": "39"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-snap-coordinate.json
+++ b/css/properties/scroll-snap-coordinate.json
@@ -18,23 +18,13 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "39"
+              "version_added": "39",
+              "version_removed": "68"
             },
-            "firefox_android": [
-              {
-                "version_added": "46"
-              },
-              {
-                "version_added": "39",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.scroll-snap.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "46",
+              "version_removed": "68"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/scroll-snap-destination.json
+++ b/css/properties/scroll-snap-destination.json
@@ -18,12 +18,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "39",
-              "version_removed": "68"
+              "version_removed": "68",
+              "version_added": "39"
             },
             "firefox_android": {
-              "version_added": "46",
-              "version_removed": "68"
+              "version_removed": "68",
+              "version_added": "39"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-snap-destination.json
+++ b/css/properties/scroll-snap-destination.json
@@ -18,23 +18,13 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "39"
+              "version_added": "39",
+              "version_removed": "68"
             },
-            "firefox_android": [
-              {
-                "version_added": "46"
-              },
-              {
-                "version_added": "39",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.scroll-snap.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "46",
+              "version_removed": "68"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/scroll-snap-points-x.json
+++ b/css/properties/scroll-snap-points-x.json
@@ -18,12 +18,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "39",
-              "version_removed": "68"
+              "version_removed": "68",
+              "version_added": "39"
             },
             "firefox_android": {
-              "version_added": "46",
-              "version_removed": "68"
+              "version_removed": "68",
+              "version_added": "39"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-snap-points-x.json
+++ b/css/properties/scroll-snap-points-x.json
@@ -18,23 +18,13 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "39"
+              "version_added": "39",
+              "version_removed": "68"
             },
-            "firefox_android": [
-              {
-                "version_added": "46"
-              },
-              {
-                "version_added": "39",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.scroll-snap.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "46",
+              "version_removed": "68"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/scroll-snap-points-y.json
+++ b/css/properties/scroll-snap-points-y.json
@@ -18,12 +18,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "39",
-              "version_removed": "68"
+              "version_removed": "68",
+              "version_added": "39"
             },
             "firefox_android": {
-              "version_added": "46",
-              "version_removed": "68"
+              "version_removed": "68",
+              "version_added": "39"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-snap-points-y.json
+++ b/css/properties/scroll-snap-points-y.json
@@ -18,23 +18,13 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "39"
+              "version_added": "39",
+              "version_removed": "68"
             },
-            "firefox_android": [
-              {
-                "version_added": "46"
-              },
-              {
-                "version_added": "39",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.scroll-snap.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "46",
+              "version_removed": "68"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/scroll-snap-stop.json
+++ b/css/properties/scroll-snap-stop.json
@@ -6,10 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-snap-stop",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "75"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "75"
             },
             "edge": {
               "version_added": false
@@ -42,7 +42,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "75"
             }
           },
           "status": {

--- a/css/properties/scroll-snap-type-x.json
+++ b/css/properties/scroll-snap-type-x.json
@@ -18,12 +18,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "39",
-              "version_removed": "68"
+              "version_removed": "68",
+              "version_added": "39"
             },
             "firefox_android": {
-              "version_added": "46",
-              "version_removed": "68"
+              "version_removed": "68",
+              "version_added": "39"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-snap-type-x.json
+++ b/css/properties/scroll-snap-type-x.json
@@ -18,23 +18,13 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "39"
+              "version_added": "39",
+              "version_removed": "68"
             },
-            "firefox_android": [
-              {
-                "version_added": "46"
-              },
-              {
-                "version_added": "39",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.scroll-snap.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "46",
+              "version_removed": "68"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/scroll-snap-type-y.json
+++ b/css/properties/scroll-snap-type-y.json
@@ -18,12 +18,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "39",
-              "version_removed": "68"
+              "version_removed": "68",
+              "version_added": "39"
             },
             "firefox_android": {
-              "version_added": "46",
-              "version_removed": "68"
+              "version_removed": "68",
+              "version_added": "39"
             },
             "ie": {
               "version_added": false

--- a/css/properties/scroll-snap-type-y.json
+++ b/css/properties/scroll-snap-type-y.json
@@ -18,23 +18,13 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "39"
+              "version_added": "39",
+              "version_removed": "68"
             },
-            "firefox_android": [
-              {
-                "version_added": "46"
-              },
-              {
-                "version_added": "39",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.scroll-snap.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "46",
+              "version_removed": "68"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/scroll-snap-type.json
+++ b/css/properties/scroll-snap-type.json
@@ -21,24 +21,24 @@
               "prefix": "-ms-",
               "notes": "Edge supports an earlier draft of CSS Scroll Snap without axis values."
             },
-            "firefox": {
-              "version_added": "39",
-              "notes": "Firefox supports an earlier draft of CSS Scroll Snap without axis values."
-            },
+            "firefox": [
+              {
+                "version_added": "39",
+                "version_removed": "68",
+                "notes": "An earlier draft of CSS Scroll Snap without axis values."
+              },
+              {
+                "version_added": "68"
+              }
+            ],
             "firefox_android": [
               {
                 "version_added": "46",
-                "notes": "Firefox supports an earlier draft of CSS Scroll Snap without axis values."
+                "version_removed": "68",
+                "notes": "An earlier draft of CSS Scroll Snap without axis values."
               },
               {
-                "version_added": "39",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.scroll-snap.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "68"
               }
             ],
             "ie": {

--- a/css/properties/scroll-snap-type.json
+++ b/css/properties/scroll-snap-type.json
@@ -23,22 +23,22 @@
             },
             "firefox": [
               {
+                "version_added": "68"
+              },
+              {
                 "version_added": "39",
                 "version_removed": "68",
                 "notes": "An earlier draft of CSS Scroll Snap without axis values."
-              },
-              {
-                "version_added": "68"
               }
             ],
             "firefox_android": [
               {
-                "version_added": "46",
-                "version_removed": "68",
-                "notes": "An earlier draft of CSS Scroll Snap without axis values."
+                "version_added": "68"
               },
               {
-                "version_added": "68"
+                "version_added": "39",
+                "version_removed": "68",
+                "notes": "An earlier draft of CSS Scroll Snap without axis values."
               }
             ],
             "ie": {


### PR DESCRIPTION
Firefox 68 implements the updated scroll snap spec, and removes the old implementation.
https://bugzilla.mozilla.org/show_bug.cgi?id=1544136

Additionally, Chrome implements the scroll-snap-stop property in 75: https://chromestatus.com/feature/5439846480871424

This PR updates the data for these things.
