### PR TITLE
[Chrome] Update perf APIs.

### DIFF
--- a/api/PerformanceMark.json
+++ b/api/PerformanceMark.json
@@ -8,7 +8,7 @@
             "version_added": "43"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "43"
           },
           "edge": {
             "version_added": true
@@ -41,7 +41,7 @@
             "version_added": true
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "43"
           }
         },
         "status": {

--- a/api/PerformanceMeasure.json
+++ b/api/PerformanceMeasure.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceMeasure",
         "support": {
           "chrome": {
-            "version_added": "43"
+            "version_added": "25"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "25"
           },
           "edge": {
             "version_added": true

--- a/api/PerformanceNavigation.json
+++ b/api/PerformanceNavigation.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceNavigation",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": true
           },
           "edge": {
             "version_added": true
@@ -55,10 +55,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceNavigation/type",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -93,7 +93,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {
@@ -108,10 +108,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceNavigation/redirectCount",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -144,7 +144,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {
@@ -159,10 +159,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceNavigation/toJSON",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "56"
             },
             "edge": {
               "version_added": "12"
@@ -197,7 +197,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {

--- a/api/PerformanceObserver.json
+++ b/api/PerformanceObserver.json
@@ -35,7 +35,7 @@
             "version_added": "11"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "52"
           }
         },
         "status": {
@@ -125,7 +125,7 @@
               "version_added": "11"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "52"
             }
           },
           "status": {
@@ -170,7 +170,7 @@
               "version_added": "11"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "52"
             }
           },
           "status": {
@@ -215,11 +215,56 @@
               "version_added": "11"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "52"
             }
           },
           "status": {
             "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "supportedEntryTypes": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceObserver/supportedEntryTypes",
+          "support": {
+            "chrome": {
+              "version_added": "73"
+            },
+            "chrome_android": {
+              "version_added": "73"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "73"
+            }
+          },
+          "status": {
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/PerformanceTiming.json
+++ b/api/PerformanceTiming.json
@@ -8,7 +8,7 @@
             "version_added": "6"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -55,7 +55,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -103,7 +103,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -151,7 +151,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -199,7 +199,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -247,7 +247,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -295,7 +295,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -343,7 +343,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -391,7 +391,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -439,7 +439,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -487,7 +487,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -535,7 +535,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -583,7 +583,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -631,7 +631,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -679,7 +679,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -727,7 +727,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -775,7 +775,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -823,7 +823,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -871,7 +871,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -919,7 +919,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "18"
@@ -1015,7 +1015,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1063,7 +1063,7 @@
               "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"


### PR DESCRIPTION
This replaces #3768. The previous PR included Safari data from confluence. It conflicted with more recent changes in ways that I don't even know how to research.

Source data is as follows.
`PerformanceMeasure` [in Chrome 25](https://chromium.googlesource.com/chromium/src/+/6981e8f4adf9a8e1925ac9bb4a32513031470ee2)
`PerformanceLongTaskTiming.toJSON` [in Chrome 65](https://storage.googleapis.com/chromium-find-releases-static/127.html#1278739add31c47c73d424dc561500973d4cbe4d)
`PerformanceNavigation.toJSON` [in Chrome 56](https://storage.googleapis.com/chromium-find-releases-static/fb6.html#fb6c988e174e59fed729751deabe71fbb470b1a3)
`PerformanceObserver.supportedEntryTypes` [in Chrome 73](https://storage.googleapis.com/chromium-find-releases-static/11c.html#11c9531efb1a0d4cf8f28b1c34038c713fe26207)