### PR TITLE
test: Fix chalk tagged template literals to use nested chalk tags

### DIFF
--- a/test/lint.js
+++ b/test/lint.js
@@ -139,7 +139,7 @@ const hasErrors = argv.files
 
 if (hasErrors) {
   console.warn('');
-  console.warn(chalk`{red Problems in }{red.bold ${filesWithErrors.size}}{red  ${filesWithErrors.size === 1 ? 'file' : 'files'}:}`,
+  console.warn(chalk`{red Problems in {bold ${filesWithErrors.size}} ${filesWithErrors.size === 1 ? 'file' : 'files'}:}`,
   );
   for (const [fileName, file] of filesWithErrors) {
     console.warn(chalk`{red.bold ✖ ${fileName}}`);

--- a/test/lint.js
+++ b/test/lint.js
@@ -139,8 +139,7 @@ const hasErrors = argv.files
 
 if (hasErrors) {
   console.warn('');
-  console.warn(chalk`{red Problems in {bold ${filesWithErrors.size}} ${filesWithErrors.size === 1 ? 'file' : 'files'}:}`,
-  );
+  console.warn(chalk`{red Problems in {bold ${filesWithErrors.size}} ${filesWithErrors.size === 1 ? 'file' : 'files'}:}`);
   for (const [fileName, file] of filesWithErrors) {
     console.warn(chalk`{red.bold ✖ ${fileName}}`);
     try {

--- a/test/test-browsers.js
+++ b/test/test-browsers.js
@@ -56,12 +56,12 @@ function processData(data, displayBrowsers, requiredBrowsers, category, logger, 
   if (data.__compat && data.__compat.support) {
     const invalidEntries = Object.keys(data.__compat.support).filter(value => !displayBrowsers.includes(value));
     if (invalidEntries.length > 0) {
-      logger.error(chalk`{red.bold ${path}}{red  has the following browsers, which are invalid for }{red.bold ${category}}{red  compat data: }{red.bold ${invalidEntries.join(', ')}}`);
+      logger.error(chalk`{red {bold ${path}} has the following browsers, which are invalid for {bold ${category}} compat data: {bold ${invalidEntries.join(', ')}}}`);
       hasErrors = true;
     }
     const missingEntries = requiredBrowsers.filter(value => !(value in data.__compat.support));
     if (missingEntries.length > 0) {
-      logger.error(chalk`{red.bold ${path}}{red  is missing the following browsers, which are required for }{red.bold ${category}}{red  compat data: }{red.bold ${missingEntries.join(', ')}}`);
+      logger.error(chalk`{red {bold ${path}} is missing the following browsers, which are required for {bold ${category}} compat data: {bold ${missingEntries.join(', ')}}}`);
       hasErrors = true;
     }
   }
@@ -130,7 +130,7 @@ function testBrowsers(filename) {
   processData(data, displayBrowsers, requiredBrowsers, category, logger);
 
   if (errors.length) {
-    console.error(chalk`{red   Browsers – }{red.bold ${errors.length}}{red  ${errors.length === 1 ? 'error' : 'errors'}:}`);
+    console.error(chalk`{red   Browsers – {bold ${errors.length}} ${errors.length === 1 ? 'error' : 'errors'}:}`);
     for (const error of errors) {
       console.error(`    ${error}`);
     }

--- a/test/test-prefix.js
+++ b/test/test-prefix.js
@@ -6,7 +6,7 @@ function checkPrefix(data, category, errors, prefix, path="") {
   for (var key in data) {
     if (key === "prefix" && typeof(data[key]) === "string") {
       if (data[key].includes(prefix)) {
-        var error = chalk`{red.bold ${prefix}}{red  prefix is wrong for key: }{red.bold ${path}}`;
+        var error = chalk`{red {bold ${prefix}} prefix is wrong for key: {bold ${path}}}`;
         var rules = [
           category == "api" && !data[key].startsWith(prefix),
           category == "css" && !data[key].startsWith(`-${prefix}`)
@@ -49,7 +49,7 @@ function testPrefix(filename) {
   var errors = processData(data, category);
 
   if (errors.length) {
-    console.error(chalk`{red   Prefix – }{red.bold ${errors.length}}{red  ${errors.length === 1 ? 'error' : 'errors'}:}`);
+    console.error(chalk`{red   Prefix – {bold ${errors.length}} ${errors.length === 1 ? 'error' : 'errors'}:}`);
     for (const error of errors) {
       console.error(`    ${error}`);
     }

--- a/test/test-real-values.js
+++ b/test/test-real-values.js
@@ -52,15 +52,15 @@ function checkRealValues(supportData, blockList, relPath, logger) {
 
     for (const statement of supportStatements) {
       if (statement === undefined) {
-        logger.error(chalk`{red.bold ${browser}} {red must be defined for} {red.bold ${relPath}}`);
+        logger.error(chalk`{red {bold ${browser}} must be defined for {bold ${relPath}}`);
           hasErrors = true;
       } else {
         if ([true, null].includes(statement.version_added)) {
-          logger.error(chalk`{red.bold ${relPath}} {red -} {red.bold ${browser}} {red no longer accepts} {red.bold ${statement.version_added}} {red as a value}`);
+          logger.error(chalk`{red {bold ${relPath}} - {bold ${browser}} no longer accepts {bold ${statement.version_added}} as a value}`);
           hasErrors = true;
         }
         if ([true, null].includes(statement.version_removed)) {
-          logger.error(chalk`{red.bold ${relPath}} {red -} {red.bold ${browser}} {red no longer accepts} {red.bold ${statement.version_removed}} {red as a value}`);
+          logger.error(chalk`{red {bold ${relPath}} - {bold ${browser}} no longer accepts} {bold ${statement.version_removed}} as a value}`);
           hasErrors = true;
         }
       }
@@ -106,7 +106,7 @@ function testRealValues(filename) {
   findSupport(data);
 
   if (errors.length) {
-    console.error(chalk`{red   Real values – }{red.bold ${errors.length}}{red  ${errors.length === 1 ? 'error' : 'errors'}:}`);
+    console.error(chalk`{red   Real values – {bold ${errors.length}} ${errors.length === 1 ? 'error' : 'errors'}:}`);
     for (const error of errors) {
       console.error(`    ${error}`);
     }

--- a/test/test-schema.js
+++ b/test/test-schema.js
@@ -17,7 +17,7 @@ function testSchema(dataFilename, schemaFilename = './../schemas/compat-data.sch
   const valid = ajv.validate(schema, data);
 
   if (!valid) {
-    console.error(chalk`{red   JSON Schema – }{red.bold ${ajv.errors.length}}{red  ${ajv.errors.length === 1 ? 'error' : 'errors'}:}`);
+    console.error(chalk`{red   {bold JSON Schema} – {bold ${ajv.errors.length}} ${ajv.errors.length === 1 ? 'error' : 'errors'}:}`);
     // Output messages by one since better-ajv-errors wrongly joins messages
     // (see https://github.com/atlassian/better-ajv-errors/pull/21)
     ajv.errors.forEach(e => {

--- a/test/test-style.js
+++ b/test/test-style.js
@@ -147,19 +147,19 @@ function processData(filename, logger) {
 
   if (actual !== expected) {
     hasErrors = true;
-    logger.error(chalk`{red Error on }{red.bold line ${jsonDiff(actual, expected)}}`);
+    logger.error(chalk`{red Error on {bold line ${jsonDiff(actual, expected)}}}`);
   }
 
   if (expected !== expectedSorting) {
     hasErrors = true;
-    logger.error(chalk`{red Browser sorting error on }{red.bold line ${jsonDiff(expected, expectedSorting)}}`);
+    logger.error(chalk`{red Browser sorting error on {bold line ${jsonDiff(expected, expectedSorting)}}}`);
   }
 
   const bugzillaMatch = actual.match(String.raw`https?://bugzilla\.mozilla\.org/show_bug\.cgi\?id=(\d+)`);
   if (bugzillaMatch) {
     // use https://bugzil.la/1000000 instead
     hasErrors = true;
-    logger.error(chalk`{red ${indexToPos(actual, bugzillaMatch.index)} – Use shortenable URL (}{yellow ${bugzillaMatch[0]}}{red  → }{green.bold https://bugzil.la/}{green ${bugzillaMatch[1]}}{red ).}`);
+    logger.error(chalk`{red ${indexToPos(actual, bugzillaMatch.index)} – Use shortenable URL ({yellow ${bugzillaMatch[0]} → {green {bold https://bugzil.la/}${bugzillaMatch[1]}}).}`);
   }
 
   {
@@ -180,7 +180,7 @@ function processData(filename, logger) {
 
         if (protocol !== 'https') {
           hasErrors = true;
-          logger.error(chalk`{red ${indexToPos(actual, match.index)} – Use HTTPS URL (}{yellow http://${domain}/${bugId}}{red  → }{green http}{green.bold s}{green ://${domain}/${bugId}}{red ).}`);
+          logger.error(chalk`{red ${indexToPos(actual, match.index)} – Use HTTPS URL ({yellow http://${domain}/${bugId}} → {green http{bold s}://${domain}/${bugId}}).}`);
         }
 
         if (domain !== 'bugzil.la') {
@@ -189,15 +189,15 @@ function processData(filename, logger) {
 
         if (/^bug $/.test(before)) {
           hasErrors = true;
-          logger.error(chalk`{red ${indexToPos(actual, match.index)} – Move word "bug" into link text (}{yellow "${before}<a href='...'>${linkText}</a>"}{red  → }{green "<a href='...'>}{green.bold ${before}}{green ${bugId}</a>"}{red ).}`);
+          logger.error(chalk`{red ${indexToPos(actual, match.index)} – Move word "bug" into link text ({yellow "${before}<a href='...'>${linkText}</a>"} → {green "<a href='...'>{bold ${before}}${bugId}</a>"}).}`);
         } else if (linkText === `Bug ${bugId}`) {
           if (!/(\. |")$/.test(before)) {
             hasErrors = true;
-            logger.error(chalk`{red ${indexToPos(actual, match.index)} – Use lowercase "bug" word within sentence (}{yellow "Bug ${bugId}"}{red  → }{green "}{green.bold bug}{green  ${bugId}"}{red ).}`);
+            logger.error(chalk`{red ${indexToPos(actual, match.index)} – Use lowercase "bug" word within sentence ({yellow "Bug ${bugId}"} → {green "{bold bug} ${bugId}"}).}`);
           }
         } else if (linkText !== `bug ${bugId}`) {
           hasErrors = true;
-          logger.error(chalk`{red ${indexToPos(actual, match.index)} – Use standard link text (}{yellow "${linkText}"}{red  → }{green "bug ${bugId}"}{red ).}`);
+          logger.error(chalk`{red ${indexToPos(actual, match.index)} – Use standard link text ({yellow "${linkText}"} → {green "bug ${bugId}"}).}`);
         }
       }
     } while (match != null);
@@ -207,37 +207,38 @@ function processData(filename, logger) {
   if (crbugMatch) {
     // use https://crbug.com/100000 instead
     hasErrors = true;
-    logger.error(chalk`{red ${indexToPos(actual, crbugMatch.index)} – Use shortenable URL (}{yellow ${crbugMatch[0]}}{red  → }{green.bold https://crbug.com/}{green ${crbugMatch[1]}}{red ).}`);
+    logger.error(chalk`{red ${indexToPos(actual, crbugMatch.index)} – Use shortenable URL ({yellow ${crbugMatch[0]}} → {green {bold https://crbug.com/}${crbugMatch[1]}}).}`);
   }
 
   const webkitMatch = actual.match(String.raw`https?://bugs\.webkit\.org/show_bug\.cgi\?id=(\d+)`);
   if (webkitMatch) {
     // use https://webkit.org/b/100000 instead
     hasErrors = true;
-    logger.error(chalk`{red ${indexToPos(actual, webkitMatch.index)} – Use shortenable URL (}{yellow ${webkitMatch[0]}}{red  → }{green.bold https://webkit.org/b/}{green ${webkitMatch[1]}}{red ).}`);
+    logger.error(chalk`{red ${indexToPos(actual, webkitMatch.index)} – Use shortenable URL ({yellow ${webkitMatch[0]}} → }{green {bold https://webkit.org/b/}${webkitMatch[1]}}).}`);
   }
 
   const mdnUrlMatch = actual.match(String.raw`https?://developer.mozilla.org/(\w\w-\w\w)/(.*?)(?=["'\s])`);
   if (mdnUrlMatch) {
     hasErrors = true;
-    logger.error(chalk`{red ${indexToPos(actual, mdnUrlMatch.index)} – Use non-localized MDN URL (}{yellow ${mdnUrlMatch[0]}}{red  → }{green https://developer.mozilla.org/${mdnUrlMatch[2]}}{red ).}`);
+    logger.error(chalk`{red ${indexToPos(actual, mdnUrlMatch.index)} – Use non-localized MDN URL ({yellow ${mdnUrlMatch[0]}} → {green https://developer.mozilla.org/${mdnUrlMatch[2]}}).}`);
   }
 
   const msdevUrlMatch = actual.match(String.raw`https?://developer.microsoft.com/(\w\w-\w\w)/(.*?)(?=["'\s])`);
   if (msdevUrlMatch) {
     hasErrors = true;
-    logger.error(chalk`{red ${indexToPos(actual, msdevUrlMatch.index)} – Use non-localized Microsoft Developer URL (}{yellow ${msdevUrlMatch[0]}}{red  → }{green https://developer.microsoft.com/${msdevUrlMatch[2]}}{red ).}`);
+    logger.error(chalk`{red ${indexToPos(actual, msdevUrlMatch.index)} – Use non-localized Microsoft Developer URL ({yellow ${msdevUrlMatch[0]}} → {green https://developer.microsoft.com/${msdevUrlMatch[2]}}).}`);
   }
 
   let constructorMatch = actual.match(String.raw`"<code>([^)]*?)</code> constructor"`)
   if (constructorMatch) {
     hasErrors = true;
-    logger.error(chalk`{red ${indexToPos(actual, constructorMatch.index)} – Use parentheses in constructor description (}{yellow ${constructorMatch[1]}}{red  → }{green ${constructorMatch[1]}}{green.bold ()}{red ).}`);
+    logger.error(chalk`{red ${indexToPos(actual, constructorMatch.index)} – Use parentheses in constructor description ({yellow ${constructorMatch[1]}} → {green ${constructorMatch[1]}{bold ()}}).}`);
   }
 
-  if (actual.includes("href=\\\"")) {
+  let hrefDoubleQuoteIndex = actual.indexOf('href=\\"');
+  if (hrefDoubleQuoteIndex >= 0) {
     hasErrors = true;
-    logger.error(chalk`{red Found }{yellow \\"}{red  but expected }{green \'}{red  for <a href>.}`);
+    logger.error(chalk`{red ${indexToPos(actual, hrefDoubleQuoteIndex)} - Found {yellow \\"}, but expected {green \'} for <a href>.}`);
   }
 
   const regexp = new RegExp(String.raw`<a href='([^'>]+)'>((?:.(?!</a>))*.)</a>`, 'g');
@@ -246,7 +247,7 @@ function processData(filename, logger) {
     var a_url = url.parse(match[1]);
     if (a_url.hostname === null) {
       hasErrors = true;
-      logger.error(chalk`{red ${indexToPos(actual, constructorMatch.index)} - Include hostname in URL (}{yellow ${match[1]}}{red  → }{green.bold https://developer.mozilla.org/}{green ${match[1]}}{red ).}`);
+      logger.error(chalk`{red ${indexToPos(actual, constructorMatch.index)} - Include hostname in URL ({yellow ${match[1]}} → {green {bold https://developer.mozilla.org/}${match[1]}}).}`);
     }
   }
 
@@ -266,7 +267,7 @@ function testStyle(filename) {
   processData(filename, logger);
 
   if (errors.length) {
-    console.error(chalk`{red   Style – }{red.bold ${errors.length}}{red  ${errors.length === 1 ? 'error' : 'errors'}:}`);
+    console.error(chalk`{red   Style – {bold ${errors.length}} ${errors.length === 1 ? 'error' : 'errors'}:}`);
     for (const error of errors) {
       console.error(`    ${error}`);
     }

--- a/test/test-versions.js
+++ b/test/test-versions.js
@@ -52,11 +52,11 @@ function checkVersions(supportData, relPath, logger) {
 
       for (const statement of supportStatements) {
         if (!isValidVersion(browser, statement.version_added)) {
-          logger.error(chalk`{red.bold ${relPath}} {red -} {red.bold version_added: "${statement.version_added}"}{red  is }{red.bold NOT}{red  a valid version number for }{red.bold ${browser}}\n    {red Valid }{red.bold ${browser}}{red  versions are: ${validBrowserVersionsString}}`);
+          logger.error(chalk`{red {bold ${relPath}} - {bold version_added: "${statement.version_added}"} is {bold NOT} a valid version number for {bold ${browser}}\n    Valid {bold ${browser}} versions are: ${validBrowserVersionsString}}`);
           hasErrors = true;
         }
         if (!isValidVersion(browser, statement.version_removed)) {
-          logger.error(chalk`{red.bold ${relPath}} {red -} {red.bold version_removed: "${statement.version_removed}"}{red  is }{red.bold NOT}{red  a valid version number for }{red.bold ${browser}}\n    {red Valid }{red.bold ${browser}}{red  versions are: ${validBrowserVersionsString}}`);
+          logger.error(chalk`{red {bold ${relPath}} - {bold version_removed: "${statement.version_removed}"} is {bold NOT} a valid version number for {bold ${browser}}\n    Valid {bold ${browser}} versions are: ${validBrowserVersionsString}}`);
           hasErrors = true;
         }
         if ('version_removed' in statement && 'version_added' in statement) {
@@ -64,14 +64,14 @@ function checkVersions(supportData, relPath, logger) {
             typeof statement.version_added !== 'string' &&
             statement.version_added !== true
           ) {
-            logger.error(chalk`{red.bold ${relPath}} {red -} {red.bold version_added: "${statement.version_added}"}{red  is }{red.bold NOT}{red  a valid version number for }{red.bold ${browser}}{red  when }{red.bold version_removed}{red  is present}\n    {red Valid }{red.bold ${browser}}{red  versions are: ${validBrowserVersionsTruthy}}`);
+            logger.error(chalk`{red {bold ${relPath}} - {bold version_added: "${statement.version_added}"} is {bold NOT} a valid version number for {bold ${browser}} when {bold version_removed} is present\n    Valid {bold ${browser}} versions are: ${validBrowserVersionsTruthy}}`);
             hasErrors = true;
           } else if (
             typeof statement.version_added === 'string' &&
             typeof statement.version_removed === 'string' &&
             compareVersions(statement.version_added, statement.version_removed) >= 0
           ) {
-            logger.error(chalk`{red.bold ${relPath}} {red -} {red.bold version_removed: "${statement.version_removed}"}{red  must be greater than }{red.bold version_added: "${statement.version_added}"}`);
+            logger.error(chalk`{red {bold ${relPath}} - {bold version_removed: "${statement.version_removed}"} must be greater than {bold version_added: "${statement.version_added}"}}`);
             hasErrors = true;
           }
         }
@@ -117,7 +117,7 @@ function testVersions(filename) {
   findSupport(data);
 
   if (errors.length) {
-    console.error(chalk`{red   Versions – }{red.bold ${errors.length}}{red  ${errors.length === 1 ? 'error' : 'errors'}:}`);
+    console.error(chalk`{red   Versions – {bold ${errors.length}} ${errors.length === 1 ? 'error' : 'errors'}:}`);
     for (const error of errors) {
       console.error(`    ${error}`);
     }


### PR DESCRIPTION
Calls like:
```js
chalk`{red  red }{red.bold  red & bold }{red red again }`
```
will always produce:
```
\e[31m red \e[39m\e[31m\e[1m red & bold \e[22m\e[39m\e[31m red again \e[39m
```
as Chalk is unable to know that it’s meant to be nested, whereas:
```js
chalk`{red  red {bold  red & bold } red again }`
```
can be optimised to produce:
```
\e[31m red \e[1m red & bold \e[22m red again \e[39m
```
as Chalk knows that the bold style is a sub‑section of the whole red style (note that this isn’t yet fully implemented).

The second call is also a lot cleaner.