### PR TITLE
Chromium is reconsidering immutable Cache-Control header

### DIFF
--- a/http/headers/cache-control.json
+++ b/http/headers/cache-control.json
@@ -57,7 +57,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "There is no plan to implement this directive. See <a href='https://crbug.com/611416'>bug 611416</a>."
+                "notes": "See Chromium <a href='https://crbug.com/611416'>bug 611416</a>."
               },
               "chrome_android": {
                 "version_added": false


### PR DESCRIPTION
Chromium is [reconsidering](https://bugs.chromium.org/p/chromium/issues/detail?id=611416#c55) implementation so this removes the statement they won't implement.
