### PR TITLE
Remove Edge Mobile in http/*

### DIFF
--- a/http/data-url.json
+++ b/http/data-url.json
@@ -15,10 +15,6 @@
             "version_added": "12",
             "notes": "The maximum size supported is 4GB"
           },
-          "edge_mobile": {
-            "version_added": true,
-            "notes": "The maximum size supported is 4GB"
-          },
           "firefox": {
             "version_added": true
           },
@@ -66,10 +62,6 @@
             },
             "edge": {
               "version_added": "12",
-              "notes": "The maximum size supported is 4GB"
-            },
-            "edge_mobile": {
-              "version_added": true,
               "notes": "The maximum size supported is 4GB"
             },
             "firefox": {
@@ -127,9 +119,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": true
             },
@@ -179,10 +168,6 @@
               "version_added": "12",
               "notes": "The maximum size supported is 4GB"
             },
-            "edge_mobile": {
-              "version_added": true,
-              "notes": "The maximum size supported is 4GB"
-            },
             "firefox": {
               "version_added": true
             },
@@ -230,9 +215,6 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
               "version_added": null
             },
             "firefox": {

--- a/http/headers/accept-ch-lifetime.json
+++ b/http/headers/accept-ch-lifetime.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/http/headers/accept-ch.json
+++ b/http/headers/accept-ch.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },
@@ -62,9 +59,6 @@
                 "version_added": "46"
               },
               "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
                 "version_added": null
               },
               "firefox": {
@@ -115,9 +109,6 @@
               "edge": {
                 "version_added": null
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": null
               },
@@ -164,9 +155,6 @@
                 "version_added": "46"
               },
               "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
                 "version_added": null
               },
               "firefox": {

--- a/http/headers/accept-charset.json
+++ b/http/headers/accept-charset.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/accept-encoding.json
+++ b/http/headers/accept-encoding.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/accept-language.json
+++ b/http/headers/accept-language.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/accept-ranges.json
+++ b/http/headers/accept-ranges.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/accept.json
+++ b/http/headers/accept.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true,
               "notes": "In Firefox 66, the default <code>Accept</code> header value changed to <code>*/*</code>."

--- a/http/headers/access-control-allow-credentials.json
+++ b/http/headers/access-control-allow-credentials.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "3.5"
             },

--- a/http/headers/access-control-allow-headers.json
+++ b/http/headers/access-control-allow-headers.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "3.5"
             },

--- a/http/headers/access-control-allow-methods.json
+++ b/http/headers/access-control-allow-methods.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "3.5"
             },

--- a/http/headers/access-control-allow-origin.json
+++ b/http/headers/access-control-allow-origin.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "3.5"
             },

--- a/http/headers/access-control-expose-headers.json
+++ b/http/headers/access-control-expose-headers.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "3.5"
             },

--- a/http/headers/access-control-max-age.json
+++ b/http/headers/access-control-max-age.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "3.5"
             },

--- a/http/headers/access-control-request-headers.json
+++ b/http/headers/access-control-request-headers.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "3.5"
             },

--- a/http/headers/access-control-request-method.json
+++ b/http/headers/access-control-request-method.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "3.5"
             },

--- a/http/headers/age.json
+++ b/http/headers/age.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/alt-svc.json
+++ b/http/headers/alt-svc.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": [
               {
                 "version_added": "38"

--- a/http/headers/cache-control.json
+++ b/http/headers/cache-control.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -64,9 +61,6 @@
               },
               "edge": {
                 "version_added": "15"
-              },
-              "edge_mobile": {
-                "version_added": false
               },
               "firefox": {
                 "version_added": "49"
@@ -117,9 +111,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false,
                 "notes": "See Bugzilla <a href='https://bugzil.la/995651'>bug 995651</a> comment 7."
@@ -168,9 +159,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/http/headers/clear-site-data.json
+++ b/http/headers/clear-site-data.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": [
               {
                 "version_added": "63"

--- a/http/headers/connection.json
+++ b/http/headers/connection.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/content-disposition.json
+++ b/http/headers/content-disposition.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/content-dpr.json
+++ b/http/headers/content-dpr.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/http/headers/content-encoding.json
+++ b/http/headers/content-encoding.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -63,9 +60,6 @@
               },
               "edge": {
                 "version_added": "15"
-              },
-              "edge_mobile": {
-                "version_added": false
               },
               "firefox": {
                 "version_added": "44"

--- a/http/headers/content-language.json
+++ b/http/headers/content-language.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/content-length.json
+++ b/http/headers/content-length.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/content-location.json
+++ b/http/headers/content-location.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/content-range.json
+++ b/http/headers/content-range.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/content-security-policy-report-only.json
+++ b/http/headers/content-security-policy-report-only.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "14"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "23"
             },

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -21,9 +21,6 @@
               "edge": {
                 "version_added": "14"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": [
                 {
                   "version_added": "23"
@@ -91,9 +88,6 @@
                 "edge": {
                   "version_added": true
                 },
-                "edge_mobile": {
-                  "version_added": true
-                },
                 "firefox": {
                   "version_added": "45"
                 },
@@ -140,9 +134,6 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -194,9 +185,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "35"
               },
@@ -243,9 +231,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
                 "version_added": null
               },
               "firefox": {
@@ -296,9 +281,6 @@
               "edge": {
                 "version_added": "15"
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "45"
               },
@@ -346,9 +328,6 @@
               },
               "edge": {
                 "version_added": "14"
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": {
                 "version_added": "23",
@@ -399,9 +378,6 @@
               "edge": {
                 "version_added": "14"
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "23"
               },
@@ -447,9 +423,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -500,9 +473,6 @@
               "edge": {
                 "version_added": "14"
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "23"
               },
@@ -551,9 +521,6 @@
               "edge": {
                 "version_added": "15"
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "36"
               },
@@ -601,9 +568,6 @@
               },
               "edge": {
                 "version_added": "15"
-              },
-              "edge_mobile": {
-                "version_added": false
               },
               "firefox": {
                 "version_added": "33",
@@ -655,9 +619,6 @@
               "edge": {
                 "version_added": "14"
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "23"
               },
@@ -706,9 +667,6 @@
               "edge": {
                 "version_added": "14"
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "23"
               },
@@ -755,9 +713,6 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -808,9 +763,6 @@
               "edge": {
                 "version_added": "14"
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "23"
               },
@@ -856,9 +808,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -909,9 +858,6 @@
               "edge": {
                 "version_added": "14"
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "23"
               },
@@ -959,9 +905,6 @@
               },
               "edge": {
                 "version_added": "15"
-              },
-              "edge_mobile": {
-                "version_added": false
               },
               "firefox": {
                 "version_added": false,
@@ -1012,9 +955,6 @@
                 "version_removed": "56"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -1069,9 +1009,6 @@
               "edge": {
                 "version_added": null
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": null
               },
@@ -1117,9 +1054,6 @@
                 "version_added": "70"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -1170,9 +1104,6 @@
               "edge": {
                 "version_added": "14"
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "23"
               },
@@ -1219,9 +1150,6 @@
                 "version_added": "54"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -1286,9 +1214,6 @@
               "edge": {
                 "version_added": "14"
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "50"
               },
@@ -1337,9 +1262,6 @@
               "edge": {
                 "version_added": "14"
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "23"
               },
@@ -1385,9 +1307,6 @@
                   "version_added": "59"
                 },
                 "edge": {
-                  "version_added": null
-                },
-                "edge_mobile": {
                   "version_added": null
                 },
                 "firefox": {
@@ -1439,9 +1358,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "52"
               },
@@ -1489,9 +1405,6 @@
               },
               "edge": {
                 "version_added": "14"
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": {
                 "version_added": "23"
@@ -1542,9 +1455,6 @@
                 "version_added": false,
                 "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/cspupgradeinsecurerequestsdirective'>Under consideration</a> for future release."
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "42"
               },
@@ -1593,9 +1503,6 @@
                 "notes": "Chrome 59 and higher skips the deprecated <code>child-src</code> directive."
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/http/headers/content-type.json
+++ b/http/headers/content-type.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/cookie.json
+++ b/http/headers/cookie.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/cookie2.json
+++ b/http/headers/cookie2.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/http/headers/cross-origin-resource-policy.json
+++ b/http/headers/cross-origin-resource-policy.json
@@ -16,9 +16,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/http/headers/date.json
+++ b/http/headers/date.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/device-memory.json
+++ b/http/headers/device-memory.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/http/headers/dnt.json
+++ b/http/headers/dnt.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "4"
             },

--- a/http/headers/downlink.json
+++ b/http/headers/downlink.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/http/headers/dpr.json
+++ b/http/headers/dpr.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/http/headers/early-data.json
+++ b/http/headers/early-data.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": "58"
             },

--- a/http/headers/ect.json
+++ b/http/headers/ect.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/http/headers/etag.json
+++ b/http/headers/etag.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/expect-ct.json
+++ b/http/headers/expect-ct.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/http/headers/expect.json
+++ b/http/headers/expect.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/http/headers/expires.json
+++ b/http/headers/expires.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "65",
               "flags": [
@@ -90,9 +87,6 @@
                 ]
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -178,9 +172,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -250,9 +241,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "65",
                 "flags": [
@@ -313,9 +301,6 @@
                 "version_added": "60"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -380,9 +365,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "67",
                 "flags": [
@@ -443,9 +425,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -510,9 +489,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "65",
                 "flags": [
@@ -575,9 +551,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "65",
                 "flags": [
@@ -638,9 +611,6 @@
                 "version_added": "60"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -719,9 +689,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -791,9 +758,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -854,9 +818,6 @@
                 ]
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -942,9 +903,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -1014,9 +972,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "65",
                 "flags": [
@@ -1077,9 +1032,6 @@
                 "version_added": "60"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -1158,9 +1110,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -1230,9 +1179,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "65",
                 "flags": [
@@ -1295,9 +1241,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -1346,9 +1289,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -1395,9 +1335,6 @@
                 "version_added": "65"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -1460,9 +1397,6 @@
                 ]
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -1548,9 +1482,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -1620,9 +1551,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -1671,9 +1599,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -1720,9 +1645,6 @@
                 "version_added": "62"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/http/headers/forwarded.json
+++ b/http/headers/forwarded.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/http/headers/from.json
+++ b/http/headers/from.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/host.json
+++ b/http/headers/host.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/if-match.json
+++ b/http/headers/if-match.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/if-modified-since.json
+++ b/http/headers/if-modified-since.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/if-none-match.json
+++ b/http/headers/if-none-match.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/if-range.json
+++ b/http/headers/if-range.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/if-unmodified-since.json
+++ b/http/headers/if-unmodified-since.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/keep-alive.json
+++ b/http/headers/keep-alive.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/large-allocation.json
+++ b/http/headers/large-allocation.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "53"
             },

--- a/http/headers/last-modified.json
+++ b/http/headers/last-modified.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/location.json
+++ b/http/headers/location.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/origin.json
+++ b/http/headers/origin.json
@@ -15,9 +15,6 @@
               "version_added": true,
               "notes": "Not sent with <code>POST</code> requests, see <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/10482384/'>bug 10482384</a>."
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": [
               {
                 "version_added": "59",

--- a/http/headers/pragma.json
+++ b/http/headers/pragma.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/proxy-authenticate.json
+++ b/http/headers/proxy-authenticate.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/http/headers/public-key-pins-report-only.json
+++ b/http/headers/public-key-pins-report-only.json
@@ -17,9 +17,6 @@
               "version_added": false,
               "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/publickeypinningextensionforhttp'>Under consideration</a> for future release."
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/1091177'>bug 1091177</a>."

--- a/http/headers/public-key-pins.json
+++ b/http/headers/public-key-pins.json
@@ -17,9 +17,6 @@
               "version_added": false,
               "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/publickeypinningextensionforhttp'>Under consideration</a> for future release."
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": "35"
             },
@@ -68,9 +65,6 @@
               },
               "edge": {
                 "version_added": false
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": {
                 "version_added": false,

--- a/http/headers/range.json
+++ b/http/headers/range.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/referer.json
+++ b/http/headers/referer.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/referrer-policy.json
+++ b/http/headers/referrer-policy.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "50"
             },
@@ -62,9 +59,6 @@
                 "version_added": "61"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -115,9 +109,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "52"
               },
@@ -164,9 +155,6 @@
                 "version_added": "61"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/http/headers/report-to.json
+++ b/http/headers/report-to.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/http/headers/retry-after.json
+++ b/http/headers/retry-after.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/230260'>bug 230260</a>."

--- a/http/headers/rtt.json
+++ b/http/headers/rtt.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/http/headers/save-data.json
+++ b/http/headers/save-data.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/http/headers/server-timing.json
+++ b/http/headers/server-timing.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": "61"
             },

--- a/http/headers/server.json
+++ b/http/headers/server.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -62,9 +59,6 @@
                 "version_added": "49"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -115,9 +109,6 @@
               "edge": {
                 "version_added": true
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "3"
               },
@@ -166,9 +157,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": true
               },
@@ -216,9 +204,6 @@
               },
               "edge": {
                 "version_added": "16"
-              },
-              "edge_mobile": {
-                "version_added": false
               },
               "firefox": {
                 "version_added": "60"

--- a/http/headers/set-cookie2.json
+++ b/http/headers/set-cookie2.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/http/headers/snapshot-content-location.json
+++ b/http/headers/snapshot-content-location.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false
             },

--- a/http/headers/sourcemap.json
+++ b/http/headers/sourcemap.json
@@ -26,9 +26,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": [
               {
                 "version_added": "55"

--- a/http/headers/strict-transport-security.json
+++ b/http/headers/strict-transport-security.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "4"
             },

--- a/http/headers/te.json
+++ b/http/headers/te.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/timing-allow-origin.json
+++ b/http/headers/timing-allow-origin.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/tk.json
+++ b/http/headers/tk.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/http/headers/trailer.json
+++ b/http/headers/trailer.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/transfer-encoding.json
+++ b/http/headers/transfer-encoding.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/upgrade-insecure-requests.json
+++ b/http/headers/upgrade-insecure-requests.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "17"
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "48"
             },

--- a/http/headers/user-agent.json
+++ b/http/headers/user-agent.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/vary.json
+++ b/http/headers/vary.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/via.json
+++ b/http/headers/via.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/viewport-width.json
+++ b/http/headers/viewport-width.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/http/headers/warning.json
+++ b/http/headers/warning.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },

--- a/http/headers/width.json
+++ b/http/headers/width.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/http/headers/www-authenticate.json
+++ b/http/headers/www-authenticate.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": "1"
             },

--- a/http/headers/x-content-type-options.json
+++ b/http/headers/x-content-type-options.json
@@ -28,9 +28,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "50"
             },

--- a/http/headers/x-dns-prefetch-control.json
+++ b/http/headers/x-dns-prefetch-control.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": "2"
             },

--- a/http/headers/x-forwarded-for.json
+++ b/http/headers/x-forwarded-for.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/http/headers/x-forwarded-host.json
+++ b/http/headers/x-forwarded-host.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/http/headers/x-forwarded-proto.json
+++ b/http/headers/x-forwarded-proto.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": null
             },

--- a/http/headers/x-frame-options.json
+++ b/http/headers/x-frame-options.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "3.6.9"
             },
@@ -63,9 +60,6 @@
               },
               "edge": {
                 "version_added": true
-              },
-              "edge_mobile": {
-                "version_added": null
               },
               "firefox": {
                 "version_added": "18"
@@ -115,9 +109,6 @@
                 "notes": "Starting in Chrome 61, this applies to all of a frame's ancestors."
               },
               "edge": {
-                "version_added": null
-              },
-              "edge_mobile": {
                 "version_added": null
               },
               "firefox": {

--- a/http/headers/x-xss-protection.json
+++ b/http/headers/x-xss-protection.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": false
             },

--- a/http/methods.json
+++ b/http/methods.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -63,9 +60,6 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
               "version_added": true
             },
             "firefox": {
@@ -116,9 +110,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -165,9 +156,6 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
               "version_added": true
             },
             "firefox": {
@@ -218,9 +206,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -267,9 +252,6 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
               "version_added": true
             },
             "firefox": {
@@ -320,9 +302,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -369,9 +348,6 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
               "version_added": null
             },
             "firefox": {

--- a/http/status.json
+++ b/http/status.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -63,9 +60,6 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
               "version_added": true
             },
             "firefox": {
@@ -116,9 +110,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -165,9 +156,6 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
               "version_added": true
             },
             "firefox": {
@@ -218,9 +206,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -267,9 +252,6 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
               "version_added": true
             },
             "firefox": {
@@ -320,9 +302,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -369,9 +348,6 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
               "version_added": true
             },
             "firefox": {
@@ -422,9 +398,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -473,9 +446,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -522,9 +492,6 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
               "version_added": true
             },
             "firefox": {
@@ -576,9 +543,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -625,9 +589,6 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
               "version_added": true
             },
             "firefox": {
@@ -678,9 +639,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -727,9 +685,6 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
               "version_added": true
             },
             "firefox": {
@@ -780,9 +735,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -829,9 +781,6 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
               "version_added": true
             },
             "firefox": {
@@ -882,9 +831,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -931,9 +877,6 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
               "version_added": true
             },
             "firefox": {
@@ -984,9 +927,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -1033,9 +973,6 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
               "version_added": null
             },
             "firefox": {
@@ -1086,9 +1023,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -1135,9 +1069,6 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
               "version_added": true
             },
             "firefox": {
@@ -1188,9 +1119,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -1237,9 +1165,6 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
               "version_added": true
             },
             "firefox": {
@@ -1290,9 +1215,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": true
             },
@@ -1339,9 +1261,6 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
-            },
-            "edge_mobile": {
               "version_added": true
             },
             "firefox": {


### PR DESCRIPTION
This is a PR based off of #3888.  Since the Windows Phone OS is deprecated platform, Edge Mobile is as well.  It was mentioned that Microsoft suggested we drop Edge Mobile.