### PR TITLE
Mark -webkit-animation media query deprecated

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1775,7 +1775,7 @@
             "status": {
               "experimental": false,
               "standard_track": false,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },


### PR DESCRIPTION
# Summary
Mark -webkit-animation as deprecated since all browsers that supported it dropped it already.

# Data
All browsers dropped this feature already, as noted in the JSON already.

# Data from tests
None

# Relevant information
Please consider also marking Microsoft Edge support as "No". Just out of curiosity I tried to check if browsers I have installed support this feature: Chrome, Firefox and Microsoft Edge by running `window.matchMedia('(-webkit-animation)')` in console. As expected, all browsers return ` {matches: false, media: "not all"}` indicating this is not supported. I'm not sure this test is sufficient to do this change.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
