### PR TITLE
Show support in Edge for @charset

### DIFF
--- a/css/at-rules/charset.json
+++ b/css/at-rules/charset.json
@@ -13,10 +13,10 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": false
+              "version_added": "12"
             },
             "edge_mobile": {
-              "version_added": false
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1.5",


### PR DESCRIPTION
Verified by testing in Edge 18, but I have no reason to believe this was ever unsupported given how old this feature is in the web platform. I also ran a few searches to check if anyone had complained about issues using this feature in Edge and did not find anything.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
