### PR TITLE
Add compat data for fullscreen events

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -4629,6 +4629,92 @@
           }
         }
       },
+      "fullscreenchange_event": {
+        "__compat": {
+          "description": "<code>fullscreenchange</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/fullscreenchange_event",
+          "support": {
+            "chrome": {
+              "version_added": "45"
+            },
+            "chrome_android": {
+              "version_added": "45"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "64"
+              },
+              {
+                "version_added": "47",
+                "version_removed": "64",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "full-screen-api.unprefix.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "10",
+                "version_removed": "64",
+                "alternative_name": "mozfullscreenchange"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "64"
+              },
+              {
+                "version_added": "47",
+                "version_removed": "64",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "full-screen-api.unprefix.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "10",
+                "version_removed": "64",
+                "alternative_name": "mozfullscreenchange"
+              }
+            ],
+            "ie": {
+              "version_added": "11",
+              "alternative_name": "MSFullscreenChange"
+            },
+            "opera": {
+              "version_added": "32"
+            },
+            "opera_android": {
+              "version_added": "32"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "45"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "fullscreenEnabled": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/fullscreenEnabled",
@@ -4724,6 +4810,92 @@
                 "prefix": "webkit"
               }
             ]
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "fullscreenerror_event": {
+        "__compat": {
+          "description": "<code>fullscreenerror</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/fullscreenerror_event",
+          "support": {
+            "chrome": {
+              "version_added": "45"
+            },
+            "chrome_android": {
+              "version_added": "45"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "64"
+              },
+              {
+                "version_added": "47",
+                "version_removed": "64",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "full-screen-api.unprefix.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "10",
+                "version_removed": "64",
+                "alternative_name": "mozfullscreenerror"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "64"
+              },
+              {
+                "version_added": "47",
+                "version_removed": "64",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "full-screen-api.unprefix.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "10",
+                "version_removed": "65",
+                "alternative_name": "mozfullscreenerror"
+              }
+            ],
+            "ie": {
+              "version_added": "11",
+              "alternative_name": "MSFullscreenError"
+            },
+            "opera": {
+              "version_added": "32"
+            },
+            "opera_android": {
+              "version_added": "32"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "45"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/Element.json
+++ b/api/Element.json
@@ -2821,6 +2821,132 @@
           }
         }
       },
+      "fullscreenchange_event": {
+        "__compat": {
+          "description": "<code>fullscreenchange</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/fullscreenchange_event",
+          "support": {
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "64"
+              },
+              {
+                "version_added": "10",
+                "version_removed": "64",
+                "alternative_name": "mozfullscreenchange"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "64"
+              },
+              {
+                "version_added": "10",
+                "version_removed": "64",
+                "alternative_name": "mozfullscreenchange"
+              }
+            ],
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "44"
+            },
+            "opera_android": {
+              "version_added": "43"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "57"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "fullscreenerror_event": {
+        "__compat": {
+          "description": "<code>fullscreenerror</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/fullscreenerror_event",
+          "support": {
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": [
+              {
+                "version_added": "64"
+              },
+              {
+                "version_added": "10",
+                "version_removed": "64",
+                "alternative_name": "mozfullscreenerror"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "64"
+              },
+              {
+                "version_added": "10",
+                "version_removed": "64",
+                "alternative_name": "mozfullscreenerror"
+              }
+            ],
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "44"
+            },
+            "opera_android": {
+              "version_added": "43"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "57"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "gesturechange_event": {
         "__compat": {
           "description": "<code>gesturechange</code> event",


### PR DESCRIPTION
This PR supersedes https://github.com/mdn/browser-compat-data/pull/4054, which I'm about to close.

This adds compat data for:

* [Document.fullscreenchange_event](https://developer.mozilla.org/en-US/docs/Web/API/Document/fullscreenchange_event)
* [Document.fullscreenerror_event](https://developer.mozilla.org/en-US/docs/Web/API/Document/fullscreenerror_event)
* [Element.fullscreenchange_event](https://developer.mozilla.org/en-US/docs/Web/API/Element/fullscreenchange_event)
* [Element.fullscreenerror_event](https://developer.mozilla.org/en-US/docs/Web/API/Element/fullscreenerror_event)

It's copied from the corresponding `on-*` event handler properties:
* [Document.onfullscreenchange](https://developer.mozilla.org/en-US/docs/Web/API/Document/onfullscreenchange)
* [Document.onfullscreenerror](https://developer.mozilla.org/en-US/docs/Web/API/Document/onfullscreenerror)
* [Element.onfullscreenchange](https://developer.mozilla.org/en-US/docs/Web/API/Element/onfullscreenchange)
* [Element.onfullscreenerror](https://developer.mozilla.org/en-US/docs/Web/API/Element/onfullscreenerror)

The only changes I've made are:
* strategic removal of the `on` prefix in the notes for alternative names
* fixes for `version_removed` as noted in the original review: https://github.com/mdn/browser-compat-data/pull/3996#discussion_r278681832.
* added compat for Opera and Opera Android, based on comments in the original review, e.g. https://github.com/mdn/browser-compat-data/pull/3996#discussion_r278681959. It was a little hard to reconstruct these, but as far as I could tell:
    * for `Document`, Chrome lists support from 45 for both features, so Opera and Opera Android both get "32"
    * for `Element`, Chrome lists support for 57 for both features, and Opera then gets "44" but Opera Android gets "43". I'm a bit surprised to see this difference, but I believe that's what the original comment recommended (e.g. https://github.com/mdn/browser-compat-data/pull/3996#discussion_r278682710 versus https://github.com/mdn/browser-compat-data/pull/3996#discussion_r278682825).

I'm asking @vinyldarkscratch to review this because she reviewed the original PR. But please let me know if you'd like to reassign review (or just do it :). Thanks!