### PR TITLE
Complete data for Edge flexbox/grid support

### DIFF
--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -161,10 +161,10 @@
                   "version_added": "57"
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "edge_mobile": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "45"
@@ -212,10 +212,10 @@
                   "version_added": false
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "edge_mobile": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "52"
@@ -263,10 +263,10 @@
                   "version_added": "57"
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "edge_mobile": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "45"
@@ -314,10 +314,10 @@
                   "version_added": "57"
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "edge_mobile": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "52"
@@ -365,10 +365,10 @@
                   "version_added": "57"
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "edge_mobile": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "52"

--- a/css/properties/column-gap.json
+++ b/css/properties/column-gap.json
@@ -14,7 +14,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": false

--- a/css/properties/column-width.json
+++ b/css/properties/column-width.json
@@ -102,7 +102,10 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
               },
               "firefox": {
                 "version_added": false

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -205,10 +205,10 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": [
                 {
@@ -267,10 +267,10 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": [
                 {

--- a/css/properties/gap.json
+++ b/css/properties/gap.json
@@ -14,7 +14,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": false
@@ -309,7 +309,7 @@
                   "version_added": "66"
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": "16"
                 },
                 "edge_mobile": {
                   "version_added": false

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -322,10 +322,10 @@
                 "version_added": "25"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "16",

--- a/css/properties/place-items.json
+++ b/css/properties/place-items.json
@@ -14,10 +14,10 @@
                 "version_added": "59"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "45"
@@ -66,10 +66,10 @@
                 "version_added": "59"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "45"

--- a/css/properties/place-self.json
+++ b/css/properties/place-self.json
@@ -14,10 +14,10 @@
                 "version_added": "59"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "45"
@@ -66,10 +66,10 @@
                 "version_added": "59"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "45"

--- a/css/properties/row-gap.json
+++ b/css/properties/row-gap.json
@@ -14,7 +14,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": false


### PR DESCRIPTION
Testing (https://codepen.io/team/css-tricks/pen/GBMZKR) suggests this doesn't work. 
Also already set to false for the same values in align-contents or justify-content.

- css.properties.align-self.flex_context.start_end: false
- css.properties.align-self.flex_context.left_right: false
- css.properties.align-self.flex_context.baseline: false
- css.properties.align-self.flex_context.first_last_baseline: false
- css.properties.align-self.flex_context.stretch: false


Testing (https://codepen.io/rachelandrew/pen/KrqBbg) shows this doesn't work in Edge
- css.properties.column-gap.flex_context: false
- css.properties.row-gap.flex_context: false
- css.properties.gap.flex_context

"Intrinsic sizes" refers to min-content, max-content, fit-content, fill-available values which don't work and have been set to false for other properties as well
- css.properties.column-width.intrinsic_sizes: false

Same here: Edge doesn't support "intrinsic sizes"
- css.properties.flex-basis.max-content: false
- css.properties.flex-basis.min-content: false

Testing (interactive example on https://developer.mozilla.org/en-US/docs/Web/CSS/gap) shows that this works.
- css.properties.gap.grid_context.calc_values: 16

WPT tests mostly fail for this, so I guess this isn't supported
https://wpt.fyi/results/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox?label=master&product=chrome%5Bexperimental%5D&product=edge&product=firefox%5Bexperimental%5D&product=safari%5Bexperimental%5D&aligned&q=min-height
- css.properties.min-height.auto: false

I checked webplatform tests and they all fail in the latest Edge
https://wpt.fyi/results/css/css-align/default-alignment?label=master&product=chrome%5Bexperimental%5D&product=edge&product=firefox%5Bexperimental%5D&product=safari%5Bexperimental%5D&aligned&q=place-items
- css.properties.place-items.flex_context: false
- css.properties.place-items.grid_context: false

Same for place-self:
https://wpt.fyi/results/css/css-align/self-alignment?label=master&product=chrome%5Bexperimental%5D&product=edge&product=firefox%5Bexperimental%5D&product=safari%5Bexperimental%5D&aligned&q=place-self
- css.properties.place-self.flex_context: false
- css.properties.place-self.grid_context: false
