### PR TITLE
Update css.properties.zoom

### DIFF
--- a/css/properties/zoom.json
+++ b/css/properties/zoom.json
@@ -6,10 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/zoom",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -35,7 +35,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "4"
+              "version_added": "3.1"
             },
             "safari_ios": {
               "version_added": "3"
@@ -59,11 +59,11 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/zoom#Values",
             "support": {
               "chrome": {
-                "version_added": true,
+                "version_added": "1",
                 "version_removed": "59"
               },
               "chrome_android": {
-                "version_added": true,
+                "version_added": "18",
                 "version_removed": "59"
               },
               "edge": {
@@ -88,10 +88,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": true
+                "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "3"
               },
               "samsunginternet_android": {
                 "version_added": null


### PR DESCRIPTION
For #3804, I looked into the history of the `zoom` property in WebKit.

This WebKit bug establishes that Safari 3.1 first shipped `zoom`: https://bugs.webkit.org/show_bug.cgi?id=18467

This changeset establishes that `reset` was implemented at the same time as `zoom`: https://trac.webkit.org/changeset/31155/webkit

Since those changes predate Chrome, I set both to their first release.

I derived the Safari for iOS version based on our existing WebKit engine number data.