### PR TITLE
Document statistics script

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -17,3 +17,7 @@ You can use `npm run render $query $depth $aggregateMode` to output an HTML like
 The parameters are the same as the [`{{compat}}` macro](https://github.com/mdn/kumascript/blob/master/macros/Compat.ejs).
 
 Paste the generated HTML into the MDN editor (source mode). You can use a new page, for example: https://developer.mozilla.org/en-US/docs/new and verify if the output looks correct.
+
+## Statistics
+
+To see how changes will affect the statistics of real, true, and null values, you can run `npm run stats`.  This generates a Markdown-formatted table of the percentages of real, true, and null values for the eight primary browsers that browser-compat-data is focusing on.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -22,4 +22,4 @@ Paste the generated HTML into the MDN editor (source mode). You can use a new pa
 
 To see how changes will affect the statistics of real, true, and null values, you can run `npm run stats`.  This generates a Markdown-formatted table of the percentages of real, true, and null values for the eight primary browsers that browser-compat-data is focusing on.
 
-* "Real" values are values of which are either "false" or a version number, as defined in [#3555](https://github.com/mdn/browser-compat-data/issues/3555).
+* _Real_ values are values of which are either `false` or a version number, as defined in [#3555](https://github.com/mdn/browser-compat-data/issues/3555).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -21,3 +21,5 @@ Paste the generated HTML into the MDN editor (source mode). You can use a new pa
 ## Statistics
 
 To see how changes will affect the statistics of real, true, and null values, you can run `npm run stats`.  This generates a Markdown-formatted table of the percentages of real, true, and null values for the eight primary browsers that browser-compat-data is focusing on.
+
+* "Real" values are values of which are either "false" or a version number, as defined in [#3555](https://github.com/mdn/browser-compat-data/issues/3555).


### PR DESCRIPTION
This adds some basic documentation regarding the statistics script, and what it is used for.  Closes #4180.