### PR TITLE
Set Webview back to true for certain css values.

### DIFF
--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -252,7 +252,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "1"
+                "version_added": true
               }
             },
             "status": {
@@ -302,7 +302,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "1"
+                "version_added": true
               }
             },
             "status": {

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -271,7 +271,7 @@
                 ]
               },
               "webview_android": {
-                "version_added": "1",
+                "version_added": true,
                 "partial_implementation": true,
                 "notes": [
                   "This value is supported with the prefixed version of the property only.",


### PR DESCRIPTION
Updates #4290 and #4291 by setting WebView back to true. Chromium WebView didn't arrive until version 37 and I have no way of finding out when or if pre-Chromium WebView supported this.