### PR TITLE
Payment Request API: Add the Safari version supported

### DIFF
--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -58,10 +58,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": true
+            "version_added": "11.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "11.3"
           },
           "samsunginternet_android": {
             "version_added": "6.0"


### PR DESCRIPTION
Add the precise version of Safari that saw the addition of the Payment Request API.
Source: https://webkit.org/blog/8182/introducing-the-payment-request-api-for-apple-pay/
