### PR TITLE
Add Element.getAnimations entry

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2977,6 +2977,57 @@
           }
         }
       },
+      "getAnimations": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/getAnimations",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getAttribute": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/getAttribute",


### PR DESCRIPTION
I've just added an entry for the following MDN page: https://developer.mozilla.org/en-US/docs/Web/API/Element/getAnimations

As discussed with @chrisdavidmills on (Mozilla bug 1553021](https://bugzilla.mozilla.org/show_bug.cgi?id=1553021#c4) this method is actually defined on the `Animatable` mixin which is then implemented by `Element` (and `CSSPseudoElement`). It seems simplest and most consistent to just add an entry for `Element.getAnimations` since UAs might not implement the method on `CSSPseudoElement` for example and because we already define `Element.animate` as a separate item despite it also being specified on the `Animatable` mixin interface.

Also, despite this being implemented in Firefox Nightly / Chrome Canary / Safari TP, it's not shipping to release channels anywhere and so to keep things simple we've decided just not to mark any Web Animations API features as implemented until they are actually on track to be released.