### PR TITLE
Add note about i18n.getUILanguage bug in older versions of Firefox

### DIFF
--- a/webextensions/api/i18n.json
+++ b/webextensions/api/i18n.json
@@ -106,7 +106,8 @@
                 "version_added": "14"
               },
               "firefox": {
-                "version_added": "47"
+                "version_added": "47",
+                "notes": "Firefox 55 and earlier returns a language tag that's seperated with the underscore character instead of hyphen, see <a href='https://bugzil.la/1374552'>bug 1374552</a>."
               },
               "firefox_android": {
                 "version_added": "48"


### PR DESCRIPTION
It turns out that with older versions of Firefox `browser.i18n.getUILanguage()` returns a language tag separated with underscores instead of hyphens. For example, with Firefox 55 the function returns `"en_GB"` for me instead of `"en-GB"`. This was fixed with Firefox 56, see [bug 1374552](https://bugzilla.mozilla.org/show_bug.cgi?id=1374552).