### PR TITLE
fix: Correct type of preference flags

### DIFF
--- a/css/selectors/focus-visible.json
+++ b/css/selectors/focus-visible.json
@@ -11,7 +11,7 @@
               "flags": [
                 {
                   "name": "#enable-experimental-web-platform-features",
-                  "type": "runtime_flag",
+                  "type": "preference",
                   "value_to_set": "enabled"
                 }
               ]
@@ -21,7 +21,7 @@
               "flags": [
                 {
                   "name": "#enable-experimental-web-platform-features",
-                  "type": "runtime_flag",
+                  "type": "preference",
                   "value_to_set": "enabled"
                 }
               ]


### PR DESCRIPTION
This applies a flag type correction that I noticed while making #4250.

This was the only case of such mistake in the repository.

---

review?(@vinyldarkscratch)