### PR TITLE
Add locales/options to BigInt#toLocaleString

### DIFF
--- a/javascript/builtins/BigInt.json
+++ b/javascript/builtins/BigInt.json
@@ -265,6 +265,106 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "locales": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "76"
+                },
+                "chrome_android": {
+                  "version_added": "76"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": "76"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "options": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "76"
+                },
+                "chrome_android": {
+                  "version_added": "76"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": "76"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         },
         "toString": {


### PR DESCRIPTION
Much like https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString#Browser_compatibility, the BigInt.toLocaleString data also needs entries for locales/options. 

Currently only implemented in Chrome 76: https://www.chromestatus.com/features/5742274625404928

Not yet in Firefox or anywhere else afaik:
https://bugzilla.mozilla.org/show_bug.cgi?id=1543677