### PR TITLE
Update Safari on iOS compatibility for HTMLCanvasElement.toBlob

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -736,7 +736,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "12"
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -736,7 +736,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": "5.0"


### PR DESCRIPTION
- Resources:
  + https://bugs.webkit.org/buglist.cgi?quicksearch=canvas.toBlob
  + https://trac.webkit.org/search?q=canvas.toBlob

- Tested on iOS 12.3

- Related PR, safari on macOS:
  + https://github.com/mdn/browser-compat-data/pull/3936

