### PR TITLE
Add IDBFactory.databases

### DIFF
--- a/api/IDBFactory.json
+++ b/api/IDBFactory.json
@@ -223,13 +223,13 @@
               "notes": "See <a href='https://bugzil.la/934640'>bug 934640</a>."
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "58"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": null

--- a/api/IDBFactory.json
+++ b/api/IDBFactory.json
@@ -27,9 +27,6 @@
           "edge": {
             "version_added": true
           },
-          "edge_mobile": {
-            "version_added": null
-          },
           "firefox": [
             {
               "version_added": "16"
@@ -99,9 +96,6 @@
             "edge": {
               "version_added": true
             },
-            "edge_mobile": {
-              "version_added": true
-            },
             "firefox": {
               "version_added": "37"
             },
@@ -156,9 +150,6 @@
             },
             "edge": {
               "version_added": "12"
-            },
-            "edge_mobile": {
-              "version_added": true
             },
             "firefox": [
               {
@@ -223,9 +214,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/934640'>bug 934640</a>."
@@ -282,9 +270,6 @@
             },
             "edge": {
               "version_added": "12"
-            },
-            "edge_mobile": {
-              "version_added": true
             },
             "firefox": [
               {
@@ -355,9 +340,6 @@
             },
             "edge": {
               "version_added": "12"
-            },
-            "edge_mobile": {
-              "version_added": true
             },
             "firefox": [
               {

--- a/api/IDBFactory.json
+++ b/api/IDBFactory.json
@@ -228,11 +228,11 @@
             },
             "firefox": {
               "version_added": false,
-              "notes": "See bug https://bugzilla.mozilla.org/show_bug.cgi?id=934640"
+              "notes": "See <a href='https://bugzil.la/934640'>bug 934640</a>."
             },
             "firefox_android": {
               "version_added": false,
-              "notes": "See bug https://bugzilla.mozilla.org/show_bug.cgi?id=934640"
+              "notes": "See <a href='https://bugzil.la/934640'>bug 934640</a>."
             },
             "ie": {
               "version_added": null

--- a/api/IDBFactory.json
+++ b/api/IDBFactory.json
@@ -210,6 +210,59 @@
           }
         }
       },
+      "databases": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBFactory/databases",
+          "support": {
+            "chrome": {
+              "version_added": "71"
+            },
+            "chrome_android": {
+              "version_added": "71"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "See bug https://bugzilla.mozilla.org/show_bug.cgi?id=934640"
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "See bug https://bugzilla.mozilla.org/show_bug.cgi?id=934640"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "71"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "deleteDatabase": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBFactory/deleteDatabase",

--- a/api/IDBFactory.json
+++ b/api/IDBFactory.json
@@ -232,13 +232,13 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "71"


### PR DESCRIPTION
# Summary
Adds information about `window.indexedDB.databases`.  This PR fixes #4237.

# Data
- Chrome (desktop, Android, Android WebView) added support in version 71, according to the [Chrome Platform Status](https://chromestatus.com/features/6084476278931456).
- [Firefox does  not support it yet](https://bugzilla.mozilla.org/show_bug.cgi?id=934640).
- Internet Explorer does not support it (based on test).
- Edge (legacy) does not support it (based on test). 
- Edge based on Chromium (pre-release) does support it (since it is based on Chromium after 71) (based on test).
- Opera supports it (based on test with Opera 60 and release notes saying Opera 58 is based on Chromium 71. Please note that Opera 59 was never released to stable.)

## Test
1. open console
2. check that `window.indexedDB` is an object with a bunch of attributes
3. check whether `window.indexedDB.databases` it is defied. If databases is supported, it should be defined and be a function that returns an empty array `[]`; `undefined` means it is not supported,

I have no data for Safari, but I believe it does not support it yet because the platform status does not list "Indexed Databases 3.0" at all.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
