### PR TITLE
The `Error.stack` property seems to be supported by Edge:

### DIFF
--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -372,7 +372,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"


### PR DESCRIPTION
The `Error.stack` property seems to be supported by Edge:
```
> new Error("foo").stack

< "Error: foo
     at eval code (eval code:1:1)"
```

Hard to say since when, the [JavaScript Version Information on MSDN](https://docs.microsoft.com/en-us/microsoft-edge/dev-guide/whats-new/javascript-version-information) lists just “Microsoft Edge” as supporting the property (at EdgeHTML 12).