### PR TITLE
Clean up -webkit-background-clip data

### DIFF
--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -12,7 +12,7 @@
               {
                 "version_added": "1",
                 "prefix": "-webkit-",
-                "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+                "notes": "Chrome also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
             "chrome_android": [
@@ -22,7 +22,7 @@
               {
                 "version_added": "18",
                 "prefix": "-webkit-",
-                "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+                "notes": "Chrome also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
             "edge": {
@@ -38,7 +38,7 @@
               {
                 "version_added": "49",
                 "prefix": "-webkit-",
-                "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+                "notes": "Firefox also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
               },
               {
                 "version_added": "1",
@@ -55,7 +55,7 @@
               {
                 "version_added": "49",
                 "prefix": "-webkit-",
-                "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+                "notes": "Firefox also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
             "ie": {
@@ -69,7 +69,7 @@
               {
                 "version_added": "15",
                 "prefix": "-webkit-",
-                "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+                "notes": "Opera also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
             "opera_android": [
@@ -79,18 +79,18 @@
               {
                 "version_added": "14",
                 "prefix": "-webkit-",
-                "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+                "notes": "Opera also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
             "safari": {
               "version_added": "3",
               "prefix": "-webkit-",
-              "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+              "notes": "Safari also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
             },
             "safari_ios": {
               "version_added": "1",
               "prefix": "-webkit-",
-              "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+              "notes": "Safari also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -102,7 +102,7 @@
               {
                 "version_added": true,
                 "prefix": "-webkit-",
-                "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+                "notes": "WebView also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ]
           },

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -169,12 +169,12 @@
             "description": "<code>text</code>",
             "support": {
               "chrome": {
-                "version_added": true,
+                "version_added": "3",
                 "prefix": "-webkit-",
                 "notes": "Support the prefixed version of the property only; according to the <a href='https://webkit.org/blog/164/background-clip-text/'>official blog</a>, WebKit does not include text decorations or shadows in the clipping."
               },
               "chrome_android": {
-                "version_added": true,
+                "version_added": "18",
                 "prefix": "-webkit-",
                 "notes": "Support the prefixed version of the property only; according to the <a href='https://webkit.org/blog/164/background-clip-text/'>official blog</a>, WebKit does not include text decorations or shadows in the clipping."
               },
@@ -225,30 +225,30 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true,
+                "version_added": "15",
                 "prefix": "-webkit-",
                 "notes": "Support the prefixed version of the property only; according to the <a href='https://webkit.org/blog/164/background-clip-text/'>official blog</a>, WebKit does not include text decorations or shadows in the clipping."
               },
               "opera_android": {
-                "version_added": true,
+                "version_added": "14",
                 "prefix": "-webkit-",
                 "notes": "Support the prefixed version of the property only; according to the <a href='https://webkit.org/blog/164/background-clip-text/'>official blog</a>, WebKit does not include text decorations or shadows in the clipping."
               },
               "safari": {
-                "version_added": true,
+                "version_added": "4",
                 "prefix": "-webkit-",
                 "notes": "Support the prefixed version of the property only; according to the <a href='https://webkit.org/blog/164/background-clip-text/'>official blog</a>, WebKit does not include text decorations or shadows in the clipping."
               },
               "safari_ios": {
-                "version_added": true,
+                "version_added": "3.2",
                 "prefix": "-webkit-",
                 "notes": "Support the prefixed version of the property only; according to the <a href='https://webkit.org/blog/164/background-clip-text/'>official blog</a>, WebKit does not include text decorations or shadows in the clipping."
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true,
+                "version_added": "1",
                 "prefix": "-webkit-",
                 "notes": "Support the prefixed version of the property only; according to the <a href='https://webkit.org/blog/164/background-clip-text/'>official blog</a>, WebKit does not include text decorations or shadows in the clipping."
               }

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -170,13 +170,19 @@
             "support": {
               "chrome": {
                 "version_added": "3",
-                "prefix": "-webkit-",
-                "notes": "Support the prefixed version of the property only; according to the <a href='https://webkit.org/blog/164/background-clip-text/'>official blog</a>, WebKit does not include text decorations or shadows in the clipping."
+                "partial_implementation": true,
+                "notes": [
+                  "This value is supported with the prefixed version of the property only.",
+                  "According to the <a href='https://webkit.org/blog/164/background-clip-text/'>WebKit blog</a>, text decorations or shadows are not included in the clipping."
+                ]
               },
               "chrome_android": {
                 "version_added": "18",
-                "prefix": "-webkit-",
-                "notes": "Support the prefixed version of the property only; according to the <a href='https://webkit.org/blog/164/background-clip-text/'>official blog</a>, WebKit does not include text decorations or shadows in the clipping."
+                "partial_implementation": true,
+                "notes": [
+                  "This value is supported with the prefixed version of the property only.",
+                  "According to the <a href='https://webkit.org/blog/164/background-clip-text/'>WebKit blog</a>, text decorations or shadows are not included in the clipping."
+                ]
               },
               "edge": [
                 {
@@ -184,8 +190,8 @@
                 },
                 {
                   "version_added": "12",
-                  "prefix": "-webkit-",
-                  "notes": "Support the prefixed version of the property only; according to the <a href='https://webkit.org/blog/164/background-clip-text/'>official blog</a>, WebKit does not include text decorations or shadows in the clipping."
+                  "partial_implementation": true,
+                  "notes": "Before Edge 15, this value was supported with the prefixed version of the property only."
                 }
               ],
               "edge_mobile": {
@@ -226,31 +232,51 @@
               },
               "opera": {
                 "version_added": "15",
-                "prefix": "-webkit-",
-                "notes": "Support the prefixed version of the property only; according to the <a href='https://webkit.org/blog/164/background-clip-text/'>official blog</a>, WebKit does not include text decorations or shadows in the clipping."
+                "partial_implementation": true,
+                "notes": [
+                  "This value is supported with the prefixed version of the property only.",
+                  "According to the <a href='https://webkit.org/blog/164/background-clip-text/'>WebKit blog</a>, text decorations or shadows are not included in the clipping."
+                ]
               },
               "opera_android": {
                 "version_added": "14",
-                "prefix": "-webkit-",
-                "notes": "Support the prefixed version of the property only; according to the <a href='https://webkit.org/blog/164/background-clip-text/'>official blog</a>, WebKit does not include text decorations or shadows in the clipping."
+                "partial_implementation": true,
+                "notes": [
+                  "This value is supported with the prefixed version of the property only.",
+                  "According to the <a href='https://webkit.org/blog/164/background-clip-text/'>WebKit blog</a>, text decorations or shadows are not included in the clipping."
+                ]
               },
               "safari": {
                 "version_added": "4",
-                "prefix": "-webkit-",
-                "notes": "Support the prefixed version of the property only; according to the <a href='https://webkit.org/blog/164/background-clip-text/'>official blog</a>, WebKit does not include text decorations or shadows in the clipping."
+                "partial_implementation": true,
+                "notes": [
+                  "This value is supported with the prefixed version of the property only.",
+                  "According to the <a href='https://webkit.org/blog/164/background-clip-text/'>WebKit blog</a>, text decorations or shadows are not included in the clipping."
+                ]
               },
               "safari_ios": {
                 "version_added": "3.2",
-                "prefix": "-webkit-",
-                "notes": "Support the prefixed version of the property only; according to the <a href='https://webkit.org/blog/164/background-clip-text/'>official blog</a>, WebKit does not include text decorations or shadows in the clipping."
+                "partial_implementation": true,
+                "notes": [
+                  "This value is supported with the prefixed version of the property only.",
+                  "According to the <a href='https://webkit.org/blog/164/background-clip-text/'>WebKit blog</a>, text decorations or shadows are not included in the clipping."
+                ]
               },
               "samsunginternet_android": {
-                "version_added": "1.0"
+                "version_added": "1.0",
+                "partial_implementation": true,
+                "notes": [
+                  "This value is supported with the prefixed version of the property only.",
+                  "According to the <a href='https://webkit.org/blog/164/background-clip-text/'>WebKit blog</a>, text decorations or shadows are not included in the clipping."
+                ]
               },
               "webview_android": {
                 "version_added": "1",
-                "prefix": "-webkit-",
-                "notes": "Support the prefixed version of the property only; according to the <a href='https://webkit.org/blog/164/background-clip-text/'>official blog</a>, WebKit does not include text decorations or shadows in the clipping."
+                "partial_implementation": true,
+                "notes": [
+                  "This value is supported with the prefixed version of the property only.",
+                  "According to the <a href='https://webkit.org/blog/164/background-clip-text/'>WebKit blog</a>, text decorations or shadows are not included in the clipping."
+                ]
               }
             },
             "status": {

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -10,17 +10,17 @@
                 "version_added": "1"
               },
               {
-                "version_added": true,
+                "version_added": "1",
                 "prefix": "-webkit-",
                 "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
             "chrome_android": [
               {
-                "version_added": true
+                "version_added": "18"
               },
               {
-                "version_added": true,
+                "version_added": "18",
                 "prefix": "-webkit-",
                 "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
@@ -93,7 +93,7 @@
               "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": [
               {

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -120,7 +120,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -148,10 +148,10 @@
                 "version_added": "3"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4.1"


### PR DESCRIPTION
This PR fixes a number of issues with the background-clip data. It was kind of a mess. This also contributes to #3804 and #3805.

## Update `-webkit-background-clip` property data for WebKit and Chromium

While working on #4290, I found that `-webkit-background-clip` was added to WebKit at the same time as `appearance`: https://trac.webkit.org/changeset/13874/webkit

Because this predates Chromium, I've set the `-webkit-background-clip` version
on Chromium and derived browsers to their first releases.

Since I was changing this data anyway, I also corrected the style of the notes, to refer to the browsers specifically (rather than WebKit generically).

## Update `content-box` value data for Chromium

This blog post on the WebKit post establishes that the `content-box` value was original to `-webkit-background-clip`, so I updated the Chromiums accordingly: https://webkit.org/blog/164/background-clip-text/

## Clean up `text` value data

First, I cleaned up the version data itself:

* This page establishes that Safari 4 first shipped the `text` value: https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariCSSRef/Articles/StandardCSSProperties.html
* Following that, I derived the iOS version from Safari 4's WebKit engine number.
* Finally, the discussion on this Chromium bug suggests that the `text` value started
working in Chrome 3: https://crbug.com/8872

Then I cleaned up the messy `prefix` data and notes. Mostly, I replaced `prefix` data with `partial_implementation` to catch that apparently some browsers only allow `text` with the `-webkit-` prefix on the property itself (not the value), or I removed the data where it didn't appear to be applicable. Since I was changing the notes, I also corrected for style, splitting the distinct notes into arrays.