### PR TITLE
Update Firefox CSS support

### DIFF
--- a/css/at-rules/supports.json
+++ b/css/at-rules/supports.json
@@ -40,7 +40,7 @@
               },
               {
                 "version_added": "17",
-                "version_removed": true,
+                "version_removed": "22",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/at-rules/supports.json
+++ b/css/at-rules/supports.json
@@ -24,7 +24,7 @@
               },
               {
                 "version_added": "17",
-                "version_removed": true,
+                "version_removed": "22",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -63,7 +63,7 @@
                   "version_added": "49"
                 },
                 {
-                  "version_removed": true,
+                  "version_removed": "20",
                   "version_added": "18",
                   "flags": [
                     {
@@ -95,7 +95,7 @@
                   "version_added": "49"
                 },
                 {
-                  "version_removed": true,
+                  "version_removed": "20",
                   "version_added": "18",
                   "flags": [
                     {
@@ -432,10 +432,10 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": true
+                  "version_added": "52"
                 },
                 "firefox_android": {
-                  "version_added": true
+                  "version_added": "52"
                 },
                 "ie": {
                   "version_added": false

--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -228,10 +228,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false
@@ -278,10 +278,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false

--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -234,12 +234,12 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": true,
-                "notes": "<code>element()</code> is supported only in its <code>-moz-element()</code> prefixed version"
+                "version_added": "4",
+                "prefix": "-moz-"
               },
               "firefox_android": {
-                "version_added": true,
-                "notes": "<code>element()</code> is supported only in its <code>-moz-element()</code> prefixed version"
+                "version_added": "4",
+                "prefix": "-moz-"
               },
               "ie": {
                 "version_added": false
@@ -289,13 +289,11 @@
               },
               "firefox": {
                 "prefix": "-moz-",
-                "version_added": true,
-                "notes": "<code>image-rect()</code> is supported only in its <code>-moz-image-rect()</code> prefixed version."
+                "version_added": "4"
               },
               "firefox_android": {
                 "prefix": "-moz-",
-                "version_added": true,
-                "notes": "<code>image-rect()</code> is supported only in its <code>-moz-image-rect()</code> prefixed version."
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false

--- a/css/properties/border-inline-end-color.json
+++ b/css/properties/border-inline-end-color.json
@@ -30,7 +30,7 @@
                 "notes": "Enabled by default since Firefox 41."
               },
               {
-                "version_added": true,
+                "version_added": "3",
                 "alternative_name": "-moz-border-end-color"
               }
             ],
@@ -50,7 +50,7 @@
                 "notes": "Enabled by default since Firefox 41."
               },
               {
-                "version_added": true,
+                "version_added": "4",
                 "alternative_name": "-moz-border-end-color"
               }
             ],

--- a/css/properties/border-inline-end-style.json
+++ b/css/properties/border-inline-end-style.json
@@ -30,7 +30,7 @@
                 "notes": "Enabled by default since Firefox 41."
               },
               {
-                "version_added": "38",
+                "version_added": "3",
                 "alternative_name": "-moz-border-end-style"
               }
             ],
@@ -50,7 +50,7 @@
                 "notes": "Enabled by default since Firefox 41."
               },
               {
-                "version_added": "38",
+                "version_added": "4",
                 "alternative_name": "-moz-border-end-style"
               }
             ],

--- a/css/properties/border-inline-end-width.json
+++ b/css/properties/border-inline-end-width.json
@@ -30,7 +30,7 @@
                 "notes": "Enabled by default since Firefox 41."
               },
               {
-                "version_added": true,
+                "version_added": "3",
                 "alternative_name": "-moz-border-end-width"
               }
             ],
@@ -50,7 +50,7 @@
                 "notes": "Enabled by default since Firefox 41."
               },
               {
-                "version_added": true,
+                "version_added": "4",
                 "alternative_name": "-moz-border-end-width"
               }
             ],

--- a/css/properties/border-inline-start-color.json
+++ b/css/properties/border-inline-start-color.json
@@ -30,7 +30,7 @@
                 "notes": "Enabled by default since Firefox 41."
               },
               {
-                "version_added": "38",
+                "version_added": "3",
                 "alternative_name": "-moz-border-start-color"
               }
             ],
@@ -50,7 +50,7 @@
                 "notes": "Enabled by default since Firefox 41."
               },
               {
-                "version_added": "38",
+                "version_added": "4",
                 "alternative_name": "-moz-border-start-color"
               }
             ],

--- a/css/properties/border-inline-start-style.json
+++ b/css/properties/border-inline-start-style.json
@@ -30,7 +30,7 @@
                 "notes": "Enabled by default since Firefox 41."
               },
               {
-                "version_added": true,
+                "version_added": "3",
                 "alternative_name": "-moz-border-start-style"
               }
             ],
@@ -50,7 +50,7 @@
                 "notes": "Enabled by default since Firefox 41."
               },
               {
-                "version_added": true,
+                "version_added": "4",
                 "alternative_name": "-moz-border-start-style"
               }
             ],

--- a/css/properties/border-radius.json
+++ b/css/properties/border-radius.json
@@ -116,7 +116,7 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "3.5"
+                "version_added": "4"
               },
               "firefox_android": {
                 "version_added": "4"
@@ -168,10 +168,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": true
+                "version_added": "4"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"

--- a/css/properties/box-align.json
+++ b/css/properties/box-align.json
@@ -23,28 +23,24 @@
             },
             "firefox": [
               {
+                "version_added": "1",
+                "prefix": "-moz-"
+              },
+              {
                 "version_added": "49",
                 "prefix": "-webkit-"
-              },
-              {
-                "version_added": "48",
-                "prefix": "-webkit-",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefixes.webkit",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": true,
-                "prefix": "-moz-"
               }
             ],
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": [
+              {
+                "version_added": "4",
+                "prefix": "-moz-"
+              },
+              {
+                "version_added": "49",
+                "prefix": "-webkit-"
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/css/properties/box-decoration-break.json
+++ b/css/properties/box-decoration-break.json
@@ -27,7 +27,7 @@
               },
               {
                 "alternative_name": "-moz-background-inline-policy",
-                "version_added": true,
+                "version_added": "1",
                 "version_removed": "32"
               }
             ],
@@ -37,7 +37,7 @@
               },
               {
                 "alternative_name": "-moz-background-inline-policy",
-                "version_added": true,
+                "version_added": "4",
                 "version_removed": "32"
               }
             ],

--- a/css/properties/box-direction.json
+++ b/css/properties/box-direction.json
@@ -24,7 +24,7 @@
             "firefox": [
               {
                 "prefix": "-moz-",
-                "version_added": true
+                "version_added": "1"
               },
               {
                 "prefix": "-webkit-",
@@ -45,7 +45,7 @@
             "firefox_android": [
               {
                 "prefix": "-moz-",
-                "version_added": true
+                "version_added": "4"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/box-flex.json
+++ b/css/properties/box-flex.json
@@ -24,7 +24,7 @@
             "firefox": [
               {
                 "prefix": "-moz-",
-                "version_added": true
+                "version_added": "1"
               },
               {
                 "prefix": "-webkit-",
@@ -45,7 +45,7 @@
             "firefox_android": [
               {
                 "prefix": "-moz-",
-                "version_added": true
+                "version_added": "4"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/box-ordinal-group.json
+++ b/css/properties/box-ordinal-group.json
@@ -23,7 +23,7 @@
             "firefox": [
               {
                 "prefix": "-moz-",
-                "version_added": true
+                "version_added": "1"
               },
               {
                 "prefix": "-webkit-",
@@ -44,7 +44,7 @@
             "firefox_android": [
               {
                 "prefix": "-moz-",
-                "version_added": true
+                "version_added": "4"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/box-orient.json
+++ b/css/properties/box-orient.json
@@ -24,7 +24,7 @@
             "firefox": [
               {
                 "prefix": "-moz-",
-                "version_added": true
+                "version_added": "1"
               },
               {
                 "prefix": "-webkit-",
@@ -45,7 +45,7 @@
             "firefox_android": [
               {
                 "prefix": "-moz-",
-                "version_added": true
+                "version_added": "4"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/box-pack.json
+++ b/css/properties/box-pack.json
@@ -24,7 +24,7 @@
             "firefox": [
               {
                 "prefix": "-moz-",
-                "version_added": true
+                "version_added": "1"
               },
               {
                 "prefix": "-webkit-",
@@ -45,7 +45,7 @@
             "firefox_android": [
               {
                 "prefix": "-moz-",
-                "version_added": true
+                "version_added": "4"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/column-rule-style.json
+++ b/css/properties/column-rule-style.json
@@ -47,7 +47,7 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": true
+                "version_added": "3.5"
               }
             ],
             "firefox_android": [

--- a/css/properties/column-rule-style.json
+++ b/css/properties/column-rule-style.json
@@ -56,7 +56,7 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "3.5"
+                "version_added": "4"
               }
             ],
             "ie": {

--- a/css/properties/column-rule-style.json
+++ b/css/properties/column-rule-style.json
@@ -56,7 +56,7 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": true
+                "version_added": "3.5"
               }
             ],
             "ie": {

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -657,7 +657,7 @@
                 },
                 {
                   "version_added": "18",
-                  "version_removed": true,
+                  "version_removed": "20",
                   "flags": [
                     {
                       "type": "preference",

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -640,7 +640,7 @@
                 },
                 {
                   "version_added": "18",
-                  "version_removed": true,
+                  "version_removed": "20",
                   "flags": [
                     {
                       "type": "preference",
@@ -1295,7 +1295,7 @@
               },
               "firefox": [
                 {
-                  "version_added": true,
+                  "version_added": "1",
                   "version_removed": "64",
                   "notes": "This is still available to Firefox UI code."
                 },
@@ -1312,7 +1312,7 @@
               ],
               "firefox_android": [
                 {
-                  "version_added": true,
+                  "version_added": "4",
                   "version_removed": "64",
                   "notes": "This is still available to Firefox UI code."
                 },
@@ -1374,7 +1374,7 @@
               },
               "firefox": [
                 {
-                  "version_added": true,
+                  "version_added": "1",
                   "version_removed": "62",
                   "notes": "This is still available to Firefox UI code."
                 },
@@ -1391,7 +1391,7 @@
               ],
               "firefox_android": [
                 {
-                  "version_added": true,
+                  "version_added": "4",
                   "version_removed": "62",
                   "notes": "This is still available to Firefox UI code."
                 },
@@ -1453,7 +1453,7 @@
               },
               "firefox": [
                 {
-                  "version_added": true,
+                  "version_added": "1",
                   "version_removed": "62",
                   "notes": "This is still available to Firefox UI code."
                 },
@@ -1470,7 +1470,7 @@
               ],
               "firefox_android": [
                 {
-                  "version_added": true,
+                  "version_added": "4",
                   "version_removed": "62",
                   "notes": "This is still available to Firefox UI code."
                 },
@@ -1532,7 +1532,7 @@
               },
               "firefox": [
                 {
-                  "version_added": true,
+                  "version_added": "1",
                   "version_removed": "62",
                   "notes": "This is still available to Firefox UI code."
                 },
@@ -1549,7 +1549,7 @@
               ],
               "firefox_android": [
                 {
-                  "version_added": true,
+                  "version_added": "4",
                   "version_removed": "62",
                   "notes": "This is still available to Firefox UI code."
                 },
@@ -1611,7 +1611,7 @@
               },
               "firefox": [
                 {
-                  "version_added": true,
+                  "version_added": "1",
                   "version_removed": "62",
                   "notes": "This is still available to Firefox UI code."
                 },
@@ -1628,7 +1628,7 @@
               ],
               "firefox_android": [
                 {
-                  "version_added": true,
+                  "version_added": "4",
                   "version_removed": "62",
                   "notes": "This is still available to Firefox UI code."
                 },

--- a/css/properties/resize.json
+++ b/css/properties/resize.json
@@ -17,26 +17,12 @@
             "edge_mobile": {
               "version_added": false
             },
-            "firefox": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "4",
-                "version_removed": true
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "4",
-                "version_removed": true
-              }
-            ],
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/text-combine-upright.json
+++ b/css/properties/text-combine-upright.json
@@ -44,7 +44,7 @@
               },
               {
                 "version_added": "31",
-                "version_removed": true,
+                "version_removed": "41",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/text-combine-upright.json
+++ b/css/properties/text-combine-upright.json
@@ -83,7 +83,7 @@
               },
               {
                 "version_added": "31",
-                "version_removed": true,
+                "version_removed": "41",
                 "flags": [
                   {
                     "type": "preference",


### PR DESCRIPTION
Update more Firefox compat data to get closer to 100% real values. How I came to which versions is outlined in this table:


| id(s) | change / explanation |
|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| css.at-rules.supports | close the range for the preffed version |
| css.properties.align-items.flex_context | Other flex_context have this as 20 as well, seems only consistent. |
| css.properties.align-items.grid_context.start_end | I believe this landed with the initial support for align-items in grid_context |
| css.properties.background-image.element | taken from https://developer.mozilla.org/en-US/docs/Web/CSS/element#Browser_compatibility |
| css.properties.background-image.image-rect | taken from https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-image-rect#Browser_compatibility |
| css.properties.border-inline-end-color css.properties.border-inline-end-style css.properties.border-inline-end-width css.properties.border-inline-start-color css.properties.border-inline-start-style | https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/releases/3/CSS_improvements mentions "-moz-border-*-start and -moz-border-*-end CSS properties are implemented (https://bugzilla.mozilla.org/show_bug.cgi?id=74880)" |
| css.properties.border-radius.4_values_for_4_corners css.properties.border-radius.elliptical_borders | See older revision that this was supported early, so setting "4" when the unprefixed variant became available. https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius$revision/36202 |
| css.properties.box-align (-moz- prefix) | Added in https://bugzilla.mozilla.org/show_bug.cgi?id=71471 |
| css.properties.box-pack (-moz- prefix) | https://bugzilla.mozilla.org/show_bug.cgi?id=71471 |
| css.properties.box-direction (-moz- prefix) | Added in https://bugzilla.mozilla.org/show_bug.cgi?id=93177 |
| css.properties.box-flex (-moz- prefix) | Added in https://bugzilla.mozilla.org/show_bug.cgi?id=70860 |
| css.properties.box-orient (-moz- prefix) | Added in https://bugzilla.mozilla.org/show_bug.cgi?id=70809 |
| css.properties.box-ordinal-group (-moz- prefix) | Added in https://bugzilla.mozilla.org/show_bug.cgi?id=93519 |
| css.properties.box-decoration-break (-moz-background-inline-policy): | was previously documented here and says version 1: https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-background-inline-policy$revision/933439 |
| css.properties.column-rule-style (-moz- prefix) | column-rule-color and column-rule-width also have 3.5 for the -moz- prefix, so this is only consistent. |
| css.properties.display.inline-flex | close the range for the preffed version |
| css.properties.display.xul_box_values css.properties.display.xul_grid_values css.properties.display.xul_stack_values css.properties.display.xul_deck_values css.properties.display.xul_popup_values | Couldn't find an implementation bugs, but other bug reports that appeared with very early Firefoxes, so it must have been in 1.0 or earlier https://bugzilla.mozilla.org/show_bug.cgi?id=271227 |
| css.properties.resize css.properties.resize (-moz- prefix) | https://bugzilla.mozilla.org/show_bug.cgi?id=442228 implemented this prefixed https://bugzilla.mozilla.org/show_bug.cgi?id=553576 implemented this unprefixed Both were in the cycle for Firefox 4, so the prefixed version hasn't actually seen any released product. |
| css.properties.text-combine-upright | close the range for the flag change |