### PR TITLE
fix fetch() support data of iOS Safari

### DIFF
--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -640,7 +640,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "webview_android": {
               "version_added": "42"


### PR DESCRIPTION
I used an iPad with iOS 10.2.2 to test a page using fetch() API, found it is not supported. The WebKit's blog https://webkit.org/blog/7477/new-web-features-in-safari-10-1/ mentioned the fetch() shipped with the release of iOS 10.3.
