### PR TITLE
Add Cross-Origin-Opener-Policy header

### DIFF
--- a/http/headers/cross-origin-opener-policy.json
+++ b/http/headers/cross-origin-opener-policy.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "67",
               "flags": [

--- a/http/headers/cross-origin-opener-policy.json
+++ b/http/headers/cross-origin-opener-policy.json
@@ -1,0 +1,57 @@
+{
+  "http": {
+    "headers": {
+      "Cross-Origin-Opener-Policy": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "67"
+            },
+            "firefox_android": {
+              "version_added": "67"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/http/headers/cross-origin-opener-policy.json
+++ b/http/headers/cross-origin-opener-policy.json
@@ -18,10 +18,24 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "67"
+              "version_added": "67",
+              "flags": [
+                {
+                  "name": "browser.tabs.remote.useCrossOriginOpenerPolicy",
+                  "type": "preference",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": "67"
+              "version_added": "67",
+              "flags": [
+                {
+                  "name": "browser.tabs.remote.useCrossOriginOpenerPolicy",
+                  "type": "preference",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": false

--- a/http/headers/cross-origin-opener-policy.json
+++ b/http/headers/cross-origin-opener-policy.json
@@ -60,7 +60,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
Fixes https://github.com/mdn/browser-compat-data/issues/4197

~COOP ships in Firefox 67~ https://bugzilla.mozilla.org/show_bug.cgi?id=1521808
Not in Chromiums yet https://bugs.chromium.org/p/chromium/issues/detail?id=922191#c10
Not anywhere else I believe.