### PR TITLE
Complete Edge data for CSS selectors

### DIFF
--- a/css/selectors/-moz-color-swatch.json
+++ b/css/selectors/-moz-color-swatch.json
@@ -13,10 +13,10 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "27"

--- a/css/selectors/-moz-focusring.json
+++ b/css/selectors/-moz-focusring.json
@@ -13,10 +13,10 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "4"

--- a/css/selectors/-webkit-search-cancel-button.json
+++ b/css/selectors/-webkit-search-cancel-button.json
@@ -13,10 +13,10 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": false

--- a/css/selectors/-webkit-search-results-button.json
+++ b/css/selectors/-webkit-search-results-button.json
@@ -13,10 +13,10 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": false

--- a/css/selectors/after.json
+++ b/css/selectors/after.json
@@ -26,20 +26,20 @@
             ],
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "alternative_name": ":after",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "alternative_name": ":after",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "firefox": [
@@ -137,10 +137,10 @@
                 "version_added": "26"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "4"

--- a/css/selectors/before.json
+++ b/css/selectors/before.json
@@ -26,20 +26,20 @@
             ],
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "alternative_name": ":before",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "alternative_name": ":before",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "firefox": [
@@ -133,10 +133,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "4"

--- a/css/selectors/default.json
+++ b/css/selectors/default.json
@@ -13,10 +13,10 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "4"

--- a/css/selectors/first-letter.json
+++ b/css/selectors/first-letter.json
@@ -26,20 +26,20 @@
             ],
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "alternative_name": ":first-letter",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "alternative_name": ":first-letter",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "firefox": [

--- a/css/selectors/first-line.json
+++ b/css/selectors/first-line.json
@@ -30,20 +30,20 @@
             ],
             "edge": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "alternative_name": ":first-line",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [
               {
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "alternative_name": ":first-line",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "firefox": [

--- a/css/selectors/in-range.json
+++ b/css/selectors/in-range.json
@@ -15,10 +15,10 @@
               "notes": "Before Chrome 52, <code>:in-range</code> matched disabled and read-only inputs (see <a href='https://crbug.com/602568'>Chromium bug 602568</a>). In Chrome 52, it was changed to only match enabled read-write inputs."
             },
             "edge": {
-              "version_added": true
+              "version_added": "13"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "13"
             },
             "firefox": {
               "version_added": "29",

--- a/css/selectors/out-of-range.json
+++ b/css/selectors/out-of-range.json
@@ -13,10 +13,10 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "13"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "13"
             },
             "firefox": {
               "version_added": "29"

--- a/css/selectors/placeholder.json
+++ b/css/selectors/placeholder.json
@@ -27,21 +27,21 @@
             "edge": [
               {
                 "prefix": "-webkit-input-",
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-ms-input-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "edge_mobile": [
               {
                 "prefix": "-webkit-input-",
-                "version_added": true
+                "version_added": "12"
               },
               {
                 "prefix": "-ms-input-",
-                "version_added": true
+                "version_added": "12"
               }
             ],
             "firefox": [

--- a/css/selectors/read-only.json
+++ b/css/selectors/read-only.json
@@ -13,10 +13,10 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "13"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "13"
             },
             "firefox": {
               "prefix": "-moz-",

--- a/css/selectors/read-write.json
+++ b/css/selectors/read-write.json
@@ -13,10 +13,10 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "13"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "13"
             },
             "firefox": {
               "prefix": "-moz-",

--- a/css/selectors/slotted.json
+++ b/css/selectors/slotted.json
@@ -13,10 +13,10 @@
               "version_added": "50"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {


### PR DESCRIPTION
- A few proprietary ones aren't in Edge
- Those which are in IE are also in Edge (12)
- Manual testing and caniuse agree that a few range/read-write related ones were added in version 13.