### PR TITLE
Add support data for CSSPseudoElement

### DIFF
--- a/api/CSSPseudoElement.json
+++ b/api/CSSPseudoElement.json
@@ -1,0 +1,95 @@
+{
+  "api": {
+    "CSSPseudoElement": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPseudoElement",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "edge_mobile": {
+            "version_added": false
+          },
+          "firefox": [
+            {
+              "version_added": false
+            },
+            {
+              "version_added": "63",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.animations-api.getAnimations.enabled"
+                }
+              ]
+            },
+            {
+              "version_added": "47",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.animations-api.core.enabled"
+                }
+              ]
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": false
+            },
+            {
+              "version_added": "63",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.animations-api.getAnimations.enabled"
+                }
+              ]
+            },
+            {
+              "version_added": "47",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.animations-api.core.enabled"
+                }
+              ]
+            }
+          ],
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/CSSPseudoElement.json
+++ b/api/CSSPseudoElement.json
@@ -31,6 +31,7 @@
             },
             {
               "version_added": "47",
+              "version_removed": "63",
               "flags": [
                 {
                   "type": "preference",
@@ -54,6 +55,7 @@
             },
             {
               "version_added": "47",
+              "version_removed": "63",
               "flags": [
                 {
                   "type": "preference",
@@ -88,6 +90,216 @@
           "experimental": true,
           "standard_track": true,
           "deprecated": false
+        }
+      },
+      "element": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPseudoElement/element",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": [
+              {
+                "version_added": false
+              },
+              {
+                "version_added": "67",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.getAnimations.enabled"
+                  }
+                ]
+              },
+              {
+                "alternative_name": "parentElement",
+                "version_added": "63",
+                "version_removed": "67",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.getAnimations.enabled"
+                  }
+                ]
+              },
+              {
+                "alternative_name": "parentElement",
+                "version_added": "47",
+                "version_removed": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.core.enabled"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": false
+              },
+              {
+                "version_added": "67",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.getAnimations.enabled"
+                  }
+                ]
+              },
+              {
+                "alternative_name": "parentElement",
+                "version_added": "63",
+                "version_removed": "67",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.getAnimations.enabled"
+                  }
+                ]
+              },
+              {
+                "alternative_name": "parentElement",
+                "version_added": "47",
+                "version_removed": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.core.enabled"
+                  }
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "type": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSPseudoElement/type",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": [
+              {
+                "version_added": false
+              },
+              {
+                "version_added": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.getAnimations.enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "47",
+                "version_removed": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.core.enabled"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": false
+              },
+              {
+                "version_added": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.getAnimations.enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "47",
+                "version_removed": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.core.enabled"
+                  }
+                ]
+              }
+            ],
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
         }
       }
     }

--- a/api/CSSPseudoElement.json
+++ b/api/CSSPseudoElement.json
@@ -18,9 +18,6 @@
           },
           "firefox": [
             {
-              "version_added": false
-            },
-            {
               "version_added": "63",
               "flags": [
                 {
@@ -41,9 +38,6 @@
             }
           ],
           "firefox_android": [
-            {
-              "version_added": false
-            },
             {
               "version_added": "63",
               "flags": [
@@ -110,9 +104,6 @@
             },
             "firefox": [
               {
-                "version_added": false
-              },
-              {
                 "version_added": "67",
                 "flags": [
                   {
@@ -145,9 +136,6 @@
               }
             ],
             "firefox_android": [
-              {
-                "version_added": false
-              },
               {
                 "version_added": "67",
                 "flags": [
@@ -227,9 +215,6 @@
             },
             "firefox": [
               {
-                "version_added": false
-              },
-              {
                 "version_added": "63",
                 "flags": [
                   {
@@ -250,9 +235,6 @@
               }
             ],
             "firefox_android": [
-              {
-                "version_added": false
-              },
               {
                 "version_added": "63",
                 "flags": [


### PR DESCRIPTION
Add support data for [`CSSPseudoElement`](https://developer.mozilla.org/en-US/docs/Web/API/CSSPseudoElement).

#### Firefox ####

Current status is flagged off for stable but present in Nightly.

* First implementation https://bugzilla.mozilla.org/show_bug.cgi?id=1174575
* Pref rename https://bugzilla.mozilla.org/show_bug.cgi?id=1471814

#### Chromium ####

Not present in Canary. See also https://bugs.chromium.org/p/chromium/issues/detail?id=813902#c5

#### Edge ####

Web Animations API is unsupported entirely by EdgeHTML.

#### Safari ####

Not present in iOS v12.3.1 (Safari 12.1.1) with both `Web Animations` and `CSS Animations via Web Animations` experiments turned on.

Probably not present in MacOS Safari 12.1 but may be present in Safari 13 technological preview (unsure). Possibly relevant patch: https://bugs.webkit.org/show_bug.cgi?id=186518