### PR TITLE
Bug 1492739: Unprefix `user‑select`

### DIFF
--- a/css/properties/user-select.json
+++ b/css/properties/user-select.json
@@ -45,6 +45,9 @@
             ],
             "firefox": [
               {
+                "version_added": "69"
+              },
+              {
                 "prefix": "-moz-",
                 "version_added": "1"
               },
@@ -65,6 +68,9 @@
               }
             ],
             "firefox_android": [
+              {
+                "version_added": "69"
+              },
               {
                 "prefix": "-moz-",
                 "version_added": "4"

--- a/css/properties/user-select.json
+++ b/css/properties/user-select.json
@@ -69,9 +69,6 @@
             ],
             "firefox_android": [
               {
-                "version_added": "69"
-              },
-              {
                 "prefix": "-moz-",
                 "version_added": "4"
               },


### PR DESCRIPTION
See [bug 1492739](https://bugzilla.mozilla.org/show_bug.cgi?id=1492739) for details.

review?(@vinyldarkscratch)