### PR TITLE
Firefox support for css.properties.background-color

### DIFF
--- a/css/properties/background-color.json
+++ b/css/properties/background-color.json
@@ -72,7 +72,7 @@
                 "version_added": "49"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "49"
               },
               "ie": {
                 "version_added": false

--- a/css/properties/background-color.json
+++ b/css/properties/background-color.json
@@ -69,7 +69,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": "49"
               },
               "firefox_android": {
                 "version_added": false


### PR DESCRIPTION
Firefox 49 delivered support for #rrggbbaa/#rgba notation in all contexts, not just background-color.

- https://hg.mozilla.org/mozilla-central/rev/8751a7511341
- https://bugzilla.mozilla.org/show_bug.cgi?id=1271191
- https://groups.google.com/forum/#!topic/mozilla.dev.platform/00Tq2s58GwA
- https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/49

Many other browsers did too. I don't understand why `background-color` has its own entry here; if other browsers don't support the syntax everywhere, a note should be added for those browsers specifically.