### PR TITLE
Add Safari 13 beta browser data

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -158,6 +158,11 @@
           "status": "current",
           "engine": "WebKit",
           "engine_version": "605.1"
+        },
+        "13": {
+          "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_13_beta_release_notes",
+          "status": "beta",
+          "engine": "WebKit"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -155,6 +155,11 @@
           "status": "current",
           "engine": "WebKit",
           "engine_version": "605.1"
+        },
+        "13": {
+          "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_13_beta_release_notes",
+          "status": "beta",
+          "engine": "WebKit"
         }
       }
     }


### PR DESCRIPTION
Apple has published the Safari 13 beta release notes.

https://developer.apple.com/documentation/safari_release_notes/safari_13_beta_release_notes

I added that in the browser data and will try over the next few days to open PR to include the compat data for all the new features they support.