### PR TITLE
remove special "alpha hex value" entry

### DIFF
--- a/css/properties/background-color.json
+++ b/css/properties/background-color.json
@@ -51,57 +51,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "alpha_ch_for_hex": {
-          "__compat": {
-            "description": "Alpha channel for hex values",
-            "support": {
-              "chrome": {
-                "version_added": "52"
-              },
-              "chrome_android": {
-                "version_added": "52"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": "6.0"
-              },
-              "webview_android": {
-                "version_added": "52"
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
This information already exists at https://developer.mozilla.org/en-US/docs/Web/CSS/color, and the copy here is incomplete anyway. Alternative to #4227.