### PR TITLE
Update -webkit-device-pixel-ratio range media feature

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1798,6 +1798,10 @@
               },
               "firefox": [
                 {
+                  "version_added": "63",
+                  "notes": "Implemented as an alias for for <code>-moz-device-pixel-ratio</code>."
+                },
+                {
                   "version_added": "49",
                   "flags": [
                     {
@@ -1826,6 +1830,10 @@
                 }
               ],
               "firefox_android": [
+                {
+                  "version_added": "63",
+                  "notes": "Implemented as an alias for for <code>-moz-device-pixel-ratio</code>."
+                },
                 {
                   "version_added": "49",
                   "flags": [
@@ -1902,6 +1910,10 @@
               },
               "firefox": [
                 {
+                  "version_added": "63",
+                  "notes": "Implemented as an alias for for <code>max--moz-device-pixel-ratio</code>."
+                },
+                {
                   "version_added": "49",
                   "flags": [
                     {
@@ -1930,6 +1942,10 @@
                 }
               ],
               "firefox_android": [
+                {
+                  "version_added": "63",
+                  "notes": "Implemented as an alias for for <code>max--moz-device-pixel-ratio</code>."
+                },
                 {
                   "version_added": "49",
                   "flags": [
@@ -2007,7 +2023,7 @@
               "firefox": [
                 {
                   "version_added": "63",
-                  "notes": "Implemented as an alias for for <code>-moz-device-pixel-ratio</code>."
+                  "notes": "Implemented as an alias for for <code>min--moz-device-pixel-ratio</code>."
                 },
                 {
                   "version_added": "49",
@@ -2040,7 +2056,7 @@
               "firefox_android": [
                 {
                   "version_added": "63",
-                  "notes": "Implemented as an alias for for <code>-moz-device-pixel-ratio</code>."
+                  "notes": "Implemented as an alias for for <code>min--moz-device-pixel-ratio</code>."
                 },
                 {
                   "version_added": "49",


### PR DESCRIPTION
# Summary

`-webkit-device-pixel-ratio`, `-webkit-min-device-pixel-ratio`, and `-webkit-max-device-pixel-ratio` were all shipped together in Firefox 63, but only `-webkit-device-pixel-ratio` was updated. This PR updates the other two, `-webkit-min-device-pixel-ratio` and `-webkit-max-device-pixel-ratio`.

This fixes #4222.

# Data
All three media queries (or is a single "range" media query) are controlled by the same flag which was flipped in Firefox 63, but the bug explicitly mentioned just `-webkit-device-pixel-ratio` as an example, leading to the confusion. This  [Commit](https://hg.mozilla.org/mozilla-central/rev/7d3fe27beec5) flips the flag for all queries, as stated in the comment above the flag.

As a side note, comment says `-webkit-{min|max}-device-pixel-ratio` while it actually means `-webkit-{min-|max-}device-pixel-ratio`.

# Relevant issues
This is a follow-up to #2581, which is based on [Bugzilla issue 1444139](https://bugzilla.mozilla.org/show_bug.cgi?id=1444139).

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
