### PR TITLE
Adding counter-set

### DIFF
--- a/css/properties/counter-set.json
+++ b/css/properties/counter-set.json
@@ -1,0 +1,57 @@
+{
+  "css": {
+    "properties": {
+      "counter-set": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/counter-set",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "68"
+            },
+            "firefox_android": {
+              "version_added": "68"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Firefox 68 implements the `counter-set` property. As far as I can see it isn't implemented anywhere else.

https://bugzilla.mozilla.org/show_bug.cgi?id=1518201