### PR TITLE
Enforce real values for Edge in css/

### DIFF
--- a/css/types/dimension.json
+++ b/css/types/dimension.json
@@ -1,7 +1,7 @@
 {
   "css": {
     "types": {
-      "number": {
+      "dimension": {
         "__compat": {
           "description": "&lt;dimension&gt;",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/dimension",
@@ -13,10 +13,10 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"

--- a/test/test-real-values.js
+++ b/test/test-real-values.js
@@ -21,7 +21,7 @@ const blockMany = [
 /** @type {Record<string, string[]>} */
 const blockList = {
   api: [],
-  css: ['firefox', 'firefox_android', 'ie'],
+  css: ['edge', 'firefox', 'firefox_android', 'ie'],
   html: [],
   http: [],
   svg: [],


### PR DESCRIPTION
Finally all Edge CSS data has real values. \o/

I assume this dimension type is so basic that it was around since version 12. 

Also, the file had the wrong export id. I think https://github.com/mdn/browser-compat-data/issues/4200 would have caught this.