### PR TITLE
Set css.properties.font-smooth to unsupported in Edge

### DIFF
--- a/css/properties/font-smooth.json
+++ b/css/properties/font-smooth.json
@@ -14,7 +14,7 @@
               "alternative_name": "-webkit-font-smoothing"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null


### PR DESCRIPTION
Based on these results from Edge 12-18:
https://github.com/foolip/mdn-bcd-results/tree/e7617f76c8aa1d52bbfbc1445d4fa1a62c7bebb7

None of the tested variants were supported in any version of Edge.