### PR TITLE
colors/frame is supported in Fennec

### DIFF
--- a/webextensions/manifest/theme.json
+++ b/webextensions/manifest/theme.json
@@ -148,7 +148,7 @@
                   "notes": "Before version 59, the CSS color form was not supported for this property."
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": true
                 },
                 "opera": {
                   "version_added": false


### PR DESCRIPTION
An actual version number should be added.

Somewhat related, <https://bugzilla.mozilla.org/show_bug.cgi?id=1554037>. Since the frame property operates differently on Fennec than Firefox, I think a note with an explanation might be helpful.