### PR TITLE
latest firefox and safari@12 support RTCDataChannel.buffered​Amount

### DIFF
--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -132,7 +132,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": 18
+              "version_added": "18"
             },
             "firefox_android": {
               "version_added": false

--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -132,7 +132,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": 18
             },
             "firefox_android": {
               "version_added": false

--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -132,7 +132,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": true
             },
             "firefox_android": {
               "version_added": false
@@ -147,7 +147,7 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
latest firefox and safari@12 support RTCDataChannel.buffered​Amount
Change the `version_added` from `false` to `true`

- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
[DataChannel bufferedAmount test page](https://ajlovechina.github.io/browser-compat-data/DC/bufferedAmount/index.html)

- [x] Data: if you tested something, describe how you tested with details like browser and version
1. create two dataChannels in one webpage
2. connect both the dataChannels
3. print dataChannel.bufferedAmount on the webpage
4. test 1 - 3 in latest firefox and safari@12

- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)