### PR TITLE
Update Edge compat data for CSS types

### DIFF
--- a/css/types/global_keywords.json
+++ b/css/types/global_keywords.json
@@ -113,10 +113,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "13"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": "13"
               },
               "firefox": [
                 {
@@ -234,10 +234,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "13"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": "13"
               },
               "firefox": {
                 "version_added": "27"

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -1807,10 +1807,10 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false,
@@ -1863,10 +1863,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false,
@@ -1931,10 +1931,10 @@
                 "notes": "Supports the original dual-image with percentage implementation only."
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false

--- a/css/types/length-percentage.json
+++ b/css/types/length-percentage.json
@@ -684,7 +684,7 @@
                 "version_added": "16"
               },
               "edge_mobile": {
-                "version_added": "16"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "19",

--- a/css/types/length-percentage.json
+++ b/css/types/length-percentage.json
@@ -858,10 +858,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
+                "version_added": null
               },
               "edge_mobile": {
-                "version_added": "12"
+                "version_added": null
               },
               "firefox": {
                 "version_added": "4"

--- a/css/types/length-percentage.json
+++ b/css/types/length-percentage.json
@@ -477,10 +477,10 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": true
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -681,10 +681,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "16"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "16"
               },
               "firefox": {
                 "version_added": "19",
@@ -858,10 +858,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "4"

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -860,10 +860,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
+                "version_added": null
               },
               "edge_mobile": {
-                "version_added": "12"
+                "version_added": null
               },
               "firefox": {
                 "version_added": "4"

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -477,10 +477,10 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": true
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -683,10 +683,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "16"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "16"
               },
               "firefox": {
                 "version_added": "19",
@@ -860,10 +860,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "4"

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -686,7 +686,7 @@
                 "version_added": "16"
               },
               "edge_mobile": {
-                "version_added": "16"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "19",

--- a/css/types/resolution.json
+++ b/css/types/resolution.json
@@ -128,10 +128,10 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "62"


### PR DESCRIPTION
This PR aims to complete CSS type data for Edge. Some notes on how I came to the versions:


`css.types.global_keywords.initial`, `css.types.global_keywords.unset`: version 13
https://developer.microsoft.com/en-us/microsoft-edge/platform/changelog/desktop/10565/
https://developer.microsoft.com/en-us/microsoft-edge/platform/status/cssinitialvalue
https://developer.microsoft.com/en-us/microsoft-edge/platform/status/cssunsetvalue

`css.types.image.image`: false
(manual testing in Edge 18 in Saucelabs)

`css.types.image.image-set`: false
https://developer.microsoft.com/en-us/microsoft-edge/platform/status/cssimageset/

`css.types.image.crossfade`: false
https://caniuse.com/#feat=css-cross-fade

`css.types.length-percentage.rlh`: false
(Coudn't find any evidence this very new unit is supported. "lh" was already marked as false which seems correct)

`css.types.length-percentage.vmax`: 16
https://developer.microsoft.com/en-us/microsoft-edge/platform/status/cssvmaxunit/

`css.types.resolution.x`: false
(this is fairly new and it doesn't look like Edge has it)

`css.types.length-percentage.1in_is_96px`: 12
`css.types.length.1in_is_96px`: 12
(I believe only Firefox had this wrong before version 4)