### PR TITLE
Update versions for nodeList.forEach()

### DIFF
--- a/api/NodeList.json
+++ b/api/NodeList.json
@@ -166,7 +166,7 @@
               "version_added": "16"
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
               "version_added": "50"
@@ -181,7 +181,7 @@
               "version_added": "38"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": "10"

--- a/api/NodeList.json
+++ b/api/NodeList.json
@@ -181,7 +181,7 @@
               "version_added": "38"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": "10"


### PR DESCRIPTION
### Summary

Some browsers don't allow you to loop over a nodeLiust using `forEach`. You'd normally be expected to convert the nodeList to an array. 

Opera and Edge for Android don't require you to do this, so this PR updates the versions accordingly.

This JSFiddle gets all the elements by the class `.test` and loops thorugh them. The results are written to a list: https://jsfiddle.net/sjn8z0e7/1/

I've tested this in Edge and Opera on Android and both write to the list as expected.
