### PR TITLE
Remove unneeded 'sloppy' data points

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -241,10 +241,12 @@
           "spec_url": "https://tc39.github.io/ecma262/#sec-class-definitions",
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": "49",
+              "notes": "From Chrome 42 to 48 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
             },
             "chrome_android": {
-              "version_added": "42"
+              "version_added": "49",
+              "notes": "From Chrome 42 to 48 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
             },
             "edge": {
               "version_added": true
@@ -280,121 +282,14 @@
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "42"
+              "version_added": "49",
+              "notes": "From Chrome 42 to 48 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
             }
           },
           "status": {
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "array_subclassing": {
-          "__compat": {
-            "description": "Array subclassing",
-            "support": {
-              "chrome": {
-                "version_added": "43"
-              },
-              "chrome_android": {
-                "version_added": "43"
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": null
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": "36"
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": "4.0"
-              },
-              "webview_android": {
-                "version_added": "43"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "allow_in_sloppy_mode": {
-          "__compat": {
-            "description": "Allowed in sloppy mode",
-            "support": {
-              "chrome": {
-                "version_added": "49"
-              },
-              "chrome_android": {
-                "version_added": "49"
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": null
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": "36"
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": "5.0"
-              },
-              "webview_android": {
-                "version_added": "49"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },
@@ -1382,60 +1277,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "allow_in_sloppy_mode": {
-          "__compat": {
-            "description": "Allowed in sloppy mode",
-            "support": {
-              "chrome": {
-                "version_added": "49"
-              },
-              "chrome_android": {
-                "version_added": "49"
-              },
-              "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": null
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "nodejs": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "49"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         },
         "trailing_comma_in_parameters": {


### PR DESCRIPTION
Ths table has a Chrome specific row on "sloppy" mode that is better captured in notes
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/class#Browser_compatibility
LIn other tables we've done this better already: See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes#Browser_compatibility

This also contains a "sloppy mode" entry, saying that function wouldn't work in sloppy before Chrome 49. I very doubt it. I think this was confused with classes.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function#Browser_compatibility

Finally, I've also remove "Array subclassing" as it isn't directly related to this compat data and doesn't really belong there.


Side note: This brings us to 100% real values for Firefox in `javascript/`.