### PR TITLE
Revise publishing process in contributor docs

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -34,12 +34,20 @@ Let us know if these look good to you.
 
 ## Updating compatibility tables on MDN
 
-It takes 1-2 weeks for changes in this data to be reflected in MDN's browser compatibility tables. The process is:
+It takes up to four weeks for BCD changes to be reflected in MDN's browser compatibility tables.
+The process is:
 
-1. A pull request is reviewed and merged to master.
-2. A new release of [mdn-browser-compat-data](https://www.npmjs.com/package/mdn-browser-compat-data) is created by MDN staff. This happens every 4-14 days.
-3. A new image of [Kumascript](https://github.com/mdn/kumascript), which includes the BCD release, is built and deployed to production. This happens within a day of the npm package release.
-4. The MDN page using the data is regenerated. For newly converted pages, a staff member switches to the [{{Compat}}](https://github.com/mdn/kumascript/blob/master/macros/Compat.ejs) macro, and re-checks the conversion. For updates to converted pages, a logged-in MDN user [force-refreshes the page](https://en.wikipedia.org/wiki/Wikipedia:Bypass_your_cache#Bypassing_cache) to regenerate it.
+1. A pull request is reviewed and merged to `master`.
+2. Project owners publish a new release of [mdn-browser-compat-data](https://www.npmjs.com/package/mdn-browser-compat-data).
+   See [Publishing a new version of `mdn-browser-compat-data`](publishing.md) for details.
+3. MDN staff build and deploy a new image of [Kumascript](https://github.com/mdn/kumascript), which includes the BCD release, to production.
+   This typically happens within a day of the release of the npm package.
+4. Tables are generated on MDN:
+
+   * Existing tables automatically regenerate monthly.
+     Alternatively, logged-in MDN users can [force-refresh a page](https://en.wikipedia.org/wiki/Wikipedia:Bypass_your_cache#Bypassing_cache) to regenerate it.
+   * For new pages, you must add the [`{{Compat}}`](https://github.com/mdn/kumascript/blob/master/macros/Compat.ejs) macro to the page.
+     For instructions, see [Inserting the data into MDN pages](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Structures/Compatibility_tables#Inserting_the_data_into_MDN_pages).
 
 ## Opening issues and pull requests
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,13 +1,19 @@
 # Publishing a new version of `mdn-browser-compat-data`
 
-Regularly, a new release of [mdn-browser-compat-data](https://www.npmjs.com/package/mdn-browser-compat-data) is created by MDN staff and will then be [deployed to the MDN site](https://github.com/mdn/browser-compat-data#browser-compatibility-tables-on-mdn). Usually this is done every Thursday (MDN never deploys to production on Fridays). Releases should be coordinated with the project owner [Florian Scholz](https://github.com/Elchi3), but anyone with owner permissions on the mdn/browser-compat-data repository has the ability to run the following steps which will create a new package version:
+[Project owners](/GOVERNANCE.md#owners) publish new releases of [mdn-browser-compat-data](https://www.npmjs.com/package/mdn-browser-compat-data) on npm.
+MDN staff [deploy the package to the MDN site](contributing.md#updating-compatibility-tables-on-mdn).
+Usually, this happens every Thursday (MDN never deploys to production on Fridays).
+
+Any owner can complete the following steps to publish a new version, but please coordinate releases with [Florian Scholz](https://github.com/Elchi3).
+
+To create and publish a new version of `mdn-browser-compat-data`:
 
 1. Figure out the new version number by looking at [past releases](https://github.com/mdn/browser-compat-data/releases). The project is in alpha, so we're using only patch versions. Lets assume the next version should be `0.0.43`.
 2. On your updated and clean master branch, run `npm version patch -m "43rd alpha version"`. Locally, this updates `package.json`, creates a new commit, and creates a new release tag (see also the docs for [npm version](https://docs.npmjs.com/cli/version)).
-3. Push the commit to master: `git push origin master`.
+3. Push the commit to `master`: `git push origin master`.
 4. Check if the commit passes fine on [Travis CI](https://travis-ci.org/mdn/browser-compat-data).
 5. If Travis is alright, push the git tag as well: `git push origin v0.0.43`.
 This step will trigger Travis to publish to npm automatically (see our [.travis.yml file](https://github.com/mdn/browser-compat-data/blob/master/.travis.yml)).
 6. Check [Travis CI](https://travis-ci.org/mdn/browser-compat-data) again for the v0.0.43 build and also check [mdn-browser-compat-data on npm](https://www.npmjs.com/package/mdn-browser-compat-data) to see if `0.0.43` shows up correctly once Travis has finished its work.
-7. Notify the [#mdndev](irc://irc.mozilla.org/mdndev) IRC channel on irc.mozilla.org about the new release and coordinate with jwhitlock or rjohnson a deployment of the new package to the MDN site.
+7. Notify the [#mdndev](irc://irc.mozilla.org/mdndev) IRC channel on irc.mozilla.org about the new release.
 8. Create a new [release on GitHub](https://github.com/mdn/browser-compat-data/releases) by running `npm run release-notes -- v0.0.43`).


### PR DESCRIPTION
This updates our docs to more accurately reflect the process of publishing a new version of the package and updating tables on MDN. These changes mostly come from two suggestions from @Elchi3:

* https://github.com/mdn/browser-compat-data/issues/4024#issuecomment-493160106
* https://github.com/mdn/browser-compat-data/pull/4161#discussion_r284652750

This is a follow up to #4024.

When reviewing this, you may want to look at GitHub's rich diffs for Markdown and the updated pages on my fork, [`publishing.md`](https://github.com/ddbeck/browser-compat-data/blob/publishing-rewrite/docs/publishing.md) and [`contributing.md`](https://github.com/ddbeck/browser-compat-data/blob/publishing-rewrite/docs/contributing.md#updating-compatibility-tables-on-mdn), in addition to the regular diff.