### PR TITLE
Update Edge support for CSS properties

### DIFF
--- a/css/properties/animation-timing-function.json
+++ b/css/properties/animation-timing-function.json
@@ -182,10 +182,10 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "65"

--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -222,10 +222,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -272,10 +272,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -323,11 +323,11 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true,
+                "version_added": "12",
                 "partial_implementation": true
               },
               "edge_mobile": {
-                "version_added": true,
+                "version_added": "12",
                 "partial_implementation": true
               },
               "firefox": {

--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -338,10 +338,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false,

--- a/css/properties/color.json
+++ b/css/properties/color.json
@@ -571,10 +571,10 @@
                 "version_added": "65"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "52"
@@ -622,10 +622,10 @@
                 "version_added": "66"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "52"

--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -62,10 +62,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "63"

--- a/css/properties/custom-property.json
+++ b/css/properties/custom-property.json
@@ -205,7 +205,7 @@
                 "version_added": "69"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "65"

--- a/css/properties/font-style.json
+++ b/css/properties/font-style.json
@@ -64,10 +64,10 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "61"

--- a/css/properties/font-weight.json
+++ b/css/properties/font-weight.json
@@ -62,10 +62,10 @@
                 "version_added": "62"
               },
               "edge": {
-                "version_added": true
+                "version_added": "17"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "61"

--- a/css/properties/list-style.json
+++ b/css/properties/list-style.json
@@ -62,10 +62,10 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "35"

--- a/css/properties/mask-image.json
+++ b/css/properties/mask-image.json
@@ -73,10 +73,10 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "53"
@@ -124,10 +124,10 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "53"

--- a/css/properties/mask.json
+++ b/css/properties/mask.json
@@ -118,10 +118,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "3.5"
@@ -173,10 +173,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "53"

--- a/css/properties/ruby-position.json
+++ b/css/properties/ruby-position.json
@@ -15,7 +15,7 @@
               "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": false
             },
             "firefox": {
               "version_added": "38"
@@ -65,7 +65,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": false

--- a/css/properties/ruby-position.json
+++ b/css/properties/ruby-position.json
@@ -15,7 +15,7 @@
               "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "38"

--- a/css/properties/text-align.json
+++ b/css/properties/text-align.json
@@ -64,10 +64,10 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "prefix": "-moz-",
@@ -177,10 +177,10 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "40"

--- a/css/properties/text-size-adjust.json
+++ b/css/properties/text-size-adjust.json
@@ -103,10 +103,10 @@
                 "version_added": "54"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": false

--- a/css/properties/text-underline-position.json
+++ b/css/properties/text-underline-position.json
@@ -15,7 +15,7 @@
               "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": false
@@ -62,10 +62,10 @@
                 "version_added": "33"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -113,10 +113,10 @@
                 "version_added": "71"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false

--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -192,10 +192,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "17"
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": [
                 {

--- a/css/properties/user-modify.json
+++ b/css/properties/user-modify.json
@@ -15,7 +15,7 @@
             },
             "edge": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": false
@@ -86,7 +86,7 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "edge_mobile": {
                 "version_added": false

--- a/css/properties/word-break.json
+++ b/css/properties/word-break.json
@@ -121,7 +121,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": false

--- a/css/properties/word-spacing.json
+++ b/css/properties/word-spacing.json
@@ -62,10 +62,10 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "45"

--- a/css/properties/writing-mode.json
+++ b/css/properties/writing-mode.json
@@ -234,10 +234,10 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "43"


### PR DESCRIPTION
This updates more Edge CSS property data. Some raw notes on how I came to the information:

`css.properties.animation-timing-function.jump`: false (manual testing in saucelabs)

`css.properties.appearance.button`: 12 (manual testing in saucelabs)
`css.properties.appearance.textfield`: 12 (manual testing in saucelabs)
`css.properties.appearance.compat`: 12 (manual testing in saucelabs)

`css.properties.background-image.image-set`: false https://developer.microsoft.com/en-us/microsoft-edge/platform/status/cssimageset/

`css.properties.color.space_separated_functional_notation`: false (manual testing in saucelabs)
`css.properties.color.floats_in_rgb_rgba`: false (manual testing in saucelabs)

`css.properties.content.element_replacement`: false (manual testing in saucelabs)

`css.properties.custom-property.env`: false, see https://caniuse.com/#feat=css-env-function

`css.properties.font-style.oblique-angle`: false (manual testing in saucelabs)

`css.properties.font-weight.number:` 17 (landed with variable fonts, see https://caniuse.com/#search=font-variation-settings)

`css.properties.list-style.symbols`: false (see also list-style-type)

`css.properties.mask-image.svg_masks`: 18 (manual testing in saucelabs)
`css.properties.mask-image.multiple_mask_images`: 18 (manual testing in saucelabs)
`css.properties.mask.applies_to_html_elements`: 12 (manual testing in saucelabs)
`css.properties.mask.shorthand_for_mask_properties`: 12 (manual testing in saucelabs)

`css.properties.ruby-position.inter-character`: false (manual testing in saucelabs)
`css.properties.text-align.block_alignment_values`: false (manual testing in saucelabs)
`css.properties.text-align.match-parent: false` (manual testing in saucelabs)
`css.properties.text-size-adjust.percentages`: 12 (manual testing in saucelabs)

`css.properties.text-underline-position.under`: false (manual testing in saucelabs)
`css.properties.text-underline-position.left_right`: false (manual testing in saucelabs)

`css.properties.transform-origin.support_in_svg`: 17
https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6820655-add-css-transforms-on-svg-elements

`css.properties.user-modify`: 12 (manual testing in Saucelabs)

`css.properties.word-break.break-word`: false (see notes on https://caniuse.com/#feat=word-break)

`css.properties.word-spacing.percentages`: false (manual testing in saucelabs (Edge 18))
`css.properties.writing-mode.sideways_values`: false (manual testing in saucelabs (Edge 18)