### PR TITLE
Add HTML audio containers and codecs

### DIFF
--- a/html/elements/audio.json
+++ b/html/elements/audio.json
@@ -545,6 +545,3416 @@
               "deprecated": false
             }
           }
+        },
+        "3gp_container": {
+          "__compat": {
+            "description": "<code>3gp</code> media container",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "adts_container": {
+          "__compat": {
+            "description": "<code>adts</code> media container",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "aac_codec": {
+            "__compat": {
+              "description": "<code>adts</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "amr_codec": {
+            "__compat": {
+              "description": "<code>adts</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "flac_codec": {
+            "__compat": {
+              "description": "<code>adts</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "mp3_codec": {
+            "__compat": {
+              "description": "<code>adts</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "opus_codec": {
+            "__compat": {
+              "description": "<code>adts</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "pcm_codec": {
+            "__compat": {
+              "description": "<code>adts</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "vorbis_codec": {
+            "__compat": {
+              "description": "<code>adts</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          }
+        },
+        "flac_container": {
+          "__compat": {
+            "description": "<code>flac</code> media container",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "aac_codec": {
+            "__compat": {
+              "description": "<code>flac</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "amr_codec": {
+            "__compat": {
+              "description": "<code>flac</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "flac_codec": {
+            "__compat": {
+              "description": "<code>flac</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "mp3_codec": {
+            "__compat": {
+              "description": "<code>flac</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "opus_codec": {
+            "__compat": {
+              "description": "<code>flac</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "pcm_codec": {
+            "__compat": {
+              "description": "<code>flac</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "vorbis_codec": {
+            "__compat": {
+              "description": "<code>flac</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          }
+        },
+        "mkv_container": {
+          "__compat": {
+            "description": "<code>mkv</code> media container",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "aac_codec": {
+            "__compat": {
+              "description": "<code>mkv</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "amr_codec": {
+            "__compat": {
+              "description": "<code>mkv</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "flac_codec": {
+            "__compat": {
+              "description": "<code>mkv</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "mp3_codec": {
+            "__compat": {
+              "description": "<code>mkv</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "opus_codec": {
+            "__compat": {
+              "description": "<code>mkv</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "pcm_codec": {
+            "__compat": {
+              "description": "<code>mkv</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "vorbis_codec": {
+            "__compat": {
+              "description": "<code>mkv</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          }
+        },
+        "mp4_container": {
+          "__compat": {
+            "description": "<code>mp4</code> media container",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "aac_codec": {
+            "__compat": {
+              "description": "<code>mp4</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "amr_codec": {
+            "__compat": {
+              "description": "<code>mp4</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "flac_codec": {
+            "__compat": {
+              "description": "<code>mp4</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "mp3_codec": {
+            "__compat": {
+              "description": "<code>mp4</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "opus_codec": {
+            "__compat": {
+              "description": "<code>mp4</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "pcm_codec": {
+            "__compat": {
+              "description": "<code>mp4</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "vorbis_codec": {
+            "__compat": {
+              "description": "<code>mp4</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          }
+        },
+        "mpeg_container": {
+          "__compat": {
+            "description": "<code>mpeg</code> media container",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "aac_codec": {
+            "__compat": {
+              "description": "<code>mpeg</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "amr_codec": {
+            "__compat": {
+              "description": "<code>mpeg</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "flac_codec": {
+            "__compat": {
+              "description": "<code>mpeg</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "mp3_codec": {
+            "__compat": {
+              "description": "<code>mpeg</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "opus_codec": {
+            "__compat": {
+              "description": "<code>mpeg</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "pcm_codec": {
+            "__compat": {
+              "description": "<code>mpeg</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "vorbis_codec": {
+            "__compat": {
+              "description": "<code>mpeg</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          }
+        },
+        "ogg_container": {
+          "__compat": {
+            "description": "<code>ogg</code> media container",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "aac_codec": {
+            "__compat": {
+              "description": "<code>ogg</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "amr_codec": {
+            "__compat": {
+              "description": "<code>ogg</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "flac_codec": {
+            "__compat": {
+              "description": "<code>ogg</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "mp3_codec": {
+            "__compat": {
+              "description": "<code>ogg</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "opus_codec": {
+            "__compat": {
+              "description": "<code>ogg</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "pcm_codec": {
+            "__compat": {
+              "description": "<code>ogg</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "vorbis_codec": {
+            "__compat": {
+              "description": "<code>ogg</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          }
+        },
+        "mov_container": {
+          "__compat": {
+            "description": "<code>mov</code> media container",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "notes": "QuickTime is supported only if available on the host device, such as on macOS.",
+                "version_added": true
+              },
+              "firefox_android": {
+                "notes": "QuickTime is supported only if available on the host device, such as on macOS.",
+                "version_added": true
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "aac_codec": {
+            "__compat": {
+              "description": "<code>mov</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "amr_codec": {
+            "__compat": {
+              "description": "<code>mov</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "flac_codec": {
+            "__compat": {
+              "description": "<code>mov</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "mp3_codec": {
+            "__compat": {
+              "description": "<code>mov</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "opus_codec": {
+            "__compat": {
+              "description": "<code>mov</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": null
+                },
+                "firefox_android": {
+                  "version_added": null
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "pcm_codec": {
+            "__compat": {
+              "description": "<code>mov</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "vorbis_codec": {
+            "__compat": {
+              "description": "<code>mov</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          }
+        },
+        "wav_container": {
+          "__compat": {
+            "description": "<code>wav</code> media container",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "aac_codec": {
+            "__compat": {
+              "description": "<code>wav</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "amr_codec": {
+            "__compat": {
+              "description": "<code>wav</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "flac_codec": {
+            "__compat": {
+              "description": "<code>wav</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "mp3_codec": {
+            "__compat": {
+              "description": "<code>wav</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "opus_codec": {
+            "__compat": {
+              "description": "<code>wav</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "pcm_codec": {
+            "__compat": {
+              "description": "<code>wav</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "vorbis_codec": {
+            "__compat": {
+              "description": "<code>wav</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          }
+        },
+        "webm_container": {
+          "__compat": {
+            "description": "<code>webm</code> media container",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "aac_codec": {
+            "__compat": {
+              "description": "<code>webm</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "amr_codec": {
+            "__compat": {
+              "description": "<code>webm</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "flac_codec": {
+            "__compat": {
+              "description": "<code>webm</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "mp3_codec": {
+            "__compat": {
+              "description": "<code>webm</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "opus_codec": {
+            "__compat": {
+              "description": "<code>webm</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "pcm_codec": {
+            "__compat": {
+              "description": "<code>webm</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "vorbis_codec": {
+            "__compat": {
+              "description": "<code>webm</code> codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/html/elements/audio.json
+++ b/html/elements/audio.json
@@ -546,9 +546,9 @@
             }
           }
         },
-        "3gp_container": {
+        "3gp_media_container": {
           "__compat": {
-            "description": "<code>3gp</code> media container",
+            "description": "3GP media container",
             "support": {
               "chrome": {
                 "version_added": null
@@ -597,9 +597,9 @@
             }
           }
         },
-        "adts_container": {
+        "adts_media_container": {
           "__compat": {
-            "description": "<code>adts</code> media container",
+            "description": "ADTS media container",
             "support": {
               "chrome": {
                 "version_added": null
@@ -647,9 +647,9 @@
               "deprecated": false
             }
           },
-          "aac_codec": {
+          "aac_media_codec": {
             "__compat": {
-              "description": "<code>adts</code> codec",
+              "description": "AAC codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -693,9 +693,9 @@
               }
             }
           },
-          "amr_codec": {
+          "amr_media_codec": {
             "__compat": {
-              "description": "<code>adts</code> codec",
+              "description": "AMR codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -739,9 +739,9 @@
               }
             }
           },
-          "flac_codec": {
+          "flac_media_codec": {
             "__compat": {
-              "description": "<code>adts</code> codec",
+              "description": "FLAC codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -785,9 +785,9 @@
               }
             }
           },
-          "mp3_codec": {
+          "mp3_media_codec": {
             "__compat": {
-              "description": "<code>adts</code> codec",
+              "description": "MP3 codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -831,9 +831,9 @@
               }
             }
           },
-          "opus_codec": {
+          "opus_media_codec": {
             "__compat": {
-              "description": "<code>adts</code> codec",
+              "description": "Opus codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -877,9 +877,9 @@
               }
             }
           },
-          "pcm_codec": {
+          "pcm_media_codec": {
             "__compat": {
-              "description": "<code>adts</code> codec",
+              "description": "PCM codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -923,9 +923,9 @@
               }
             }
           },
-          "vorbis_codec": {
+          "vorbis_media_codec": {
             "__compat": {
-              "description": "<code>adts</code> codec",
+              "description": "Vorbis codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -970,9 +970,9 @@
             }
           }
         },
-        "flac_container": {
+        "flac_media_container": {
           "__compat": {
-            "description": "<code>flac</code> media container",
+            "description": "FLAC media container",
             "support": {
               "chrome": {
                 "version_added": null
@@ -1020,9 +1020,9 @@
               "deprecated": false
             }
           },
-          "aac_codec": {
+          "aac_media_codec": {
             "__compat": {
-              "description": "<code>flac</code> codec",
+              "description": "AAC codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -1066,9 +1066,9 @@
               }
             }
           },
-          "amr_codec": {
+          "amr_media_codec": {
             "__compat": {
-              "description": "<code>flac</code> codec",
+              "description": "AMR codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -1112,9 +1112,9 @@
               }
             }
           },
-          "flac_codec": {
+          "flac_media_codec": {
             "__compat": {
-              "description": "<code>flac</code> codec",
+              "description": "FLAC codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -1158,9 +1158,9 @@
               }
             }
           },
-          "mp3_codec": {
+          "mp3_media_codec": {
             "__compat": {
-              "description": "<code>flac</code> codec",
+              "description": "MP3 codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -1204,9 +1204,9 @@
               }
             }
           },
-          "opus_codec": {
+          "opus_media_codec": {
             "__compat": {
-              "description": "<code>flac</code> codec",
+              "description": "Opus codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -1250,9 +1250,9 @@
               }
             }
           },
-          "pcm_codec": {
+          "pcm_media_codec": {
             "__compat": {
-              "description": "<code>flac</code> codec",
+              "description": "PCM codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -1296,9 +1296,9 @@
               }
             }
           },
-          "vorbis_codec": {
+          "vorbis_media_codec": {
             "__compat": {
-              "description": "<code>flac</code> codec",
+              "description": "Vorbis codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -1343,9 +1343,9 @@
             }
           }
         },
-        "mkv_container": {
+        "mkv_media_container": {
           "__compat": {
-            "description": "<code>mkv</code> media container",
+            "description": "MKV media container",
             "support": {
               "chrome": {
                 "version_added": null
@@ -1393,9 +1393,9 @@
               "deprecated": false
             }
           },
-          "aac_codec": {
+          "aac_media_codec": {
             "__compat": {
-              "description": "<code>mkv</code> codec",
+              "description": "AAC codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -1439,9 +1439,9 @@
               }
             }
           },
-          "amr_codec": {
+          "amr_media_codec": {
             "__compat": {
-              "description": "<code>mkv</code> codec",
+              "description": "AMR codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -1485,9 +1485,9 @@
               }
             }
           },
-          "flac_codec": {
+          "flac_media_codec": {
             "__compat": {
-              "description": "<code>mkv</code> codec",
+              "description": "FLAC codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -1531,9 +1531,9 @@
               }
             }
           },
-          "mp3_codec": {
+          "mp3_media_codec": {
             "__compat": {
-              "description": "<code>mkv</code> codec",
+              "description": "MP3 codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -1577,9 +1577,9 @@
               }
             }
           },
-          "opus_codec": {
+          "opus_media_codec": {
             "__compat": {
-              "description": "<code>mkv</code> codec",
+              "description": "Opus codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -1623,9 +1623,9 @@
               }
             }
           },
-          "pcm_codec": {
+          "pcm_media_codec": {
             "__compat": {
-              "description": "<code>mkv</code> codec",
+              "description": "PCM codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -1669,9 +1669,9 @@
               }
             }
           },
-          "vorbis_codec": {
+          "vorbis_media_codec": {
             "__compat": {
-              "description": "<code>mkv</code> codec",
+              "description": "Vorbis codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -1716,9 +1716,9 @@
             }
           }
         },
-        "mp4_container": {
+        "mp4_media_container": {
           "__compat": {
-            "description": "<code>mp4</code> media container",
+            "description": "MP4 media container",
             "support": {
               "chrome": {
                 "version_added": null
@@ -1766,9 +1766,9 @@
               "deprecated": false
             }
           },
-          "aac_codec": {
+          "aac_media_codec": {
             "__compat": {
-              "description": "<code>mp4</code> codec",
+              "description": "AAC codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -1812,9 +1812,9 @@
               }
             }
           },
-          "amr_codec": {
+          "amr_media_codec": {
             "__compat": {
-              "description": "<code>mp4</code> codec",
+              "description": "AMR codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -1858,101 +1858,9 @@
               }
             }
           },
-          "flac_codec": {
+          "flac_media_codec": {
             "__compat": {
-              "description": "<code>mp4</code> codec",
-              "support": {
-                "chrome": {
-                  "version_added": null
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
-                "webview_android": {
-                  "version_added": null
-                }
-              }
-            }
-          },
-          "mp3_codec": {
-            "__compat": {
-              "description": "<code>mp4</code> codec",
-              "support": {
-                "chrome": {
-                  "version_added": null
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
-                "webview_android": {
-                  "version_added": null
-                }
-              }
-            }
-          },
-          "opus_codec": {
-            "__compat": {
-              "description": "<code>mp4</code> codec",
+              "description": "FLAC codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -1996,9 +1904,9 @@
               }
             }
           },
-          "pcm_codec": {
+          "mp3_media_codec": {
             "__compat": {
-              "description": "<code>mp4</code> codec",
+              "description": "MP3 codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -2042,9 +1950,101 @@
               }
             }
           },
-          "vorbis_codec": {
+          "opus_media_codec": {
             "__compat": {
-              "description": "<code>mp4</code> codec",
+              "description": "Opus codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "pcm_media_codec": {
+            "__compat": {
+              "description": "PCM codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "vorbis_media_codec": {
+            "__compat": {
+              "description": "Vorbis codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -2089,9 +2089,9 @@
             }
           }
         },
-        "mpeg_container": {
+        "mpeg_media_container": {
           "__compat": {
-            "description": "<code>mpeg</code> media container",
+            "description": "MPEG media container",
             "support": {
               "chrome": {
                 "version_added": null
@@ -2139,9 +2139,9 @@
               "deprecated": false
             }
           },
-          "aac_codec": {
+          "aac_media_codec": {
             "__compat": {
-              "description": "<code>mpeg</code> codec",
+              "description": "AAC codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -2185,9 +2185,9 @@
               }
             }
           },
-          "amr_codec": {
+          "amr_media_codec": {
             "__compat": {
-              "description": "<code>mpeg</code> codec",
+              "description": "AMR codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -2231,9 +2231,9 @@
               }
             }
           },
-          "flac_codec": {
+          "flac_media_codec": {
             "__compat": {
-              "description": "<code>mpeg</code> codec",
+              "description": "FLAC codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -2277,9 +2277,9 @@
               }
             }
           },
-          "mp3_codec": {
+          "mp3_media_codec": {
             "__compat": {
-              "description": "<code>mpeg</code> codec",
+              "description": "MP3 codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -2323,9 +2323,9 @@
               }
             }
           },
-          "opus_codec": {
+          "opus_media_codec": {
             "__compat": {
-              "description": "<code>mpeg</code> codec",
+              "description": "Opus codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -2369,9 +2369,9 @@
               }
             }
           },
-          "pcm_codec": {
+          "pcm_media_codec": {
             "__compat": {
-              "description": "<code>mpeg</code> codec",
+              "description": "PCM codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -2415,9 +2415,9 @@
               }
             }
           },
-          "vorbis_codec": {
+          "vorbis_media_codec": {
             "__compat": {
-              "description": "<code>mpeg</code> codec",
+              "description": "Vorbis codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -2462,9 +2462,9 @@
             }
           }
         },
-        "ogg_container": {
+        "ogg_media_container": {
           "__compat": {
-            "description": "<code>ogg</code> media container",
+            "description": "Ogg media container",
             "support": {
               "chrome": {
                 "version_added": null
@@ -2512,9 +2512,9 @@
               "deprecated": false
             }
           },
-          "aac_codec": {
+          "aac_media_codec": {
             "__compat": {
-              "description": "<code>ogg</code> codec",
+              "description": "AAC codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -2558,9 +2558,9 @@
               }
             }
           },
-          "amr_codec": {
+          "amr_media_codec": {
             "__compat": {
-              "description": "<code>ogg</code> codec",
+              "description": "AMR codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -2604,101 +2604,9 @@
               }
             }
           },
-          "flac_codec": {
+          "flac_media_codec": {
             "__compat": {
-              "description": "<code>ogg</code> codec",
-              "support": {
-                "chrome": {
-                  "version_added": null
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "firefox": {
-                  "version_added": true
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
-                "webview_android": {
-                  "version_added": null
-                }
-              }
-            }
-          },
-          "mp3_codec": {
-            "__compat": {
-              "description": "<code>ogg</code> codec",
-              "support": {
-                "chrome": {
-                  "version_added": null
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
-                  "version_added": null
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
-                "webview_android": {
-                  "version_added": null
-                }
-              }
-            }
-          },
-          "opus_codec": {
-            "__compat": {
-              "description": "<code>ogg</code> codec",
+              "description": "FLAC codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -2742,9 +2650,9 @@
               }
             }
           },
-          "pcm_codec": {
+          "mp3_media_codec": {
             "__compat": {
-              "description": "<code>ogg</code> codec",
+              "description": "MP3 codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -2788,9 +2696,101 @@
               }
             }
           },
-          "vorbis_codec": {
+          "opus_media_codec": {
             "__compat": {
-              "description": "<code>ogg</code> codec",
+              "description": "Opus codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "pcm_media_codec": {
+            "__compat": {
+              "description": "PCM codec",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "edge_mobile": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              }
+            }
+          },
+          "vorbis_media_codec": {
+            "__compat": {
+              "description": "Vorbis codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -2835,9 +2835,9 @@
             }
           }
         },
-        "mov_container": {
+        "mov_media_container": {
           "__compat": {
-            "description": "<code>mov</code> media container",
+            "description": "MOV media container",
             "support": {
               "chrome": {
                 "version_added": null
@@ -2887,9 +2887,9 @@
               "deprecated": false
             }
           },
-          "aac_codec": {
+          "aac_media_codec": {
             "__compat": {
-              "description": "<code>mov</code> codec",
+              "description": "AAC codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -2933,9 +2933,9 @@
               }
             }
           },
-          "amr_codec": {
+          "amr_media_codec": {
             "__compat": {
-              "description": "<code>mov</code> codec",
+              "description": "AMR codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -2979,9 +2979,9 @@
               }
             }
           },
-          "flac_codec": {
+          "flac_media_codec": {
             "__compat": {
-              "description": "<code>mov</code> codec",
+              "description": "FLAC codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -3025,9 +3025,9 @@
               }
             }
           },
-          "mp3_codec": {
+          "mp3_media_codec": {
             "__compat": {
-              "description": "<code>mov</code> codec",
+              "description": "MP3 codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -3071,9 +3071,9 @@
               }
             }
           },
-          "opus_codec": {
+          "opus_media_codec": {
             "__compat": {
-              "description": "<code>mov</code> codec",
+              "description": "Opus codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -3117,9 +3117,9 @@
               }
             }
           },
-          "pcm_codec": {
+          "pcm_media_codec": {
             "__compat": {
-              "description": "<code>mov</code> codec",
+              "description": "PCM codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -3163,9 +3163,9 @@
               }
             }
           },
-          "vorbis_codec": {
+          "vorbis_media_codec": {
             "__compat": {
-              "description": "<code>mov</code> codec",
+              "description": "Vorbis codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -3210,9 +3210,9 @@
             }
           }
         },
-        "wav_container": {
+        "wav_media_container": {
           "__compat": {
-            "description": "<code>wav</code> media container",
+            "description": "WAV media container",
             "support": {
               "chrome": {
                 "version_added": null
@@ -3260,9 +3260,9 @@
               "deprecated": false
             }
           },
-          "aac_codec": {
+          "aac_media_codec": {
             "__compat": {
-              "description": "<code>wav</code> codec",
+              "description": "AAC codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -3306,9 +3306,9 @@
               }
             }
           },
-          "amr_codec": {
+          "amr_media_codec": {
             "__compat": {
-              "description": "<code>wav</code> codec",
+              "description": "AMR codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -3352,9 +3352,9 @@
               }
             }
           },
-          "flac_codec": {
+          "flac_media_codec": {
             "__compat": {
-              "description": "<code>wav</code> codec",
+              "description": "FLAC codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -3398,9 +3398,9 @@
               }
             }
           },
-          "mp3_codec": {
+          "mp3_media_codec": {
             "__compat": {
-              "description": "<code>wav</code> codec",
+              "description": "MP3 codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -3444,9 +3444,9 @@
               }
             }
           },
-          "opus_codec": {
+          "opus_media_codec": {
             "__compat": {
-              "description": "<code>wav</code> codec",
+              "description": "Opus codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -3490,9 +3490,9 @@
               }
             }
           },
-          "pcm_codec": {
+          "pcm_media_codec": {
             "__compat": {
-              "description": "<code>wav</code> codec",
+              "description": "PCM codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -3536,9 +3536,9 @@
               }
             }
           },
-          "vorbis_codec": {
+          "vorbis_media_codec": {
             "__compat": {
-              "description": "<code>wav</code> codec",
+              "description": "Vorbis codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -3583,9 +3583,9 @@
             }
           }
         },
-        "webm_container": {
+        "webm_media_container": {
           "__compat": {
-            "description": "<code>webm</code> media container",
+            "description": "WebM media container",
             "support": {
               "chrome": {
                 "version_added": null
@@ -3633,9 +3633,9 @@
               "deprecated": false
             }
           },
-          "aac_codec": {
+          "aac_media_codec": {
             "__compat": {
-              "description": "<code>webm</code> codec",
+              "description": "AAC codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -3679,9 +3679,9 @@
               }
             }
           },
-          "amr_codec": {
+          "amr_media_codec": {
             "__compat": {
-              "description": "<code>webm</code> codec",
+              "description": "AMR codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -3725,9 +3725,9 @@
               }
             }
           },
-          "flac_codec": {
+          "flac_media_codec": {
             "__compat": {
-              "description": "<code>webm</code> codec",
+              "description": "FLAC codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -3771,9 +3771,9 @@
               }
             }
           },
-          "mp3_codec": {
+          "mp3_media_codec": {
             "__compat": {
-              "description": "<code>webm</code> codec",
+              "description": "MP3 codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -3817,9 +3817,9 @@
               }
             }
           },
-          "opus_codec": {
+          "opus_media_codec": {
             "__compat": {
-              "description": "<code>webm</code> codec",
+              "description": "Opus codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -3863,9 +3863,9 @@
               }
             }
           },
-          "pcm_codec": {
+          "pcm_media_codec": {
             "__compat": {
-              "description": "<code>webm</code> codec",
+              "description": "PCM codec",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -3909,9 +3909,9 @@
               }
             }
           },
-          "vorbis_codec": {
+          "vorbis_media_codec": {
             "__compat": {
-              "description": "<code>webm</code> codec",
+              "description": "Vorbis codec",
               "support": {
                 "chrome": {
                   "version_added": null

--- a/html/elements/audio.json
+++ b/html/elements/audio.json
@@ -690,6 +690,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -736,6 +741,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -782,6 +792,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -828,6 +843,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -874,6 +894,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -920,6 +945,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -966,6 +996,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           }
@@ -1063,6 +1098,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -1109,6 +1149,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -1155,6 +1200,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -1201,6 +1251,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -1247,6 +1302,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -1293,6 +1353,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -1339,6 +1404,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           }
@@ -1436,6 +1506,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -1482,6 +1557,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -1528,6 +1608,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -1574,6 +1659,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -1620,6 +1710,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -1666,6 +1761,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -1712,6 +1812,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           }
@@ -1809,6 +1914,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -1855,6 +1965,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -1901,6 +2016,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -1947,6 +2067,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -1993,6 +2118,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -2039,6 +2169,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -2085,6 +2220,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           }
@@ -2182,6 +2322,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -2228,6 +2373,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -2274,6 +2424,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -2320,6 +2475,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -2366,6 +2526,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -2412,6 +2577,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -2458,6 +2628,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           }
@@ -2555,6 +2730,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -2601,6 +2781,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -2647,6 +2832,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -2693,6 +2883,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -2739,6 +2934,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -2785,6 +2985,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -2831,6 +3036,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           }
@@ -2930,6 +3140,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -2976,6 +3191,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -3022,6 +3242,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -3068,6 +3293,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -3114,6 +3344,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -3160,6 +3395,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -3206,6 +3446,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           }
@@ -3303,6 +3548,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -3349,6 +3599,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -3395,6 +3650,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -3441,6 +3701,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -3487,6 +3752,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -3533,6 +3803,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -3579,6 +3854,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           }
@@ -3676,6 +3956,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -3722,6 +4007,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -3768,6 +4058,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -3814,6 +4109,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -3860,6 +4160,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -3906,6 +4211,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },
@@ -3952,6 +4262,11 @@
                 "webview_android": {
                   "version_added": null
                 }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           }

--- a/html/elements/audio.json
+++ b/html/elements/audio.json
@@ -559,9 +559,6 @@
               "edge": {
                 "version_added": null
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": false
               },
@@ -610,9 +607,6 @@
               "edge": {
                 "version_added": null
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": true
               },
@@ -658,9 +652,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -711,9 +702,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -760,9 +748,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -813,9 +798,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": true
                 },
@@ -862,9 +844,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -915,9 +894,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -964,9 +940,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -1018,9 +991,6 @@
               "edge": {
                 "version_added": null
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": true
               },
@@ -1066,9 +1036,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -1119,9 +1086,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -1168,9 +1132,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -1221,9 +1182,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": true
                 },
@@ -1270,9 +1228,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -1323,9 +1278,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -1372,9 +1324,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -1426,9 +1375,6 @@
               "edge": {
                 "version_added": null
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": false
               },
@@ -1474,9 +1420,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -1527,9 +1470,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -1576,9 +1516,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -1629,9 +1566,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -1678,9 +1612,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -1731,9 +1662,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -1780,9 +1708,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -1834,9 +1759,6 @@
               "edge": {
                 "version_added": null
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": true
               },
@@ -1882,9 +1804,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -1935,9 +1854,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -1984,9 +1900,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -2037,9 +1950,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -2086,9 +1996,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -2139,9 +2046,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -2188,9 +2092,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -2242,9 +2143,6 @@
               "edge": {
                 "version_added": null
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": true
               },
@@ -2290,9 +2188,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -2343,9 +2238,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -2392,9 +2284,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -2445,9 +2334,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": true
                 },
@@ -2494,9 +2380,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -2547,9 +2430,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -2596,9 +2476,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -2650,9 +2527,6 @@
               "edge": {
                 "version_added": null
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": true
               },
@@ -2698,9 +2572,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -2751,9 +2622,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -2800,9 +2668,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -2853,9 +2718,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -2902,9 +2764,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -2955,9 +2814,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -3004,9 +2860,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -3058,9 +2911,6 @@
               "edge": {
                 "version_added": null
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "notes": "QuickTime is supported only if available on the host device, such as on macOS.",
                 "version_added": true
@@ -3108,9 +2958,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -3161,9 +3008,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -3210,9 +3054,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -3263,9 +3104,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": true
                 },
@@ -3312,9 +3150,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -3365,9 +3200,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -3414,9 +3246,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -3468,9 +3297,6 @@
               "edge": {
                 "version_added": null
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": true
               },
@@ -3516,9 +3342,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -3569,9 +3392,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -3618,9 +3438,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -3671,9 +3488,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -3720,9 +3534,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -3773,9 +3584,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": true
                 },
@@ -3822,9 +3630,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -3876,9 +3681,6 @@
               "edge": {
                 "version_added": null
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": true
               },
@@ -3924,9 +3726,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -3977,9 +3776,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -4026,9 +3822,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -4079,9 +3872,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -4128,9 +3918,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -4181,9 +3968,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -4230,9 +4014,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {


### PR DESCRIPTION
Summary: a partial attempt to get audio containers and codec data into BCD, borrowing from @a2sheppy 's [previous work](#3446).

While triaging open PRs, I was trying to imagine how we might merge @a2sheppy's data from #3446. For a number of reasons, I think changing the schema is unlikely to happen soon. In the interim, I'd like to see us migrate that data. With that in mind, I took inspiration from the way we handled events, by naming them in the form `<eventname>_event`. Why couldn't we do likewise for containers and codecs?

This PR takes Sheppy's data (I included him has a coauthor on the commit—he did all the work) and restructures it, using standard `__compat` statements and renaming the features throughout to use a `<containername>_container` and `<codecname>_codec` naming scheme. I've also added human-readable descriptions.

Having generated the JSON, this seems pretty legible to me, but I'd be interested in other perspectives. There's also a couple of issues which I hadn't really attempted to resolve (thus the draft PR):

* ~The codec data does not have status blocks. I'm not sure what statuses would be correct. The HTML spec doesn't demand anything and I'm not sure what other specs would be relevant.~ Never mind; see https://github.com/mdn/browser-compat-data/pull/4193#issuecomment-500441936.
* The PR would introduce a bunch of new `null` data points, which I'd like to avoid. Does anyone know of sources of data for containers and codecs apart for browsers other than Firefox?