### PR TITLE
Add missing real values for Firefox/FxA

### DIFF
--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -331,7 +331,7 @@
                 "partial_implementation": true
               },
               "firefox": {
-                "version_added": true,
+                "version_added": "1",
                 "partial_implementation": true
               },
               "firefox_android": {

--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -214,7 +214,7 @@
                 },
                 {
                   "version_added": "47",
-                  "version_removed": true,
+                  "version_removed": "54",
                   "flags": [
                     {
                       "type": "preference",
@@ -230,7 +230,7 @@
                 },
                 {
                   "version_added": "47",
-                  "version_removed": true,
+                  "version_removed": "54",
                   "flags": [
                     {
                       "type": "preference",

--- a/css/properties/column-rule-color.json
+++ b/css/properties/column-rule-color.json
@@ -56,7 +56,7 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": true
+                "version_added": "4"
               }
             ],
             "ie": {

--- a/css/properties/column-rule-width.json
+++ b/css/properties/column-rule-width.json
@@ -51,7 +51,7 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": true
+                "version_added": "4"
               }
             ],
             "ie": {

--- a/css/properties/column-rule.json
+++ b/css/properties/column-rule.json
@@ -51,7 +51,7 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": true
+                "version_added": "4"
               }
             ],
             "ie": {

--- a/css/properties/flex-direction.json
+++ b/css/properties/flex-direction.json
@@ -73,6 +73,38 @@
                 ]
               }
             ],
+            "firefox_android": [
+              {
+                "version_added": "20",
+                "notes": "Since Firefox 28, multi-line flexbox is supported."
+              },
+              {
+                "version_added": "18",
+                "version_removed": "20",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.flexbox.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "44",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefixes.webkit",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": [
               {
                 "version_added": "11"

--- a/css/properties/height.json
+++ b/css/properties/height.json
@@ -81,7 +81,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "4",
                   "prefix": "-moz-"
                 }
               ],
@@ -144,7 +144,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "4",
                   "prefix": "-moz-"
                 }
               ],
@@ -196,10 +196,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -60,7 +60,7 @@
                 },
                 {
                   "version_added": "18",
-                  "version_removed": true,
+                  "version_removed": "20",
                   "flags": [
                     {
                       "type": "preference",
@@ -92,7 +92,7 @@
                 },
                 {
                   "version_added": "18",
-                  "version_removed": true,
+                  "version_removed": "20",
                   "flags": [
                     {
                       "type": "preference",

--- a/css/properties/max-block-size.json
+++ b/css/properties/max-block-size.json
@@ -170,7 +170,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "41",
                   "prefix": "-moz-"
                 }
               ],

--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -22,7 +22,7 @@
               "notes": "CSS 2.1 leaves the behavior of <code>max-height</code> with <a href='https://developer.mozilla.org/docs/Web/HTML/Element/table'><code>table</code></a> undefined. Firefox supports applying <code>max-height</code> to <code>table</code> elements."
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "7"
@@ -162,7 +162,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "4",
                   "prefix": "-moz-"
                 }
               ],
@@ -225,7 +225,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "4",
                   "prefix": "-moz-"
                 }
               ],

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -83,7 +83,10 @@
                 "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
               },
               "firefox_android": {
-                "version_added": null
+                "partial_implementation": true,
+                "prefix": "-moz-",
+                "version_added": "4",
+                "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
               },
               "ie": {
                 "version_added": false
@@ -163,7 +166,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "4",
                   "prefix": "-moz-"
                 }
               ],
@@ -245,7 +248,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "4",
                   "prefix": "-moz-"
                 }
               ],

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -85,7 +85,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "4",
                   "prefix": "-moz-"
                 }
               ],
@@ -148,7 +148,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "4",
                   "prefix": "-moz-"
                 }
               ],

--- a/css/properties/min-inline-size.json
+++ b/css/properties/min-inline-size.json
@@ -171,7 +171,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "41",
                   "prefix": "-moz-"
                 }
               ],

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -90,7 +90,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "4",
                   "prefix": "-moz-"
                 }
               ],
@@ -176,7 +176,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "4",
                   "prefix": "-moz-"
                 }
               ],

--- a/css/properties/offset-path.json
+++ b/css/properties/offset-path.json
@@ -119,10 +119,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": true
+                "version_added": "63"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "63"
               },
               "ie": {
                 "version_added": false

--- a/css/properties/outline-color.json
+++ b/css/properties/outline-color.json
@@ -76,7 +76,7 @@
               },
               "firefox": {
                 "version_removed": "3",
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
                 "version_added": false

--- a/css/properties/outline-style.json
+++ b/css/properties/outline-style.json
@@ -75,10 +75,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1.5"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false

--- a/css/properties/place-content.json
+++ b/css/properties/place-content.json
@@ -20,10 +20,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": true
+                "version_added": "45"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "45"
               },
               "ie": {
                 "version_added": false

--- a/css/properties/position.json
+++ b/css/properties/position.json
@@ -73,7 +73,8 @@
                 "notes": "Before Firefox 44, <code>position: fixed</code> didn't create a stacking context in most cases. Firefox and the specification have been modified to mimic Chrome and Safari's long-time behavior."
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "4",
+                "notes": "Before Firefox 44, <code>position: fixed</code> didn't create a stacking context in most cases. Firefox and the specification have been modified to mimic Chrome and Safari's long-time behavior."
               },
               "ie": {
                 "version_added": "7",
@@ -137,9 +138,22 @@
                   ]
                 }
               ],
-              "firefox_android": {
-                "version_added": null
-              },
+              "firefox_android": [
+                {
+                  "version_added": "32"
+                },
+                {
+                  "version_added": "26",
+                  "version_removed": "48",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.sticky.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "ie": {
                 "version_added": false
               },

--- a/css/properties/text-size-adjust.json
+++ b/css/properties/text-size-adjust.json
@@ -38,7 +38,7 @@
             "firefox_android": [
               {
                 "prefix": "-moz-",
-                "version_added": true
+                "version_added": "14"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/transform-box.json
+++ b/css/properties/transform-box.json
@@ -59,7 +59,7 @@
               },
               {
                 "version_added": "41",
-                "version_removed": true,
+                "version_removed": "43",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -204,7 +204,7 @@
                 },
                 {
                   "version_added": "41",
-                  "version_removed": true,
+                  "version_removed": "43",
                   "flags": [
                     {
                       "type": "preference",
@@ -222,7 +222,7 @@
                 },
                 {
                   "version_added": "41",
-                  "version_removed": true,
+                  "version_removed": "43",
                   "flags": [
                     {
                       "type": "preference",

--- a/css/properties/transition-property.json
+++ b/css/properties/transition-property.json
@@ -180,10 +180,10 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "16"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "16"
               },
               "ie": {
                 "version_added": "10"

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -138,7 +138,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "4",
                   "prefix": "-moz-"
                 }
               ],
@@ -213,7 +213,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "4",
                   "prefix": "-moz-"
                 }
               ],

--- a/css/selectors/any-link.json
+++ b/css/selectors/any-link.json
@@ -36,7 +36,7 @@
               },
               {
                 "version_added": "1",
-                "version_removed": true,
+                "version_removed": "50",
                 "prefix": "-moz-"
               }
             ],
@@ -46,7 +46,7 @@
               },
               {
                 "version_added": "4",
-                "version_removed": true,
+                "version_removed": "50",
                 "prefix": "-moz-"
               }
             ],

--- a/css/selectors/before.json
+++ b/css/selectors/before.json
@@ -57,11 +57,12 @@
             ],
             "firefox_android": [
               {
-                "version_added": true
+                "version_added": "4",
+                "notes": "Before Firefox 57, Firefox had a bug where <code>::before</code> pseudo-elements were still generated, even if the <a href='https://developer.mozilla.org/docs/Web/CSS/content'><code>content</code></a> property value were set to <code>normal</code> or <code>none</code>."
               },
               {
                 "alternative_name": ":before",
-                "version_added": true
+                "version_added": "4"
               }
             ],
             "ie": [

--- a/css/selectors/placeholder-shown.json
+++ b/css/selectors/placeholder-shown.json
@@ -86,10 +86,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": true
+                "version_added": "51"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "51"
               },
               "ie": {
                 "version_added": false

--- a/css/selectors/read-write.json
+++ b/css/selectors/read-write.json
@@ -73,10 +73,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1.5"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false

--- a/css/types/dimension.json
+++ b/css/types/dimension.json
@@ -22,7 +22,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "5"

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -19,10 +19,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -72,11 +72,11 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": true,
+                "version_added": "16",
                 "notes": "Gradients are limited to <a href='https://developer.mozilla.org/docs/Web/CSS/background-image'><code>background-image</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/border-image'><code>border-image</code></a>, and <a href='https://developer.mozilla.org/docs/Web/CSS/mask-image'><code>mask-image</code></a>."
               },
               "firefox_android": {
-                "version_added": true,
+                "version_added": "16",
                 "notes": "Gradients are limited to <a href='https://developer.mozilla.org/docs/Web/CSS/background-image'><code>background-image</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/border-image'><code>border-image</code></a>, and <a href='https://developer.mozilla.org/docs/Web/CSS/mask-image'><code>mask-image</code></a>."
               },
               "ie": {

--- a/css/types/length-percentage.json
+++ b/css/types/length-percentage.json
@@ -175,10 +175,10 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "4"

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -175,10 +175,10 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "4"

--- a/test/test-real-values.js
+++ b/test/test-real-values.js
@@ -21,7 +21,7 @@ const blockMany = [
 /** @type {Record<string, string[]>} */
 const blockList = {
   api: [],
-  css: ['ie'],
+  css: ['firefox', 'firefox_android', 'ie'],
   html: [],
   http: [],
   svg: [],


### PR DESCRIPTION
Fixes https://github.com/mdn/browser-compat-data/issues/3126 and forbids `null` and `true` values for Firefox and Firefox Android in `css/` going forward.