### PR TITLE
Remove Edge Mobile in webdriver/*

### DIFF
--- a/test/test-real-values.js
+++ b/test/test-real-values.js
@@ -27,7 +27,7 @@ const blockList = {
   svg: [],
   javascript: ['firefox', 'firefox_android'],
   mathml: blockMany,
-  webdriver: blockMany.concat(['samsunginternet_android']),
+  webdriver: blockMany.concat(['samsunginternet_android', 'edge_mobile']),
   webextensions: [],
   xpath: [],
   xslt: []

--- a/test/test-real-values.js
+++ b/test/test-real-values.js
@@ -7,7 +7,6 @@ const blockMany = [
   'chrome',
   'chrome_android',
   'edge',
-  'edge_mobile',
   'firefox',
   'firefox_android',
   'ie',
@@ -27,7 +26,7 @@ const blockList = {
   svg: [],
   javascript: ['firefox', 'firefox_android'],
   mathml: blockMany,
-  webdriver: blockMany.concat(['samsunginternet_android', 'edge_mobile']),
+  webdriver: blockMany.concat(['samsunginternet_android']),
   webextensions: [],
   xpath: [],
   xslt: []

--- a/webdriver/commands/AcceptAlert.json
+++ b/webdriver/commands/AcceptAlert.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/AddCookie.json
+++ b/webdriver/commands/AddCookie.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/Back.json
+++ b/webdriver/commands/Back.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/CloseWindow.json
+++ b/webdriver/commands/CloseWindow.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/DeleteAllCookies.json
+++ b/webdriver/commands/DeleteAllCookies.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/DeleteCookie.json
+++ b/webdriver/commands/DeleteCookie.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/DeleteSession.json
+++ b/webdriver/commands/DeleteSession.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/DismissAlert.json
+++ b/webdriver/commands/DismissAlert.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/ElementClear.json
+++ b/webdriver/commands/ElementClear.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/ElementClick.json
+++ b/webdriver/commands/ElementClick.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/ElementSendKeys.json
+++ b/webdriver/commands/ElementSendKeys.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/ExecuteAsyncScript.json
+++ b/webdriver/commands/ExecuteAsyncScript.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/ExecuteScript.json
+++ b/webdriver/commands/ExecuteScript.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/FindElement.json
+++ b/webdriver/commands/FindElement.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/FindElementFromElement.json
+++ b/webdriver/commands/FindElementFromElement.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/FindElements.json
+++ b/webdriver/commands/FindElements.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/FindElementsFromElement.json
+++ b/webdriver/commands/FindElementsFromElement.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/Forward.json
+++ b/webdriver/commands/Forward.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/FullscreenWindow.json
+++ b/webdriver/commands/FullscreenWindow.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/GetActiveElement.json
+++ b/webdriver/commands/GetActiveElement.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/GetAlertText.json
+++ b/webdriver/commands/GetAlertText.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/GetAllCookies.json
+++ b/webdriver/commands/GetAllCookies.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/GetCurrentURL.json
+++ b/webdriver/commands/GetCurrentURL.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/GetElementAttribute.json
+++ b/webdriver/commands/GetElementAttribute.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/GetElementCSSValue.json
+++ b/webdriver/commands/GetElementCSSValue.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/GetElementProperty.json
+++ b/webdriver/commands/GetElementProperty.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/GetElementRect.json
+++ b/webdriver/commands/GetElementRect.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/GetElementTagName.json
+++ b/webdriver/commands/GetElementTagName.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/GetElementText.json
+++ b/webdriver/commands/GetElementText.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/GetNamedCookie.json
+++ b/webdriver/commands/GetNamedCookie.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/GetPageSource.json
+++ b/webdriver/commands/GetPageSource.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/GetTimeouts.json
+++ b/webdriver/commands/GetTimeouts.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/GetTitle.json
+++ b/webdriver/commands/GetTitle.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/GetWindowHandle.json
+++ b/webdriver/commands/GetWindowHandle.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/GetWindowHandles.json
+++ b/webdriver/commands/GetWindowHandles.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/GetWindowRect.json
+++ b/webdriver/commands/GetWindowRect.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/IsElementEnabled.json
+++ b/webdriver/commands/IsElementEnabled.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/IsElementSelected.json
+++ b/webdriver/commands/IsElementSelected.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/MaximizeWindow.json
+++ b/webdriver/commands/MaximizeWindow.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/MinimizeWindow.json
+++ b/webdriver/commands/MinimizeWindow.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/NavigateTo.json
+++ b/webdriver/commands/NavigateTo.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/NewSession.json
+++ b/webdriver/commands/NewSession.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/NewWindow.json
+++ b/webdriver/commands/NewWindow.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "66"
             },

--- a/webdriver/commands/PerformActions.json
+++ b/webdriver/commands/PerformActions.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/Refresh.json
+++ b/webdriver/commands/Refresh.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/ReleaseActions.json
+++ b/webdriver/commands/ReleaseActions.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/SendAlertText.json
+++ b/webdriver/commands/SendAlertText.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/SetTimeouts.json
+++ b/webdriver/commands/SetTimeouts.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/SetWindowRect.json
+++ b/webdriver/commands/SetWindowRect.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/Status.json
+++ b/webdriver/commands/Status.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/SwitchToFrame.json
+++ b/webdriver/commands/SwitchToFrame.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/SwitchToParentFrame.json
+++ b/webdriver/commands/SwitchToParentFrame.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/SwitchToWindow.json
+++ b/webdriver/commands/SwitchToWindow.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/TakeElementScreenshot.json
+++ b/webdriver/commands/TakeElementScreenshot.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },

--- a/webdriver/commands/TakeScreenshot.json
+++ b/webdriver/commands/TakeScreenshot.json
@@ -17,10 +17,6 @@
               "version_added": false,
               "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
             },
-            "edge_mobile": {
-              "version_added": false,
-              "notes": "The vendor-supported implementation for Edge is non-spec-conforming and incompatible."
-            },
             "firefox": {
               "version_added": "55"
             },


### PR DESCRIPTION
This is a PR based off of #3888.  Since the Windows Phone OS is deprecated platform, Edge Mobile is as well.  It was mentioned that Microsoft suggested we drop Edge Mobile.