### PR TITLE
Correct user-select: all Edge compat

### DIFF
--- a/css/properties/user-select.json
+++ b/css/properties/user-select.json
@@ -195,10 +195,10 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "edge_mobile": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "1"
@@ -207,7 +207,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": "10"
+                "version_added": false
               },
               "opera": {
                 "version_added": true


### PR DESCRIPTION
Edge does not support this.

Test: https://jsfiddle.net/82pe1mzd/

Tested with Edge 42 (EdgeHTML 17)

It looks like this table might have been populated from https://css-tricks.com/almanac/properties/u/user-select/, which is specific to `user-select: none`.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
