### PR TITLE
Update chrome stable version to M75

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -518,19 +518,26 @@
         "74": {
           "release_date": "2019-04-23",
           "release_notes": "https://chromereleases.googleblog.com/2019/04/stable-channel-update-for-desktop_23.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "74"
         },
         "75": {
+          "release_date": "2019-06-04",
+          "release_notes": "https://chromereleases.googleblog.com/2019/06/stable-channel-update-for-desktop.html",
           "status": "beta",
           "engine": "Blink",
           "engine_version": "75"
         },
         "76": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "76"
+        },
+        "77": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "77"
         }
       }
     }

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -355,19 +355,26 @@
         "74": {
           "release_date": "2019-04-24",
           "release_notes": "https://chromereleases.googleblog.com/2019/04/chrome-for-android-update.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "74"
         },
         "75": {
+          "release_date": "2019-06-04",
+          "release_notes": "https://chromereleases.googleblog.com/2019/06/chrome-for-android-update.html",
           "status": "beta",
           "engine": "Blink",
           "engine_version": "75"
         },
         "76": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "76"
+        },
+        "77": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "77"
         }
       }
     }

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -346,19 +346,26 @@
         "74": {
           "release_date": "2019-04-24",
           "release_notes": "https://chromereleases.googleblog.com/2019/04/chrome-for-android-update.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "74"
         },
         "75": {
+          "release_date": "2019-06-04",
+          "release_notes": "https://chromereleases.googleblog.com/2019/06/chrome-for-android-update.html",
           "status": "beta",
           "engine": "Blink",
           "engine_version": "75"
         },
         "76": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "76"
+        },
+        "77": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "77"
         }
       }
     }


### PR DESCRIPTION
Looks like Chrome M75 is now stable https://developers.google.com/web/updates/2019/06/nic75

This PR updates the browser data to reflect this