### PR TITLE
Prefixed support for transition properties in IE 10, 11

### DIFF
--- a/css/properties/transition-delay.json
+++ b/css/properties/transition-delay.json
@@ -89,9 +89,15 @@
                 ]
               }
             ],
-            "ie": {
-              "version_added": "10"
-            },
+            "ie": [
+              {
+                "version_added": "10"
+              },
+              {
+                "prefix": "-ms-",
+                "version_added": "10"
+              }
+            ],
             "opera": [
               {
                 "version_added": "12.1"

--- a/css/properties/transition-duration.json
+++ b/css/properties/transition-duration.json
@@ -89,9 +89,15 @@
                 ]
               }
             ],
-            "ie": {
-              "version_added": "10"
-            },
+            "ie": [
+              {
+                "version_added": "10"
+              },
+              {
+                "prefix": "-ms-",
+                "version_added": "10"
+              }
+            ],
             "opera": [
               {
                 "version_added": "12.1"

--- a/css/properties/transition-property.json
+++ b/css/properties/transition-property.json
@@ -89,9 +89,15 @@
                 ]
               }
             ],
-            "ie": {
-              "version_added": "10"
-            },
+            "ie": [
+              {
+                "version_added": "10"
+              },
+              {
+                "prefix": "-ms-",
+                "version_added": "10"
+              }
+            ],
             "opera": [
               {
                 "version_added": "12.1"

--- a/css/properties/transition-timing-function.json
+++ b/css/properties/transition-timing-function.json
@@ -89,9 +89,15 @@
                 ]
               }
             ],
-            "ie": {
-              "version_added": "10"
-            },
+            "ie": [
+              {
+                "version_added": "10"
+              },
+              {
+                "prefix": "-ms-",
+                "version_added": "10"
+              }
+            ],
             "opera": [
               {
                 "version_added": "12.1"

--- a/css/properties/transition.json
+++ b/css/properties/transition.json
@@ -99,9 +99,15 @@
                 ]
               }
             ],
-            "ie": {
-              "version_added": "10"
-            },
+            "ie": [
+              {
+                "version_added": "10"
+              },
+              {
+                "prefix": "-ms-",
+                "version_added": "10"
+              }
+            ],
             "opera": [
               {
                 "version_added": "12.1"


### PR DESCRIPTION
IE 10 and 11 include support for '-ms-' prefixed versions of the transition properties in addition to unprefixed versions.

Confirmed by testing in 10 and 11 modes of IE11.

-----

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
