### PR TITLE
Add IE/Edge data for KeyboardEvent.code

### DIFF
--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -265,7 +265,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null
@@ -277,7 +277,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
It's neither supported by current Edge nor IE. 

## Data
https://www.lambdatest.com/keyboard-event.code
https://developer.microsoft.com/en-us/microsoft-edge/platform/catalog/?q=specName%3Auievents
https://caniuse.com/#search=KeyboardEvent.code (Caniuse lists it as supported by Edge 75, but I don't know any way to install Edge 75).

## Screenshots
![KeyboardEvent_code_IE](https://user-images.githubusercontent.com/1061218/58258915-d339c380-7d73-11e9-9937-60641631e762.png)

![KeyboardEvent_code_Edge](https://user-images.githubusercontent.com/1061218/58258916-d339c380-7d73-11e9-9205-b6872b13f8bc.png)