### PR TITLE
Progressive Web Apps manifest compatibility

### DIFF
--- a/html/manifest/background_color.json
+++ b/html/manifest/background_color.json
@@ -3,7 +3,7 @@
     "manifest": {
       "background_color": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/background_color",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/background_color.json
+++ b/html/manifest/background_color.json
@@ -1,0 +1,59 @@
+{
+  "html": {
+    "manifest": {
+      "background_color": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": "46",
+              "notes": "Does not support <code>lang</code> or <code>scope</code>."
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "46",
+              "notes": "Does not support <code>lang</code> or <code>scope</code>."
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/manifest/categories.json
+++ b/html/manifest/categories.json
@@ -3,7 +3,7 @@
     "manifest": {
       "categories": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/categories",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/categories.json
+++ b/html/manifest/categories.json
@@ -1,0 +1,57 @@
+{
+  "html": {
+    "manifest": {
+      "categories": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/manifest/description.json
+++ b/html/manifest/description.json
@@ -3,7 +3,7 @@
     "manifest": {
       "description": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/description",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/description.json
+++ b/html/manifest/description.json
@@ -1,0 +1,57 @@
+{
+  "html": {
+    "manifest": {
+      "description": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/manifest/dir.json
+++ b/html/manifest/dir.json
@@ -1,0 +1,57 @@
+{
+  "html": {
+    "manifest": {
+      "dir": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/manifest/dir.json
+++ b/html/manifest/dir.json
@@ -3,7 +3,7 @@
     "manifest": {
       "dir": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/dir",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/display.json
+++ b/html/manifest/display.json
@@ -1,0 +1,57 @@
+{
+  "html": {
+    "manifest": {
+      "display": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": "47"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/manifest/display.json
+++ b/html/manifest/display.json
@@ -3,7 +3,7 @@
     "manifest": {
       "display": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/display",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/iarc_rating_id.json
+++ b/html/manifest/iarc_rating_id.json
@@ -1,0 +1,57 @@
+{
+  "html": {
+    "manifest": {
+      "iarc_rating_id": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/manifest/iarc_rating_id.json
+++ b/html/manifest/iarc_rating_id.json
@@ -3,7 +3,7 @@
     "manifest": {
       "iarc_rating_id": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/iarc_rating_id",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/icons.json
+++ b/html/manifest/icons.json
@@ -1,0 +1,58 @@
+{
+  "html": {
+    "manifest": {
+      "icons": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": "53",
+              "notes": "By default, used for as the source for \"Add to home screen\" (see bug 1234558). Experimental support for this feature is available behind the boolean flag manifest.install.enabled in about:config."
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/manifest/icons.json
+++ b/html/manifest/icons.json
@@ -3,7 +3,7 @@
     "manifest": {
       "icons": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/icons",
           "support": {
             "chrome": {
               "version_added": null
@@ -22,7 +22,14 @@
             },
             "firefox_android": {
               "version_added": "53",
-              "notes": "By default, used for as the source for \"Add to home screen\" (see bug 1234558). Experimental support for this feature is available behind the boolean flag manifest.install.enabled in about:config."
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "manifest.install.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "By default, used for as the source for \"Add to home screen\" (see bug 1234558)."
             },
             "ie": {
               "version_added": null

--- a/html/manifest/lang.json
+++ b/html/manifest/lang.json
@@ -1,0 +1,57 @@
+{
+  "html": {
+    "manifest": {
+      "lang": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/manifest/lang.json
+++ b/html/manifest/lang.json
@@ -3,7 +3,7 @@
     "manifest": {
       "lang": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/lang",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/name.json
+++ b/html/manifest/name.json
@@ -1,0 +1,58 @@
+{
+  "html": {
+    "manifest": {
+      "name": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": "53",
+              "notes": "By default, used for as the source for \"Add to home screen\" (see bug 1234558). Experimental support for this feature is available behind the boolean flag manifest.install.enabled in about:config."
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/manifest/name.json
+++ b/html/manifest/name.json
@@ -3,7 +3,7 @@
     "manifest": {
       "name": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/name",
           "support": {
             "chrome": {
               "version_added": null
@@ -22,7 +22,14 @@
             },
             "firefox_android": {
               "version_added": "53",
-              "notes": "By default, used for as the source for \"Add to home screen\" (see bug 1234558). Experimental support for this feature is available behind the boolean flag manifest.install.enabled in about:config."
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "manifest.install.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "By default, used for as the source for \"Add to home screen\" (see bug 1234558)."
             },
             "ie": {
               "version_added": null

--- a/html/manifest/orientation.json
+++ b/html/manifest/orientation.json
@@ -1,0 +1,57 @@
+{
+  "html": {
+    "manifest": {
+      "orientation": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/manifest/orientation.json
+++ b/html/manifest/orientation.json
@@ -3,7 +3,7 @@
     "manifest": {
       "orientation": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/orientation",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/prefer_related_applications.json
+++ b/html/manifest/prefer_related_applications.json
@@ -1,0 +1,57 @@
+{
+  "html": {
+    "manifest": {
+      "prefer_related_applications": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/manifest/prefer_related_applications.json
+++ b/html/manifest/prefer_related_applications.json
@@ -3,7 +3,7 @@
     "manifest": {
       "prefer_related_applications": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/prefer_related_applications",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/related_applications.json
+++ b/html/manifest/related_applications.json
@@ -1,0 +1,57 @@
+{
+  "html": {
+    "manifest": {
+      "related_applications": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/manifest/related_applications.json
+++ b/html/manifest/related_applications.json
@@ -3,7 +3,7 @@
     "manifest": {
       "related_applications": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/related_applications",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/scope.json
+++ b/html/manifest/scope.json
@@ -1,0 +1,57 @@
+{
+  "html": {
+    "manifest": {
+      "scope": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/manifest/scope.json
+++ b/html/manifest/scope.json
@@ -3,7 +3,7 @@
     "manifest": {
       "scope": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/scope",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/screenshots.json
+++ b/html/manifest/screenshots.json
@@ -3,7 +3,7 @@
     "manifest": {
       "screenshots": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/screenshots",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/screenshots.json
+++ b/html/manifest/screenshots.json
@@ -1,0 +1,57 @@
+{
+  "html": {
+    "manifest": {
+      "screenshots": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/manifest/serviceworker.json
+++ b/html/manifest/serviceworker.json
@@ -1,0 +1,57 @@
+{
+  "html": {
+    "manifest": {
+      "serviceworker": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/manifest/serviceworker.json
+++ b/html/manifest/serviceworker.json
@@ -3,7 +3,7 @@
     "manifest": {
       "serviceworker": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/serviceworker",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/short_name.json
+++ b/html/manifest/short_name.json
@@ -1,0 +1,58 @@
+{
+  "html": {
+    "manifest": {
+      "short_name": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": "53",
+              "notes": "By default, used for as the source for \"Add to home screen\" (see bug 1234558). Experimental support for this feature is available behind the boolean flag manifest.install.enabled in about:config."
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/manifest/short_name.json
+++ b/html/manifest/short_name.json
@@ -3,7 +3,7 @@
     "manifest": {
       "short_name": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/short_name",
           "support": {
             "chrome": {
               "version_added": null
@@ -22,7 +22,14 @@
             },
             "firefox_android": {
               "version_added": "53",
-              "notes": "By default, used for as the source for \"Add to home screen\" (see bug 1234558). Experimental support for this feature is available behind the boolean flag manifest.install.enabled in about:config."
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "manifest.install.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "By default, used for as the source for \"Add to home screen\" (see bug 1234558)."
             },
             "ie": {
               "version_added": null

--- a/html/manifest/start_url.json
+++ b/html/manifest/start_url.json
@@ -1,0 +1,57 @@
+{
+  "html": {
+    "manifest": {
+      "start_url": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/manifest/start_url.json
+++ b/html/manifest/start_url.json
@@ -3,7 +3,7 @@
     "manifest": {
       "start_url": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/start_url",
           "support": {
             "chrome": {
               "version_added": null

--- a/html/manifest/theme_color.json
+++ b/html/manifest/theme_color.json
@@ -1,0 +1,58 @@
+{
+  "html": {
+    "manifest": {
+      "theme_color": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": "53",
+              "notes": "By default, used for as the source for \"Add to home screen\" (see bug 1234558). Experimental support for this feature is available behind the boolean flag manifest.install.enabled in about:config."
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/manifest/theme_color.json
+++ b/html/manifest/theme_color.json
@@ -3,7 +3,7 @@
     "manifest": {
       "theme_color": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/theme_color",
           "support": {
             "chrome": {
               "version_added": null
@@ -22,7 +22,14 @@
             },
             "firefox_android": {
               "version_added": "53",
-              "notes": "By default, used for as the source for \"Add to home screen\" (see bug 1234558). Experimental support for this feature is available behind the boolean flag manifest.install.enabled in about:config."
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "manifest.install.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "By default, used for as the source for \"Add to home screen\" (see bug 1234558)."
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
# Summary 
This is an attempt to fix #3998.

# Data
Data comes directly from the current docs table at https://developer.mozilla.org/en-US/docs/Web/Manifest#Browser_compatibility

# Related issues
This is an attempt to fix #3998.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] N/A - Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
