### PR TITLE
Enforce real Firefox values for javascript/

### DIFF
--- a/test/test-real-values.js
+++ b/test/test-real-values.js
@@ -25,7 +25,7 @@ const blockList = {
   html: [],
   http: [],
   svg: [],
-  javascript: [],
+  javascript: ['firefox', 'firefox_android'],
   mathml: blockMany,
   webdriver: blockMany.concat(['samsunginternet_android']),
   webextensions: [],


### PR DESCRIPTION
Follow-up to #4174.  Since we've got 100% real values in Firefox (Desktop + Android) in the `javascript/` data, let's keep it that way!