### PR TITLE
Fix support for unprefixed transform properties in Chrome

### DIFF
--- a/css/properties/backface-visibility.json
+++ b/css/properties/backface-visibility.json
@@ -5,14 +5,24 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/backface-visibility",
           "support": {
-            "chrome": {
-              "prefix": "-webkit-",
-              "version_added": "12"
-            },
-            "chrome_android": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
+            "chrome": [
+              {
+                "version_added": "36"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "12"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "36"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
             "edge": [
               {
                 "version_added": "12"
@@ -101,10 +111,15 @@
             "samsunginternet_android": {
               "version_added": true
             },
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "3"
-            }
+            "webview_android": [
+              {
+                "version_added": "37"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "3"
+              }
+            ]
           },
           "status": {
             "experimental": true,

--- a/css/properties/perspective-origin.json
+++ b/css/properties/perspective-origin.json
@@ -5,14 +5,24 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/perspective-origin",
           "support": {
-            "chrome": {
-              "prefix": "-webkit-",
-              "version_added": "12"
-            },
-            "chrome_android": {
-              "prefix": "-webkit-",
-              "version_added": "18"
-            },
+            "chrome": [
+              {
+                "version_added": "36"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "12"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "36"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "18"
+              }
+            ],
             "edge": [
               {
                 "version_added": "12"
@@ -101,10 +111,15 @@
             "samsunginternet_android": {
               "version_added": null
             },
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "3"
-            }
+            "webview_android": [
+              {
+                "version_added": "37"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "3"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/perspective.json
+++ b/css/properties/perspective.json
@@ -7,7 +7,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "45"
+                "version_added": "36"
               },
               {
                 "prefix": "-webkit-",
@@ -16,7 +16,7 @@
             ],
             "chrome_android": [
               {
-                "version_added": "45"
+                "version_added": "36"
               },
               {
                 "prefix": "-webkit-",
@@ -111,10 +111,15 @@
             "samsunginternet_android": {
               "version_added": null
             },
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "3"
-            }
+            "webview_android": [
+              {
+                "version_added": "37"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "3"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -5,14 +5,24 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-origin",
           "support": {
-            "chrome": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
-            "chrome_android": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
+            "chrome": [
+              {
+                "version_added": "36"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "36"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
             "edge": [
               {
                 "version_added": "12"
@@ -116,10 +126,15 @@
             "samsunginternet_android": {
               "version_added": null
             },
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": true
-            }
+            "webview_android": [
+              {
+                "version_added": "37"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/transform-style.json
+++ b/css/properties/transform-style.json
@@ -5,14 +5,24 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-style",
           "support": {
-            "chrome": {
-              "prefix": "-webkit-",
-              "version_added": "12"
-            },
-            "chrome_android": {
-              "prefix": "-webkit-",
-              "version_added": "18"
-            },
+            "chrome": [
+              {
+                "version_added": "36"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "12"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "36"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "18"
+              }
+            ],
             "edge": [
               {
                 "version_added": "12"
@@ -101,10 +111,15 @@
             "samsunginternet_android": {
               "version_added": null
             },
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "3"
-            }
+            "webview_android": [
+              {
+                "version_added": "37"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "3"
+              }
+            ]
           },
           "status": {
             "experimental": true,

--- a/css/properties/transform.json
+++ b/css/properties/transform.json
@@ -14,10 +14,15 @@
                 "version_added": true
               }
             ],
-            "chrome_android": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
+            "chrome_android": [
+              {
+                "version_added": "36"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ],
             "edge": [
               {
                 "version_added": "12"
@@ -143,11 +148,16 @@
             "samsunginternet_android": {
               "version_added": true
             },
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "2",
-              "notes": "Android 2.3 has a bug where input forms will \"jump\" when typing, if any container element has a <code>-webkit-transform</code>."
-            }
+            "webview_android": [
+              {
+                "version_added": "37"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "2",
+                "notes": "Android 2.3 has a bug where input forms will \"jump\" when typing, if any container element has a <code>-webkit-transform</code>."
+              }
+            ]
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
Transform properties were unprefixed in Chrome 36 according to https://www.chromestatus.com/feature/6437640580628480

For the Android WebView this means the properties were unprefixed in version 37 since that was the first evergreen version to ship after Android 4.4.3 (which was based on Chrome 33 according to the browsers portion of BCD).

The list of properties unprefixed in that update was pulled from changes referenced in Chromium bug https://bugs.chromium.org/p/chromium/issues/detail?id=154772

-----

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
