### PR TITLE
Update String#matchAll support in nodejs 12

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -1958,7 +1958,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "12.0.0"
               },
               "opera": {
                 "version_added": "60"

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -1640,7 +1640,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "12.0.0"
               },
               "opera": {
                 "version_added": "60"

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -546,7 +546,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "12.0.0"
               },
               "opera": {
                 "version_added": "60"


### PR DESCRIPTION
String.prototype.matchAll support was added in nodejs 12.0.0. Tested in all versions > 12.