### PR TITLE
Remove Edge Mobile in css/*

### DIFF
--- a/css/at-rules/charset.json
+++ b/css/at-rules/charset.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1.5",
               "notes": "Firefox 1 supported an invalid syntax where the character encoding is not between single or double quotes."

--- a/css/at-rules/counter-style.json
+++ b/css/at-rules/counter-style.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "33"
             },
@@ -64,9 +61,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -118,9 +112,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "33"
               },
@@ -168,9 +159,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -222,9 +210,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "33"
               },
@@ -272,9 +257,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -326,9 +308,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "33"
               },
@@ -376,9 +355,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -430,9 +406,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "33"
               },
@@ -482,9 +455,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "33"
               },
@@ -532,9 +502,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/at-rules/document.json
+++ b/css/at-rules/document.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "prefix": "-moz-",
@@ -95,9 +92,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "3.5"
             },
@@ -63,9 +60,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -114,9 +108,6 @@
                 "version_added": "36"
               },
               "edge": {
-                "version_added": "14"
-              },
-              "edge_mobile": {
                 "version_added": "14"
               },
               "firefox": [
@@ -194,9 +185,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -249,9 +237,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "58"
               },
@@ -300,9 +285,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "3.5"
               },
@@ -348,9 +330,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -417,9 +396,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "60",
                 "flags": [
@@ -482,9 +458,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "3.5"
               },
@@ -530,9 +503,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -583,9 +553,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "3.5"
               },
@@ -632,9 +599,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {

--- a/css/at-rules/font-feature-values.json
+++ b/css/at-rules/font-feature-values.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "34"
@@ -88,9 +85,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -166,9 +160,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "34"
@@ -240,9 +231,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -318,9 +306,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "34"
@@ -392,9 +377,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -470,9 +452,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "34"
@@ -543,9 +522,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [

--- a/css/at-rules/import.json
+++ b/css/at-rules/import.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -27,9 +27,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": [
               {
                 "version_added": "16",
@@ -172,9 +169,6 @@
                 "version_added": "45"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -65,9 +62,6 @@
               },
               "edge": {
                 "version_added": "16"
-              },
-              "edge_mobile": {
-                "version_added": false
               },
               "firefox": {
                 "version_added": "64"
@@ -118,9 +112,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "64"
               },
@@ -165,9 +156,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -219,9 +207,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "59"
               },
@@ -269,9 +254,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -323,9 +305,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -373,9 +352,6 @@
                 "version_added": "29"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -427,9 +403,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "2"
               },
@@ -477,9 +450,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -531,9 +501,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "2"
               },
@@ -581,9 +548,6 @@
                 "version_added": "45"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -637,9 +601,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "2"
               },
@@ -687,9 +648,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -742,9 +700,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "64"
               },
@@ -790,9 +745,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -844,9 +796,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -895,9 +844,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -944,9 +890,6 @@
                 "version_added": "66"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -998,9 +941,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "2"
               },
@@ -1048,9 +988,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -1102,9 +1039,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "66"
               },
@@ -1152,9 +1086,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -1206,9 +1137,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "64"
               },
@@ -1253,9 +1181,6 @@
                 "version_added": "76"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -1304,9 +1229,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "63"
               },
@@ -1351,9 +1273,6 @@
                 "version_added": "27"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": [
@@ -1419,9 +1338,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -1471,9 +1387,6 @@
                 "notes": "See <a href='https://crbug.com/489957'>bug 489957</a>."
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -1527,9 +1440,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -1577,9 +1487,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -1631,9 +1538,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "2"
               },
@@ -1681,9 +1585,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -1737,9 +1638,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -1791,9 +1689,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": [
@@ -1905,9 +1800,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": [
                 {
                   "version_added": "63",
@@ -2015,9 +1907,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": [
@@ -2131,9 +2020,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -2187,9 +2073,6 @@
                 "version_removed": "36"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": [
@@ -2269,9 +2152,6 @@
                 "version_removed": "36"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/at-rules/namespace.json
+++ b/css/at-rules/namespace.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/at-rules/page.json
+++ b/css/at-rules/page.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "19"
             },
@@ -64,9 +61,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -118,9 +112,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -168,9 +159,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/at-rules/supports.json
+++ b/css/at-rules/supports.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": [
               {
                 "version_added": "22"
@@ -89,9 +86,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/at-rules/viewport.json
+++ b/css/at-rules/viewport.json
@@ -33,16 +33,6 @@
                 }
               ]
             },
-            "edge_mobile": {
-              "prefix": "-ms-",
-              "version_added": "12",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Enable @-ms-viewport rules"
-                }
-              ]
-            },
             "firefox": {
               "version_added": false,
               "notes": "See Firefox <a href='https://bugzil.la/747754'>bug 747754</a>."
@@ -131,10 +121,6 @@
                 "prefix": "-ms-",
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "prefix": "-ms-",
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": false
               },
@@ -195,10 +181,6 @@
                 "version_added": "29"
               },
               "edge": {
-                "prefix": "-ms-",
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "prefix": "-ms-",
                 "version_added": "12"
               },
@@ -265,10 +247,6 @@
                 "prefix": "-ms-",
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "prefix": "-ms-",
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": false
               },
@@ -332,10 +310,6 @@
                 "prefix": "-ms-",
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "prefix": "-ms-",
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": false
               },
@@ -384,10 +358,6 @@
                 "version_added": "29"
               },
               "edge": {
-                "prefix": "-ms-",
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "prefix": "-ms-",
                 "version_added": "12"
               },
@@ -454,10 +424,6 @@
                 "prefix": "-ms-",
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "prefix": "-ms-",
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": false
               },
@@ -521,10 +487,6 @@
                 "prefix": "-ms-",
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "prefix": "-ms-",
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": false
               },
@@ -573,10 +535,6 @@
                 "version_added": false
               },
               "edge": {
-                "prefix": "-ms-",
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "prefix": "-ms-",
                 "version_added": "12"
               },
@@ -630,10 +588,6 @@
                 "version_added": "29"
               },
               "edge": {
-                "prefix": "-ms-",
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "prefix": "-ms-",
                 "version_added": "12"
               },
@@ -725,10 +679,6 @@
                 "prefix": "-ms-",
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "prefix": "-ms-",
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": false
               },
@@ -789,10 +739,6 @@
                 "version_added": "61"
               },
               "edge": {
-                "prefix": "-ms-",
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "prefix": "-ms-",
                 "version_added": "12"
               },

--- a/css/properties/-moz-binding.json
+++ b/css/properties/-moz-binding.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "1",
               "version_removed": "67",

--- a/css/properties/-moz-border-bottom-colors.json
+++ b/css/properties/-moz-border-bottom-colors.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "1",
               "version_removed": "59",

--- a/css/properties/-moz-border-left-colors.json
+++ b/css/properties/-moz-border-left-colors.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "1",
               "version_removed": "59",

--- a/css/properties/-moz-border-right-colors.json
+++ b/css/properties/-moz-border-right-colors.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "1",
               "version_removed": "59",

--- a/css/properties/-moz-border-top-colors.json
+++ b/css/properties/-moz-border-top-colors.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "1",
               "version_removed": "59",

--- a/css/properties/-moz-context-properties.json
+++ b/css/properties/-moz-context-properties.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "55",
               "flags": [

--- a/css/properties/-moz-image-region.json
+++ b/css/properties/-moz-image-region.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/-moz-orient.json
+++ b/css/properties/-moz-orient.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "6"
             },
@@ -62,9 +59,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -117,9 +111,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/-moz-outline-radius.json
+++ b/css/properties/-moz-outline-radius.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "1.5"
             },

--- a/css/properties/-moz-text-blink.json
+++ b/css/properties/-moz-text-blink.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "6",
               "version_removed": "26"

--- a/css/properties/-moz-user-focus.json
+++ b/css/properties/-moz-user-focus.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/-moz-user-input.json
+++ b/css/properties/-moz-user-input.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -111,9 +105,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -165,9 +156,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "1",
                 "version_removed": "60"
@@ -215,9 +203,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/-moz-window-shadow.json
+++ b/css/properties/-moz-window-shadow.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "3.5",
               "version_removed": "44",
@@ -77,9 +74,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "3.5",
                 "version_removed": "44"
@@ -135,9 +129,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -197,9 +188,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "3.5",
                 "version_removed": "44"
@@ -257,9 +245,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "4",
                 "version_removed": "44"
@@ -315,9 +300,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/-webkit-border-before.json
+++ b/css/properties/-webkit-border-before.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/-webkit-box-reflect.json
+++ b/css/properties/-webkit-box-reflect.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/-webkit-line-clamp.json
+++ b/css/properties/-webkit-line-clamp.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "17"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "68"
             },

--- a/css/properties/-webkit-mask-attachment.json
+++ b/css/properties/-webkit-mask-attachment.json
@@ -16,9 +16,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/-webkit-mask-box-image.json
+++ b/css/properties/-webkit-mask-box-image.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "18"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/-webkit-mask-composite.json
+++ b/css/properties/-webkit-mask-composite.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "18"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/-webkit-mask-position-x.json
+++ b/css/properties/-webkit-mask-position-x.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "18"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/-webkit-mask-position-y.json
+++ b/css/properties/-webkit-mask-position-y.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "18"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/-webkit-mask-repeat-x.json
+++ b/css/properties/-webkit-mask-repeat-x.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "18"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/-webkit-mask-repeat-y.json
+++ b/css/properties/-webkit-mask-repeat-y.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "18"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/-webkit-overflow-scrolling.json
+++ b/css/properties/-webkit-overflow-scrolling.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/-webkit-print-color-adjust.json
+++ b/css/properties/-webkit-print-color-adjust.json
@@ -22,9 +22,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/-webkit-text-fill-color.json
+++ b/css/properties/-webkit-text-fill-color.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": [
               {
                 "version_added": "49"

--- a/css/properties/-webkit-text-stroke-color.json
+++ b/css/properties/-webkit-text-stroke-color.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "15"
             },
-            "edge_mobile": {
-              "version_added": "15"
-            },
             "firefox": [
               {
                 "version_added": "49"

--- a/css/properties/-webkit-text-stroke-width.json
+++ b/css/properties/-webkit-text-stroke-width.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "15"
             },
-            "edge_mobile": {
-              "version_added": "15"
-            },
             "firefox": [
               {
                 "version_added": "49"

--- a/css/properties/-webkit-text-stroke.json
+++ b/css/properties/-webkit-text-stroke.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "15"
             },
-            "edge_mobile": {
-              "version_added": "15"
-            },
             "firefox": [
               {
                 "version_added": "49"

--- a/css/properties/-webkit-touch-callout.json
+++ b/css/properties/-webkit-touch-callout.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -34,15 +34,6 @@
                   "version_added": "12"
                 }
               ],
-              "edge_mobile": [
-                {
-                  "version_added": true
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": true
-                }
-              ],
               "firefox": [
                 {
                   "version_added": "28"
@@ -142,9 +133,6 @@
                 "edge": {
                   "version_added": false
                 },
-                "edge_mobile": {
-                  "version_added": false
-                },
                 "firefox": {
                   "version_added": "45"
                 },
@@ -191,9 +179,6 @@
                   "version_added": "57"
                 },
                 "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
                   "version_added": false
                 },
                 "firefox": {
@@ -244,9 +229,6 @@
                 "edge": {
                   "version_added": false
                 },
-                "edge_mobile": {
-                  "version_added": false
-                },
                 "firefox": {
                   "version_added": "52"
                 },
@@ -295,9 +277,6 @@
                   "notes": "This value is recognized, but has no effect."
                 },
                 "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
                   "version_added": false
                 },
                 "firefox": {
@@ -351,9 +330,6 @@
                   "notes": "This value is recognized, but has no effect."
                 },
                 "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
                   "version_added": false
                 },
                 "firefox": {
@@ -411,9 +387,6 @@
                 "edge": {
                   "version_added": false
                 },
-                "edge_mobile": {
-                  "version_added": false
-                },
                 "firefox": {
                   "version_added": "52"
                 },
@@ -460,9 +433,6 @@
                   "version_added": false
                 },
                 "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
                   "version_added": false
                 },
                 "firefox": {
@@ -514,9 +484,6 @@
               },
               "edge": {
                 "version_added": "16"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "52"

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -44,15 +44,6 @@
                   "version_added": "12"
                 }
               ],
-              "edge_mobile": [
-                {
-                  "version_added": true
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": true
-                }
-              ],
               "firefox": [
                 {
                   "version_added": "20",
@@ -182,9 +173,6 @@
                 "edge": {
                   "version_added": false
                 },
-                "edge_mobile": {
-                  "version_added": false
-                },
                 "firefox": {
                   "version_added": "45"
                 },
@@ -231,9 +219,6 @@
                   "version_added": "57"
                 },
                 "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
                   "version_added": false
                 },
                 "firefox": {
@@ -284,9 +269,6 @@
                 "edge": {
                   "version_added": false
                 },
-                "edge_mobile": {
-                  "version_added": false
-                },
                 "firefox": {
                   "version_added": "45"
                 },
@@ -333,9 +315,6 @@
                   "version_added": false
                 },
                 "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
                   "version_added": false
                 },
                 "firefox": {
@@ -388,9 +367,6 @@
               "edge": {
                 "version_added": "16"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "52"
               },
@@ -436,9 +412,6 @@
                   "version_added": "57"
                 },
                 "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
                   "version_added": false
                 },
                 "firefox": {

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -38,15 +38,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": [
-                {
-                  "version_added": true
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": true
-                }
-              ],
               "firefox": [
                 {
                   "version_added": "20",
@@ -175,9 +166,6 @@
                 "edge": {
                   "version_added": false
                 },
-                "edge_mobile": {
-                  "version_added": false
-                },
                 "firefox": {
                   "version_added": "45"
                 },
@@ -224,9 +212,6 @@
                   "version_added": false
                 },
                 "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
                   "version_added": false
                 },
                 "firefox": {
@@ -277,9 +262,6 @@
                 "edge": {
                   "version_added": false
                 },
-                "edge_mobile": {
-                  "version_added": false
-                },
                 "firefox": {
                   "version_added": "45"
                 },
@@ -326,9 +308,6 @@
                   "version_added": "57"
                 },
                 "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
                   "version_added": false
                 },
                 "firefox": {
@@ -379,9 +358,6 @@
                 "edge": {
                   "version_added": false
                 },
-                "edge_mobile": {
-                  "version_added": false
-                },
                 "firefox": {
                   "version_added": "52"
                 },
@@ -428,9 +404,6 @@
                   "version_added": false
                 },
                 "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
                   "version_added": false
                 },
                 "firefox": {
@@ -482,9 +455,6 @@
               },
               "edge": {
                 "version_added": "16"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "52"

--- a/css/properties/all.json
+++ b/css/properties/all.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "27"
             },
@@ -62,9 +59,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/animation-delay.json
+++ b/css/properties/animation-delay.json
@@ -26,15 +26,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "16",

--- a/css/properties/animation-direction.json
+++ b/css/properties/animation-direction.json
@@ -32,15 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "16"
@@ -184,9 +175,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "16"
               },
@@ -231,9 +219,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "16"

--- a/css/properties/animation-duration.json
+++ b/css/properties/animation-duration.json
@@ -32,15 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "16"

--- a/css/properties/animation-fill-mode.json
+++ b/css/properties/animation-fill-mode.json
@@ -32,15 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "16"

--- a/css/properties/animation-iteration-count.json
+++ b/css/properties/animation-iteration-count.json
@@ -32,15 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "16"

--- a/css/properties/animation-name.json
+++ b/css/properties/animation-name.json
@@ -32,15 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": "12"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "12"
-              }
-            ],
             "firefox": [
               {
                 "version_added": "16"

--- a/css/properties/animation-play-state.json
+++ b/css/properties/animation-play-state.json
@@ -32,15 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "16"

--- a/css/properties/animation-timing-function.json
+++ b/css/properties/animation-timing-function.json
@@ -32,15 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "16"
@@ -182,9 +173,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/animation.json
+++ b/css/properties/animation.json
@@ -32,15 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "16"

--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -20,11 +20,6 @@
               "partial_implementation": true,
               "prefix": "-webkit-"
             },
-            "edge_mobile": {
-              "version_added": "12",
-              "partial_implementation": true,
-              "prefix": "-webkit-"
-            },
             "firefox": [
               {
                 "version_added": "1",
@@ -115,9 +110,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": [
                 {
                   "version_added": "54"
@@ -174,9 +166,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -222,9 +211,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -274,9 +260,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -323,10 +306,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12",
-                "partial_implementation": true
-              },
-              "edge_mobile": {
                 "version_added": "12",
                 "partial_implementation": true
               },

--- a/css/properties/azimuth.json
+++ b/css/properties/azimuth.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/backdrop-filter.json
+++ b/css/properties/backdrop-filter.json
@@ -26,9 +26,6 @@
             "edge": {
               "version_added": "17"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/1178765'>bug 1178765</a>."

--- a/css/properties/backface-visibility.json
+++ b/css/properties/backface-visibility.json
@@ -32,15 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "16"

--- a/css/properties/background-attachment.json
+++ b/css/properties/background-attachment.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -63,9 +60,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "25"
@@ -114,9 +108,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "3.6"

--- a/css/properties/background-blend-mode.json
+++ b/css/properties/background-blend-mode.json
@@ -15,9 +15,6 @@
               "version_added": false,
               "notes": "EdgeHTML 18 has an <i>Enable CSS background-blend-mode property</i> flag, however the feature is an early prototype with no discernable end-user effect."
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "30"
             },

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -28,9 +28,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": [
               {
                 "version_added": "4"
@@ -142,9 +139,6 @@
                   "notes": "Before Edge 15, this value was supported with the prefixed version of the property only."
                 }
               ],
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": [
                 {
                   "version_added": "49"
@@ -246,9 +240,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "4"

--- a/css/properties/background-color.json
+++ b/css/properties/background-color.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1",
               "notes": "If the <code>browser.display.use_document_colors</code> user preference in <code>about:config</code> is set to <code>false</code>, background images will not be displayed."
@@ -64,9 +61,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -122,9 +116,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "3.6",
                 "notes": "Some versions support only experimental gradients prefixed with <code>-moz</code>."
@@ -179,9 +170,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "3.6"
               },
@@ -229,9 +217,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "4"
@@ -282,9 +267,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -338,9 +320,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/background-origin.json
+++ b/css/properties/background-origin.json
@@ -28,9 +28,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": [
               {
                 "version_added": "4"
@@ -134,9 +131,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "4"

--- a/css/properties/background-position-x.json
+++ b/css/properties/background-position-x.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "49"
             },
@@ -63,9 +60,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "49"

--- a/css/properties/background-position-y.json
+++ b/css/properties/background-position-y.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "49"
             },
@@ -63,9 +60,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "49"

--- a/css/properties/background-position.json
+++ b/css/properties/background-position.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -63,9 +60,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "3.6"
@@ -114,9 +108,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "13"

--- a/css/properties/background-repeat.json
+++ b/css/properties/background-repeat.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -63,9 +60,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "3.6"
@@ -115,9 +109,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "13"
               },
@@ -165,9 +156,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "49"

--- a/css/properties/background-size.json
+++ b/css/properties/background-size.json
@@ -28,9 +28,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": [
               {
                 "version_added": "4"
@@ -134,9 +131,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "3.6"

--- a/css/properties/background.json
+++ b/css/properties/background.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -63,9 +60,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "3.6"
@@ -115,9 +109,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "4"
               },
@@ -165,9 +156,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "9"
@@ -217,9 +205,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "22"
               },
@@ -267,9 +252,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "22"

--- a/css/properties/block-size.json
+++ b/css/properties/block-size.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "41"
@@ -90,9 +87,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "66"
@@ -153,9 +147,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "66"
@@ -214,9 +205,6 @@
                 "version_added": "57"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/border-block-color.json
+++ b/css/properties/border-block-color.json
@@ -21,9 +21,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "66"
             },

--- a/css/properties/border-block-end-color.json
+++ b/css/properties/border-block-end-color.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/border-block-end-style.json
+++ b/css/properties/border-block-end-style.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/border-block-end-width.json
+++ b/css/properties/border-block-end-width.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/border-block-end.json
+++ b/css/properties/border-block-end.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/border-block-start-color.json
+++ b/css/properties/border-block-start-color.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/border-block-start-style.json
+++ b/css/properties/border-block-start-style.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/border-block-start-width.json
+++ b/css/properties/border-block-start-width.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/border-block-start.json
+++ b/css/properties/border-block-start.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/border-block-style.json
+++ b/css/properties/border-block-style.json
@@ -21,9 +21,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "66"
             },

--- a/css/properties/border-block-width.json
+++ b/css/properties/border-block-width.json
@@ -21,9 +21,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "66"
             },

--- a/css/properties/border-block.json
+++ b/css/properties/border-block.json
@@ -21,9 +21,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "66"
             },

--- a/css/properties/border-bottom-color.json
+++ b/css/properties/border-bottom-color.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1",
               "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-bottom-colors'><code>-moz-border-bottom-colors</code></a> CSS property that sets the bottom border to multiple colors."

--- a/css/properties/border-bottom-left-radius.json
+++ b/css/properties/border-bottom-left-radius.json
@@ -26,15 +26,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "4",
@@ -134,9 +125,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": [
                 {
                   "version_added": "4"
@@ -190,9 +178,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "3.5"

--- a/css/properties/border-bottom-right-radius.json
+++ b/css/properties/border-bottom-right-radius.json
@@ -26,15 +26,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "4",
@@ -134,9 +125,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": [
                 {
                   "version_added": "4"
@@ -190,9 +178,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "3.5"

--- a/css/properties/border-bottom-style.json
+++ b/css/properties/border-bottom-style.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1",
               "notes": "Prior to Firefox 50, border styles of rounded corners (with <a href='https://developer.mozilla.org/docs/Web/CSS/border-radius'><code>border-radius</code></a>) were always rendered as if <code>border-bottom-style</code> was <code>solid</code>. This has been fixed in Firefox 50."

--- a/css/properties/border-bottom-width.json
+++ b/css/properties/border-bottom-width.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/border-bottom.json
+++ b/css/properties/border-bottom.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/border-collapse.json
+++ b/css/properties/border-collapse.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/border-color.json
+++ b/css/properties/border-color.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1",
               "notes": "Firefox also supports the following non-standard CSS properties to set the border sides to multiple colors: <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-top-colors'><code>-moz-border-top-colors</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-right-colors'><code>-moz-border-right-colors</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-bottom-colors'><code>-moz-border-bottom-colors</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-left-colors'><code>-moz-border-left-colors</code></a>"

--- a/css/properties/border-end-end-radius.json
+++ b/css/properties/border-end-end-radius.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "66"
             },

--- a/css/properties/border-end-start-radius.json
+++ b/css/properties/border-end-start-radius.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "66"
             },

--- a/css/properties/border-image-outset.json
+++ b/css/properties/border-image-outset.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "15"
             },

--- a/css/properties/border-image-repeat.json
+++ b/css/properties/border-image-repeat.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "15"
             },
@@ -49,9 +46,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "15"
               },
@@ -84,9 +78,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "50"

--- a/css/properties/border-image-slice.json
+++ b/css/properties/border-image-slice.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "15",
               "notes": [

--- a/css/properties/border-image-source.json
+++ b/css/properties/border-image-source.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "15"
             },

--- a/css/properties/border-image-width.json
+++ b/css/properties/border-image-width.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "13"
             },

--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -32,15 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "15",

--- a/css/properties/border-inline-color.json
+++ b/css/properties/border-inline-color.json
@@ -21,9 +21,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "66"
             },

--- a/css/properties/border-inline-end-color.json
+++ b/css/properties/border-inline-end-color.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/border-inline-end-style.json
+++ b/css/properties/border-inline-end-style.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/border-inline-end-width.json
+++ b/css/properties/border-inline-end-width.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/border-inline-start-color.json
+++ b/css/properties/border-inline-start-color.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/border-inline-start-style.json
+++ b/css/properties/border-inline-start-style.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/border-inline-start-width.json
+++ b/css/properties/border-inline-start-width.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/border-inline-style.json
+++ b/css/properties/border-inline-style.json
@@ -21,9 +21,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "66"
             },

--- a/css/properties/border-inline-width.json
+++ b/css/properties/border-inline-width.json
@@ -21,9 +21,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "66"
             },

--- a/css/properties/border-inline.json
+++ b/css/properties/border-inline.json
@@ -21,9 +21,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "66"
             },

--- a/css/properties/border-left-color.json
+++ b/css/properties/border-left-color.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1",
               "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-left-colors'><code>-moz-border-left-colors</code></a> CSS property that sets the bottom border to multiple colors."

--- a/css/properties/border-left-style.json
+++ b/css/properties/border-left-style.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1",
               "notes": "Prior to Firefox 50, border styles of rounded corners (with <a href='https://developer.mozilla.org/docs/Web/CSS/border-radius'><code>border-radius</code></a>) were always rendered as if <code>border-bottom-style</code> was <code>solid</code>. This has been fixed in Firefox 50."

--- a/css/properties/border-left-width.json
+++ b/css/properties/border-left-width.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/border-left.json
+++ b/css/properties/border-left.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/border-radius.json
+++ b/css/properties/border-radius.json
@@ -27,15 +27,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "4",
@@ -111,9 +102,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "4",
                 "notes": "<code>&lt;percentage&gt;</code> values are implemented in a non-standard way prior to Firefox 4. Both horizontal and vertical radii were relative to the width of the border box."
@@ -165,9 +153,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "4"
               },
@@ -216,9 +201,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "4"

--- a/css/properties/border-right-color.json
+++ b/css/properties/border-right-color.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1",
               "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-right-colors'><code>-moz-border-right-colors</code></a> CSS property that sets the right border to multiple colors."

--- a/css/properties/border-right-style.json
+++ b/css/properties/border-right-style.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1",
               "notes": "Prior to Firefox 50, border styles of rounded corners (with <a href='https://developer.mozilla.org/docs/Web/CSS/border-radius'><code>border-radius</code></a>) were always rendered as if <code>border-bottom-style</code> was <code>solid</code>. This has been fixed in Firefox 50."

--- a/css/properties/border-right-width.json
+++ b/css/properties/border-right-width.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/border-right.json
+++ b/css/properties/border-right.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/border-spacing.json
+++ b/css/properties/border-spacing.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/border-start-end-radius.json
+++ b/css/properties/border-start-end-radius.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "66"
             },

--- a/css/properties/border-start-start-radius.json
+++ b/css/properties/border-start-start-radius.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "66"
             },

--- a/css/properties/border-style.json
+++ b/css/properties/border-style.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1",
               "notes": "Prior to Firefox 50, border styles of rounded corners were always rendered as if <code>border-style</code> was solid. This has been fixed in Firefox 50."

--- a/css/properties/border-top-color.json
+++ b/css/properties/border-top-color.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1",
               "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-top-colors'><code>-moz-border-top-colors</code></a> CSS property that sets the top border to multiple colors."

--- a/css/properties/border-top-left-radius.json
+++ b/css/properties/border-top-left-radius.json
@@ -26,15 +26,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "4",
@@ -134,9 +125,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": [
                 {
                   "version_added": "4"
@@ -190,9 +178,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "3.5"

--- a/css/properties/border-top-right-radius.json
+++ b/css/properties/border-top-right-radius.json
@@ -26,15 +26,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "4",
@@ -134,9 +125,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": [
                 {
                   "version_added": "4"
@@ -190,9 +178,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "3.5"

--- a/css/properties/border-top-style.json
+++ b/css/properties/border-top-style.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1",
               "notes": "Prior to Firefox 50, border styles of rounded corners (with <a href='https://developer.mozilla.org/docs/Web/CSS/border-radius'><code>border-radius</code></a>) were always rendered as if <code>border-top-style</code> was <code>solid</code>. This has been fixed in Firefox 50."

--- a/css/properties/border-top-width.json
+++ b/css/properties/border-top-width.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/border-top.json
+++ b/css/properties/border-top.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/border-width.json
+++ b/css/properties/border-width.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/border.json
+++ b/css/properties/border.json
@@ -11,9 +11,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/bottom.json
+++ b/css/properties/bottom.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/box-align.json
+++ b/css/properties/box-align.json
@@ -17,10 +17,6 @@
               "version_added": "12",
               "prefix": "-webkit-"
             },
-            "edge_mobile": {
-              "version_added": true,
-              "prefix": "-webkit-"
-            },
             "firefox": [
               {
                 "version_added": "1",

--- a/css/properties/box-decoration-break.json
+++ b/css/properties/box-decoration-break.json
@@ -18,9 +18,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": [
               {
                 "version_added": "32"

--- a/css/properties/box-direction.json
+++ b/css/properties/box-direction.json
@@ -17,10 +17,6 @@
               "prefix": "-webkit-",
               "version_added": "12"
             },
-            "edge_mobile": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
             "firefox": [
               {
                 "prefix": "-moz-",

--- a/css/properties/box-flex-group.json
+++ b/css/properties/box-flex-group.json
@@ -18,9 +18,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/box-flex.json
+++ b/css/properties/box-flex.json
@@ -17,10 +17,6 @@
               "prefix": "-webkit-",
               "version_added": "12"
             },
-            "edge_mobile": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
             "firefox": [
               {
                 "prefix": "-moz-",

--- a/css/properties/box-lines.json
+++ b/css/properties/box-lines.json
@@ -18,9 +18,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/box-ordinal-group.json
+++ b/css/properties/box-ordinal-group.json
@@ -17,9 +17,6 @@
               "version_added": "12",
               "prefix": "-webkit-"
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": [
               {
                 "prefix": "-moz-",

--- a/css/properties/box-orient.json
+++ b/css/properties/box-orient.json
@@ -17,10 +17,6 @@
               "prefix": "-webkit-",
               "version_added": "12"
             },
-            "edge_mobile": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
             "firefox": [
               {
                 "prefix": "-moz-",

--- a/css/properties/box-pack.json
+++ b/css/properties/box-pack.json
@@ -17,10 +17,6 @@
               "prefix": "-webkit-",
               "version_added": "12"
             },
-            "edge_mobile": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
             "firefox": [
               {
                 "prefix": "-moz-",

--- a/css/properties/box-shadow.json
+++ b/css/properties/box-shadow.json
@@ -28,9 +28,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": [
               {
                 "version_added": "4",
@@ -158,9 +155,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": [
                 {
                   "version_added": "4"
@@ -253,9 +247,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": [
                 {
                   "version_added": "4"
@@ -343,9 +334,6 @@
               ],
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": [
                 {

--- a/css/properties/box-sizing.json
+++ b/css/properties/box-sizing.json
@@ -34,15 +34,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "29"
@@ -147,9 +138,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/break-after.json
+++ b/css/properties/break-after.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": false
               },
@@ -78,9 +75,6 @@
                 "edge": {
                   "version_added": false
                 },
-                "edge_mobile": {
-                  "version_added": false
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -129,9 +123,6 @@
                 "edge": {
                   "version_added": "12"
                 },
-                "edge_mobile": {
-                  "version_added": true
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -179,9 +170,6 @@
                 },
                 "edge": {
                   "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
                 },
                 "firefox": {
                   "version_added": false
@@ -233,9 +221,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "65"
               },
@@ -295,9 +280,6 @@
                 "edge": {
                   "version_added": "12"
                 },
-                "edge_mobile": {
-                  "version_added": "12"
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -345,9 +327,6 @@
                   "version_added": "50"
                 },
                 "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
                   "version_added": "12"
                 },
                 "firefox": {
@@ -399,9 +378,6 @@
                 "edge": {
                   "version_added": false
                 },
-                "edge_mobile": {
-                  "version_added": false
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -450,9 +426,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/break-before.json
+++ b/css/properties/break-before.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "65"
               },
@@ -78,9 +75,6 @@
                 "edge": {
                   "version_added": false
                 },
-                "edge_mobile": {
-                  "version_added": false
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -129,9 +123,6 @@
                 "edge": {
                   "version_added": "12"
                 },
-                "edge_mobile": {
-                  "version_added": false
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -179,9 +170,6 @@
                 },
                 "edge": {
                   "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": false
                 },
                 "firefox": {
                   "version_added": false
@@ -233,9 +221,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "65"
               },
@@ -295,9 +280,6 @@
                 "edge": {
                   "version_added": "12"
                 },
-                "edge_mobile": {
-                  "version_added": "12"
-                },
                 "firefox": {
                   "version_added": "65"
                 },
@@ -345,9 +327,6 @@
                   "version_added": "50"
                 },
                 "edge": {
-                  "version_added": "12"
-                },
-                "edge_mobile": {
                   "version_added": "12"
                 },
                 "firefox": {
@@ -399,9 +378,6 @@
                 "edge": {
                   "version_added": false
                 },
-                "edge_mobile": {
-                  "version_added": false
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -450,9 +426,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/break-inside.json
+++ b/css/properties/break-inside.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "65"
               },
@@ -78,9 +75,6 @@
                 "edge": {
                   "version_added": "12"
                 },
-                "edge_mobile": {
-                  "version_added": "12"
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -130,9 +124,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "65"
@@ -193,9 +184,6 @@
                 "edge": {
                   "version_added": "12"
                 },
-                "edge_mobile": {
-                  "version_added": "12"
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -245,9 +233,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/caption-side.json
+++ b/css/properties/caption-side.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -62,9 +59,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -113,9 +107,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/caret-color.json
+++ b/css/properties/caret-color.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "53"
             },

--- a/css/properties/clear.json
+++ b/css/properties/clear.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -62,9 +59,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -27,10 +27,6 @@
               "version_added": "12",
               "notes": "Edge only supports clip paths defined by <code>url()</code>."
             },
-            "edge_mobile": {
-              "version_added": "12",
-              "notes": "Edge only supports clip paths defined by <code>url()</code>."
-            },
             "firefox": {
               "version_added": "3.5"
             },
@@ -97,9 +93,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "49"
               },
@@ -158,9 +151,6 @@
                 }
               ],
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -229,9 +219,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "63",
                 "flags": [
@@ -294,9 +281,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "52"
               },
@@ -355,9 +339,6 @@
                 "version_added": "55"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -444,9 +425,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/clip.json
+++ b/css/properties/clip.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/color-adjust.json
+++ b/css/properties/color-adjust.json
@@ -16,9 +16,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "48"
             },

--- a/css/properties/color.json
+++ b/css/properties/color.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -65,9 +62,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "3"
               },
@@ -115,9 +109,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -169,9 +160,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -218,9 +206,6 @@
                 "version_added": "38"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -272,9 +257,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "3"
               },
@@ -323,9 +305,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "1"
@@ -377,9 +356,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -428,9 +404,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "1"
@@ -505,9 +478,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "49"
               },
@@ -573,9 +543,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "52"
               },
@@ -622,9 +589,6 @@
                 "version_added": "66"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/column-count.json
+++ b/css/properties/column-count.json
@@ -26,15 +26,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "52"
@@ -113,9 +104,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {

--- a/css/properties/column-fill.json
+++ b/css/properties/column-fill.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": [
               {
                 "version_added": "52"

--- a/css/properties/column-gap.json
+++ b/css/properties/column-gap.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "63"
               },
@@ -117,9 +114,6 @@
                   "alternative_name": "grid-gap"
                 }
               ],
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "61"
@@ -283,9 +277,6 @@
                   "version_added": "12"
                 }
               ],
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "52"
@@ -399,9 +390,6 @@
                 "edge": {
                   "version_added": "16"
                 },
-                "edge_mobile": {
-                  "version_added": false
-                },
                 "firefox": {
                   "version_added": "61"
                 },
@@ -458,9 +446,6 @@
                 },
                 "edge": {
                   "version_added": "16"
-                },
-                "edge_mobile": {
-                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "61"

--- a/css/properties/column-rule-color.json
+++ b/css/properties/column-rule-color.json
@@ -32,15 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "52"

--- a/css/properties/column-rule-style.json
+++ b/css/properties/column-rule-style.json
@@ -32,15 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "52"

--- a/css/properties/column-rule-width.json
+++ b/css/properties/column-rule-width.json
@@ -32,10 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
             "firefox": [
               {
                 "version_added": "50"

--- a/css/properties/column-rule.json
+++ b/css/properties/column-rule.json
@@ -32,9 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": [
               {
                 "version_added": "52"

--- a/css/properties/column-span.json
+++ b/css/properties/column-span.json
@@ -32,15 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": {
               "version_added": "65",
               "flags": [

--- a/css/properties/column-width.json
+++ b/css/properties/column-width.json
@@ -32,15 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "50"
@@ -115,9 +106,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -161,9 +149,6 @@
                 "version_added": "50"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {

--- a/css/properties/columns.json
+++ b/css/properties/columns.json
@@ -26,15 +26,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "52"
@@ -119,9 +110,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {

--- a/css/properties/contain.json
+++ b/css/properties/contain.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": "41",
               "flags": [

--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -65,9 +62,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -114,9 +108,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/counter-increment.json
+++ b/css/properties/counter-increment.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/counter-reset.json
+++ b/css/properties/counter-reset.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/counter-set.json
+++ b/css/properties/counter-set.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "68"
             },

--- a/css/properties/cursor.json
+++ b/css/properties/cursor.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": "1",
               "notes": "Starting in Firefox 67, the maximum size allowed for custom cursors is 32x32 pixels due to cursors being misused by certain malicious sites."
@@ -66,9 +63,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "1.5"
               },
@@ -116,9 +110,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": {
                 "version_added": "1"
@@ -168,9 +159,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "1.5"
               },
@@ -218,9 +206,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": {
                 "version_added": "1.5"
@@ -270,9 +255,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -320,9 +302,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": {
                 "version_added": "1"
@@ -387,9 +366,6 @@
               ],
               "edge": {
                 "version_added": "14"
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": [
                 {
@@ -459,9 +435,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -509,9 +482,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": {
                 "version_added": "1"
@@ -561,9 +531,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -611,9 +578,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": {
                 "version_added": "3"
@@ -663,9 +627,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -713,9 +674,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": {
                 "version_added": "1"
@@ -765,9 +723,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -815,9 +770,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": {
                 "version_added": "1.5",
@@ -867,9 +819,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": {
                 "version_added": "1"
@@ -930,9 +879,6 @@
               ],
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": [
                 {
@@ -1010,9 +956,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "1.5",
                 "notes": "This cursor is only supported on macOS and Linux."
@@ -1062,9 +1005,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "1.5"
               },
@@ -1112,9 +1052,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": {
                 "version_added": "1.5"
@@ -1164,9 +1101,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "1.5"
               },
@@ -1214,9 +1148,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": {
                 "version_added": "1.5"
@@ -1266,9 +1197,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "1.5"
               },
@@ -1316,9 +1244,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": {
                 "version_added": "1.5"
@@ -1368,9 +1293,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -1419,9 +1341,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "1.5"
               },
@@ -1468,9 +1387,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/custom-property.json
+++ b/css/properties/custom-property.json
@@ -26,9 +26,6 @@
             "edge": {
               "version_added": "15"
             },
-            "edge_mobile": {
-              "version_added": "15"
-            },
             "firefox": [
               {
                 "version_added": "31"
@@ -127,9 +124,6 @@
                 }
               ],
               "edge": {
-                "version_added": "15"
-              },
-              "edge_mobile": {
                 "version_added": "15"
               },
               "firefox": [

--- a/css/properties/direction.json
+++ b/css/properties/direction.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -113,9 +107,6 @@
                   "version_removed": "32"
                 },
                 "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
                   "version_added": false
                 },
                 "firefox": {
@@ -171,9 +162,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -219,9 +207,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -271,9 +256,6 @@
                 "edge": {
                   "version_added": false
                 },
-                "edge_mobile": {
-                  "version_added": false
-                },
                 "firefox": {
                   "version_added": "64"
                 },
@@ -320,9 +302,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -379,9 +358,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "3"
               },
@@ -428,9 +404,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -490,9 +463,6 @@
                 }
               ],
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": [
@@ -630,9 +600,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": [
                 {
                   "version_added": "20",
@@ -750,10 +717,6 @@
                   "version_added": "12"
                 }
               ],
-              "edge_mobile": {
-                "prefix": "-ms-",
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "52"
               },
@@ -810,10 +773,6 @@
                   "version_added": "12"
                 }
               ],
-              "edge_mobile": {
-                "prefix": "-ms-",
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "52"
               },
@@ -862,9 +821,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -922,9 +878,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": [
@@ -1004,9 +957,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -1058,9 +1008,6 @@
                 "version_added": "58"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -1120,9 +1067,6 @@
                 "version_added": "65"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -1185,9 +1129,6 @@
                 "edge": {
                   "version_added": false
                 },
-                "edge_mobile": {
-                  "version_added": false
-                },
                 "firefox": {
                   "version_added": "59"
                 },
@@ -1238,9 +1179,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -1288,9 +1226,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -1369,9 +1304,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "1",
@@ -1446,9 +1378,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -1527,9 +1456,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "1",
@@ -1604,9 +1530,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [

--- a/css/properties/empty-cells.json
+++ b/css/properties/empty-cells.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/filter.json
+++ b/css/properties/filter.json
@@ -27,15 +27,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "35"
@@ -168,9 +159,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -32,15 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "22",
@@ -171,9 +162,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "18"
               },
@@ -213,9 +201,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "61"
@@ -259,9 +244,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -321,9 +303,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [

--- a/css/properties/flex-direction.json
+++ b/css/properties/flex-direction.json
@@ -32,15 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "20",

--- a/css/properties/flex-flow.json
+++ b/css/properties/flex-flow.json
@@ -26,9 +26,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": [
               {
                 "version_added": "28"

--- a/css/properties/flex-grow.json
+++ b/css/properties/flex-grow.json
@@ -32,15 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "20",

--- a/css/properties/flex-shrink.json
+++ b/css/properties/flex-shrink.json
@@ -32,15 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "20",

--- a/css/properties/flex-wrap.json
+++ b/css/properties/flex-wrap.json
@@ -26,9 +26,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "28"
             },

--- a/css/properties/flex.json
+++ b/css/properties/flex.json
@@ -32,15 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "20",

--- a/css/properties/float.json
+++ b/css/properties/float.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -62,9 +59,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/font-family.json
+++ b/css/properties/font-family.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1",
               "notes": "Not supported on <code>option</code> elements. See <a href='https://bugzil.la/1536148'>bug 1536148</a>."
@@ -63,9 +60,6 @@
                 "version_added": "56"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [

--- a/css/properties/font-feature-settings.json
+++ b/css/properties/font-feature-settings.json
@@ -20,9 +20,6 @@
             "edge": {
               "version_added": "15"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": [
               {
                 "version_added": "34",

--- a/css/properties/font-kerning.json
+++ b/css/properties/font-kerning.json
@@ -16,9 +16,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "32"

--- a/css/properties/font-language-override.json
+++ b/css/properties/font-language-override.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "34"

--- a/css/properties/font-optical-sizing.json
+++ b/css/properties/font-optical-sizing.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "17"
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": [
               {
                 "version_added": "62"

--- a/css/properties/font-size-adjust.json
+++ b/css/properties/font-size-adjust.json
@@ -21,9 +21,6 @@
               "version_added": false,
               "notes": "Although <code>'fontSizeAdjust' in element.style</code> returns <code>true</code>, this feature isn't supported."
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "40"

--- a/css/properties/font-size.json
+++ b/css/properties/font-size.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -62,9 +59,6 @@
                 "version_added": "42"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {

--- a/css/properties/font-smooth.json
+++ b/css/properties/font-smooth.json
@@ -16,9 +16,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": "25",
               "alternative_name": "-moz-osx-font-smoothing",

--- a/css/properties/font-stretch.json
+++ b/css/properties/font-stretch.json
@@ -16,9 +16,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "9"
             },
@@ -69,9 +66,6 @@
               },
               "edge": {
                 "version_added": "18"
-              },
-              "edge_mobile": {
-                "version_added": false
               },
               "firefox": {
                 "version_added": "61"

--- a/css/properties/font-style.json
+++ b/css/properties/font-style.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1",
               "notes": "Before Firefox 44, <code>oblique</code> was not distinguished from <code>italic</code>."
@@ -64,9 +61,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/font-synthesis.json
+++ b/css/properties/font-synthesis.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "34"

--- a/css/properties/font-variant-alternates.json
+++ b/css/properties/font-variant-alternates.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "34"
@@ -89,9 +86,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -169,9 +163,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "34"
@@ -245,9 +236,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -325,9 +313,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "34"
@@ -403,9 +388,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "34"
@@ -479,9 +461,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [

--- a/css/properties/font-variant-caps.json
+++ b/css/properties/font-variant-caps.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "34"

--- a/css/properties/font-variant-east-asian.json
+++ b/css/properties/font-variant-east-asian.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "34"

--- a/css/properties/font-variant-ligatures.json
+++ b/css/properties/font-variant-ligatures.json
@@ -20,9 +20,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "34"

--- a/css/properties/font-variant-numeric.json
+++ b/css/properties/font-variant-numeric.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "34"

--- a/css/properties/font-variant-position.json
+++ b/css/properties/font-variant-position.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "34"

--- a/css/properties/font-variant.json
+++ b/css/properties/font-variant.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -62,9 +59,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -115,9 +109,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "14"
               },
@@ -166,9 +157,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "15"
               },
@@ -215,9 +203,6 @@
                 "version_added": "52"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [

--- a/css/properties/font-variation-settings.json
+++ b/css/properties/font-variation-settings.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "17"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "62"

--- a/css/properties/font-weight.json
+++ b/css/properties/font-weight.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -63,9 +60,6 @@
               },
               "edge": {
                 "version_added": "17"
-              },
-              "edge_mobile": {
-                "version_added": false
               },
               "firefox": {
                 "version_added": "61"

--- a/css/properties/font.json
+++ b/css/properties/font.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -64,9 +61,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -113,9 +107,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/gap.json
+++ b/css/properties/gap.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "63"
               },
@@ -115,9 +112,6 @@
                   "alternative_name": "grid-gap"
                 }
               ],
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "61"
@@ -251,9 +245,6 @@
                 "edge": {
                   "version_added": "16"
                 },
-                "edge_mobile": {
-                  "version_added": false
-                },
                 "firefox": {
                   "version_added": "52"
                 },
@@ -310,9 +301,6 @@
                 },
                 "edge": {
                   "version_added": "16"
-                },
-                "edge_mobile": {
-                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "52"
@@ -372,9 +360,6 @@
               },
               "edge": {
                 "version_added": "16"
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": {
                 "version_added": "61"

--- a/css/properties/grid-area.json
+++ b/css/properties/grid-area.json
@@ -36,9 +36,6 @@
             "edge": {
               "version_added": "16"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "52"

--- a/css/properties/grid-auto-columns.json
+++ b/css/properties/grid-auto-columns.json
@@ -42,10 +42,6 @@
                 "alternative_name": "-ms-grid-columns"
               }
             ],
-            "edge_mobile": {
-              "version_added": "12",
-              "alternative_name": "-ms-grid-columns"
-            },
             "firefox": [
               {
                 "version_added": "52",

--- a/css/properties/grid-auto-flow.json
+++ b/css/properties/grid-auto-flow.json
@@ -36,9 +36,6 @@
             "edge": {
               "version_added": "16"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "52"

--- a/css/properties/grid-auto-rows.json
+++ b/css/properties/grid-auto-rows.json
@@ -42,10 +42,6 @@
                 "alternative_name": "-ms-grid-rows"
               }
             ],
-            "edge_mobile": {
-              "version_added": "12",
-              "alternative_name": "-ms-grid-rows"
-            },
             "firefox": [
               {
                 "version_added": "52",

--- a/css/properties/grid-column-end.json
+++ b/css/properties/grid-column-end.json
@@ -36,9 +36,6 @@
             "edge": {
               "version_added": "16"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "52"

--- a/css/properties/grid-column-start.json
+++ b/css/properties/grid-column-start.json
@@ -36,9 +36,6 @@
             "edge": {
               "version_added": "16"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "52"

--- a/css/properties/grid-column.json
+++ b/css/properties/grid-column.json
@@ -36,9 +36,6 @@
             "edge": {
               "version_added": "16"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "52"

--- a/css/properties/grid-row-end.json
+++ b/css/properties/grid-row-end.json
@@ -36,9 +36,6 @@
             "edge": {
               "version_added": "16"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "52"

--- a/css/properties/grid-row-start.json
+++ b/css/properties/grid-row-start.json
@@ -36,9 +36,6 @@
             "edge": {
               "version_added": "16"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "52"

--- a/css/properties/grid-row.json
+++ b/css/properties/grid-row.json
@@ -36,9 +36,6 @@
             "edge": {
               "version_added": "16"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "52"

--- a/css/properties/grid-template-areas.json
+++ b/css/properties/grid-template-areas.json
@@ -36,9 +36,6 @@
             "edge": {
               "version_added": "16"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "52"

--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -36,9 +36,6 @@
             "edge": {
               "version_added": "16"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "52"
@@ -156,9 +153,6 @@
               ],
               "edge": {
                 "version_added": "16"
-              },
-              "edge_mobile": {
-                "version_added": false
               },
               "firefox": [
                 {
@@ -278,9 +272,6 @@
               ],
               "edge": {
                 "version_added": "16"
-              },
-              "edge_mobile": {
-                "version_added": false
               },
               "firefox": [
                 {
@@ -404,9 +395,6 @@
               "edge": {
                 "version_added": "16"
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "51"
               },
@@ -454,9 +442,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -36,9 +36,6 @@
             "edge": {
               "version_added": "16"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "52"
@@ -156,9 +153,6 @@
               ],
               "edge": {
                 "version_added": "16"
-              },
-              "edge_mobile": {
-                "version_added": false
               },
               "firefox": [
                 {
@@ -278,9 +272,6 @@
               ],
               "edge": {
                 "version_added": "16"
-              },
-              "edge_mobile": {
-                "version_added": false
               },
               "firefox": [
                 {
@@ -404,9 +395,6 @@
               "edge": {
                 "version_added": "16"
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "51"
               },
@@ -454,9 +442,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/grid-template.json
+++ b/css/properties/grid-template.json
@@ -36,9 +36,6 @@
             "edge": {
               "version_added": "16"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "52"

--- a/css/properties/grid.json
+++ b/css/properties/grid.json
@@ -36,9 +36,6 @@
             "edge": {
               "version_added": "16"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "52"

--- a/css/properties/hanging-punctuation.json
+++ b/css/properties/hanging-punctuation.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/height.json
+++ b/css/properties/height.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -64,9 +61,6 @@
                 "version_added": "28"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -117,9 +111,6 @@
                 "version_added": "46"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -182,9 +173,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "66"
@@ -243,9 +231,6 @@
                 "version_added": "46"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/hyphens.json
+++ b/css/properties/hyphens.json
@@ -32,12 +32,6 @@
               "partial_implementation": true,
               "notes": "Only works if the specified language is the same as the language of the underlying OS."
             },
-            "edge_mobile": {
-              "prefix": "-ms-",
-              "version_added": "12",
-              "partial_implementation": true,
-              "notes": "Only works if the specified language is the same as the language of the underlying OS."
-            },
             "firefox": [
               {
                 "version_added": "43"
@@ -112,9 +106,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "8"
               },
@@ -161,9 +152,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -214,9 +202,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "8"
               },
@@ -263,9 +248,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -316,9 +298,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "8"
               },
@@ -365,9 +344,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -418,9 +394,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "8"
               },
@@ -469,9 +442,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "8"
               },
@@ -518,9 +488,6 @@
                 "version_added": "55"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -574,9 +541,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "8"
               },
@@ -623,9 +587,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -676,9 +637,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "8"
               },
@@ -725,9 +683,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -778,9 +733,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "9"
               },
@@ -827,9 +779,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -880,9 +829,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "8"
               },
@@ -929,9 +875,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -982,9 +925,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "9"
               },
@@ -1031,9 +971,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -1084,9 +1021,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "8"
               },
@@ -1133,9 +1067,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -1186,9 +1117,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "8"
               },
@@ -1235,9 +1163,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -1288,9 +1213,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "8"
               },
@@ -1337,9 +1259,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -1390,9 +1309,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "8"
               },
@@ -1439,9 +1355,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -1492,9 +1405,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "8"
               },
@@ -1541,9 +1451,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -1594,9 +1501,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "9"
               },
@@ -1643,9 +1547,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -1696,9 +1597,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "8"
               },
@@ -1745,9 +1643,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -1798,9 +1693,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "8"
               },
@@ -1847,9 +1739,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -1900,9 +1789,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "8"
               },
@@ -1949,9 +1835,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -2002,9 +1885,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/image-orientation.json
+++ b/css/properties/image-orientation.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "26"
             },
@@ -62,9 +59,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/image-rendering.json
+++ b/css/properties/image-rendering.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": "3.6"
             },
@@ -64,9 +61,6 @@
               },
               "edge": {
                 "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": [
                 {
@@ -130,9 +124,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -180,9 +171,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "3.6"
               },
@@ -229,9 +217,6 @@
               },
               "edge": {
                 "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": {
                 "version_added": "3.6"

--- a/css/properties/ime-mode.json
+++ b/css/properties/ime-mode.json
@@ -20,15 +20,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": "12"
-              },
-              {
-                "prefix": "-ms-",
-                "version_added": "12"
-              }
-            ],
             "firefox": {
               "version_added": "3"
             },

--- a/css/properties/initial-letter-align.json
+++ b/css/properties/initial-letter-align.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/initial-letter.json
+++ b/css/properties/initial-letter.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/1223880'>bug 1223880</a>"

--- a/css/properties/inline-size.json
+++ b/css/properties/inline-size.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "41"
@@ -90,9 +87,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "66"
@@ -153,9 +147,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "66"
@@ -214,9 +205,6 @@
                 "version_added": "57"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/inset-block-end.json
+++ b/css/properties/inset-block-end.json
@@ -21,9 +21,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "63"

--- a/css/properties/inset-block-start.json
+++ b/css/properties/inset-block-start.json
@@ -21,9 +21,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "63"

--- a/css/properties/inset-block.json
+++ b/css/properties/inset-block.json
@@ -28,9 +28,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "63"

--- a/css/properties/inset-inline-end.json
+++ b/css/properties/inset-inline-end.json
@@ -21,9 +21,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "63"

--- a/css/properties/inset-inline-start.json
+++ b/css/properties/inset-inline-start.json
@@ -21,9 +21,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "63"

--- a/css/properties/inset-inline.json
+++ b/css/properties/inset-inline.json
@@ -28,9 +28,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "63"

--- a/css/properties/inset.json
+++ b/css/properties/inset.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "66"
             },

--- a/css/properties/isolation.json
+++ b/css/properties/isolation.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "36"
             },

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -44,15 +44,6 @@
                   "version_added": "12"
                 }
               ],
-              "edge_mobile": [
-                {
-                  "version_added": true
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": true
-                }
-              ],
               "firefox": [
                 {
                   "version_added": "20",
@@ -181,9 +172,6 @@
                 "edge": {
                   "version_added": false
                 },
-                "edge_mobile": {
-                  "version_added": false
-                },
                 "firefox": {
                   "version_added": "45",
                   "version_removed": "60",
@@ -236,9 +224,6 @@
                 "edge": {
                   "version_added": false
                 },
-                "edge_mobile": {
-                  "version_added": false
-                },
                 "firefox": {
                   "version_added": "52"
                 },
@@ -285,9 +270,6 @@
                   "version_added": "60"
                 },
                 "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
                   "version_added": false
                 },
                 "firefox": {
@@ -340,9 +322,6 @@
                 },
                 "edge": {
                   "version_added": false
-                },
-                "edge_mobile": {
-                  "version_added": null
                 },
                 "firefox": {
                   "version_added": "45"
@@ -398,9 +377,6 @@
                 "edge": {
                   "version_added": false
                 },
-                "edge_mobile": {
-                  "version_added": false
-                },
                 "firefox": {
                   "version_added": "52"
                 },
@@ -451,9 +427,6 @@
                   "version_added": false
                 },
                 "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
                   "version_added": false
                 },
                 "firefox": {
@@ -508,9 +481,6 @@
                 "edge": {
                   "version_added": false
                 },
-                "edge_mobile": {
-                  "version_added": false
-                },
                 "firefox": {
                   "version_added": "63"
                 },
@@ -560,9 +530,6 @@
               },
               "edge": {
                 "version_added": "16"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "52"

--- a/css/properties/justify-items.json
+++ b/css/properties/justify-items.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "20"
               },
@@ -67,9 +64,6 @@
               },
               "edge": {
                 "version_added": "16"
-              },
-              "edge_mobile": {
-                "version_added": false
               },
               "firefox": {
                 "version_added": "45"

--- a/css/properties/justify-self.json
+++ b/css/properties/justify-self.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": "16"
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "45"
               },
@@ -67,9 +64,6 @@
               },
               "edge": {
                 "version_added": "16"
-              },
-              "edge_mobile": {
-                "version_added": false
               },
               "firefox": {
                 "version_added": "45"

--- a/css/properties/left.json
+++ b/css/properties/left.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/letter-spacing.json
+++ b/css/properties/letter-spacing.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -62,9 +59,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {

--- a/css/properties/line-break.json
+++ b/css/properties/line-break.json
@@ -26,9 +26,6 @@
             "edge": {
               "version_added": "14"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/line-height-step.json
+++ b/css/properties/line-height-step.json
@@ -26,9 +26,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/line-height.json
+++ b/css/properties/line-height.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/list-style-image.json
+++ b/css/properties/list-style-image.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/list-style-position.json
+++ b/css/properties/list-style-position.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -64,9 +61,6 @@
                 "version_removed": "45"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -123,9 +117,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -178,9 +169,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -229,9 +217,6 @@
                 "version_removed": "45"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -284,9 +269,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -351,9 +333,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -406,9 +385,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "33"
               },
@@ -455,9 +431,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -508,9 +481,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -557,9 +527,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -622,9 +589,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -673,9 +637,6 @@
                 "version_removed": "45"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -732,9 +693,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -787,9 +745,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -836,9 +791,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -901,9 +853,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "33"
@@ -964,9 +913,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "1",
                 "prefix": "-moz-"
@@ -1017,9 +963,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -1068,9 +1011,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -1117,9 +1057,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -1182,9 +1119,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -1231,9 +1165,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -1296,9 +1227,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "33"
@@ -1357,9 +1285,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -1422,9 +1347,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "33"
               },
@@ -1471,9 +1393,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -1538,9 +1457,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -1591,9 +1507,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -1658,9 +1571,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -1711,9 +1621,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -1778,9 +1685,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -1835,9 +1739,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -1890,9 +1791,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -1939,9 +1837,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -1992,9 +1887,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "35"
               },
@@ -2041,9 +1933,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -2106,9 +1995,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "33"
@@ -2167,9 +2053,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -2232,9 +2115,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "33"
               },
@@ -2283,9 +2163,6 @@
                 "version_removed": "45"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -2340,9 +2217,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "prefix": "-moz-",
                 "version_added": "33"
@@ -2395,9 +2269,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -2448,9 +2319,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -2513,9 +2381,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "28"
               },
@@ -2562,9 +2427,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -2627,9 +2489,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "33"
@@ -2688,9 +2547,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -2755,9 +2611,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -2804,9 +2657,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -2857,9 +2707,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "33"
               },
@@ -2908,9 +2755,6 @@
                 "version_removed": "45"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -2967,9 +2811,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -3022,9 +2863,6 @@
                 "version_removed": "45"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -3081,9 +2919,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -3138,9 +2973,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -3193,9 +3025,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "1",
                 "prefix": "-moz-"
@@ -3246,9 +3075,6 @@
                 "version_removed": "45"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -3305,9 +3131,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -3360,9 +3183,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "1",
                 "prefix": "-moz-"
@@ -3413,9 +3233,6 @@
                 "version_removed": "45"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -3472,9 +3289,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -3527,9 +3341,6 @@
                 "version_removed": "45"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -3586,9 +3397,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -3643,9 +3451,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -3698,9 +3503,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "1",
                 "prefix": "-moz-"
@@ -3749,9 +3551,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -3806,9 +3605,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -3859,9 +3655,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -3926,9 +3719,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "1",
                 "prefix": "-moz-"
@@ -3979,9 +3769,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -4028,9 +3815,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -4093,9 +3877,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "28"
@@ -4156,9 +3937,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -4205,9 +3983,6 @@
                 "version_added": "45"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -4258,9 +4033,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "28"
               },
@@ -4307,9 +4079,6 @@
                 "version_added": "45"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -4360,9 +4129,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -4409,9 +4175,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -4462,9 +4225,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -4513,9 +4273,6 @@
                 "version_removed": "45"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -4570,9 +4327,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -4621,9 +4375,6 @@
                 "version_removed": "45"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -4678,9 +4429,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -4727,9 +4475,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -4790,9 +4535,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -4857,9 +4599,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -4912,9 +4651,6 @@
                 "version_removed": "45"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -4971,9 +4707,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -5028,9 +4761,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -5081,9 +4811,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -5146,9 +4873,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "28"
@@ -5209,9 +4933,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -5258,9 +4979,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -5311,9 +5029,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -5362,9 +5077,6 @@
                 "version_removed": "45"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -5419,9 +5131,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -5470,9 +5179,6 @@
                 "version_removed": "45"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -5525,9 +5231,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {

--- a/css/properties/list-style.json
+++ b/css/properties/list-style.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -62,9 +59,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/margin-block-end.json
+++ b/css/properties/margin-block-end.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/margin-block-start.json
+++ b/css/properties/margin-block-start.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/margin-block.json
+++ b/css/properties/margin-block.json
@@ -21,9 +21,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "66"
             },

--- a/css/properties/margin-bottom.json
+++ b/css/properties/margin-bottom.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -62,10 +59,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12",
-                "notes": "The <code>auto</code> value is not supported in quirks mode."
-              },
-              "edge_mobile": {
                 "version_added": "12",
                 "notes": "The <code>auto</code> value is not supported in quirks mode."
               },

--- a/css/properties/margin-inline-end.json
+++ b/css/properties/margin-inline-end.json
@@ -26,9 +26,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/margin-inline-start.json
+++ b/css/properties/margin-inline-start.json
@@ -26,9 +26,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/margin-inline.json
+++ b/css/properties/margin-inline.json
@@ -21,9 +21,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "66"
             },

--- a/css/properties/margin-left.json
+++ b/css/properties/margin-left.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -62,10 +59,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12",
-                "notes": "The <code>auto</code> value is not supported in quirks mode."
-              },
-              "edge_mobile": {
                 "version_added": "12",
                 "notes": "The <code>auto</code> value is not supported in quirks mode."
               },

--- a/css/properties/margin-right.json
+++ b/css/properties/margin-right.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -62,10 +59,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12",
-                "notes": "The <code>auto</code> value is not supported in quirks mode."
-              },
-              "edge_mobile": {
                 "version_added": "12",
                 "notes": "The <code>auto</code> value is not supported in quirks mode."
               },

--- a/css/properties/margin-top.json
+++ b/css/properties/margin-top.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -62,10 +59,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12",
-                "notes": "The <code>auto</code> value is not supported in quirks mode."
-              },
-              "edge_mobile": {
                 "version_added": "12",
                 "notes": "The <code>auto</code> value is not supported in quirks mode."
               },

--- a/css/properties/margin.json
+++ b/css/properties/margin.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -62,10 +59,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12",
-                "notes": "The <code>auto</code> value is not supported in quirks mode."
-              },
-              "edge_mobile": {
                 "version_added": "12",
                 "notes": "The <code>auto</code> value is not supported in quirks mode."
               },

--- a/css/properties/mask-clip.json
+++ b/css/properties/mask-clip.json
@@ -16,9 +16,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "53"
@@ -98,9 +95,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -147,9 +141,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -200,9 +191,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -249,9 +237,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/mask-composite.json
+++ b/css/properties/mask-composite.json
@@ -16,9 +16,6 @@
             "edge": {
               "version_added": "18"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "53"
             },

--- a/css/properties/mask-image.json
+++ b/css/properties/mask-image.json
@@ -18,9 +18,6 @@
             "edge": {
               "version_added": "16"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "53"
             },
@@ -75,9 +72,6 @@
               "edge": {
                 "version_added": "18"
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "53"
               },
@@ -125,9 +119,6 @@
               },
               "edge": {
                 "version_added": "18"
-              },
-              "edge_mobile": {
-                "version_added": false
               },
               "firefox": {
                 "version_added": "53"

--- a/css/properties/mask-mode.json
+++ b/css/properties/mask-mode.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "53"
             },

--- a/css/properties/mask-origin.json
+++ b/css/properties/mask-origin.json
@@ -18,9 +18,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "53"
@@ -106,9 +103,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -155,9 +149,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -208,9 +199,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -259,9 +247,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/mask-position.json
+++ b/css/properties/mask-position.json
@@ -16,9 +16,6 @@
             "edge": {
               "version_added": "18"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "53"

--- a/css/properties/mask-repeat.json
+++ b/css/properties/mask-repeat.json
@@ -16,9 +16,6 @@
             "edge": {
               "version_added": "18"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "53"

--- a/css/properties/mask-size.json
+++ b/css/properties/mask-size.json
@@ -16,9 +16,6 @@
             "edge": {
               "version_added": "18"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "53"

--- a/css/properties/mask-type.json
+++ b/css/properties/mask-type.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "35"
@@ -88,9 +85,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/mask.json
+++ b/css/properties/mask.json
@@ -32,9 +32,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "2",
               "notes": "From Firefox 10, the default color space when handling masks is sRGB. Previously, the default and only supported color space was linear RGB. This changes the appearance of mask effects, but brings Firefox into compliance with the second edition of the SVG 1.1 specification."
@@ -140,9 +137,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "3.5"
               },
@@ -193,9 +187,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {

--- a/css/properties/max-block-size.json
+++ b/css/properties/max-block-size.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "41"
@@ -90,9 +87,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "66"
@@ -153,9 +147,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "66"
@@ -214,9 +205,6 @@
                 "version_added": "57"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1",
               "notes": "CSS 2.1 leaves the behavior of <code>max-height</code> with <a href='https://developer.mozilla.org/docs/Web/HTML/Element/table'><code>table</code></a> undefined. Firefox supports applying <code>max-height</code> to <code>table</code> elements."
@@ -76,9 +73,6 @@
                 }
               ],
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -145,9 +139,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "66"
@@ -206,9 +197,6 @@
                 "version_added": "46"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -271,9 +259,6 @@
                 "version_added": "28"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/max-inline-size.json
+++ b/css/properties/max-inline-size.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "41"
@@ -102,9 +99,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "66"
@@ -165,9 +159,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "66"
@@ -226,9 +217,6 @@
                 "version_added": "57"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1",
               "notes": "CSS 2.1 leaves the behavior of <code>max-width</code> with <a href='https://developer.mozilla.org/docs/Web/HTML/Element/table'><code>table</code></a> undefined. Firefox supports applying <code>max-width</code> to <code>table</code> elements."
@@ -71,9 +68,6 @@
                 "version_added": "46"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -147,9 +141,6 @@
                 "version_added": "46"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -231,9 +222,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "66"
@@ -302,9 +290,6 @@
               },
               "edge": {
                 "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": {
                 "version_added": false

--- a/css/properties/min-block-size.json
+++ b/css/properties/min-block-size.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "41"
@@ -90,9 +87,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "66"
@@ -153,9 +147,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "66"
@@ -214,9 +205,6 @@
                 "version_added": "57"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "3",
               "notes": "CSS 2.1 leaves the behavior of <code>min-height</code> with <a href='https://developer.mozilla.org/docs/Web/HTML/Element/table'><code>table</code></a> undefined. Firefox supports applying <code>min-height</code> to <code>table</code> elements."
@@ -66,9 +63,6 @@
                 "version_added": "46"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -129,9 +123,6 @@
                 "version_added": "46"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -196,9 +187,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": false
               },
@@ -256,9 +244,6 @@
                 "version_added": "46"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -322,9 +307,6 @@
                 "version_added": "25"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/min-inline-size.json
+++ b/css/properties/min-inline-size.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "41"
@@ -90,9 +87,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "66"
@@ -154,9 +148,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "66"
@@ -216,9 +207,6 @@
                 "version_added": "57"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1",
               "notes": "CSS 2.1 leaves the behavior of <code>min-width</code> with <a href='https://developer.mozilla.org/docs/Web/HTML/Element/table'><code>table</code></a> undefined. Firefox supports applying <code>min-width</code> to <code>table</code> elements."
@@ -71,9 +68,6 @@
                 "version_added": "46"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -159,9 +153,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "66"
@@ -236,9 +227,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -292,9 +280,6 @@
                 "version_added": "46"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -365,9 +350,6 @@
               "edge": {
                 "version_added": "12",
                 "notes": "Edge uses <code>auto</code> as the initial value for <code>min-width</code>."
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": [
                 {

--- a/css/properties/mix-blend-mode.json
+++ b/css/properties/mix-blend-mode.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "32"
             },
@@ -63,9 +60,6 @@
               },
               "edge": {
                 "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "32"

--- a/css/properties/object-fit.json
+++ b/css/properties/object-fit.json
@@ -15,9 +15,6 @@
               "version_added": "16",
               "notes": "Edge supports <code>object-fit</code> on <code>img</code> elements only. <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/13603873/#comment-0'>See Edge issue 13603873 for details</a>."
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": "36"
             },

--- a/css/properties/object-position.json
+++ b/css/properties/object-position.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "16"
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": "36"
             },

--- a/css/properties/offset-distance.json
+++ b/css/properties/offset-distance.json
@@ -26,9 +26,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/offset-path.json
+++ b/css/properties/offset-path.json
@@ -28,9 +28,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "63",
               "notes": "<code>path()</code> is the only value type supported.",
@@ -113,9 +110,6 @@
                 "version_added": "64"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/offset-rotate.json
+++ b/css/properties/offset-rotate.json
@@ -34,9 +34,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/offset.json
+++ b/css/properties/offset.json
@@ -26,9 +26,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/opacity.json
+++ b/css/properties/opacity.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": [
               {
                 "version_added": "1"

--- a/css/properties/order.json
+++ b/css/properties/order.json
@@ -32,15 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "20",
@@ -169,9 +160,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": {
                 "version_added": false

--- a/css/properties/orphans.json
+++ b/css/properties/orphans.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/outline-color.json
+++ b/css/properties/outline-color.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": [
               {
                 "version_added": "1.5"
@@ -69,9 +66,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {

--- a/css/properties/outline-offset.json
+++ b/css/properties/outline-offset.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "15"
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": "1.5"
             },

--- a/css/properties/outline-style.json
+++ b/css/properties/outline-style.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": [
               {
                 "version_added": "1.5"
@@ -69,9 +66,6 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/outline-width.json
+++ b/css/properties/outline-width.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": [
               {
                 "version_added": "1.5"

--- a/css/properties/outline.json
+++ b/css/properties/outline.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": [
               {
                 "version_added": "1.5",

--- a/css/properties/overflow-anchor.json
+++ b/css/properties/overflow-anchor.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "66"
             },

--- a/css/properties/overflow-block.json
+++ b/css/properties/overflow-block.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "69"
             },

--- a/css/properties/overflow-clip-box-block.json
+++ b/css/properties/overflow-clip-box-block.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "59"
             },

--- a/css/properties/overflow-clip-box-inline.json
+++ b/css/properties/overflow-clip-box-inline.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "59"
             },

--- a/css/properties/overflow-clip-box.json
+++ b/css/properties/overflow-clip-box.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "29"
             },
@@ -62,9 +59,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/overflow-inline.json
+++ b/css/properties/overflow-inline.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "69"
             },

--- a/css/properties/overflow-wrap.json
+++ b/css/properties/overflow-wrap.json
@@ -26,10 +26,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": {
-              "alternative_name": "word-wrap",
-              "version_added": true
-            },
             "firefox": [
               {
                 "version_added": "49"
@@ -120,9 +116,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "65"
               },
@@ -170,9 +163,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "3.5"

--- a/css/properties/overflow-x.json
+++ b/css/properties/overflow-x.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "3.5"
             },

--- a/css/properties/overflow-y.json
+++ b/css/properties/overflow-y.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1.5"
             },

--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1",
               "notes": "After Firefox 3.6, the <code>overflow</code> property is correctly applied to table group elements (<code>&lt;thead&gt;</code>, <code>&lt;tbody&gt;</code>, <code>&lt;tfoot&gt;</code>)."
@@ -64,9 +61,6 @@
                 "version_added": "68"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/overscroll-behavior-x.json
+++ b/css/properties/overscroll-behavior-x.json
@@ -16,9 +16,6 @@
               "partial_implementation": true,
               "notes": "Currently the <code>none</code> value incorrectly behaves as <code>contain</code> (allowing for the elastic bounce effect)."
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "59"
             },

--- a/css/properties/overscroll-behavior-y.json
+++ b/css/properties/overscroll-behavior-y.json
@@ -16,9 +16,6 @@
               "partial_implementation": true,
               "notes": "Currently the <code>none</code> value incorrectly behaves as <code>contain</code> (allowing for the elastic bounce effect)."
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "59"
             },

--- a/css/properties/overscroll-behavior.json
+++ b/css/properties/overscroll-behavior.json
@@ -16,9 +16,6 @@
               "partial_implementation": true,
               "notes": "Currently the <code>none</code> value incorrectly behaves as <code>contain</code> (allowing for the elastic bounce effect)."
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "59"
             },

--- a/css/properties/padding-block-end.json
+++ b/css/properties/padding-block-end.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/padding-block-start.json
+++ b/css/properties/padding-block-start.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/padding-block.json
+++ b/css/properties/padding-block.json
@@ -21,9 +21,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "66"
             },

--- a/css/properties/padding-bottom.json
+++ b/css/properties/padding-bottom.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/padding-inline-end.json
+++ b/css/properties/padding-inline-end.json
@@ -26,9 +26,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/padding-inline-start.json
+++ b/css/properties/padding-inline-start.json
@@ -26,9 +26,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/padding-inline.json
+++ b/css/properties/padding-inline.json
@@ -21,9 +21,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "66"
             },

--- a/css/properties/padding-left.json
+++ b/css/properties/padding-left.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/padding-right.json
+++ b/css/properties/padding-right.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/padding-top.json
+++ b/css/properties/padding-top.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/padding.json
+++ b/css/properties/padding.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/page-break-after.json
+++ b/css/properties/page-break-after.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1",
               "notes": "The values <code>avoid</code>, <code>left</code>, and <code>right</code> are unsupported."

--- a/css/properties/page-break-before.json
+++ b/css/properties/page-break-before.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1",
               "notes": "The values <code>avoid</code>, <code>left</code>, and <code>right</code> are unsupported."

--- a/css/properties/page-break-inside.json
+++ b/css/properties/page-break-inside.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "19",
               "notes": "Until Firefox 25, <code>page-break-inside</code><code>: avoid</code> did not work with the height of a block."

--- a/css/properties/paint-order.json
+++ b/css/properties/paint-order.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "17"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "60"
             },

--- a/css/properties/perspective-origin.json
+++ b/css/properties/perspective-origin.json
@@ -32,15 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "16"

--- a/css/properties/perspective.json
+++ b/css/properties/perspective.json
@@ -32,15 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "16"

--- a/css/properties/place-content.json
+++ b/css/properties/place-content.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "45"
               },
@@ -68,9 +65,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "53"
               },
@@ -118,9 +112,6 @@
               },
               "edge": {
                 "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": {
                 "version_added": "60"

--- a/css/properties/place-items.json
+++ b/css/properties/place-items.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "45"
               },
@@ -66,9 +63,6 @@
                 "version_added": "59"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/place-self.json
+++ b/css/properties/place-self.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "45"
               },
@@ -66,9 +63,6 @@
                 "version_added": "59"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/pointer-events.json
+++ b/css/properties/pointer-events.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1.5"
             },
@@ -63,9 +60,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "3.6"

--- a/css/properties/position.json
+++ b/css/properties/position.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1",
               "notes": "Before Firefox 57, absolute positioning did not work correctly when applied to elements inside tables that have <a href='https://developer.mozilla.org/docs/Web/CSS/border-collapse'><code>border-collapse</code></a> applied to them (<a href='https://bugzil.la/1379306'>bug 1379306</a>)."
@@ -64,9 +61,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": {
                 "version_added": "1",
@@ -118,9 +112,6 @@
               },
               "edge": {
                 "version_added": "16"
-              },
-              "edge_mobile": {
-                "version_added": false
               },
               "firefox": [
                 {
@@ -197,9 +188,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "30",
                 "notes": "Firefox helps developers transition to the new behavior and detect any rendering issues it may cause on their sites by printing the following warning to the JavaScript console: &quot;Absolute positioning of table rows and row groups is now supported. This site may need to be updated because it may depend on this feature having no effect.&quot;"
@@ -249,9 +237,6 @@
               },
               "edge": {
                 "version_added": "16"
-              },
-              "edge_mobile": {
-                "version_added": false
               },
               "firefox": {
                 "version_added": "59"

--- a/css/properties/quotes.json
+++ b/css/properties/quotes.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1.5"
             },

--- a/css/properties/resize.json
+++ b/css/properties/resize.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "4"
             },
@@ -62,9 +59,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -115,9 +109,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/right.json
+++ b/css/properties/right.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/rotate.json
+++ b/css/properties/rotate.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "60",
               "flags": [
@@ -76,9 +73,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/row-gap.json
+++ b/css/properties/row-gap.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "63"
               },
@@ -114,9 +111,6 @@
                   "alternative_name": "grid-row-gap"
                 }
               ],
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "61"

--- a/css/properties/ruby-align.json
+++ b/css/properties/ruby-align.json
@@ -15,9 +15,6 @@
               "version_added": false,
               "notes": "Edge supports an earlier draft of CSS Ruby with non-standard values for this property: <code>auto</code>, <code>left</code>, <code>center</code>, <code>right</code>, <code>distribute-letter</code>, <code>distribute-space</code>, and <code>line-edge</code>."
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": "38"
             },

--- a/css/properties/ruby-position.json
+++ b/css/properties/ruby-position.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "38"
             },
@@ -65,9 +62,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/scale.json
+++ b/css/properties/scale.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "60",
               "flags": [

--- a/css/properties/scroll-behavior.json
+++ b/css/properties/scroll-behavior.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "36"
             },

--- a/css/properties/scroll-margin-block-end.json
+++ b/css/properties/scroll-margin-block-end.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "68"
             },

--- a/css/properties/scroll-margin-block-start.json
+++ b/css/properties/scroll-margin-block-start.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "68"
             },

--- a/css/properties/scroll-margin-block.json
+++ b/css/properties/scroll-margin-block.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "68"
             },

--- a/css/properties/scroll-margin-bottom.json
+++ b/css/properties/scroll-margin-bottom.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "68"
             },

--- a/css/properties/scroll-margin-inline-end.json
+++ b/css/properties/scroll-margin-inline-end.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "68"
             },

--- a/css/properties/scroll-margin-inline-start.json
+++ b/css/properties/scroll-margin-inline-start.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "68"
             },

--- a/css/properties/scroll-margin-inline.json
+++ b/css/properties/scroll-margin-inline.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "68"
             },

--- a/css/properties/scroll-margin-left.json
+++ b/css/properties/scroll-margin-left.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "68"
             },

--- a/css/properties/scroll-margin-right.json
+++ b/css/properties/scroll-margin-right.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "68"
             },

--- a/css/properties/scroll-margin-top.json
+++ b/css/properties/scroll-margin-top.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "68"
             },

--- a/css/properties/scroll-margin.json
+++ b/css/properties/scroll-margin.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "68"
             },

--- a/css/properties/scroll-padding-block-end.json
+++ b/css/properties/scroll-padding-block-end.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "68"
             },

--- a/css/properties/scroll-padding-block-start.json
+++ b/css/properties/scroll-padding-block-start.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "68"
             },

--- a/css/properties/scroll-padding-block.json
+++ b/css/properties/scroll-padding-block.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "68"
             },

--- a/css/properties/scroll-padding-bottom.json
+++ b/css/properties/scroll-padding-bottom.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "68"
             },

--- a/css/properties/scroll-padding-inline-end.json
+++ b/css/properties/scroll-padding-inline-end.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "68"
             },

--- a/css/properties/scroll-padding-inline-start.json
+++ b/css/properties/scroll-padding-inline-start.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "68"
             },

--- a/css/properties/scroll-padding-inline.json
+++ b/css/properties/scroll-padding-inline.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "68"
             },

--- a/css/properties/scroll-padding-left.json
+++ b/css/properties/scroll-padding-left.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "68"
             },

--- a/css/properties/scroll-padding-right.json
+++ b/css/properties/scroll-padding-right.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "68"
             },

--- a/css/properties/scroll-padding-top.json
+++ b/css/properties/scroll-padding-top.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "68"
             },

--- a/css/properties/scroll-padding.json
+++ b/css/properties/scroll-padding.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "68"
             },

--- a/css/properties/scroll-snap-align.json
+++ b/css/properties/scroll-snap-align.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "68"
             },

--- a/css/properties/scroll-snap-coordinate.json
+++ b/css/properties/scroll-snap-coordinate.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_removed": "68",
               "version_added": "39"

--- a/css/properties/scroll-snap-destination.json
+++ b/css/properties/scroll-snap-destination.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_removed": "68",
               "version_added": "39"

--- a/css/properties/scroll-snap-points-x.json
+++ b/css/properties/scroll-snap-points-x.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_removed": "68",
               "version_added": "39"

--- a/css/properties/scroll-snap-points-y.json
+++ b/css/properties/scroll-snap-points-y.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_removed": "68",
               "version_added": "39"

--- a/css/properties/scroll-snap-stop.json
+++ b/css/properties/scroll-snap-stop.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/scroll-snap-type-x.json
+++ b/css/properties/scroll-snap-type-x.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_removed": "68",
               "version_added": "39"

--- a/css/properties/scroll-snap-type-y.json
+++ b/css/properties/scroll-snap-type-y.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_removed": "68",
               "version_added": "39"

--- a/css/properties/scroll-snap-type.json
+++ b/css/properties/scroll-snap-type.json
@@ -16,11 +16,6 @@
               "prefix": "-ms-",
               "notes": "Edge supports an earlier draft of CSS Scroll Snap without axis values."
             },
-            "edge_mobile": {
-              "version_added": "12",
-              "prefix": "-ms-",
-              "notes": "Edge supports an earlier draft of CSS Scroll Snap without axis values."
-            },
             "firefox": [
               {
                 "version_added": "68"

--- a/css/properties/scrollbar-3dlight-color.json
+++ b/css/properties/scrollbar-3dlight-color.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/scrollbar-arrow-color.json
+++ b/css/properties/scrollbar-arrow-color.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/scrollbar-base-color.json
+++ b/css/properties/scrollbar-base-color.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/scrollbar-color.json
+++ b/css/properties/scrollbar-color.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "64",

--- a/css/properties/scrollbar-darkshadow-color.json
+++ b/css/properties/scrollbar-darkshadow-color.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/scrollbar-face-color.json
+++ b/css/properties/scrollbar-face-color.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/scrollbar-highlight-color.json
+++ b/css/properties/scrollbar-highlight-color.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/scrollbar-shadow-color.json
+++ b/css/properties/scrollbar-shadow-color.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/scrollbar-track-color.json
+++ b/css/properties/scrollbar-track-color.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/scrollbar-width.json
+++ b/css/properties/scrollbar-width.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "64"

--- a/css/properties/shape-image-threshold.json
+++ b/css/properties/shape-image-threshold.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": [
               {
                 "version_added": "62"

--- a/css/properties/shape-margin.json
+++ b/css/properties/shape-margin.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": [
               {
                 "version_added": "62"

--- a/css/properties/shape-outside.json
+++ b/css/properties/shape-outside.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "62"
@@ -89,9 +86,6 @@
                 "version_added": "37"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -169,9 +163,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "62"
@@ -245,9 +236,6 @@
                 "version_added": "37"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -325,9 +313,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "62"
@@ -401,9 +386,6 @@
                 "version_added": "37"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [

--- a/css/properties/tab-size.json
+++ b/css/properties/tab-size.json
@@ -16,9 +16,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "prefix": "-moz-",
               "version_added": "4",
@@ -88,9 +85,6 @@
               },
               "edge": {
                 "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": {
                 "version_added": "53"

--- a/css/properties/table-layout.json
+++ b/css/properties/table-layout.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/text-align-last.json
+++ b/css/properties/text-align-last.json
@@ -40,9 +40,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": [
               {
                 "version_added": "49"

--- a/css/properties/text-align.json
+++ b/css/properties/text-align.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -62,9 +59,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -115,9 +109,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -179,9 +170,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -230,9 +218,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "40"
               },
@@ -279,9 +264,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/text-combine-upright.json
+++ b/css/properties/text-combine-upright.json
@@ -23,10 +23,6 @@
               "version_added": "12",
               "alternative_name": "-ms-text-combine-horizontal"
             },
-            "edge_mobile": {
-              "version_added": "12",
-              "alternative_name": "-ms-text-combine-horizontal"
-            },
             "firefox": [
               {
                 "version_added": "48",
@@ -164,9 +160,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {

--- a/css/properties/text-decoration-color.json
+++ b/css/properties/text-decoration-color.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": [
               {
                 "version_added": "36"

--- a/css/properties/text-decoration-line.json
+++ b/css/properties/text-decoration-line.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "36"
@@ -90,9 +87,6 @@
                 "notes": "The <code>blink</code> value does not have any effect."
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/text-decoration-skip-ink.json
+++ b/css/properties/text-decoration-skip-ink.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/text-decoration-skip.json
+++ b/css/properties/text-decoration-skip.json
@@ -18,9 +18,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/text-decoration-style.json
+++ b/css/properties/text-decoration-style.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "36"
@@ -88,9 +85,6 @@
                 "version_added": "57"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/text-decoration.json
+++ b/css/properties/text-decoration.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -62,9 +59,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -117,9 +111,6 @@
                 "version_added": "57"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [

--- a/css/properties/text-emphasis-color.json
+++ b/css/properties/text-emphasis-color.json
@@ -16,9 +16,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": [
               {
                 "version_added": "46"

--- a/css/properties/text-emphasis-position.json
+++ b/css/properties/text-emphasis-position.json
@@ -20,9 +20,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "46"
@@ -118,9 +115,6 @@
                 "version_added": "62"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/text-emphasis-style.json
+++ b/css/properties/text-emphasis-style.json
@@ -16,9 +16,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": [
               {
                 "version_added": "46"

--- a/css/properties/text-emphasis.json
+++ b/css/properties/text-emphasis.json
@@ -16,9 +16,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": [
               {
                 "version_added": "46"

--- a/css/properties/text-indent.json
+++ b/css/properties/text-indent.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -62,9 +59,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -113,9 +107,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/text-justify.json
+++ b/css/properties/text-justify.json
@@ -31,10 +31,6 @@
               "version_added": "14",
               "notes": "Standard values <code>inter-character</code> and <code>none</code> are supported. The deprecated <code>distribute</code> value is also supported."
             },
-            "edge_mobile": {
-              "version_added": "14",
-              "notes": "Standard values <code>inter-character</code> and <code>none</code> are supported. The deprecated <code>distribute</code> value is also supported."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/css/properties/text-orientation.json
+++ b/css/properties/text-orientation.json
@@ -26,9 +26,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "41"
@@ -113,9 +110,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/text-overflow.json
+++ b/css/properties/text-overflow.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "7",
               "notes": "Until Firefox 10, handling of <code>text-overflow</code> on blocks with inline overflow on both horizontal sides was incorrect. Before Firefox 10, if only one value was specified (such as <code>text-overflow: ellipsis;</code>), text was ellipsed on both sides of the block, instead of only the end edge based on the block's text direction."
@@ -84,9 +81,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "9"
               },
@@ -133,9 +127,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -186,9 +177,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -235,9 +223,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/text-rendering.json
+++ b/css/properties/text-rendering.json
@@ -22,9 +22,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "1",
               "notes": [
@@ -77,9 +74,6 @@
                 "notes": "Chrome treats <code>auto</code> as <code>optimizeSpeed</code>."
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -135,9 +129,6 @@
                 "notes": "Supports true geometric precision without rounding up or down to the nearest supported font size in the operating system."
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/text-shadow.json
+++ b/css/properties/text-shadow.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "3.5",
               "notes": [

--- a/css/properties/text-size-adjust.json
+++ b/css/properties/text-size-adjust.json
@@ -22,16 +22,6 @@
               "prefix": "-webkit-",
               "version_added": "12"
             },
-            "edge_mobile": [
-              {
-                "prefix": "-ms-",
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": {
               "version_added": false
             },
@@ -103,9 +93,6 @@
                 "version_added": "54"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {

--- a/css/properties/text-transform.json
+++ b/css/properties/text-transform.json
@@ -16,9 +16,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -70,9 +67,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "14"
               },
@@ -119,9 +113,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -172,9 +163,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "64"
               },
@@ -221,9 +209,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -274,9 +259,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "15"
               },
@@ -323,9 +305,6 @@
                 "version_added": "30"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -376,9 +355,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "14"
               },
@@ -426,9 +402,6 @@
               },
               "edge": {
                 "version_added": "18"
-              },
-              "edge_mobile": {
-                "version_added": false
               },
               "firefox": {
                 "version_added": "1"

--- a/css/properties/text-underline-position.json
+++ b/css/properties/text-underline-position.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": false
             },
@@ -62,9 +59,6 @@
                 "version_added": "33"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -115,9 +109,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -166,9 +157,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": false
               },
@@ -215,9 +203,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {

--- a/css/properties/top.json
+++ b/css/properties/top.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/transform-box.json
+++ b/css/properties/transform-box.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "55"

--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -32,15 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "16"
@@ -169,9 +160,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "10"
               },
@@ -219,9 +207,6 @@
               },
               "edge": {
                 "version_added": "17"
-              },
-              "edge_mobile": {
-                "version_added": false
               },
               "firefox": [
                 {

--- a/css/properties/transform-style.json
+++ b/css/properties/transform-style.json
@@ -32,15 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "16"

--- a/css/properties/transform.json
+++ b/css/properties/transform.json
@@ -32,10 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
             "firefox": [
               {
                 "version_added": "16"
@@ -191,9 +187,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "16"

--- a/css/properties/transition-delay.json
+++ b/css/properties/transition-delay.json
@@ -32,15 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": "12"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "12"
-              }
-            ],
             "firefox": [
               {
                 "version_added": "16"

--- a/css/properties/transition-duration.json
+++ b/css/properties/transition-duration.json
@@ -32,15 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": "12"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "12"
-              }
-            ],
             "firefox": [
               {
                 "version_added": "16"

--- a/css/properties/transition-property.json
+++ b/css/properties/transition-property.json
@@ -32,15 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": "12"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "12"
-              }
-            ],
             "firefox": [
               {
                 "version_added": "16"
@@ -180,9 +171,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {

--- a/css/properties/transition-timing-function.json
+++ b/css/properties/transition-timing-function.json
@@ -32,15 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": "12"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "12"
-              }
-            ],
             "firefox": [
               {
                 "version_added": "16"
@@ -180,9 +171,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/transition.json
+++ b/css/properties/transition.json
@@ -32,15 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": "12"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "12"
-              }
-            ],
             "firefox": [
               {
                 "version_added": "16",
@@ -191,9 +182,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": false

--- a/css/properties/translate.json
+++ b/css/properties/translate.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "60",
               "flags": [

--- a/css/properties/unicode-bidi.json
+++ b/css/properties/unicode-bidi.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -72,9 +69,6 @@
                 "version_added": "48"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -141,9 +135,6 @@
                 "version_added": "48"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -214,9 +205,6 @@
                 "version_added": "48"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [

--- a/css/properties/user-modify.json
+++ b/css/properties/user-modify.json
@@ -17,9 +17,6 @@
               "prefix": "-webkit-",
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "prefix": "-moz-",
               "version_added": "1",
@@ -87,9 +84,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": false
               },
               "firefox": {
                 "version_added": false

--- a/css/properties/user-select.json
+++ b/css/properties/user-select.json
@@ -33,16 +33,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "prefix": "-ms-",
-                "version_added": "12"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "12"
-              }
-            ],
             "firefox": [
               {
                 "version_added": "69"
@@ -147,9 +137,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -195,9 +182,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -248,10 +232,6 @@
                 "alternative_name": "element",
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "alternative_name": "element",
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": false
               },
@@ -298,9 +278,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": [
@@ -362,9 +339,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {

--- a/css/properties/vertical-align.json
+++ b/css/properties/vertical-align.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/properties/visibility.json
+++ b/css/properties/visibility.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -74,9 +71,6 @@
                 ]
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {

--- a/css/properties/white-space.json
+++ b/css/properties/white-space.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -63,9 +60,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": {
                 "version_added": "1"
@@ -114,9 +108,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": [
                 {
@@ -174,9 +165,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "3.5"
               },
@@ -225,9 +213,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "36"
               },
@@ -274,9 +259,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {

--- a/css/properties/widows.json
+++ b/css/properties/widows.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -62,9 +59,6 @@
                 "version_added": "26"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -115,9 +109,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -166,9 +157,6 @@
                 "version_added": "25"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -228,9 +216,6 @@
                 "version_added": "46"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -305,9 +290,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "66"
@@ -380,9 +362,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "prefix": "-moz-",
                 "version_added": "3"
@@ -441,9 +420,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -490,9 +466,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/will-change.json
+++ b/css/properties/will-change.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "36",

--- a/css/properties/word-break.json
+++ b/css/properties/word-break.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "15"
             },
@@ -72,9 +69,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "15"
               },
@@ -121,9 +115,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/word-spacing.json
+++ b/css/properties/word-spacing.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -62,9 +59,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/word-wrap.json
+++ b/css/properties/word-wrap.json
@@ -26,9 +26,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": [
               {
                 "alternative_name": "overflow-wrap",

--- a/css/properties/writing-mode.json
+++ b/css/properties/writing-mode.json
@@ -32,15 +32,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": true
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
-            ],
             "firefox": [
               {
                 "version_added": "41",
@@ -133,9 +124,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "43"
               },
@@ -185,9 +173,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "43"
               },
@@ -234,9 +219,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/z-index.json
+++ b/css/properties/z-index.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -63,9 +60,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "3"

--- a/css/properties/zoom.json
+++ b/css/properties/zoom.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/390936'>bug 390936</a>."
@@ -67,9 +64,6 @@
                 "version_removed": "59"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/selectors/-moz-color-swatch.json
+++ b/css/selectors/-moz-color-swatch.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "27"
             },

--- a/css/selectors/-moz-full-screen-ancestor.json
+++ b/css/selectors/-moz-full-screen-ancestor.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "10",
               "version_removed": "50"

--- a/css/selectors/-moz-only-whitespace.json
+++ b/css/selectors/-moz-only-whitespace.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "1",
               "notes": "See <a href='https://bugzil.la/1106296'>bug 1106296</a>."

--- a/css/selectors/-moz-page-sequence.json
+++ b/css/selectors/-moz-page-sequence.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/selectors/-moz-page.json
+++ b/css/selectors/-moz-page.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/selectors/-moz-range-progress.json
+++ b/css/selectors/-moz-range-progress.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "22"
             },

--- a/css/selectors/-moz-range-thumb.json
+++ b/css/selectors/-moz-range-thumb.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "21"
             },

--- a/css/selectors/-moz-range-track.json
+++ b/css/selectors/-moz-range-track.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "21"
             },

--- a/css/selectors/-moz-scrolled-page-sequence.json
+++ b/css/selectors/-moz-scrolled-page-sequence.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "1.5"
             },

--- a/css/selectors/-moz-submit-invalid.json
+++ b/css/selectors/-moz-submit-invalid.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "4"
             },

--- a/css/selectors/-moz-system-metric.json
+++ b/css/selectors/-moz-system-metric.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "3",
               "version_removed": "58",
@@ -76,9 +73,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -143,9 +137,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "3",
                 "version_removed": "58",
@@ -206,9 +197,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -273,9 +261,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "3",
                 "version_removed": "58",
@@ -336,9 +321,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -403,9 +385,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "3",
                 "version_removed": "58",
@@ -466,9 +445,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -533,9 +509,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "3",
                 "version_removed": "58",
@@ -596,9 +569,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/selectors/-moz-ui-invalid.json
+++ b/css/selectors/-moz-ui-invalid.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "4"
             },

--- a/css/selectors/-moz-ui-valid.json
+++ b/css/selectors/-moz-ui-valid.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "4"
             },

--- a/css/selectors/-moz-window-inactive.json
+++ b/css/selectors/-moz-window-inactive.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "4"
             },

--- a/css/selectors/-ms-browse.json
+++ b/css/selectors/-ms-browse.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/selectors/-ms-check.json
+++ b/css/selectors/-ms-check.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/selectors/-ms-clear.json
+++ b/css/selectors/-ms-clear.json
@@ -16,10 +16,6 @@
               "version_added": "12",
               "notes": "In an <code>&lt;input type='text'&gt;</code> element styled with <code>text-align: right</code>, if the clear button is shown, it will clip off the right edge of the text value of the <code>&lt;input type='text'&gt;</code> element. A workaround is to hide the clear button using <code>display: none</code>."
             },
-            "edge_mobile": {
-              "version_added": "12",
-              "notes": "In an <code>&lt;input type='text'&gt;</code> element styled with <code>text-align: right</code>, if the clear button is shown, it will clip off the right edge of the text value of the <code>&lt;input type='text'&gt;</code> element. A workaround is to hide the clear button using <code>display: none</code>."
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/selectors/-ms-fill-lower.json
+++ b/css/selectors/-ms-fill-lower.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/selectors/-ms-fill-upper.json
+++ b/css/selectors/-ms-fill-upper.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/selectors/-ms-fill.json
+++ b/css/selectors/-ms-fill.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/selectors/-ms-reveal.json
+++ b/css/selectors/-ms-reveal.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/selectors/-ms-value.json
+++ b/css/selectors/-ms-value.json
@@ -23,9 +23,6 @@
                 "notes": "Edge 12-15 do not render the <code>color</code> property on <code>&lt;input&gt;</code> elements with a pre-filled <code>value</code> until the user selects a range of text or changes the input's value."
               }
             ],
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/selectors/-webkit-autofill.json
+++ b/css/selectors/-webkit-autofill.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/selectors/-webkit-file-upload-button.json
+++ b/css/selectors/-webkit-file-upload-button.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/selectors/-webkit-inner-spin-button.json
+++ b/css/selectors/-webkit-inner-spin-button.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/selectors/-webkit-meter-bar.json
+++ b/css/selectors/-webkit-meter-bar.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/selectors/-webkit-meter-even-less-good-value.json
+++ b/css/selectors/-webkit-meter-even-less-good-value.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/selectors/-webkit-meter-inner-element.json
+++ b/css/selectors/-webkit-meter-inner-element.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/selectors/-webkit-meter-optimum-value.json
+++ b/css/selectors/-webkit-meter-optimum-value.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/selectors/-webkit-meter-suboptimum-value.json
+++ b/css/selectors/-webkit-meter-suboptimum-value.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/selectors/-webkit-outer-spin-button.json
+++ b/css/selectors/-webkit-outer-spin-button.json
@@ -16,9 +16,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/selectors/-webkit-progress-bar.json
+++ b/css/selectors/-webkit-progress-bar.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/selectors/-webkit-progress-inner-element.json
+++ b/css/selectors/-webkit-progress-inner-element.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/selectors/-webkit-progress-value.json
+++ b/css/selectors/-webkit-progress-value.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/selectors/-webkit-resizer.json
+++ b/css/selectors/-webkit-resizer.json
@@ -16,9 +16,6 @@
               "version_added": false,
               "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/webkitscrollbars/'>Under consideration</a>"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/1432935'>bug 1432935</a>."

--- a/css/selectors/-webkit-scrollbar-button.json
+++ b/css/selectors/-webkit-scrollbar-button.json
@@ -16,9 +16,6 @@
               "version_added": false,
               "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/webkitscrollbars/'>Under consideration</a>"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/1432935'>bug 1432935</a>."

--- a/css/selectors/-webkit-scrollbar-corner.json
+++ b/css/selectors/-webkit-scrollbar-corner.json
@@ -16,9 +16,6 @@
               "version_added": false,
               "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/webkitscrollbars/'>Under consideration</a>"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/1432935'>bug 1432935</a>."

--- a/css/selectors/-webkit-scrollbar-thumb.json
+++ b/css/selectors/-webkit-scrollbar-thumb.json
@@ -16,9 +16,6 @@
               "version_added": false,
               "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/webkitscrollbars/'>Under consideration</a>"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/1432935'>bug 1432935</a>."

--- a/css/selectors/-webkit-scrollbar-track-piece.json
+++ b/css/selectors/-webkit-scrollbar-track-piece.json
@@ -16,9 +16,6 @@
               "version_added": false,
               "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/webkitscrollbars/'>Under consideration</a>"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/1432935'>bug 1432935</a>."

--- a/css/selectors/-webkit-scrollbar-track.json
+++ b/css/selectors/-webkit-scrollbar-track.json
@@ -16,9 +16,6 @@
               "version_added": false,
               "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/webkitscrollbars/'>Under consideration</a>"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/1432935'>bug 1432935</a>."

--- a/css/selectors/-webkit-scrollbar.json
+++ b/css/selectors/-webkit-scrollbar.json
@@ -16,9 +16,6 @@
               "version_added": false,
               "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/webkitscrollbars/'>Under consideration</a>"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/1432935'>bug 1432935</a>."

--- a/css/selectors/-webkit-search-cancel-button.json
+++ b/css/selectors/-webkit-search-cancel-button.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/selectors/-webkit-search-results-button.json
+++ b/css/selectors/-webkit-search-results-button.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/selectors/active.json
+++ b/css/selectors/active.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -63,9 +60,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {

--- a/css/selectors/adjacent_sibling.json
+++ b/css/selectors/adjacent_sibling.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/selectors/after.json
+++ b/css/selectors/after.json
@@ -33,15 +33,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": "12"
-              },
-              {
-                "alternative_name": ":after",
-                "version_added": "12"
-              }
-            ],
             "firefox": [
               {
                 "version_added": "1.5",
@@ -137,9 +128,6 @@
                 "version_added": "26"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {

--- a/css/selectors/any-link.json
+++ b/css/selectors/any-link.json
@@ -27,9 +27,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "50"

--- a/css/selectors/attribute.json
+++ b/css/selectors/attribute.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -63,9 +60,6 @@
                 "version_added": "49"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -114,9 +108,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/selectors/backdrop.json
+++ b/css/selectors/backdrop.json
@@ -33,10 +33,6 @@
               "prefix": "-ms-",
               "version_added": "12"
             },
-            "edge_mobile": {
-              "prefix": "-ms-",
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "47"
             },
@@ -85,9 +81,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -134,9 +127,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {

--- a/css/selectors/before.json
+++ b/css/selectors/before.json
@@ -33,15 +33,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": "12"
-              },
-              {
-                "alternative_name": ":before",
-                "version_added": "12"
-              }
-            ],
             "firefox": [
               {
                 "version_added": "1.5",
@@ -134,9 +125,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {

--- a/css/selectors/blank.json
+++ b/css/selectors/blank.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/selectors/checked.json
+++ b/css/selectors/checked.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/selectors/child.json
+++ b/css/selectors/child.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/selectors/class.json
+++ b/css/selectors/class.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/selectors/cue.json
+++ b/css/selectors/cue.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": "55",
               "notes": "Firefox currently does not support a parameter on <code>::cue</code>."

--- a/css/selectors/default.json
+++ b/css/selectors/default.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "4"
             },

--- a/css/selectors/defined.json
+++ b/css/selectors/defined.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "63"
             },

--- a/css/selectors/descendant.json
+++ b/css/selectors/descendant.json
@@ -27,9 +27,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -75,9 +72,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/selectors/dir.json
+++ b/css/selectors/dir.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "49"

--- a/css/selectors/disabled.json
+++ b/css/selectors/disabled.json
@@ -16,10 +16,6 @@
               "version_added": "12",
               "notes": "Edge does not recognize <code>:disabled</code> on the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/fieldset'><code>&lt;fieldset&gt;</code></a> element."
             },
-            "edge_mobile": {
-              "version_added": "12",
-              "notes": "Edge does not recognize <code>:disabled</code> on the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/fieldset'><code>&lt;fieldset&gt;</code></a> element."
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/selectors/empty.json
+++ b/css/selectors/empty.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/selectors/enabled.json
+++ b/css/selectors/enabled.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/selectors/first-child.json
+++ b/css/selectors/first-child.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "3"
             },
@@ -67,9 +64,6 @@
                 "version_added": "57"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/selectors/first-letter.json
+++ b/css/selectors/first-letter.json
@@ -33,15 +33,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": "12"
-              },
-              {
-                "alternative_name": ":first-letter",
-                "version_added": "12"
-              }
-            ],
             "firefox": [
               {
                 "version_added": "1"
@@ -129,9 +120,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/selectors/first-line.json
+++ b/css/selectors/first-line.json
@@ -37,15 +37,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "version_added": "12"
-              },
-              {
-                "alternative_name": ":first-line",
-                "version_added": "12"
-              }
-            ],
             "firefox": [
               {
                 "version_added": "1"

--- a/css/selectors/first-of-type.json
+++ b/css/selectors/first-of-type.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "3.5"
             },

--- a/css/selectors/first.json
+++ b/css/selectors/first.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/selectors/focus-visible.json
+++ b/css/selectors/focus-visible.json
@@ -29,9 +29,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "4",
               "alternative_name": ":-moz-focusring"

--- a/css/selectors/focus-within.json
+++ b/css/selectors/focus-within.json
@@ -16,10 +16,6 @@
               "version_added": false,
               "notes": "This feature is not implemented. See <a href='https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/11725071-implement-focus-within-from-selectors-4'>the enhancement request</a>."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "This feature is not implemented. See <a href='https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/11725071-implement-focus-within-from-selectors-4'>the enhancement request</a>."
-            },
             "firefox": {
               "version_added": "52"
             },

--- a/css/selectors/focus.json
+++ b/css/selectors/focus.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/selectors/fullscreen.json
+++ b/css/selectors/fullscreen.json
@@ -17,9 +17,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": [
               {
                 "version_added": "64"
@@ -106,9 +103,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "43"

--- a/css/selectors/general_sibling.json
+++ b/css/selectors/general_sibling.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/selectors/grammar-error.json
+++ b/css/selectors/grammar-error.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/selectors/has.json
+++ b/css/selectors/has.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/418039'>bug 418039</a>"

--- a/css/selectors/host-context.json
+++ b/css/selectors/host-context.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/1082060'>bug 1082060</a>."

--- a/css/selectors/host.json
+++ b/css/selectors/host.json
@@ -16,10 +16,6 @@
               "version_added": false,
               "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/'>Under consideration</a>"
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/'>Under consideration</a>"
-            },
             "firefox": [
               {
                 "version_added": "63"

--- a/css/selectors/hostfunction.json
+++ b/css/selectors/hostfunction.json
@@ -16,10 +16,6 @@
               "version_added": false,
               "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/'>Under consideration</a>"
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/shadowdom/'>Under consideration</a>"
-            },
             "firefox": [
               {
                 "version_added": "63"

--- a/css/selectors/hover.json
+++ b/css/selectors/hover.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -66,9 +63,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -115,10 +109,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12",
-                "notes": "In Edge, hovering over an element and then scrolling up or down without moving the pointer will leave the element in the <code>:hover</code> state until the pointer is moved. See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/5381673/'>bug 5381673</a>."
-              },
-              "edge_mobile": {
                 "version_added": "12",
                 "notes": "In Edge, hovering over an element and then scrolling up or down without moving the pointer will leave the element in the <code>:hover</code> state until the pointer is moved. See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/5381673/'>bug 5381673</a>."
               },
@@ -172,9 +162,6 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {

--- a/css/selectors/id.json
+++ b/css/selectors/id.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/selectors/in-range.json
+++ b/css/selectors/in-range.json
@@ -17,9 +17,6 @@
             "edge": {
               "version_added": "13"
             },
-            "edge_mobile": {
-              "version_added": "13"
-            },
             "firefox": {
               "version_added": "29",
               "notes": "Before Firefox 50, <code>:in-range</code> matched disabled and read-only inputs (see <a href='https://bugzil.la/1264157'>bug 1264157</a>). In Firefox 50, it was changed to only match enabled read-write inputs."

--- a/css/selectors/indeterminate.json
+++ b/css/selectors/indeterminate.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "2"
             },
@@ -63,9 +60,6 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -116,9 +110,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "6"
               },
@@ -165,10 +156,6 @@
                 "version_added": "39"
               },
               "edge": {
-                "version_added": false,
-                "notes": "See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/7124038'>Edge bug 7124038</a>."
-              },
-              "edge_mobile": {
                 "version_added": false,
                 "notes": "See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/7124038'>Edge bug 7124038</a>."
               },

--- a/css/selectors/invalid.json
+++ b/css/selectors/invalid.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "4"
             },
@@ -63,9 +60,6 @@
                 "version_added": "40"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/selectors/is.json
+++ b/css/selectors/is.json
@@ -47,9 +47,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "4",
               "alternative_name": ":-moz-any()",

--- a/css/selectors/lang.json
+++ b/css/selectors/lang.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/selectors/last-child.json
+++ b/css/selectors/last-child.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -63,9 +60,6 @@
                 "version_added": "57"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/selectors/last-of-type.json
+++ b/css/selectors/last-of-type.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "3.5"
             },

--- a/css/selectors/left.json
+++ b/css/selectors/left.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/selectors/link.json
+++ b/css/selectors/link.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/selectors/marker.json
+++ b/css/selectors/marker.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "68"
             },

--- a/css/selectors/namespace.json
+++ b/css/selectors/namespace.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/selectors/not.json
+++ b/css/selectors/not.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -63,9 +60,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/selectors/nth-child.json
+++ b/css/selectors/nth-child.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "3.5"
             },
@@ -68,9 +65,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false,
                 "notes": "See <a href='https://bugzil.la/854148'>bug 854148</a>."
@@ -119,9 +113,6 @@
                 "version_added": "57"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/selectors/nth-last-child.json
+++ b/css/selectors/nth-last-child.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "3.5"
             },
@@ -64,9 +61,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -117,9 +111,6 @@
                 "version_added": "57"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/selectors/nth-last-of-type.json
+++ b/css/selectors/nth-last-of-type.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "3.5"
             },

--- a/css/selectors/nth-of-type.json
+++ b/css/selectors/nth-of-type.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "3.5"
             },

--- a/css/selectors/only-child.json
+++ b/css/selectors/only-child.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1.5"
             },
@@ -63,9 +60,6 @@
                 "version_added": "57"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/selectors/only-of-type.json
+++ b/css/selectors/only-of-type.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "3.5"
             },

--- a/css/selectors/optional.json
+++ b/css/selectors/optional.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "4"
             },

--- a/css/selectors/out-of-range.json
+++ b/css/selectors/out-of-range.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "13"
             },
-            "edge_mobile": {
-              "version_added": "13"
-            },
             "firefox": {
               "version_added": "29"
             },

--- a/css/selectors/placeholder-shown.json
+++ b/css/selectors/placeholder-shown.json
@@ -16,10 +16,6 @@
               "version_added": false,
               "notes": "This feature is not implemented. See <a href='https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/12435951--placeholder-shown-css-pseudo-class'>this enhancement request</a>."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "This feature is not implemented. See <a href='https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/12435951--placeholder-shown-css-pseudo-class'>this enhancement request</a>."
-            },
             "firefox": [
               {
                 "version_added": "51"
@@ -80,9 +76,6 @@
                 "version_added": "47"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/selectors/placeholder.json
+++ b/css/selectors/placeholder.json
@@ -34,16 +34,6 @@
                 "version_added": "12"
               }
             ],
-            "edge_mobile": [
-              {
-                "prefix": "-webkit-input-",
-                "version_added": "12"
-              },
-              {
-                "prefix": "-ms-input-",
-                "version_added": "12"
-              }
-            ],
             "firefox": [
               {
                 "version_added": "51"

--- a/css/selectors/read-only.json
+++ b/css/selectors/read-only.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "13"
             },
-            "edge_mobile": {
-              "version_added": "13"
-            },
             "firefox": {
               "prefix": "-moz-",
               "version_added": "1.5",

--- a/css/selectors/read-write.json
+++ b/css/selectors/read-write.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "13"
             },
-            "edge_mobile": {
-              "version_added": "13"
-            },
             "firefox": {
               "prefix": "-moz-",
               "version_added": "1.5",
@@ -67,9 +64,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/selectors/required.json
+++ b/css/selectors/required.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "4"
             },

--- a/css/selectors/right.json
+++ b/css/selectors/right.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/selectors/root.json
+++ b/css/selectors/root.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/selectors/scope.json
+++ b/css/selectors/scope.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": [
               {
                 "version_added": "32",
@@ -91,9 +88,6 @@
               },
               "edge": {
                 "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": {
                 "version_added": "32"

--- a/css/selectors/selection.json
+++ b/css/selectors/selection.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": [
               {
                 "version_added": "62"

--- a/css/selectors/slotted.json
+++ b/css/selectors/slotted.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "63"

--- a/css/selectors/spelling-error.json
+++ b/css/selectors/spelling-error.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/selectors/target.json
+++ b/css/selectors/target.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/selectors/type.json
+++ b/css/selectors/type.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -63,9 +60,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {

--- a/css/selectors/universal.json
+++ b/css/selectors/universal.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -63,9 +60,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {

--- a/css/selectors/valid.json
+++ b/css/selectors/valid.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "4"
             },
@@ -63,9 +60,6 @@
                 "version_added": "40"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/selectors/visited.json
+++ b/css/selectors/visited.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -63,9 +60,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {

--- a/css/types/-moz-image-rect.json
+++ b/css/types/-moz-image-rect.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "4"
             },

--- a/css/types/angle-percentage.json
+++ b/css/types/angle-percentage.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "3.6"
             },
@@ -64,9 +61,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "3.6"
@@ -116,9 +110,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "3.6"
               },
@@ -167,9 +158,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "3.6"
               },
@@ -217,9 +205,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "13"

--- a/css/types/angle.json
+++ b/css/types/angle.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "3.6"
             },
@@ -64,9 +61,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "3.6"
@@ -116,9 +110,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "3.6"
               },
@@ -167,9 +158,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "3.6"
               },
@@ -217,9 +205,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "13"

--- a/css/types/attr.json
+++ b/css/types/attr.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -63,9 +60,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -116,9 +110,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -164,9 +155,6 @@
                   "version_added": false
                 },
                 "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
                   "version_added": false
                 },
                 "firefox": {
@@ -217,9 +205,6 @@
                 "edge": {
                   "version_added": false
                 },
-                "edge_mobile": {
-                  "version_added": false
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -266,9 +251,6 @@
                   "version_added": false
                 },
                 "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
                   "version_added": false
                 },
                 "firefox": {
@@ -319,9 +301,6 @@
                 "edge": {
                   "version_added": false
                 },
-                "edge_mobile": {
-                  "version_added": false
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -368,9 +347,6 @@
                   "version_added": false
                 },
                 "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
                   "version_added": false
                 },
                 "firefox": {
@@ -421,9 +397,6 @@
                 "edge": {
                   "version_added": false
                 },
-                "edge_mobile": {
-                  "version_added": false
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -470,9 +443,6 @@
                   "version_added": false
                 },
                 "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
                   "version_added": false
                 },
                 "firefox": {
@@ -523,9 +493,6 @@
                 "edge": {
                   "version_added": false
                 },
-                "edge_mobile": {
-                  "version_added": false
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -572,9 +539,6 @@
                   "version_added": false
                 },
                 "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
                   "version_added": false
                 },
                 "firefox": {

--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "54"
             },
@@ -64,9 +61,6 @@
                 "version_added": "37"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -118,9 +112,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "54"
               },
@@ -168,9 +159,6 @@
                 "version_added": "37"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -224,9 +212,6 @@
                 "notes": "Only supported on the <code>offset-path</code> property."
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -302,9 +287,6 @@
                 "version_added": "37"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/types/blend-mode.json
+++ b/css/types/blend-mode.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "30"
             },

--- a/css/types/calc.json
+++ b/css/types/calc.json
@@ -21,9 +21,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": [
               {
                 "version_added": "16",
@@ -111,9 +108,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "59"
               },
@@ -160,9 +154,6 @@
                 "version_added": "28"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -213,9 +204,6 @@
               "edge": {
                 "version_added": "16"
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "48"
               },
@@ -262,9 +250,6 @@
                 "version_added": "31"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {

--- a/css/types/clamp.json
+++ b/css/types/clamp.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/types/counters.json
+++ b/css/types/counters.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1.5"
             },

--- a/css/types/dimension.json
+++ b/css/types/dimension.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/types/flex.json
+++ b/css/types/flex.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "40"
             },

--- a/css/types/frequency-percentage.json
+++ b/css/types/frequency-percentage.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/types/frequency.json
+++ b/css/types/frequency.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },
@@ -63,9 +60,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -114,9 +108,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/types/global_keywords.json
+++ b/css/types/global_keywords.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -62,9 +59,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -113,9 +107,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "13"
-              },
-              "edge_mobile": {
                 "version_added": "13"
               },
               "firefox": [
@@ -183,10 +174,6 @@
                 "version_added": false,
                 "notes": "See <a href='https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/10469316-the-css4-revert-value'>this enhancement request</a>."
               },
-              "edge_mobile": {
-                "version_added": false,
-                "notes": "See <a href='https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/10469316-the-css4-revert-value'>this enhancement request</a>."
-              },
               "firefox": {
                 "version_added": "67"
               },
@@ -234,9 +221,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "13"
-              },
-              "edge_mobile": {
                 "version_added": "13"
               },
               "firefox": {

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -64,10 +61,6 @@
                 "version_added": true
               },
               "edge": {
-                "prefix": "-ms-",
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "prefix": "-ms-",
                 "version_added": "12"
               },
@@ -144,9 +137,6 @@
                 "edge": {
                   "version_added": false
                 },
-                "edge_mobile": {
-                  "version_added": false
-                },
                 "firefox": {
                   "version_added": false
                 },
@@ -203,9 +193,6 @@
                     "version_added": "72"
                   },
                   "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
                     "version_added": false
                   },
                   "firefox": {
@@ -271,9 +258,6 @@
                 ],
                 "edge": {
                   "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
                 },
                 "firefox": [
                   {
@@ -417,9 +401,6 @@
                   "edge": {
                     "version_added": "12"
                   },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
                   "firefox": {
                     "version_added": "10"
                   },
@@ -466,9 +447,6 @@
                     "version_added": "71"
                   },
                   "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
                     "version_added": false
                   },
                   "firefox": {
@@ -521,9 +499,6 @@
                   "edge": {
                     "version_added": false
                   },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
                   "firefox": {
                     "version_added": "36"
                   },
@@ -570,9 +545,6 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": "12"
-                  },
-                  "edge_mobile": {
                     "version_added": "12"
                   },
                   "firefox": [
@@ -650,9 +622,6 @@
                 ],
                 "edge": {
                   "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
                 },
                 "firefox": [
                   {
@@ -783,9 +752,6 @@
                   "edge": {
                     "version_added": "12"
                   },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
                   "firefox": [
                     {
                       "version_added": "16",
@@ -877,9 +843,6 @@
                   "edge": {
                     "version_added": false
                   },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
                   "firefox": {
                     "version_added": "64"
                   },
@@ -928,9 +891,6 @@
                     "version_added": "40"
                   },
                   "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
                     "version_added": false
                   },
                   "firefox": {
@@ -993,9 +953,6 @@
                 ],
                 "edge": {
                   "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
                 },
                 "firefox": [
                   {
@@ -1140,9 +1097,6 @@
                   "edge": {
                     "version_added": "12"
                   },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
                   "firefox": {
                     "version_added": "10"
                   },
@@ -1189,9 +1143,6 @@
                     "version_added": "71"
                   },
                   "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
                     "version_added": false
                   },
                   "firefox": {
@@ -1244,9 +1195,6 @@
                   "edge": {
                     "version_added": false
                   },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
                   "firefox": {
                     "version_added": "36"
                   },
@@ -1293,9 +1241,6 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": "12"
-                  },
-                  "edge_mobile": {
                     "version_added": "12"
                   },
                   "firefox": [
@@ -1373,9 +1318,6 @@
                 ],
                 "edge": {
                   "version_added": "12"
-                },
-                "edge_mobile": {
-                  "version_added": true
                 },
                 "firefox": [
                   {
@@ -1505,9 +1447,6 @@
                   "edge": {
                     "version_added": "12"
                   },
-                  "edge_mobile": {
-                    "version_added": true
-                  },
                   "firefox": [
                     {
                       "version_added": "16",
@@ -1616,9 +1555,6 @@
                   "edge": {
                     "version_added": false
                   },
-                  "edge_mobile": {
-                    "version_added": false
-                  },
                   "firefox": {
                     "version_added": "64"
                   },
@@ -1667,9 +1603,6 @@
                     "version_added": "40"
                   },
                   "edge": {
-                    "version_added": false
-                  },
-                  "edge_mobile": {
                     "version_added": false
                   },
                   "firefox": {
@@ -1721,9 +1654,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -1809,9 +1739,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false,
                 "notes": "The <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-image-rect'><code>-moz-image-rect()</code></a> function supports fragments as of Firefox 4."
@@ -1863,9 +1790,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -1931,9 +1855,6 @@
                 "notes": "Supports the original dual-image with percentage implementation only."
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/types/integer.json
+++ b/css/types/integer.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/types/length-percentage.json
+++ b/css/types/length-percentage.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -63,9 +60,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -114,9 +108,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -171,9 +162,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -220,9 +208,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -273,9 +258,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -322,9 +304,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -377,9 +356,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "49"
               },
@@ -426,9 +402,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -479,9 +452,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -528,9 +498,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -581,9 +548,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "19"
               },
@@ -630,9 +594,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -683,9 +644,6 @@
               "edge": {
                 "version_added": "16"
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "19",
                 "notes": "Starting with version 21, viewport-percentage lengths are invalid in <code>@page</code>."
@@ -734,15 +692,6 @@
                 "version_added": true
               },
               "edge": [
-                {
-                  "version_added": "12"
-                },
-                {
-                  "alternative_name": "vm",
-                  "version_added": "12"
-                }
-              ],
-              "edge_mobile": [
                 {
                   "version_added": "12"
                 },
@@ -807,9 +756,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "19",
                 "notes": "Starting with version 21, viewport-percentage lengths are invalid in <code>@page</code>."
@@ -858,9 +804,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -63,9 +60,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -114,9 +108,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -171,9 +162,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -220,9 +208,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -273,9 +258,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -322,9 +304,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -377,9 +356,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "49"
               },
@@ -426,9 +402,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -479,9 +452,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -530,9 +500,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -579,9 +546,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -634,9 +598,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -684,9 +645,6 @@
               },
               "edge": {
                 "version_added": "16"
-              },
-              "edge_mobile": {
-                "version_added": false
               },
               "firefox": {
                 "version_added": "19",
@@ -736,15 +694,6 @@
                 "version_added": true
               },
               "edge": [
-                {
-                  "version_added": "12"
-                },
-                {
-                  "alternative_name": "vm",
-                  "version_added": "12"
-                }
-              ],
-              "edge_mobile": [
                 {
                   "version_added": "12"
                 },
@@ -809,9 +758,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "19",
                 "notes": "Starting with version 21, viewport-percentage lengths are invalid in <code>@page</code>."
@@ -860,9 +806,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/types/max.json
+++ b/css/types/max.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/types/min.json
+++ b/css/types/min.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/css/types/number.json
+++ b/css/types/number.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -63,9 +60,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {

--- a/css/types/percentage.json
+++ b/css/types/percentage.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/css/types/position.json
+++ b/css/types/position.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -64,9 +61,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "1"
@@ -115,9 +109,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": "13"

--- a/css/types/ratio.json
+++ b/css/types/ratio.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "3.5"
             },

--- a/css/types/resolution.json
+++ b/css/types/resolution.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "3.5"
             },
@@ -63,9 +60,6 @@
                 "version_added": "29"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -128,9 +122,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/types/shape.json
+++ b/css/types/shape.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -63,9 +60,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {

--- a/css/types/string.json
+++ b/css/types/string.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -63,9 +60,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {

--- a/css/types/time-percentage.json
+++ b/css/types/time-percentage.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "4"
             },

--- a/css/types/time.json
+++ b/css/types/time.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "4"
             },

--- a/css/types/timing-function.json
+++ b/css/types/timing-function.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "4"
             },
@@ -63,9 +60,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -116,9 +110,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "4"
               },
@@ -164,9 +155,6 @@
                   "version_added": false
                 },
                 "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
                   "version_added": false
                 },
                 "firefox": {

--- a/css/types/transform-function.json
+++ b/css/types/transform-function.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "3.5",
               "notes": [
@@ -68,9 +65,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {

--- a/css/types/url.json
+++ b/css/types/url.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },


### PR DESCRIPTION
This is a PR based off of #3888.  Since the Windows Phone OS is deprecated platform, Edge Mobile is as well.  It was mentioned that Microsoft suggested we drop Edge Mobile.