### PR TITLE
Mark api/CSS `escape` not supported by Edge

### DIFF
--- a/api/CSS.json
+++ b/api/CSS.json
@@ -440,7 +440,7 @@
               "version_added": "46"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
               "version_added": null

--- a/api/CSS.json
+++ b/api/CSS.json
@@ -443,7 +443,7 @@
               "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "31"


### PR DESCRIPTION
`CSS.escape()` is not presently supported on Edge:

```
> CSS.escape
< undefined
```

Tested using:

```
Microsoft Edge 21.17134.1.0
Microsoft EdgeHTML 17.17134
```