### PR TITLE
Update font-family.json

### DIFF
--- a/css/properties/font-family.json
+++ b/css/properties/font-family.json
@@ -19,7 +19,6 @@
             },
             "firefox": {
               "version_added": "1",
-              "partial_implementation" : true,
               "notes" : "Not supported on <code>option</code> elements. See <a href='https://bugzil.la/1536148'>bug 1536148</a>."
             },
             "firefox_android": {

--- a/css/properties/font-family.json
+++ b/css/properties/font-family.json
@@ -18,7 +18,9 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "partial_implementation" : true,
+              "notes" : "Not supported on <code>option</code> elements. See <a href='https://bugzil.la/1536148'>bug 1536148</a>."
             },
             "firefox_android": {
               "version_added": "4"

--- a/css/properties/font-family.json
+++ b/css/properties/font-family.json
@@ -19,7 +19,7 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes" : "Not supported on <code>option</code> elements. See <a href='https://bugzil.la/1536148'>bug 1536148</a>."
+              "notes": "Not supported on <code>option</code> elements. See <a href='https://bugzil.la/1536148'>bug 1536148</a>."
             },
             "firefox_android": {
               "version_added": "4"


### PR DESCRIPTION
Add information on `option` not respecting `font-family` with link to relevant bug
