### PR TITLE
Update Object.fromEntries spec URL; now in ES spec

### DIFF
--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -695,7 +695,7 @@
         "fromEntries": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries",
-            "spec_url": "https://tc39.es/proposal-object-from-entries/#sec-object.fromentries",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.fromentries",
             "support": {
               "chrome": {
                 "version_added": "73"


### PR DESCRIPTION
The Object.fromEntries method, which had been defined initially in the spec proposal at https://tc39.es/proposal-object-from-entries/, is now part of the ECMAScript spec itself. So, this change updates the spec_url field with the ECMAScript spec URL for the method.