### PR TITLE
Update compat data for CSS resolution media query and types

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1303,7 +1303,7 @@
                   "version_added": "16"
                 },
                 {
-                  "version_added": "10",
+                  "version_added": "10.1",
                   "version_removed": "15"
                 }
               ],

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1298,12 +1298,24 @@
               "ie": {
                 "version_added": "9"
               },
-              "opera": {
-                "version_added": "9.5"
-              },
-              "opera_android": {
-                "version_added": true
-              },
+              "opera": [
+                {
+                  "version_added": "16"
+                },
+                {
+                  "version_added": "10",
+                  "version_removed": "15"
+                }
+              ],
+              "opera_android": [
+                {
+                  "version_added": "16"
+                },
+                {
+                  "version_added": "10",
+                  "version_removed": "14"
+                }
+              ],
               "safari": {
                 "version_added": false,
                 "notes": "See <a href='https://webkit.org/b/78087'>bug 78087</a>."

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1303,7 +1303,7 @@
                   "version_added": "16"
                 },
                 {
-                  "version_added": "10.1",
+                  "version_added": "10",
                   "version_removed": "15"
                 }
               ],
@@ -1312,7 +1312,7 @@
                   "version_added": "16"
                 },
                 {
-                  "version_added": "10",
+                  "version_added": "10.1",
                   "version_removed": "14"
                 }
               ],

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1267,10 +1267,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/resolution",
             "support": {
               "chrome": {
-                "version_added": "27"
+                "version_added": "29"
               },
               "chrome_android": {
-                "version_added": "27"
+                "version_added": "29"
               },
               "edge": {
                 "version_added": "12"
@@ -1299,16 +1299,18 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "9.5"
               },
               "opera_android": {
                 "version_added": true
               },
               "safari": {
-                "version_added": "6.1"
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/78087'>bug 78087</a>."
               },
               "safari_ios": {
-                "version_added": "7"
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/78087'>bug 78087</a>."
               },
               "samsunginternet_android": {
                 "version_added": "1.5"

--- a/css/types/resolution.json
+++ b/css/types/resolution.json
@@ -15,12 +15,26 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "3.5"
-            },
-            "firefox_android": {
-              "version_added": "4"
-            },
+            "firefox": [
+              {
+                "version_added": "8"
+              },
+              {
+                "partial_implementation": true,
+                "version_added": "3.5",
+                "notes": "Supports <a href='https://developer.mozilla.org/docs/Web/CSS/integer'><code>&lt;integer&gt;</code></a> values only."
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "8"
+              },
+              {
+                "partial_implementation": true,
+                "version_added": "4",
+                "notes": "Supports <a href='https://developer.mozilla.org/docs/Web/CSS/integer'><code>&lt;integer&gt;</code></a> values only."
+              }
+            ],
             "ie": {
               "version_added": "9"
             },
@@ -31,16 +45,18 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": false,
+              "notes": "See <a href='https://webkit.org/b/78087'>bug 78087</a>."
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false,
+              "notes": "See <a href='https://webkit.org/b/78087'>bug 78087</a>."
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {
@@ -49,9 +65,105 @@
             "deprecated": false
           }
         },
+        "dpi": {
+          "__compat": {
+            "description": "<code>dpi</code> unit",
+            "support": {
+              "chrome": {
+                "version_added": "29"
+              },
+              "chrome_android": {
+                "version_added": "29"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "8"
+              },
+              "firefox_android": {
+                "version_added": "8"
+              },
+              "ie": {
+                "version_added": "9"
+              },
+              "opera": {
+                "version_added": "9.5"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "dpcm": {
+          "__compat": {
+            "description": "<code>dpcm</code> unit",
+            "support": {
+              "chrome": {
+                "version_added": "29"
+              },
+              "chrome_android": {
+                "version_added": "29"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "8"
+              },
+              "firefox_android": {
+                "version_added": "8"
+              },
+              "ie": {
+                "version_added": "9"
+              },
+              "opera": {
+                "version_added": "9.5"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "dppx": {
           "__compat": {
-            "description": "<code>dppx</code> units",
+            "description": "<code>dppx</code> unit",
             "support": {
               "chrome": {
                 "version_added": "29"
@@ -77,31 +189,17 @@
               "opera_android": {
                 "version_added": "12.1"
               },
-              "safari": [
-                {
-                  "alternative_name": "device-pixel-ratio",
-                  "version_added": true
-                },
-                {
-                  "version_added": false,
-                  "notes": "See <a href='https://webkit.org/b/16832'>bug 16832</a>."
-                }
-              ],
-              "safari_ios": [
-                {
-                  "alternative_name": "device-pixel-ratio",
-                  "version_added": true
-                },
-                {
-                  "version_added": false,
-                  "notes": "See <a href='https://webkit.org/b/16832'>bug 16832</a>."
-                }
-              ],
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
-                "version_added": false
+                "version_added": true
               }
             },
             "status": {
@@ -113,13 +211,13 @@
         },
         "x": {
           "__compat": {
-            "description": "<code>x</code> units",
+            "description": "<code>x</code> unit",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "68"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "68"
               },
               "edge": {
                 "version_added": false
@@ -134,22 +232,22 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": true
               },
               "opera_android": {
-                "version_added": false
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": true
               }
             },
             "status": {

--- a/css/types/resolution.json
+++ b/css/types/resolution.json
@@ -87,12 +87,24 @@
               "ie": {
                 "version_added": "9"
               },
-              "opera": {
-                "version_added": "9.5"
-              },
-              "opera_android": {
-                "version_added": true
-              },
+              "opera": [
+                {
+                  "version_added": "16"
+                },
+                {
+                  "version_added": "10",
+                  "version_removed": "15"
+                }
+              ],
+              "opera_android": [
+                {
+                  "version_added": "16"
+                },
+                {
+                  "version_added": "10.1",
+                  "version_removed": "14"
+                }
+              ],
               "safari": {
                 "version_added": false
               },
@@ -135,12 +147,24 @@
               "ie": {
                 "version_added": "9"
               },
-              "opera": {
-                "version_added": "9.5"
-              },
-              "opera_android": {
-                "version_added": true
-              },
+              "opera": [
+                {
+                  "version_added": "16"
+                },
+                {
+                  "version_added": "10",
+                  "version_removed": "15"
+                }
+              ],
+              "opera_android": [
+                {
+                  "version_added": "16"
+                },
+                {
+                  "version_added": "10.1",
+                  "version_removed": "14"
+                }
+              ],
               "safari": {
                 "version_added": false
               },


### PR DESCRIPTION
Fixes #4224

Changes:

1. Improve the compatibility data for the `resolution` media query. Adds information about Safari support (not supported, but adds info about `-webkit-device-pixel-ratio`).
Related MDN page: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/resolution
2. Restructure and the compatibility data for the `<resolution>` type.
Related MDN page: https://developer.mozilla.org/en-US/docs/Web/CSS/resolution
    - On that page I found the compatibility table puzzling, because it says that all browsers support the `<resolution>` type. But what does supporting a CSS type mean? Does it mean that the `resolution` media query works (nope, not in Safari)? Does that mean that all the units for the `<resolution>` type are supported (nope, not in most browsers)? Does that mean that at least one unit is supported (nope, not in Safari)?
    - So I opted to rename the `<resolution>` label to `dpi and dpcm units`, because in practice they're the first resolution types supported in browsers (both in IE9) and it seems they landed together in all browsers.
3. Update the compatibility data for the `<resolution>` type, especially for the `dppx` unit, for the `x` alias, and for Edge and Android browsers (after running a bunch of tests on BrowserStack; I didn't identify specific versions for `dppx` support in Opera and Samsung Internet).

Test case (doesn't inclue `-webkit-device-pixel-ratio`):
https://fvsch.github.io/test-pages/css-mq-resolution

Linting: passed locally.