### PR TITLE
Mark getFloatTimeDomain as not supported in safari

### DIFF
--- a/api/AnalyserNode.json
+++ b/api/AnalyserNode.json
@@ -491,7 +491,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": null


### PR DESCRIPTION
This updates `getFloatTimeDomain` browser support to mark it as not supported in Safari.

Per Apple's WebKit docs: https://developer.apple.com/documentation/webkitjs/analysernode

Related issue: https://github.com/Tonejs/Tone.js/issues/129
On the previous link is also a demo that can be used to test and a workaround that can be used as polyfill in some cases (doesn't cover all so it's not actual polyfill) 
