### PR TITLE
Remove Edge Mobile in html/*

### DIFF
--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true,
               "notes": "Starting with Firefox 41, &lt;a&gt; without <code>href</code> attribute is no longer classified as interactive content: clicking it inside &lt;label&gt; will activate labelled content (<a href='https://bugzil.la/1167816'>bug 1167816</a>)."
@@ -65,9 +62,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -113,9 +107,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -181,9 +172,6 @@
                   ]
                 }
               ],
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "20"
               },
@@ -233,9 +221,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -281,9 +266,6 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
                   "version_added": true
                 },
                 "firefox": {
@@ -334,9 +316,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -384,9 +363,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -432,9 +408,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -498,9 +471,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "50"
               },
@@ -546,9 +516,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -598,9 +565,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -646,9 +610,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -702,9 +663,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -750,9 +708,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/abbr.json
+++ b/html/elements/abbr.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1",
               "notes": "Before Firefox 4, this element implemented the <code>HTMLSpanElement</code> interface instead of the standard <code>HTMLElement</code> interface."

--- a/html/elements/acronym.json
+++ b/html/elements/acronym.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/html/elements/address.json
+++ b/html/elements/address.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/html/elements/applet.json
+++ b/html/elements/applet.json
@@ -17,10 +17,6 @@
               "version_added": true,
               "notes": "Removal in Edge is <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/11946645/'>under consideration</a>."
             },
-            "edge_mobile": {
-              "version_added": true,
-              "notes": "Removal in Edge is <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/11946645/'>under consideration</a>."
-            },
             "firefox": {
               "version_added": true,
               "version_removed": "56"
@@ -72,9 +68,6 @@
                 "version_removed": "47"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -130,9 +123,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true,
                 "version_removed": "56"
@@ -184,9 +174,6 @@
                 "version_removed": "47"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -242,9 +229,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true,
                 "version_removed": "56"
@@ -296,9 +280,6 @@
                 "version_removed": "47"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -354,9 +335,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true,
                 "version_removed": "56"
@@ -408,9 +386,6 @@
                 "version_removed": "47"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -466,9 +441,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true,
                 "version_removed": "56"
@@ -520,9 +492,6 @@
                 "version_removed": "47"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -578,9 +547,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true,
                 "version_removed": "56"
@@ -632,9 +598,6 @@
                 "version_removed": "47"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -690,9 +653,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true,
                 "version_removed": "56"
@@ -744,9 +704,6 @@
                 "version_removed": "47"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -802,9 +759,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true,
                 "version_removed": "56"
@@ -856,9 +810,6 @@
                 "version_removed": "47"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -113,9 +107,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -161,9 +152,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -213,9 +201,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -261,9 +246,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -313,9 +295,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -361,9 +340,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -413,9 +389,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -461,9 +434,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -513,9 +483,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "50"
               },
@@ -561,9 +528,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -613,9 +577,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -661,9 +622,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -713,9 +671,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -761,9 +716,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/article.json
+++ b/html/elements/article.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "4"
             },

--- a/html/elements/aside.json
+++ b/html/elements/aside.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "4"
             },

--- a/html/elements/audio.json
+++ b/html/elements/audio.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "3.5",
               "notes": "For Firefox to play audio, the server must serve the file using the correct MIME type."
@@ -63,9 +60,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -115,9 +109,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "4"
               },
@@ -163,9 +154,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -215,9 +203,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "11"
               },
@@ -263,9 +248,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -315,9 +297,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "11"
               },
@@ -363,9 +342,6 @@
                 "version_added": "49"
               },
               "edge": {
-                "version_added": "14"
-              },
-              "edge_mobile": {
                 "version_added": "14"
               },
               "firefox": {
@@ -415,9 +391,6 @@
                 "notes": "Defaults to <code>metadata</code> in Chrome 64."
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": [
@@ -491,9 +464,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "3.5"
               },
@@ -539,9 +509,6 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/b.json
+++ b/html/elements/b.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1",
               "notes": "Before Firefox 4, this element implemented the <code>HTMLSpanElement</code> interface instead of the standard <code>HTMLElement</code> interface."

--- a/html/elements/base.json
+++ b/html/elements/base.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -62,9 +59,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -114,9 +108,6 @@
                 "edge": {
                   "version_added": true
                 },
-                "edge_mobile": {
-                  "version_added": true
-                },
                 "firefox": {
                   "version_added": "4"
                 },
@@ -163,9 +154,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/basefont.json
+++ b/html/elements/basefont.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": false
             },

--- a/html/elements/bdi.json
+++ b/html/elements/bdi.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "10"
             },

--- a/html/elements/bdo.json
+++ b/html/elements/bdo.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/html/elements/bgsound.json
+++ b/html/elements/bgsound.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false,
               "notes": "Up to Firefox 22, even if not supporting this element, Firefox was associating it with <code>HTMLSpanElement</code>. This was fixed then and now the associated element is an <code>HTMLUnknownElement</code> as required by the specification."

--- a/html/elements/big.json
+++ b/html/elements/big.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/html/elements/blink.json
+++ b/html/elements/blink.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "1",
               "version_removed": "22"

--- a/html/elements/blockquote.json
+++ b/html/elements/blockquote.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/body.json
+++ b/html/elements/body.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -113,9 +107,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -163,9 +154,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -211,9 +199,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -265,9 +250,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "35",
                 "notes": "Before Firefox 35, it was supported in Quirks Mode only."
@@ -317,9 +299,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -365,9 +344,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -417,9 +393,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -465,9 +438,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -517,9 +487,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -565,9 +532,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -617,9 +581,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -665,9 +626,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -717,9 +675,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "32"
               },
@@ -765,9 +720,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -817,9 +769,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -865,9 +814,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -917,9 +863,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -965,9 +908,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -1017,9 +957,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -1065,9 +1002,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -1117,9 +1051,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -1165,9 +1096,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {
@@ -1217,9 +1145,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -1265,9 +1190,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -1319,9 +1241,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -1367,9 +1286,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -1419,9 +1335,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
                 "version_added": "12"
               },
               "firefox": {

--- a/html/elements/br.json
+++ b/html/elements/br.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/button.json
+++ b/html/elements/button.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -61,9 +58,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -113,9 +107,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "4"
               },
@@ -161,9 +152,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -213,9 +201,6 @@
               "edge": {
                 "version_added": "16"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -261,9 +246,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -313,9 +295,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "4"
               },
@@ -361,9 +340,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -413,9 +389,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -461,9 +434,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -513,9 +483,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -563,9 +530,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -611,9 +575,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/canvas.json
+++ b/html/elements/canvas.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1.5",
               "notes": [
@@ -72,9 +69,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -135,9 +129,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "3.5"
               },
@@ -183,9 +174,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/caption.json
+++ b/html/elements/caption.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/center.json
+++ b/html/elements/center.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true,
               "notes": "Before Firefox 4, this element implemented the <code>HTMLSpanElement</code> interface instead of the standard <code>HTMLElement</code> interface."

--- a/html/elements/cite.json
+++ b/html/elements/cite.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/html/elements/code.json
+++ b/html/elements/code.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/html/elements/col.json
+++ b/html/elements/col.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -115,9 +109,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -163,9 +154,6 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -217,9 +205,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": false,
                 "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>."
@@ -269,9 +254,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -317,9 +299,6 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -369,9 +348,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/colgroup.json
+++ b/html/elements/colgroup.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -115,9 +109,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -163,9 +154,6 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -217,9 +205,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": false,
                 "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
@@ -269,9 +254,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -317,9 +299,6 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -369,9 +348,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/command.json
+++ b/html/elements/command.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false,
               "notes": "Before Firefox 24, although not implemented, an object of class <code>HTMLCommandElement</code> was created, instead of the compliant <code>HTMLUnknownElement</code>."
@@ -63,9 +60,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -115,9 +109,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -163,9 +154,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -215,9 +203,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -265,9 +250,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -313,9 +295,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/html/elements/content.json
+++ b/html/elements/content.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "33",
               "version_removed": "59",

--- a/html/elements/data.json
+++ b/html/elements/data.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "22"
             },

--- a/html/elements/datalist.json
+++ b/html/elements/datalist.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "4"
             },

--- a/html/elements/dd.json
+++ b/html/elements/dd.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1",
               "notes": "Before Firefox 4, this element was implemented using the <code>HTMLSpanElement</code> interface instead of <code>HTMLElement</code>."
@@ -62,9 +59,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/del.json
+++ b/html/elements/del.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -111,9 +105,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/details.json
+++ b/html/elements/details.json
@@ -15,9 +15,6 @@
               "version_added": false,
               "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/detailssummary?q=details'>Under consideration</a>."
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "49",
               "notes": "Before Firefox 57, there was a bug meaning that <code>&lt;details&gt;</code> elements can't be made open by default using the <code>open</code> attribute if they have a CSS <code>animation</code> active on them."
@@ -66,9 +63,6 @@
               "edge": {
                 "version_added": false,
                 "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/detailssummary?q=details'>Under consideration</a>."
-              },
-              "edge_mobile": {
-                "version_added": false
               },
               "firefox": {
                 "version_added": "49"

--- a/html/elements/dfn.json
+++ b/html/elements/dfn.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/html/elements/dialog.json
+++ b/html/elements/dialog.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "53",
               "flags": [
@@ -77,9 +74,6 @@
                 "version_added": "37"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/html/elements/dir.json
+++ b/html/elements/dir.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },
@@ -61,9 +58,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/html/elements/div.json
+++ b/html/elements/div.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/dl.json
+++ b/html/elements/dl.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/html/elements/dt.json
+++ b/html/elements/dt.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/html/elements/element.json
+++ b/html/elements/element.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/html/elements/em.json
+++ b/html/elements/em.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/html/elements/embed.json
+++ b/html/elements/embed.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -62,9 +59,6 @@
               },
               "edge": {
                 "version_added": true
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": {
                 "version_added": "1"
@@ -113,9 +107,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -163,9 +154,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -212,9 +200,6 @@
               },
               "edge": {
                 "version_added": true
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": {
                 "version_added": "1"

--- a/html/elements/fieldset.json
+++ b/html/elements/fieldset.json
@@ -17,10 +17,6 @@
               "version_added": true,
               "notes": "Does not support <code>flexbox</code> and <code>grid</code> layouts within this element. See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/4511145/'>bug 4511145</a>."
             },
-            "edge_mobile": {
-              "version_added": true,
-              "notes": "Does not support <code>flexbox</code> and <code>grid</code> layouts within this element. See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/4511145/'>bug 4511145</a>."
-            },
             "firefox": {
               "version_added": true
             },
@@ -73,9 +69,6 @@
                 "version_added": true,
                 "notes": "Does not work with nested fieldsets. For example: <code>&lt;fieldset disabled&gt;&lt;fieldset&gt;&lt;!--Still enabled--&gt;&lt;/fieldset&gt;&lt;/fieldset&gt;</code>"
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": true
               },
@@ -124,9 +117,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -172,9 +162,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/figcaption.json
+++ b/html/elements/figcaption.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "4"
             },

--- a/html/elements/figure.json
+++ b/html/elements/figure.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "4"
             },

--- a/html/elements/font.json
+++ b/html/elements/font.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -61,9 +58,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -113,9 +107,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -161,9 +152,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/footer.json
+++ b/html/elements/footer.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "4"
             },

--- a/html/elements/form.json
+++ b/html/elements/form.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -61,9 +58,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -113,9 +107,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -163,9 +154,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -211,9 +199,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -264,9 +249,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -312,9 +294,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -364,9 +343,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -412,9 +388,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -464,9 +437,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "4"
               },
@@ -512,9 +482,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/frame.json
+++ b/html/elements/frame.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -61,9 +58,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -113,9 +107,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -161,9 +152,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -213,9 +201,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -261,9 +246,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -313,9 +295,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -361,9 +340,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/frameset.json
+++ b/html/elements/frameset.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -61,9 +58,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -111,9 +105,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/h1.json
+++ b/html/elements/h1.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/html/elements/h2.json
+++ b/html/elements/h2.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/html/elements/h3.json
+++ b/html/elements/h3.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/html/elements/h4.json
+++ b/html/elements/h4.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/html/elements/h5.json
+++ b/html/elements/h5.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/html/elements/h6.json
+++ b/html/elements/h6.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/html/elements/head.json
+++ b/html/elements/head.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/header.json
+++ b/html/elements/header.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "4"
             },

--- a/html/elements/hgroup.json
+++ b/html/elements/hgroup.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "4"
             },

--- a/html/elements/hr.json
+++ b/html/elements/hr.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -113,9 +107,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -161,9 +152,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -213,9 +201,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -261,9 +246,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/html.json
+++ b/html/elements/html.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -62,9 +59,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": [
@@ -121,9 +115,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": "60"
                 },
@@ -172,9 +163,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -220,9 +208,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/i.json
+++ b/html/elements/i.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true,
               "notes": "The <code>resize</code> CSS property doesn't have any effect on this element due to <a href='https://bugzil.la/680823'>bug 680823</a>."
@@ -67,9 +64,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -115,9 +109,6 @@
                 "version_added": "60"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -177,9 +168,6 @@
                 }
               ],
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": [
@@ -266,9 +254,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -315,9 +300,6 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
                 "version_added": null
               },
               "firefox": {
@@ -367,9 +349,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -415,9 +394,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -467,9 +443,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -515,9 +488,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -567,9 +537,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -616,9 +583,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -676,9 +640,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -726,9 +687,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "50"
               },
@@ -774,9 +732,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -827,9 +782,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "49"
               },
@@ -878,9 +830,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "28"
               },
@@ -927,9 +876,6 @@
                 "version_added": "46"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -980,9 +926,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "50"
               },
@@ -1029,9 +972,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -1095,9 +1035,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -1144,9 +1081,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -1196,9 +1130,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -1246,9 +1177,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "25"
               },
@@ -1294,9 +1222,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/image.json
+++ b/html/elements/image.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": true,
               "notes": "Before Firefox 22, creating an &lt;image&gt; element incorrectly resulted in an <code>HTMLSpanElement</code> object, instead of the expected <code>HTMLElement</code>."

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -61,9 +58,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -113,9 +107,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -161,9 +152,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -213,9 +201,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -261,9 +246,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
                 "version_added": null
               },
               "firefox": {
@@ -313,9 +295,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -361,9 +340,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -425,9 +401,6 @@
               "edge": {
                 "version_added": null
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": null
               },
@@ -487,9 +460,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -535,9 +505,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -587,9 +554,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -635,9 +599,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
                 "version_added": null
               },
               "firefox": {
@@ -687,9 +648,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "50"
               },
@@ -735,9 +693,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -787,9 +742,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -835,9 +787,6 @@
                 "version_added": "34"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": [
@@ -913,9 +862,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -961,9 +907,6 @@
                   "version_added": "58"
                 },
                 "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
                   "version_added": false
                 },
                 "firefox": {
@@ -1014,9 +957,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -1062,9 +1002,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/input/button.json
+++ b/html/elements/input/button.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },

--- a/html/elements/input/checkbox.json
+++ b/html/elements/input/checkbox.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },

--- a/html/elements/input/color.json
+++ b/html/elements/input/color.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": "14"
               },
-              "edge_mobile": {
-                "version_added": "14"
-              },
               "firefox": {
                 "version_added": "29",
                 "notes": "Firefox doesn't yet support inputs of type <code>color</code> on Windows Touch."
@@ -61,9 +58,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": "14"
-                },
-                "edge_mobile": {
                   "version_added": "14"
                 },
                 "firefox": {
@@ -110,9 +104,6 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": "14"
-                },
-                "edge_mobile": {
                   "version_added": "14"
                 },
                 "firefox": {

--- a/html/elements/input/date.json
+++ b/html/elements/input/date.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "57"
               },

--- a/html/elements/input/datetime-local.json
+++ b/html/elements/input/datetime-local.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": false,
                 "notes": "See <a href='https://bugzil.la/888320'>bug 888320</a> and <a href='https://wiki.mozilla.org/TPE_DOM/Date_time_input_types'>TPE DOM/Date time input types</a>."

--- a/html/elements/input/email.json
+++ b/html/elements/input/email.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": null
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": true
               },

--- a/html/elements/input/file.json
+++ b/html/elements/input/file.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": null
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "1",
                 "notes": "You can set as well as get the value of <code>HTMLInputElement.files</code> in all modern browsers; this was most recently added to Firefox, in version 57 (see <a href='https://bugzil.la/1384030'>bug 1384030</a>)."

--- a/html/elements/input/hidden.json
+++ b/html/elements/input/hidden.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },

--- a/html/elements/input/image.json
+++ b/html/elements/input/image.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": null
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": true
               },

--- a/html/elements/input/input.json
+++ b/html/elements/input/input.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -59,9 +56,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/html/elements/input/month.json
+++ b/html/elements/input/month.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": false,
                 "notes": "See <a href='https://bugzil.la/888320'>bug 888320</a>."

--- a/html/elements/input/number.json
+++ b/html/elements/input/number.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": true
               },

--- a/html/elements/input/password.json
+++ b/html/elements/input/password.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": null
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -61,9 +58,6 @@
                   "version_added": false
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {

--- a/html/elements/input/radio.json
+++ b/html/elements/input/radio.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },

--- a/html/elements/input/range.json
+++ b/html/elements/input/range.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "23"
               },
@@ -71,9 +68,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": false,
                   "notes": "See <a href='https://bugzil.la/841942'>bug 841942</a>."
@@ -121,9 +115,6 @@
                   "notes": "The slider can be oriented vertically by setting the non-standard <code>-webkit-appearance: slider-vertical</code> style on the <code>input</code> element. You shouldn't use this, since it's proprietary, unless you include appropriate fallbacks for users of other browsers."
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {

--- a/html/elements/input/reset.json
+++ b/html/elements/input/reset.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": null
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "1",
                 "notes": "Unlike other browsers, Firefox by default <a href='http://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing'>persists the dynamic disabled state</a> of a <code>&ltbutton&gt</code> across page loads. Use the <code><a href='https://developer.mozilla.org/docs/Web/HTML/Element/button#attr-autocomplete'>autocomplete</a></code> attribute to control this feature."

--- a/html/elements/input/search.json
+++ b/html/elements/input/search.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "4"
               },

--- a/html/elements/input/submit.json
+++ b/html/elements/input/submit.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1",
                 "notes": "Unlike other browsers, Firefox by default <a href='http://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing'>persists the dynamic disabled state</a> of a <code><button></code> across page loads. Use the <code><a href='https://developer.mozilla.org/docs/Web/HTML/Element/button#attr-autocomplete'>autocomplete</a></code> attribute to control this feature."

--- a/html/elements/input/tel.json
+++ b/html/elements/input/tel.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": true
               },

--- a/html/elements/input/text.json
+++ b/html/elements/input/text.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },

--- a/html/elements/input/time.json
+++ b/html/elements/input/time.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "57"
               },

--- a/html/elements/input/url.json
+++ b/html/elements/input/url.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },

--- a/html/elements/input/week.json
+++ b/html/elements/input/week.json
@@ -16,9 +16,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": false,
                 "notes": "See <a href='https://bugzil.la/888320'>bug 888320</a>."

--- a/html/elements/ins.json
+++ b/html/elements/ins.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -111,9 +105,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/isindex.json
+++ b/html/elements/isindex.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },
@@ -61,9 +58,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -111,9 +105,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/html/elements/kbd.json
+++ b/html/elements/kbd.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1",
               "notes": "Before Firefox 4, creating a &lt;kbd&gt; element incorrectly resulted in an <code>HTMLSpanElement</code> object, instead of the expected <code>HTMLElement</code>."

--- a/html/elements/keygen.json
+++ b/html/elements/keygen.json
@@ -16,9 +16,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/html/elements/label.json
+++ b/html/elements/label.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -61,9 +58,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -111,9 +105,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/legend.json
+++ b/html/elements/legend.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/html/elements/li.json
+++ b/html/elements/li.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -111,9 +105,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -113,9 +107,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "18"
               },
@@ -161,9 +152,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -213,9 +201,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -261,9 +246,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -313,9 +295,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": null
               },
@@ -361,9 +340,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -413,9 +389,6 @@
               "edge": {
                 "version_added": null
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": false
               },
@@ -463,9 +436,6 @@
               "edge": {
                 "version_added": null
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": null
               },
@@ -511,9 +481,6 @@
                   "version_added": "64"
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -564,9 +531,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "50"
               },
@@ -612,9 +576,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -664,9 +625,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": "3"
                 },
@@ -712,9 +670,6 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -764,9 +719,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": null
                 },
@@ -814,9 +766,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": null
                 },
@@ -862,9 +811,6 @@
                   "version_added": "49"
                 },
                 "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
                   "version_added": false
                 },
                 "firefox": {
@@ -916,9 +862,6 @@
                 "edge": {
                   "version_added": false
                 },
-                "edge_mobile": {
-                  "version_added": false
-                },
                 "firefox": {
                   "version_added": "39",
                   "notes": "Before Firefox 41, it doesn't obey the <code>crossorigin</code> attribute."
@@ -968,9 +911,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": null
                 },
@@ -1016,9 +956,6 @@
                   "version_added": "50"
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -1072,9 +1009,6 @@
                 "edge": {
                   "version_added": null
                 },
-                "edge_mobile": {
-                  "version_added": null
-                },
                 "firefox": {
                   "version_added": null
                 },
@@ -1123,9 +1057,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -1171,9 +1102,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -1225,9 +1153,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -1275,9 +1200,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -1323,9 +1245,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/listing.json
+++ b/html/elements/listing.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false,
               "notes": "Before Firefox 4, this element implemented the <code>HTMLSpanElement</code> interface instead of the standard <code>HTMLElement</code> interface."

--- a/html/elements/main.json
+++ b/html/elements/main.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": "12"
-            },
             "firefox": {
               "version_added": "21"
             },

--- a/html/elements/map.json
+++ b/html/elements/map.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1",
               "notes": [
@@ -65,9 +62,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/mark.json
+++ b/html/elements/mark.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "4"
             },

--- a/html/elements/marquee.json
+++ b/html/elements/marquee.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": [
               {
                 "version_added": "65"
@@ -77,9 +74,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -125,9 +119,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -177,9 +168,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -225,9 +213,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -277,9 +262,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "3"
               },
@@ -325,9 +307,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -377,9 +356,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -425,9 +401,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -477,9 +450,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "3"
               },
@@ -527,9 +497,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "3"
               },
@@ -575,9 +542,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/menu.json
+++ b/html/elements/menu.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "8"
             },
@@ -63,9 +60,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -116,9 +110,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "51"
               },
@@ -164,9 +155,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -219,9 +207,6 @@
                 "edge": {
                   "version_added": true
                 },
-                "edge_mobile": {
-                  "version_added": true
-                },
                 "firefox": {
                   "version_added": "8"
                 },
@@ -269,9 +254,6 @@
                   "version_added": false
                 },
                 "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
                   "version_added": false
                 },
                 "firefox": {

--- a/html/elements/menuitem.json
+++ b/html/elements/menuitem.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "8",
               "notes": [
@@ -71,9 +68,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "8"
               },
@@ -119,9 +113,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -171,9 +162,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "8"
               },
@@ -219,9 +207,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -271,9 +256,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "8"
               },
@@ -321,9 +303,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "8"
               },
@@ -369,9 +348,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -113,9 +107,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -163,9 +154,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -210,9 +198,6 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
                   "version_added": true
                 },
                 "firefox": {
@@ -262,9 +247,6 @@
                 "edge": {
                   "version_added": true
                 },
-                "edge_mobile": {
-                  "version_added": true
-                },
                 "firefox": {
                   "version_added": "1"
                 },
@@ -312,9 +294,6 @@
                 "edge": {
                   "version_added": true
                 },
-                "edge_mobile": {
-                  "version_added": true
-                },
                 "firefox": {
                   "version_added": "1"
                 },
@@ -360,9 +339,6 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
                   "version_added": true
                 },
                 "firefox": {
@@ -414,9 +390,6 @@
                 "edge": {
                   "version_added": true
                 },
-                "edge_mobile": {
-                  "version_added": true
-                },
                 "firefox": {
                   "version_added": "1"
                 },
@@ -466,9 +439,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -516,9 +486,6 @@
                   "notes": "Until Chrome 46, <code>content</code> values weren't constrained to the values listed in the spec."
                 },
                 "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
                   "version_added": false
                 },
                 "firefox": {
@@ -571,9 +538,6 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
                   "version_added": true
                 },
                 "firefox": {

--- a/html/elements/meter.json
+++ b/html/elements/meter.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "16"
             },
@@ -61,9 +58,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -113,9 +107,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "16"
               },
@@ -161,9 +152,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -213,9 +201,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "16"
               },
@@ -261,9 +246,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -313,9 +295,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "16"
               },
@@ -361,9 +340,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/multicol.json
+++ b/html/elements/multicol.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false,
               "notes": "Up to Firefox 22, though not supported, a this element was associated with the <code>HTMLSpanElement</code> interface. It was then fixed and is now associated with the <code>HTMLUnknownElement</code> interface as requested by the specification."

--- a/html/elements/nav.json
+++ b/html/elements/nav.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "4"
             },

--- a/html/elements/nextid.json
+++ b/html/elements/nextid.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/html/elements/nobr.json
+++ b/html/elements/nobr.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/html/elements/noembed.json
+++ b/html/elements/noembed.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/html/elements/noframes.json
+++ b/html/elements/noframes.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/html/elements/noscript.json
+++ b/html/elements/noscript.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/html/elements/object.json
+++ b/html/elements/object.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -113,9 +107,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -161,9 +152,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -213,9 +201,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -261,9 +246,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -313,9 +295,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -361,9 +340,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -413,9 +389,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -461,9 +434,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -513,9 +483,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -561,9 +528,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -613,9 +577,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -661,9 +622,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -713,9 +671,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "27"
               },
@@ -763,9 +718,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -811,9 +763,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/ol.json
+++ b/html/elements/ol.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -113,9 +107,6 @@
               "edge": {
                 "version_added": null
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "18"
               },
@@ -163,9 +154,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -211,9 +199,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/optgroup.json
+++ b/html/elements/optgroup.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -111,9 +105,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/option.json
+++ b/html/elements/option.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -111,9 +105,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -169,9 +160,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -217,9 +205,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/output.json
+++ b/html/elements/output.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "4"
             },
@@ -61,9 +58,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -112,9 +106,6 @@
                 "edge": {
                   "version_added": true
                 },
-                "edge_mobile": {
-                  "version_added": true
-                },
                 "firefox": {
                   "version_added": "4"
                 },
@@ -159,9 +150,6 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": true
-                  },
-                  "edge_mobile": {
                     "version_added": true
                   },
                   "firefox": {

--- a/html/elements/p.json
+++ b/html/elements/p.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/html/elements/param.json
+++ b/html/elements/param.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -113,9 +107,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -163,9 +154,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -211,9 +199,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/picture.json
+++ b/html/elements/picture.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "13"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": [
               {
                 "version_added": "38"

--- a/html/elements/plaintext.json
+++ b/html/elements/plaintext.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": [
               {
                 "version_added": "4"

--- a/html/elements/pre.json
+++ b/html/elements/pre.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -115,10 +109,6 @@
                 "notes": "Specifying the <code>width</code> attribute has no layout effect."
               },
               "edge": {
-                "version_added": true,
-                "notes": "Specifying the <code>width</code> attribute has no layout effect."
-              },
-              "edge_mobile": {
                 "version_added": true,
                 "notes": "Specifying the <code>width</code> attribute has no layout effect."
               },
@@ -175,9 +165,6 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/html/elements/progress.json
+++ b/html/elements/progress.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "6",
               "notes": [
@@ -72,9 +69,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "6"
               },
@@ -120,9 +114,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/q.json
+++ b/html/elements/q.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/html/elements/rb.json
+++ b/html/elements/rb.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "38"
             },

--- a/html/elements/rp.json
+++ b/html/elements/rp.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "38"
             },

--- a/html/elements/rt.json
+++ b/html/elements/rt.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "38"
             },

--- a/html/elements/rtc.json
+++ b/html/elements/rtc.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "33"
             },

--- a/html/elements/ruby.json
+++ b/html/elements/ruby.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "38"
             },

--- a/html/elements/s.json
+++ b/html/elements/s.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1",
               "notes": "Before Firefox 4, this element implemented the <code>HTMLSpanElement</code> interface instead of the standard <code>HTMLElement</code> interface."

--- a/html/elements/samp.json
+++ b/html/elements/samp.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1",
               "notes": "Starting in Firefox 4, inserting &lt;script&gt; elements that have been created by calling <code>document.createElement(\"script\")</code> no longer enforces execution in insertion order. This change lets Firefox properly abide by the specification. To make script-inserted external scripts execute in their insertion order, set <code>.async=false</code> on them."
@@ -62,9 +59,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -114,9 +108,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "13"
               },
@@ -164,9 +155,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -219,9 +207,6 @@
                 "version_added": "17",
                 "partial_implementation": true
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "43"
               },
@@ -267,9 +252,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -318,9 +300,6 @@
               },
               "edge": {
                 "version_added": "16"
-              },
-              "edge_mobile": {
-                "version_added": false
               },
               "firefox": [
                 {
@@ -395,9 +374,6 @@
               "edge": {
                 "version_added": null
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "65"
               },
@@ -440,9 +416,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -492,9 +465,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -542,9 +512,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -590,9 +557,6 @@
                 },
                 "edge": {
                   "version_added": "16"
-                },
-                "edge_mobile": {
-                  "version_added": false
                 },
                 "firefox": [
                   {
@@ -666,9 +630,6 @@
                   "version_added": false
                 },
                 "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
                   "version_added": false
                 },
                 "firefox": {

--- a/html/elements/section.json
+++ b/html/elements/section.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "4"
             },

--- a/html/elements/select.json
+++ b/html/elements/select.json
@@ -16,9 +16,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1",
               "notes": "Historically, Firefox has allowed keyboard and mouse events to bubble up from the <code>&lt;option&gt;</code> element to the parent <code>&lt;select&gt;</code> element, although this behavior is inconsistent across many browsers. For better Web compatibility (and for technical reasons), when Firefox is in multi-process mode the <code>&lt;select&gt;</code> element is displayed as a drop-down list. The behavior is unchanged if the <code>&lt;select&gt;</code> is presented inline and it has either the multiple attribute defined or a size attribute set to more than 1. Rather than watching <code>&lt;option&gt;</code> elements for events, you should watch for change events on <code>&lt;select&gt;</code>. See <a href='https://bugzil.la/1090602'>bug 1090602</a> for details."
@@ -73,9 +70,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -121,9 +115,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -173,9 +164,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -221,9 +209,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -273,9 +258,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -323,9 +305,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "4"
               },
@@ -371,9 +350,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/shadow.json
+++ b/html/elements/shadow.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "33",
               "version_removed": "59",

--- a/html/elements/slot.json
+++ b/html/elements/slot.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": [
               {
                 "version_added": "63"
@@ -119,9 +116,6 @@
                 "version_added": "53"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [

--- a/html/elements/small.json
+++ b/html/elements/small.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/html/elements/source.json
+++ b/html/elements/source.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "3.5",
               "notes": "Until Firefox 15, Firefox picked the first source element that has a type matching the MIME-type of a supported media format; see <a href='https://bugzil.la/449363'>bug 449363</a> for details."
@@ -65,9 +62,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "15"
               },
@@ -113,9 +107,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": [
@@ -201,9 +192,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "3.5"
               },
@@ -249,9 +237,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": [
@@ -335,9 +320,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/spacer.json
+++ b/html/elements/spacer.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "1",
               "version_removed": "4"

--- a/html/elements/span.json
+++ b/html/elements/span.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/html/elements/strike.json
+++ b/html/elements/strike.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true,
               "notes": "Before Firefox 4, this element implemented the <code>HTMLSpanElement</code> interface instead of the standard <code>HTMLElement</code> interface."

--- a/html/elements/strong.json
+++ b/html/elements/strong.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1",
               "notes": "Before Firefox 4, creating a <code>&lt;strong&gt;</code> element incorrectly resulted in an <code>HTMLSpanElement</code> object, instead of the expected <code>HTMLElement</code>."

--- a/html/elements/style.json
+++ b/html/elements/style.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -119,9 +113,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -201,9 +192,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -249,9 +237,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/sub.json
+++ b/html/elements/sub.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/html/elements/summary.json
+++ b/html/elements/summary.json
@@ -15,10 +15,6 @@
               "version_added": false,
               "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/detailssummary?filter=f3f0000bf&search=details'>In development</a>."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/detailssummary?filter=f3f0000bf&search=details'>In development</a>."
-            },
             "firefox": {
               "version_added": "49"
             },
@@ -66,9 +62,6 @@
                 "notes": "Chrome currently doesn't use <code>display: list-item</code> on the <code>&lt;summary&gt;</code> element, so <code>display: block</code> will not automatically hide the disclosure widget. Instead, use the non-standard pseudo-element <code>::-webit-details-marker</code> to change the disclosure widget in Chrome. See <a href='https://crbug.com/590014'>Chrome bug 590014</a> for details."
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/html/elements/sup.json
+++ b/html/elements/sup.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/html/elements/table.json
+++ b/html/elements/table.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -113,9 +107,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -161,9 +152,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -213,9 +201,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -261,9 +246,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -313,9 +295,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -361,9 +340,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -413,9 +389,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -461,9 +434,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/tbody.json
+++ b/html/elements/tbody.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -115,9 +109,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -163,9 +154,6 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -217,9 +205,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": false,
                 "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
@@ -267,9 +252,6 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/td.json
+++ b/html/elements/td.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -111,9 +105,6 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -165,9 +156,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -215,9 +203,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -263,9 +248,6 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -317,9 +299,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": false,
                 "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
@@ -369,9 +348,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -417,9 +393,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -469,9 +442,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -517,9 +487,6 @@
                   "version_added": false
                 },
                 "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
                   "version_added": false
                 },
                 "firefox": {
@@ -570,9 +537,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -618,9 +582,6 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -670,9 +631,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "13"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "22"
             },

--- a/html/elements/textarea.json
+++ b/html/elements/textarea.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true,
               "notes": [
@@ -72,9 +69,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -122,9 +116,6 @@
               },
               "edge": {
                 "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": {
                 "version_added": "59"
@@ -174,9 +165,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "4"
               },
@@ -222,9 +210,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -274,9 +259,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -322,9 +304,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -374,9 +353,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "4"
               },
@@ -422,9 +398,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -474,9 +447,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -524,9 +494,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "4"
               },
@@ -572,9 +539,6 @@
                   "version_added": "36"
                 },
                 "edge": {
-                  "version_added": true
-                },
-                "edge_mobile": {
                   "version_added": true
                 },
                 "firefox": {
@@ -627,9 +591,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -675,9 +636,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -727,9 +685,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -777,9 +732,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -825,9 +777,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/tfoot.json
+++ b/html/elements/tfoot.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -115,9 +109,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -163,9 +154,6 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -217,9 +205,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": false,
                 "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
@@ -267,9 +252,6 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/th.json
+++ b/html/elements/th.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -111,9 +105,6 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -165,9 +156,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -215,9 +203,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -263,9 +248,6 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -317,9 +299,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": false,
                 "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
@@ -369,9 +348,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -417,9 +393,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -469,9 +442,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -517,9 +487,6 @@
                   "version_added": false
                 },
                 "edge": {
-                  "version_added": false
-                },
-                "edge_mobile": {
                   "version_added": false
                 },
                 "firefox": {
@@ -570,9 +537,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "1"
               },
@@ -618,9 +582,6 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -670,9 +631,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/thead.json
+++ b/html/elements/thead.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -115,9 +109,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -163,9 +154,6 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -217,9 +205,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": false,
                 "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
@@ -267,9 +252,6 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/time.json
+++ b/html/elements/time.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "22"
             },
@@ -73,9 +70,6 @@
                 "version_added": "62"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/title.json
+++ b/html/elements/title.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/html/elements/tr.json
+++ b/html/elements/tr.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -115,9 +109,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -163,9 +154,6 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -217,9 +205,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": false,
                 "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>"
@@ -267,9 +252,6 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/track.json
+++ b/html/elements/track.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": [
               {
                 "version_added": "31"
@@ -89,9 +86,6 @@
                 "version_added": "25"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": [
@@ -167,9 +161,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": [
                 {
                   "version_added": "31"
@@ -241,9 +232,6 @@
                 "version_added": "25"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": [
@@ -319,9 +307,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": [
                 {
                   "version_added": "31"
@@ -395,9 +380,6 @@
                 "edge": {
                   "version_added": true
                 },
-                "edge_mobile": {
-                  "version_added": true
-                },
                 "firefox": {
                   "version_added": "50",
                   "notes": "Before Firefox 50, setting the <code>src</code> didn't work, though it didn't raise an error."
@@ -446,9 +428,6 @@
                 "version_added": "25"
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": [

--- a/html/elements/tt.json
+++ b/html/elements/tt.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true,
               "notes": "Before Firefox 4, this element implemented the <code>HTMLSpanElement</code> interface instead of the standard <code>HTMLElement</code> interface."

--- a/html/elements/u.json
+++ b/html/elements/u.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1",
               "notes": "Before Firefox 4, this element implemented the <code>HTMLSpanElement</code> interface instead of the standard <code>HTMLElement</code> interface."

--- a/html/elements/ul.json
+++ b/html/elements/ul.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },
@@ -61,9 +58,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -111,9 +105,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/var.json
+++ b/html/elements/var.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/html/elements/video.json
+++ b/html/elements/video.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "3.5"
             },
@@ -61,9 +58,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -114,9 +108,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "4"
               },
@@ -162,9 +153,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -214,9 +202,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "12"
               },
@@ -262,9 +247,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -326,9 +308,6 @@
               "edge": {
                 "version_added": null
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": null
               },
@@ -388,9 +367,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "11"
               },
@@ -436,9 +412,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -488,9 +461,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "15"
               },
@@ -536,9 +506,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -588,9 +555,6 @@
                 "notes": "Defaults to <code>metadata</code> in Chrome 64."
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {
@@ -643,9 +607,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "3.5"
               },
@@ -691,9 +652,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
-              },
-              "edge_mobile": {
                 "version_added": true
               },
               "firefox": {

--- a/html/elements/wbr.json
+++ b/html/elements/wbr.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/html/elements/xmp.json
+++ b/html/elements/xmp.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true,
               "notes": "Before Firefox 4, this element implemented the <code>HTMLSpanElement</code> interface instead of the standard <code>HTMLElement</code> interface."

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -63,9 +60,6 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
               "version_added": null
             },
             "firefox": {
@@ -139,9 +133,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": true
             },
@@ -205,9 +196,6 @@
               "edge": {
                 "version_added": null
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "67"
               },
@@ -266,9 +254,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "32"
             },
@@ -317,9 +302,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "3"
             },
@@ -362,9 +344,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
                 "version_added": null
               },
               "firefox": {
@@ -412,9 +391,6 @@
               "edge": {
                 "version_added": null
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": false
               },
@@ -460,9 +436,6 @@
               "edge": {
                 "version_added": null
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": false
               },
@@ -506,9 +479,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
                 "version_added": null
               },
               "firefox": {
@@ -582,9 +552,6 @@
               ]
             },
             "edge": {
-              "version_added": false
-            },
-            "edge_mobile": {
               "version_added": false
             },
             "firefox": {
@@ -665,9 +632,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -714,9 +678,6 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
               "version_added": true
             },
             "firefox": {
@@ -767,9 +728,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "2"
             },
@@ -817,9 +775,6 @@
               "version_removed": "58"
             },
             "edge": {
-              "version_added": false
-            },
-            "edge_mobile": {
               "version_added": false
             },
             "firefox": {
@@ -872,9 +827,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -921,9 +873,6 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
               "version_added": true
             },
             "firefox": [
@@ -990,9 +939,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": false
             },
@@ -1036,9 +982,6 @@
               "version_added": "67"
             },
             "edge": {
-              "version_added": false
-            },
-            "edge_mobile": {
               "version_added": false
             },
             "firefox": [
@@ -1147,9 +1090,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -1196,9 +1136,6 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
               "version_added": true
             },
             "firefox": {
@@ -1249,9 +1186,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -1298,9 +1232,6 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
               "version_added": true
             },
             "firefox": {
@@ -1351,9 +1282,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -1402,9 +1330,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -1451,9 +1376,6 @@
               "version_added": "53"
             },
             "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
               "version_added": null
             },
             "firefox": [
@@ -1563,9 +1485,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -1612,9 +1531,6 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
               "version_added": true
             },
             "firefox": {
@@ -1665,9 +1581,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -1714,9 +1627,6 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
               "version_added": true
             },
             "firefox": {
@@ -1766,9 +1676,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": true
               },
@@ -1816,9 +1723,6 @@
               "version_added": true
             },
             "edge": {
-              "version_added": false
-            },
-            "edge_mobile": {
               "version_added": false
             },
             "firefox": {

--- a/html/manifest/background_color.json
+++ b/html/manifest/background_color.json
@@ -15,9 +15,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/html/manifest/categories.json
+++ b/html/manifest/categories.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/html/manifest/description.json
+++ b/html/manifest/description.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/html/manifest/dir.json
+++ b/html/manifest/dir.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/html/manifest/display.json
+++ b/html/manifest/display.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/html/manifest/iarc_rating_id.json
+++ b/html/manifest/iarc_rating_id.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/html/manifest/icons.json
+++ b/html/manifest/icons.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/html/manifest/lang.json
+++ b/html/manifest/lang.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/html/manifest/name.json
+++ b/html/manifest/name.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/html/manifest/orientation.json
+++ b/html/manifest/orientation.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/html/manifest/prefer_related_applications.json
+++ b/html/manifest/prefer_related_applications.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/html/manifest/related_applications.json
+++ b/html/manifest/related_applications.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/html/manifest/scope.json
+++ b/html/manifest/scope.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/html/manifest/screenshots.json
+++ b/html/manifest/screenshots.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/html/manifest/serviceworker.json
+++ b/html/manifest/serviceworker.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/html/manifest/short_name.json
+++ b/html/manifest/short_name.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/html/manifest/start_url.json
+++ b/html/manifest/start_url.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/html/manifest/theme_color.json
+++ b/html/manifest/theme_color.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },


### PR DESCRIPTION
This is a PR based off of #3888.  Since the Windows Phone OS is deprecated platform, Edge Mobile is as well.  It was mentioned that Microsoft suggested we drop Edge Mobile.