### PR TITLE
[bug] fix RelativeTimeFormat support for nodejs

### DIFF
--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -2772,7 +2772,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "12.0.0"
               },
               "opera": {
                 "version_added": "58"
@@ -2826,7 +2826,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "12.0.0"
                 },
                 "opera": {
                   "version_added": "58"
@@ -2881,7 +2881,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "12.0.0"
                 },
                 "opera": {
                   "version_added": "58"
@@ -2936,7 +2936,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "12.0.0"
                 },
                 "opera": {
                   "version_added": "58"
@@ -2991,7 +2991,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "12.0.0"
                 },
                 "opera": {
                   "version_added": "58"
@@ -3046,7 +3046,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "12.0.0"
                 },
                 "opera": {
                   "version_added": "58"


### PR DESCRIPTION
`Intl.RelativeTimeFormat` is available on [v8 7.1.179](https://developers.google.com/web/updates/2018/10/intl-relativetimeformat) and Node 12 was released with [v8 7.4](https://nodejs.org/en/download/releases/). Node 11 only got v8 7.0 so Node 12 is the earliest that has this API.
