### PR TITLE
Added missing information about iOS Safari support for `backdrop-filter`

### DIFF
--- a/css/properties/backdrop-filter.json
+++ b/css/properties/backdrop-filter.json
@@ -57,7 +57,8 @@
               "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "prefix": "-webkit-",
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/backdrop-filter.json
+++ b/css/properties/backdrop-filter.json
@@ -58,7 +58,7 @@
             },
             "safari_ios": {
               "prefix": "-webkit-",
-              "version_added": "12"
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes

Added missing information about iOS Safari support for `backdrop-filter`.

- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)

According to https://caniuse.com/#feat=css-backdrop-filter iOS Safari supports `backdrop-filter` since v9. 

- [x] Data: if you tested something, describe how you tested with details like browser and version

I've tested `backdrop-filter` support using iOS Safari v12.1 on my own website lekschas.de and can confirm that it requires the `-webkit-` prefix. The topbar uses the filter.

- ~[ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)~
- ~[ ] Link to related issues or pull requests, if any~
