### PR TITLE
Update Location.json

### DIFF
--- a/api/Location.json
+++ b/api/Location.json
@@ -570,7 +570,8 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "notes": "If a page added to <em>Trusted Sites</em> contains a cross-origin iframe, then calling <code>reload()</code> from within the iframe reloads the trusted page (in other words, the top page reloads, not the iframe)."
             },
             "edge_mobile": {
               "version_added": true

--- a/api/Location.json
+++ b/api/Location.json
@@ -582,7 +582,8 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Calling location.reload() inside a nested cross-origin frame reloads the top frame, if the top frame address was added to Trusted websites."
             },
             "opera": {
               "version_added": true

--- a/api/Location.json
+++ b/api/Location.json
@@ -583,7 +583,7 @@
             },
             "ie": {
               "version_added": true,
-              "notes": "Calling location.reload() inside a nested cross-origin frame reloads the top frame, if the top frame address was added to Trusted websites."
+              "notes": "If a page added to <em>Trusted Sites</em> contains a cross-origin iframe, then calling <code>reload()</code> from within the iframe reloads the trusted page (in other words, the top page reloads, not the iframe)."
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
Add a note about location.reload() behaviour in IE.
Test case is available here: https://x.zok.pw/ie-trusted/index.html

To reproduce:

1. In IE11, open Settings - Internet Options - Security - Trusted sites - Sites
2. Add https://x.zok.pw to the list
3. open https://x.zok.pw/ie-trusted/index.html
4. the button in the cross-origin frame will relocate the top frame instead of the inner frame

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
