### PR TITLE
Update compatibility table for location.origin

### DIFF
--- a/api/Location.json
+++ b/api/Location.json
@@ -331,16 +331,16 @@
               "notes": "Intranet sites are set to Compatibility View, which will emulate IE7 and omit <code>window.location.origin</code>."
             },
             "opera": {
-              "version_added": null
+              "version_added": "10.63"
             },
             "opera_android": {
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/Location.json
+++ b/api/Location.json
@@ -338,7 +338,7 @@
             },
             "safari": {
               "version_added": true,
-              "notes": "According to <a href=\"https://developer.apple.com/documentation/webkitjs/location/1631059-origin\">Apple's documentation</a>, <code>window.location.origin</code> is supported since Safari 10 (both desktop and mobile), but the feature seems to be present in some older versions as well. Because of this, the exact versions supporting this feature cannot be determined reliably."
+              "notes": "According to <a href='https://developer.apple.com/documentation/webkitjs/location/1631059-origin'>Apple's documentation</a>, <code>window.location.origin</code> is supported since Safari 10 (both desktop and mobile), but the feature seems to be present in some older versions as well. Because of this, the exact versions supporting this feature cannot be determined reliably."
             },
             "safari_ios": {
               "version_added": "5"

--- a/api/Location.json
+++ b/api/Location.json
@@ -337,7 +337,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "4"
+              "version_added": true
             },
             "safari_ios": {
               "version_added": "5"

--- a/api/Location.json
+++ b/api/Location.json
@@ -337,7 +337,8 @@
               "version_added": null
             },
             "safari": {
-              "version_added": true
+              "version_added": true,
+              "notes": "According to <a href=\"https://developer.apple.com/documentation/webkitjs/location/1631059-origin\">Apple's documentation</a>, <code>window.location.origin</code> is supported since Safari 10 (both desktop and mobile), but the feature seems to be present in some older versions as well. Because of this, the exact versions supporting this feature cannot be determined reliably."
             },
             "safari_ios": {
               "version_added": "5"

--- a/api/Location.json
+++ b/api/Location.json
@@ -331,7 +331,7 @@
               "notes": "Intranet sites are set to Compatibility View, which will emulate IE7 and omit <code>window.location.origin</code>."
             },
             "opera": {
-              "version_added": "10.63"
+              "version_added": "10"
             },
             "opera_android": {
               "version_added": null


### PR DESCRIPTION
This PR adds compatibility information for `location.origin` for the following browsers:
- Opera desktop
- Safari desktop
- Safari iOS

I was able to track down these implementation issues for Safari (but I am not sure how to determine the actual version of Safari that shipped the feature from these):
- https://bugs.webkit.org/show_bug.cgi?id=46558
- https://bugs.webkit.org/show_bug.cgi?id=151614

I verified the compatibility by hand using browserstack.com. Since the feature is supported by the oldest Safari desktop and Opera desktop versions that browserstack offers, I am unable to determine the exact versions from which this feature has been shipped.