### PR TITLE
[bug] fix PluralRules support for nodejs

### DIFF
--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -2445,7 +2445,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "10.0.0"
               },
               "opera": {
                 "version_added": "50"
@@ -2500,7 +2500,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "10.0.0"
                 },
                 "opera": {
                   "version_added": "50"
@@ -2554,7 +2554,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "10.0.0"
                 },
                 "opera": {
                   "version_added": "50"
@@ -2608,7 +2608,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "10.0.0"
                 },
                 "opera": {
                   "version_added": "50"
@@ -2662,7 +2662,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "10.0.0"
                 },
                 "opera": {
                   "version_added": "50"
@@ -2716,7 +2716,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "10.0.0"
                 },
                 "opera": {
                   "version_added": "50"


### PR DESCRIPTION
Node 10 supports `Intl.PluralRules` since it uses [V8 6.6](https://nodejs.org/en/blog/release/v10.0.0/) and this feature's been in V8 [since 6.3](https://developers.google.com/web/updates/2017/10/intl-pluralrules).

