### PR TITLE
Mark touch-action supported by the next version of Safari

### DIFF
--- a/css/properties/touch-action.json
+++ b/css/properties/touch-action.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": "12"
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": [
               {
                 "version_added": "52",
@@ -94,9 +91,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": [
                 {
@@ -176,9 +170,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": [
                 {
@@ -260,9 +251,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": [
                 {
                   "version_added": "52",
@@ -342,9 +330,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": false
               },
@@ -397,9 +382,6 @@
               },
               "edge": {
                 "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
               },
               "firefox": {
                 "version_added": false,
@@ -455,9 +437,6 @@
                 "version_added": "55"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/touch-action.json
+++ b/css/properties/touch-action.json
@@ -491,7 +491,7 @@
               }
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/touch-action.json
+++ b/css/properties/touch-action.json
@@ -66,12 +66,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/133112'>WebKit bug 133112</a>."
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": true,
-              "notes": "See <a href='https://webkit.org/b/133112'>WebKit bug 133112</a>."
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -149,7 +147,7 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": false
+                "version_added": "13"
               },
               "safari_ios": {
                 "version_added": "9.1"
@@ -263,10 +261,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": false
+                "version_added": "13"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "13"
               },
               "samsunginternet_android": {
                 "version_added": "6.0"

--- a/css/properties/touch-action.json
+++ b/css/properties/touch-action.json
@@ -4,7 +4,6 @@
       "touch-action": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/touch-action",
-          "description": "Level 1 values",
           "support": {
             "chrome": {
               "version_added": "36"
@@ -69,7 +68,7 @@
               "version_added": "13"
             },
             "safari_ios": {
-              "version_added": "13"
+              "version_added": "9.1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -151,6 +150,171 @@
               },
               "safari_ios": {
                 "version_added": "9.1"
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": "37"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "none": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "36"
+              },
+              "chrome_android": {
+                "version_added": "36"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": [
+                {
+                  "version_added": "52",
+                  "notes": "Not applicable to Firefox platforms that support neither pointer nor touch events."
+                },
+                {
+                  "version_added": "29",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.touch_action.enabled",
+                      "value_to_set": "true"
+                    }
+                  ],
+                  "notes": "Not applicable to Firefox platforms that support neither pointer nor touch events."
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "52"
+                },
+                {
+                  "version_added": "29",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.touch_action.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "ie": [
+                {
+                  "version_added": "11"
+                },
+                {
+                  "version_added": "10",
+                  "prefix": "-ms-"
+                }
+              ],
+              "opera": {
+                "version_added": "23"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "13"
+              },
+              "safari_ios": {
+                "version_added": "13"
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": "37"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "axis-pan": {
+          "__compat": {
+            "description": "<code>pan-x</code> and <code>pan-y</code>",
+            "support": {
+              "chrome": {
+                "version_added": "36"
+              },
+              "chrome_android": {
+                "version_added": "36"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": true
+              },
+              "firefox": [
+                {
+                  "version_added": "52",
+                  "notes": "Not applicable to Firefox platforms that support neither pointer nor touch events."
+                },
+                {
+                  "version_added": "29",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.touch_action.enabled",
+                      "value_to_set": "true"
+                    }
+                  ],
+                  "notes": "Not applicable to Firefox platforms that support neither pointer nor touch events."
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "52"
+                },
+                {
+                  "version_added": "29",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.touch_action.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "ie": [
+                {
+                  "version_added": "11"
+                },
+                {
+                  "version_added": "10",
+                  "prefix": "-ms-"
+                }
+              ],
+              "opera": {
+                "version_added": "23"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "13"
+              },
+              "safari_ios": {
+                "version_added": "13"
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
Mark [`touch-action`](https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action) (L1 values and `pinch-zoom`) supported by the next version of Safari.

### Layout Changes ###

Previously Safari was given as missing basic support but [supporting the `manipulation` subfeature from 9.1 onwards in iOS only](https://webkit.org/blog/5610/more-responsive-tapping-on-ios/). This PR lists all other level 1 spec values (`none`, `pan-x`/`pan-y`) separately as well.

### Safari ###

#### Safari 12.1 ####

Tested manually on an iPad running iOS 12.3.1 (Safari 12.1.1). Loaded http://w3c-test.org/pointerevents/pointerevent_touch-action-pan-x-css_touch.html with `Pointer events` experiment enabled, was still able to pan vertically so the test failed.

#### Safari 13 ####

Untested but implementation bugs:

- https://bugs.webkit.org/show_bug.cgi?id=193314 Support parsing of additional values for the touch-action property
- https://bugs.webkit.org/show_bug.cgi?id=193447 Limit user-agent interactions based on the touch-action property on iOS
- https://bugs.webkit.org/show_bug.cgi?id=133112#c36 Touch-action css property support [exposure on Mac OS]

Plus the [version 13 release notes](https://developer.apple.com/documentation/safari_release_notes/safari_13_beta_release_notes) state that the overall pointer events API will be supported.

### Unidirectional Panning ###

`pan-up`/`pan-down`/`pan-left`/`pan-right` were removed from the Pointer Events Level 2 spec before receiving recommendation, now existing in Pointer Events Level 2 Extensions and WHATWG Compatibility Standard, so I am marking them as experimental.