### PR TITLE
Complete media at-rule data for Edge

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -321,10 +321,10 @@
                 "version_added": "58"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -373,10 +373,10 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -790,10 +790,10 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -842,10 +842,10 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -996,10 +996,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "2"
@@ -1417,10 +1417,10 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -1471,10 +1471,10 @@
                 "notes": "See <a href='https://crbug.com/489957'>bug 489957</a>."
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false,
@@ -1577,10 +1577,10 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -1681,10 +1681,10 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"
@@ -1735,10 +1735,10 @@
                 "version_removed": "36"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -1791,10 +1791,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": [
                 {
@@ -1895,10 +1895,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": [
                 {
@@ -1999,10 +1999,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": [
                 {
@@ -2163,10 +2163,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": [
                 {
@@ -2239,10 +2239,10 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false


### PR DESCRIPTION
This PR completes data for CSS at-rules for Edge. Notes on where I have the data from:

Manual testing in saucelabs
css.at-rules.media.inverted-colors: false

These look like not supported broadly anywhere really:
css.at-rules.media.color-gamut: false
css.at-rules.media.color-index: false
css.at-rules.media.monochrome: false
css.at-rules.media.light-level: false
css.at-rules.media.scan: false
css.at-rules.media.scripting: false
css.at-rules.media.update: false

Safari specific only:
css.at-rules.media.-webkit-animation: false

Per https://caniuse.com/#search=device-pixel-ratio:
css.at-rules.media.-webkit-device-pixel-ratio
css.at-rules.media.-webkit-max-device-pixel-ratio
css.at-rules.media.-webkit-min-device-pixel-ratio


Per https://www.quirksmode.org/css/tests/mediaqueries/animation.html
css.at-rules.media.-webkit-transform-3d: 12
css.at-rules.media.-webkit-transition: false