### PR TITLE
DocumentOrShadowRoot.elementsFromPoint not in IE 11

### DIFF
--- a/api/DocumentOrShadowRoot.json
+++ b/api/DocumentOrShadowRoot.json
@@ -269,28 +269,12 @@
               "version_added": "53",
               "notes": "Before Chrome 66, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
             },
-            "edge": [
-              {
-                "version_added": "12"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "12",
-                "alternative_name": "msElementsFromPoint",
-                "notes": "Before Edge 12, this method returned a <code>NodeList</code> instead of an array. See <a href='https://msdn.microsoft.com/en-us/library/hh772121(v=vs.85).aspx'>the MSDN documentation</a>."
-              }
-            ],
-            "edge_mobile": [
-              {
-                "version_added": "12"
-              },
-              {
-                "version_added": "10",
-                "version_removed": "12",
-                "alternative_name": "msElementsFromPoint",
-                "notes": "Before Edge Mobile 12, this method returned a <code>NodeList</code> instead of an array. See <a href='https://msdn.microsoft.com/en-us/library/hh772121(v=vs.85).aspx'>the MSDN documentation</a>."
-              }
-            ],
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": "12"
+            },
             "firefox": {
               "version_added": "63"
             },

--- a/api/DocumentOrShadowRoot.json
+++ b/api/DocumentOrShadowRoot.json
@@ -269,12 +269,28 @@
               "version_added": "53",
               "notes": "Before Chrome 66, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
             },
-            "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
-              "version_added": true
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "10",
+                "version_removed": "12",
+                "alternative_name": "msElementsFromPoint",
+                "notes": "Before Edge 12, this method returned a <code>NodeList</code> instead of an array. See <a href='https://msdn.microsoft.com/en-us/library/hh772121(v=vs.85).aspx'>the MSDN documentation</a>."
+              }
+            ],
+            "edge_mobile": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "10",
+                "version_removed": "12",
+                "alternative_name": "msElementsFromPoint",
+                "notes": "Before Edge Mobile 12, this method returned a <code>NodeList</code> instead of an array. See <a href='https://msdn.microsoft.com/en-us/library/hh772121(v=vs.85).aspx'>the MSDN documentation</a>."
+              }
+            ],
             "firefox": {
               "version_added": "63"
             },
@@ -282,7 +298,9 @@
               "version_added": "63"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10",
+              "alternative_name": "msElementsFromPoint",
+              "notes": "Returns a <code>NodeList</code> instead of an array. See <a href='https://msdn.microsoft.com/en-us/library/hh772121(v=vs.85).aspx'>the MSDN documentation</a>."
             },
             "opera": {
               "version_added": "40"


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
  Fix the stated compatibility of DocumentOrShadowRoot.elementsFromPoint. It is not available in IE 11, as is currently written.
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)

  https://msdn.microsoft.com/en-us/ie/ms535862(v=vs.94)#methods
  `elementFromPoint` is shown under the `document` methods, but `elementsFromPoint` is not.

  `msElementsFromPoint` documentation: https://msdn.microsoft.com/en-us/library/hh772121(v=vs.85).aspx

This duplicates the intent of #4150, but I followed up on the changes that were requested.