### PR TITLE
Update data for 1in = 96px

### DIFF
--- a/css/types/length-percentage.json
+++ b/css/types/length-percentage.json
@@ -858,10 +858,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"
@@ -876,16 +876,16 @@
                 "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
                 "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -860,10 +860,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "4"
@@ -878,16 +878,16 @@
                 "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
                 "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true


### PR DESCRIPTION
So, this one is tricky, but in WPT I found a test "<length> values are computed correctly [1in]" and it seems to test `assert_equal('1in', '96px');` and only Chromium fully passes these tests. 

https://wpt.fyi/results/css/css-properties-values-api/registered-property-computation.html?label=master&product=chrome%5Bexperimental%5D&product=edge&product=firefox%5Bexperimental%5D&product=safari%5Bexperimental%5D&aligned

With the other PR for Edge CSS compat data, this one should complete all missing Edge CSS compat data \o/