### PR TITLE
Set -webkit-box-align as supported since Edge 12

### DIFF
--- a/css/properties/box-align.json
+++ b/css/properties/box-align.json
@@ -14,7 +14,7 @@
               "prefix": "-webkit-"
             },
             "edge": {
-              "version_added": true,
+              "version_added": "12",
               "prefix": "-webkit-"
             },
             "edge_mobile": {


### PR DESCRIPTION
Based on test results from Edge 12-18:
https://github.com/foolip/mdn-bcd-results/tree/e7617f76c8aa1d52bbfbc1445d4fa1a62c7bebb7

`'webkitBoxAlign' in document.body.style` returned true in Edge 12-18.