### PR TITLE
Fix name of -webkit-line-clamp property.

### DIFF
--- a/css/properties/-webkit-line-clamp.json
+++ b/css/properties/-webkit-line-clamp.json
@@ -1,7 +1,7 @@
 {
   "css": {
     "properties": {
-      "-webkit-box-reflect": {
+      "-webkit-line-clamp": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-line-clamp",
           "support": {


### PR DESCRIPTION
Mistake introduced in #4142. Fixes the property name.
