### PR TITLE
Change tc39.github.io spec URLs to tc39.es URLs

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -4,7 +4,7 @@
       "Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-array-objects",
+          "spec_url": "https://tc39.es/ecma262/#sec-array-objects",
           "support": {
             "chrome": {
               "version_added": true
@@ -55,7 +55,7 @@
         "concat": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/concat",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.concat",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.concat",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -107,7 +107,7 @@
         "copyWithin": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/copyWithin",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.copywithin",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.copywithin",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -159,7 +159,7 @@
         "entries": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/entries",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.entries",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.entries",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -211,7 +211,7 @@
         "every": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/every",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.every",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.every",
             "support": {
               "chrome": {
                 "version_added": true
@@ -263,7 +263,7 @@
         "fill": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/fill",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.fill",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.fill",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -326,7 +326,7 @@
         "filter": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/filter",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.filter",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.filter",
             "support": {
               "chrome": {
                 "version_added": true
@@ -378,7 +378,7 @@
         "find": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/find",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.find",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.find",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -441,7 +441,7 @@
         "findIndex": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.findIndex",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.findIndex",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -504,7 +504,7 @@
         "flat": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/flat",
-            "spec_url": "https://tc39.github.io/proposal-flatMap/#sec-Array.prototype.flat",
+            "spec_url": "https://tc39.es/proposal-flatMap/#sec-Array.prototype.flat",
             "support": {
               "chrome": {
                 "version_added": "69"
@@ -556,7 +556,7 @@
         "flatMap": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap",
-            "spec_url": "https://tc39.github.io/proposal-flatMap/#sec-Array.prototype.flatMap",
+            "spec_url": "https://tc39.es/proposal-flatMap/#sec-Array.prototype.flatMap",
             "support": {
               "chrome": {
                 "version_added": "69"
@@ -608,7 +608,7 @@
         "forEach": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.foreach",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.foreach",
             "support": {
               "chrome": {
                 "version_added": true
@@ -660,7 +660,7 @@
         "from": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/from",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.from",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.from",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -712,7 +712,7 @@
         "includes": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/includes",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.includes",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.includes",
             "support": {
               "chrome": {
                 "version_added": "47"
@@ -775,7 +775,7 @@
         "indexOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.indexof",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.indexof",
             "support": {
               "chrome": {
                 "version_added": true
@@ -827,7 +827,7 @@
         "isArray": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.isarray",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.isarray",
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -879,7 +879,7 @@
         "join": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/join",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.join",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.join",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -931,7 +931,7 @@
         "keys": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/keys",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.keys",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.keys",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -983,7 +983,7 @@
         "lastIndexOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/lastIndexOf",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.lastindexof",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.lastindexof",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1035,7 +1035,7 @@
         "length": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/length",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-properties-of-array-instances-length",
+            "spec_url": "https://tc39.es/ecma262/#sec-properties-of-array-instances-length",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1087,7 +1087,7 @@
         "map": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/map",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.map",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.map",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1191,7 +1191,7 @@
         "of": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/of",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.of",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.of",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1243,7 +1243,7 @@
         "pop": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/pop",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.pop",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.pop",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1295,7 +1295,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/prototype",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1347,7 +1347,7 @@
         "push": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/push",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.push",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.push",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1399,7 +1399,7 @@
         "reduce": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.reduce",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.reduce",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1451,7 +1451,7 @@
         "reduceRight": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/reduceRight",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.reduceright",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.reduceright",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1503,7 +1503,7 @@
         "reverse": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.reverse",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.reverse",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1555,7 +1555,7 @@
         "shift": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/shift",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.shift",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.shift",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1607,7 +1607,7 @@
         "slice": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/slice",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.slice",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.slice",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1659,7 +1659,7 @@
         "some": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/some",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.some",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.some",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1711,7 +1711,7 @@
         "sort": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/sort",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.sort",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.sort",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1763,7 +1763,7 @@
         "splice": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/splice",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.splice",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.splice",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1816,8 +1816,8 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/toLocaleString",
             "spec_url": [
-              "https://tc39.github.io/ecma262/#sec-array.prototype.tolocalestring",
-              "https://tc39.github.io/ecma402/#sup-array.prototype.tolocalestring"
+              "https://tc39.es/ecma262/#sec-array.prototype.tolocalestring",
+              "https://tc39.es/ecma402/#sup-array.prototype.tolocalestring"
             ],
             "support": {
               "chrome": {
@@ -2023,7 +2023,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/toString",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.tostring",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2127,7 +2127,7 @@
         "unshift": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/unshift",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.unshift",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.unshift",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2179,7 +2179,7 @@
         "values": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/values",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype.values",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.values",
             "support": {
               "chrome": {
                 "version_added": "66"
@@ -2247,7 +2247,7 @@
         "@@iterator": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/@@iterator",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype-@@iterator",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype-@@iterator",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -2327,7 +2327,7 @@
         "@@species": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/@@species",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-get-array-@@species",
+            "spec_url": "https://tc39.es/ecma262/#sec-get-array-@@species",
             "support": {
               "chrome": {
                 "version_added": null
@@ -2390,7 +2390,7 @@
         "@@unscopables": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/@@unscopables",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-array.prototype-@@unscopables",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype-@@unscopables",
             "support": {
               "chrome": {
                 "version_added": null

--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -4,7 +4,7 @@
       "ArrayBuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-arraybuffer-constructor",
+          "spec_url": "https://tc39.es/ecma262/#sec-arraybuffer-constructor",
           "support": {
             "chrome": {
               "version_added": "7"
@@ -106,7 +106,7 @@
         "byteLength": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/byteLength",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-get-arraybuffer.prototype.bytelength",
+            "spec_url": "https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.bytelength",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -158,7 +158,7 @@
         "isView": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/isView",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-arraybuffer.isview",
+            "spec_url": "https://tc39.es/ecma262/#sec-arraybuffer.isview",
             "support": {
               "chrome": {
                 "version_added": true
@@ -210,7 +210,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/prototype",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-arraybuffer.prototype",
+            "spec_url": "https://tc39.es/ecma262/#sec-arraybuffer.prototype",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -262,7 +262,7 @@
         "slice": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/slice",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-arraybuffer.prototype.slice",
+            "spec_url": "https://tc39.es/ecma262/#sec-arraybuffer.prototype.slice",
             "support": {
               "chrome": {
                 "version_added": true
@@ -368,7 +368,7 @@
         "@@species": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/@@species",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-get-arraybuffer-@@species",
+            "spec_url": "https://tc39.es/ecma262/#sec-get-arraybuffer-@@species",
             "support": {
               "chrome": {
                 "version_added": null

--- a/javascript/builtins/AsyncFunction.json
+++ b/javascript/builtins/AsyncFunction.json
@@ -4,7 +4,7 @@
       "AsyncFunction": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncFunction",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-async-function-objects",
+          "spec_url": "https://tc39.es/ecma262/#sec-async-function-objects",
           "support": {
             "chrome": {
               "version_added": "55"
@@ -66,7 +66,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncFunction/prototype",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-async-function-constructor-prototype",
+            "spec_url": "https://tc39.es/ecma262/#sec-async-function-constructor-prototype",
             "support": {
               "chrome": {
                 "version_added": "55"

--- a/javascript/builtins/Atomics.json
+++ b/javascript/builtins/Atomics.json
@@ -4,7 +4,7 @@
       "Atomics": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-atomics-object",
+          "spec_url": "https://tc39.es/ecma262/#sec-atomics-object",
           "support": {
             "chrome": [
               {
@@ -119,7 +119,7 @@
         "add": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/add",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-atomics.add",
+            "spec_url": "https://tc39.es/ecma262/#sec-atomics.add",
             "support": {
               "chrome": [
                 {
@@ -235,7 +235,7 @@
         "and": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/and",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-atomics.and",
+            "spec_url": "https://tc39.es/ecma262/#sec-atomics.and",
             "support": {
               "chrome": [
                 {
@@ -351,7 +351,7 @@
         "compareExchange": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/compareExchange",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-atomics.compareexchange",
+            "spec_url": "https://tc39.es/ecma262/#sec-atomics.compareexchange",
             "support": {
               "chrome": [
                 {
@@ -467,7 +467,7 @@
         "exchange": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/exchange",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-atomics.exchange",
+            "spec_url": "https://tc39.es/ecma262/#sec-atomics.exchange",
             "support": {
               "chrome": [
                 {
@@ -583,7 +583,7 @@
         "isLockFree": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/isLockFree",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-atomics.islockfree",
+            "spec_url": "https://tc39.es/ecma262/#sec-atomics.islockfree",
             "support": {
               "chrome": [
                 {
@@ -699,7 +699,7 @@
         "load": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/load",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-atomics.load",
+            "spec_url": "https://tc39.es/ecma262/#sec-atomics.load",
             "support": {
               "chrome": [
                 {
@@ -815,7 +815,7 @@
         "notify": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/notify",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-atomics.notify",
+            "spec_url": "https://tc39.es/ecma262/#sec-atomics.notify",
             "support": {
               "chrome": [
                 {
@@ -986,7 +986,7 @@
         "or": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/or",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-atomics.or",
+            "spec_url": "https://tc39.es/ecma262/#sec-atomics.or",
             "support": {
               "chrome": [
                 {
@@ -1102,7 +1102,7 @@
         "store": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/store",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-atomics.store",
+            "spec_url": "https://tc39.es/ecma262/#sec-atomics.store",
             "support": {
               "chrome": [
                 {
@@ -1218,7 +1218,7 @@
         "sub": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/sub",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-atomics.sub",
+            "spec_url": "https://tc39.es/ecma262/#sec-atomics.sub",
             "support": {
               "chrome": [
                 {
@@ -1334,7 +1334,7 @@
         "wait": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-atomics.wait",
+            "spec_url": "https://tc39.es/ecma262/#sec-atomics.wait",
             "support": {
               "chrome": [
                 {
@@ -1476,7 +1476,7 @@
         "xor": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/xor",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-atomics.xor",
+            "spec_url": "https://tc39.es/ecma262/#sec-atomics.xor",
             "support": {
               "chrome": [
                 {

--- a/javascript/builtins/Boolean.json
+++ b/javascript/builtins/Boolean.json
@@ -4,7 +4,7 @@
       "Boolean": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-boolean-objects",
+          "spec_url": "https://tc39.es/ecma262/#sec-boolean-objects",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -55,7 +55,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean/prototype",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-boolean.prototype",
+            "spec_url": "https://tc39.es/ecma262/#sec-boolean.prototype",
             "support": {
               "chrome": {
                 "version_added": true
@@ -158,7 +158,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean/toString",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-boolean.prototype.tostring",
+            "spec_url": "https://tc39.es/ecma262/#sec-boolean.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -210,7 +210,7 @@
         "valueOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean/valueOf",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-boolean.prototype.valueof",
+            "spec_url": "https://tc39.es/ecma262/#sec-boolean.prototype.valueof",
             "support": {
               "chrome": {
                 "version_added": true

--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -4,7 +4,7 @@
       "DataView": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-dataview-constructor",
+          "spec_url": "https://tc39.es/ecma262/#sec-dataview-constructor",
           "support": {
             "chrome": {
               "version_added": "9"
@@ -157,7 +157,7 @@
         "buffer": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/buffer",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-get-dataview.prototype.buffer",
+            "spec_url": "https://tc39.es/ecma262/#sec-get-dataview.prototype.buffer",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -260,7 +260,7 @@
         "byteLength": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/byteLength",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-get-dataview.prototype.bytelength",
+            "spec_url": "https://tc39.es/ecma262/#sec-get-dataview.prototype.bytelength",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -312,7 +312,7 @@
         "byteOffset": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/byteOffset",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-get-dataview.prototype.byteoffset",
+            "spec_url": "https://tc39.es/ecma262/#sec-get-dataview.prototype.byteoffset",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -364,7 +364,7 @@
         "getBigInt64": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getBigInt64",
-            "spec_url": "https://tc39.github.io/proposal-bigint/#sec-dataview.prototype.getbigint64",
+            "spec_url": "https://tc39.es/proposal-bigint/#sec-dataview.prototype.getbigint64",
             "support": {
               "chrome": {
                 "version_added": "67"
@@ -419,7 +419,7 @@
         "getBigUint64": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getBigUint64",
-            "spec_url": "https://tc39.github.io/proposal-bigint/#sec-dataview.prototype.getbiguint64",
+            "spec_url": "https://tc39.es/proposal-bigint/#sec-dataview.prototype.getbiguint64",
             "support": {
               "chrome": {
                 "version_added": "67"
@@ -474,7 +474,7 @@
         "getFloat32": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getFloat32",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.getfloat32",
+            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.getfloat32",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -526,7 +526,7 @@
         "getFloat64": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getFloat64",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.getfloat64",
+            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.getfloat64",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -578,7 +578,7 @@
         "getInt16": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getInt16",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.getint16",
+            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.getint16",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -630,7 +630,7 @@
         "getInt32": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getInt32",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.getint32",
+            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.getint32",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -682,7 +682,7 @@
         "getInt8": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getInt8",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.getint8",
+            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.getint8",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -734,7 +734,7 @@
         "getUint16": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getUint16",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.getuint16",
+            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.getuint16",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -786,7 +786,7 @@
         "getUint32": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getUint32",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.getuint32",
+            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.getuint32",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -838,7 +838,7 @@
         "getUint8": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getUint8",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.getuint8",
+            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.getuint8",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -890,7 +890,7 @@
         "setBigInt64": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setBigInt64",
-            "spec_url": "https://tc39.github.io/proposal-bigint/#sec-dataview.prototype.setbigint64",
+            "spec_url": "https://tc39.es/proposal-bigint/#sec-dataview.prototype.setbigint64",
             "support": {
               "chrome": {
                 "version_added": "67"
@@ -945,7 +945,7 @@
         "setBigUint64": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setBigUint64",
-            "spec_url": "https://tc39.github.io/proposal-bigint/#sec-dataview.prototype.setbiguint64",
+            "spec_url": "https://tc39.es/proposal-bigint/#sec-dataview.prototype.setbiguint64",
             "support": {
               "chrome": {
                 "version_added": "67"
@@ -1000,7 +1000,7 @@
         "setFloat32": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setFloat32",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.setfloat32",
+            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.setfloat32",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -1052,7 +1052,7 @@
         "setFloat64": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setFloat64",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.setfloat64",
+            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.setfloat64",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -1104,7 +1104,7 @@
         "setInt16": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setInt16",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.setint16",
+            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.setint16",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -1156,7 +1156,7 @@
         "setInt32": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setInt32",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.setint32",
+            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.setint32",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -1208,7 +1208,7 @@
         "setInt8": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setInt8",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.setint8",
+            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.setint8",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -1260,7 +1260,7 @@
         "setUint16": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setUint16",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.setuint16",
+            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.setuint16",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -1312,7 +1312,7 @@
         "setUint32": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setUint32",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.setuint32",
+            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.setuint32",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -1364,7 +1364,7 @@
         "setUint8": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setUint8",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype.setuint8",
+            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.setuint8",
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -1416,7 +1416,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/prototype",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-dataview.prototype",
+            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype",
             "support": {
               "chrome": {
                 "version_added": "9"

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -4,7 +4,7 @@
       "Date": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-date-objects",
+          "spec_url": "https://tc39.es/ecma262/#sec-date-objects",
           "support": {
             "chrome": {
               "version_added": true
@@ -56,7 +56,7 @@
         "@@toPrimitive": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/@@toPrimitive",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype-@@toprimitive",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype-@@toprimitive",
             "support": {
               "chrome": {
                 "version_added": null
@@ -108,7 +108,7 @@
         "UTC": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/UTC",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.utc",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.utc",
             "support": {
               "chrome": {
                 "version_added": true
@@ -160,7 +160,7 @@
         "getDate": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getDate",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getdate",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getdate",
             "support": {
               "chrome": {
                 "version_added": true
@@ -212,7 +212,7 @@
         "getDay": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getDay",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getday",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getday",
             "support": {
               "chrome": {
                 "version_added": true
@@ -264,7 +264,7 @@
         "getFullYear": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getFullYear",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getfullyear",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getfullyear",
             "support": {
               "chrome": {
                 "version_added": true
@@ -316,7 +316,7 @@
         "getHours": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getHours",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.gethours",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.gethours",
             "support": {
               "chrome": {
                 "version_added": true
@@ -368,7 +368,7 @@
         "getMilliseconds": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getMilliseconds",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getmilliseconds",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getmilliseconds",
             "support": {
               "chrome": {
                 "version_added": true
@@ -420,7 +420,7 @@
         "getMinutes": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getMinutes",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getminutes",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getminutes",
             "support": {
               "chrome": {
                 "version_added": true
@@ -472,7 +472,7 @@
         "getMonth": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getMonth",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getmonth",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getmonth",
             "support": {
               "chrome": {
                 "version_added": true
@@ -524,7 +524,7 @@
         "getSeconds": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getSeconds",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getseconds",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getseconds",
             "support": {
               "chrome": {
                 "version_added": true
@@ -576,7 +576,7 @@
         "getTime": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.gettime",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.gettime",
             "support": {
               "chrome": {
                 "version_added": true
@@ -628,7 +628,7 @@
         "getTimezoneOffset": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getTimezoneOffset",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.gettimezoneoffset",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.gettimezoneoffset",
             "support": {
               "chrome": {
                 "version_added": true
@@ -680,7 +680,7 @@
         "getUTCDate": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCDate",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getutcdate",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getutcdate",
             "support": {
               "chrome": {
                 "version_added": true
@@ -732,7 +732,7 @@
         "getUTCDay": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCDay",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getutcday",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getutcday",
             "support": {
               "chrome": {
                 "version_added": true
@@ -784,7 +784,7 @@
         "getUTCFullYear": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCFullYear",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getutcfullyear",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getutcfullyear",
             "support": {
               "chrome": {
                 "version_added": true
@@ -836,7 +836,7 @@
         "getUTCHours": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCHours",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getutchours",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getutchours",
             "support": {
               "chrome": {
                 "version_added": true
@@ -888,7 +888,7 @@
         "getUTCMilliseconds": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCMilliseconds",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getutcmilliseconds",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getutcmilliseconds",
             "support": {
               "chrome": {
                 "version_added": true
@@ -940,7 +940,7 @@
         "getUTCMinutes": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCMinutes",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getutcminutes",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getutcminutes",
             "support": {
               "chrome": {
                 "version_added": true
@@ -992,7 +992,7 @@
         "getUTCMonth": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCMonth",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getutcmonth",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getutcmonth",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1044,7 +1044,7 @@
         "getUTCSeconds": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCSeconds",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getutcseconds",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getutcseconds",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1096,7 +1096,7 @@
         "getYear": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getYear",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.getyear",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.getyear",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1148,7 +1148,7 @@
         "now": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/now",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.now",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.now",
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -1200,7 +1200,7 @@
         "parse": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/parse",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.parse",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.parse",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1303,7 +1303,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/prototype",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-properties-of-the-date-prototype-object",
+            "spec_url": "https://tc39.es/ecma262/#sec-properties-of-the-date-prototype-object",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1357,7 +1357,7 @@
         "setDate": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setDate",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.setdate",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.setdate",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1409,7 +1409,7 @@
         "setFullYear": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setFullYear",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.setfullyear",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.setfullyear",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1461,7 +1461,7 @@
         "setHours": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setHours",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.sethours",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.sethours",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1513,7 +1513,7 @@
         "setMilliseconds": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setMilliseconds",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.setmilliseconds",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.setmilliseconds",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1565,7 +1565,7 @@
         "setMinutes": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setMinutes",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.setminutes",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.setminutes",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1617,7 +1617,7 @@
         "setMonth": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setMonth",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.setmonth",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.setmonth",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1669,7 +1669,7 @@
         "setSeconds": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setSeconds",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.setseconds",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.setseconds",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1721,7 +1721,7 @@
         "setTime": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setTime",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.settime",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.settime",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1773,7 +1773,7 @@
         "setUTCDate": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCDate",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.setutcdate",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.setutcdate",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1825,7 +1825,7 @@
         "setUTCFullYear": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCFullYear",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.setutcfullyear",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.setutcfullyear",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1877,7 +1877,7 @@
         "setUTCHours": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCHours",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.setutchours",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.setutchours",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1929,7 +1929,7 @@
         "setUTCMilliseconds": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCMilliseconds",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.setutcmilliseconds",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.setutcmilliseconds",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1981,7 +1981,7 @@
         "setUTCMinutes": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCMinutes",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.setutcminutes",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.setutcminutes",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2033,7 +2033,7 @@
         "setUTCMonth": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCMonth",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.setutcmonth",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.setutcmonth",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2085,7 +2085,7 @@
         "setUTCSeconds": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCSeconds",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.setutcseconds",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.setutcseconds",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2137,7 +2137,7 @@
         "setYear": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setYear",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.setyear",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.setyear",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2189,7 +2189,7 @@
         "toDateString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toDateString",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.todatestring",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.todatestring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2241,7 +2241,7 @@
         "toGMTString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toGMTString",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.togmtstring",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.togmtstring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2293,7 +2293,7 @@
         "toISOString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.toisostring",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.toisostring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2345,7 +2345,7 @@
         "toJSON": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toJSON",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.tojson",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.tojson",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2398,8 +2398,8 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString",
             "spec_url": [
-              "https://tc39.github.io/ecma262/#sec-date.prototype.tolocaledatestring",
-              "https://tc39.github.io/ecma402/#sec-Date.prototype.toLocaleDateString"
+              "https://tc39.es/ecma262/#sec-date.prototype.tolocaledatestring",
+              "https://tc39.es/ecma402/#sec-Date.prototype.toLocaleDateString"
             ],
             "support": {
               "chrome": {
@@ -2657,8 +2657,8 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString",
             "spec_url": [
-              "https://tc39.github.io/ecma262/#sec-date.prototype.tolocalestring",
-              "https://tc39.github.io/ecma402/#sec-Date.prototype.toLocaleString"
+              "https://tc39.es/ecma262/#sec-date.prototype.tolocalestring",
+              "https://tc39.es/ecma402/#sec-Date.prototype.toLocaleString"
             ],
             "support": {
               "chrome": {
@@ -2863,8 +2863,8 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString",
             "spec_url": [
-              "https://tc39.github.io/ecma262/#sec-date.prototype.tolocalestring",
-              "https://tc39.github.io/ecma402/#sec-Date.prototype.toLocaleTimeString"
+              "https://tc39.es/ecma262/#sec-date.prototype.tolocalestring",
+              "https://tc39.es/ecma402/#sec-Date.prototype.toLocaleTimeString"
             ],
             "support": {
               "chrome": {
@@ -3119,7 +3119,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toString",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.tostring",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -3171,7 +3171,7 @@
         "toTimeString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toTimeString",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.totimestring",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.totimestring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -3223,7 +3223,7 @@
         "toUTCString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toUTCString",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.toutcstring",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.toutcstring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -3275,7 +3275,7 @@
         "valueOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/valueOf",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-date.prototype.valueof",
+            "spec_url": "https://tc39.es/ecma262/#sec-date.prototype.valueof",
             "support": {
               "chrome": {
                 "version_added": true

--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -4,7 +4,7 @@
       "Error": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-error-objects",
+          "spec_url": "https://tc39.es/ecma262/#sec-error-objects",
           "support": {
             "chrome": {
               "version_added": true
@@ -55,7 +55,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error/prototype",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-error.prototype",
+            "spec_url": "https://tc39.es/ecma262/#sec-error.prototype",
             "support": {
               "chrome": {
                 "version_added": true
@@ -260,7 +260,7 @@
         "message": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error/message",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-error.prototype.message",
+            "spec_url": "https://tc39.es/ecma262/#sec-error.prototype.message",
             "support": {
               "chrome": {
                 "version_added": true
@@ -312,7 +312,7 @@
         "name": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error/name",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-error.prototype.name",
+            "spec_url": "https://tc39.es/ecma262/#sec-error.prototype.name",
             "support": {
               "chrome": {
                 "version_added": true
@@ -466,7 +466,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error/toString",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-error.prototype.tostring",
+            "spec_url": "https://tc39.es/ecma262/#sec-error.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": true

--- a/javascript/builtins/EvalError.json
+++ b/javascript/builtins/EvalError.json
@@ -4,7 +4,7 @@
       "EvalError": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/EvalError",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-evalerror",
+          "spec_url": "https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-evalerror",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/builtins/Float32Array.json
+++ b/javascript/builtins/Float32Array.json
@@ -4,7 +4,7 @@
       "Float32Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float32Array",
-          "spec_url": "https://tc39.github.io/ecma262/#table-49",
+          "spec_url": "https://tc39.es/ecma262/#table-49",
           "support": {
             "chrome": {
               "version_added": "7"

--- a/javascript/builtins/Float64Array.json
+++ b/javascript/builtins/Float64Array.json
@@ -4,7 +4,7 @@
       "Float64Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float64Array",
-          "spec_url": "https://tc39.github.io/ecma262/#table-49",
+          "spec_url": "https://tc39.es/ecma262/#table-49",
           "support": {
             "chrome": {
               "version_added": "7"

--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -4,7 +4,7 @@
       "Function": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-function-objects",
+          "spec_url": "https://tc39.es/ecma262/#sec-function-objects",
           "support": {
             "chrome": {
               "version_added": true
@@ -55,7 +55,7 @@
         "arguments": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/arguments",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-arguments-object",
+            "spec_url": "https://tc39.es/ecma262/#sec-arguments-object",
             "support": {
               "chrome": {
                 "version_added": true
@@ -260,7 +260,7 @@
         "length": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/length",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-function-instances-length",
+            "spec_url": "https://tc39.es/ecma262/#sec-function-instances-length",
             "support": {
               "chrome": {
                 "version_added": true
@@ -363,7 +363,7 @@
         "name": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/name",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-function-instances-name",
+            "spec_url": "https://tc39.es/ecma262/#sec-function-instances-name",
             "support": {
               "chrome": {
                 "version_added": "15"
@@ -517,7 +517,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/prototype",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-function-instances-prototype",
+            "spec_url": "https://tc39.es/ecma262/#sec-function-instances-prototype",
             "support": {
               "chrome": {
                 "version_added": true
@@ -569,7 +569,7 @@
         "apply": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/apply",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-function.prototype.apply",
+            "spec_url": "https://tc39.es/ecma262/#sec-function.prototype.apply",
             "support": {
               "chrome": {
                 "version_added": true
@@ -672,7 +672,7 @@
         "bind": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/bind",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-function.prototype.bind",
+            "spec_url": "https://tc39.es/ecma262/#sec-function.prototype.bind",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -724,7 +724,7 @@
         "call": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/call",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-function.prototype.call",
+            "spec_url": "https://tc39.es/ecma262/#sec-function.prototype.call",
             "support": {
               "chrome": {
                 "version_added": true
@@ -881,8 +881,8 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/toString",
             "spec_url": [
-              "https://tc39.github.io/Function-prototype-toString-revision/#sec-introduction",
-              "https://tc39.github.io/ecma262/#sec-function.prototype.tostring"
+              "https://tc39.es/Function-prototype-toString-revision/#sec-introduction",
+              "https://tc39.es/ecma262/#sec-function.prototype.tostring"
             ],
             "support": {
               "chrome": {
@@ -933,7 +933,7 @@
           },
           "toString_revision": {
             "__compat": {
-              "description": "Support of <a href='http://tc39.github.io/Function-prototype-toString-revision/'>toString revision</a>",
+              "description": "Support of <a href='http://tc39.es/Function-prototype-toString-revision/'>toString revision</a>",
               "support": {
                 "chrome": {
                   "version_added": false

--- a/javascript/builtins/Generator.json
+++ b/javascript/builtins/Generator.json
@@ -4,7 +4,7 @@
       "Generator": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Generator",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-generator-objects",
+          "spec_url": "https://tc39.es/ecma262/#sec-generator-objects",
           "support": {
             "chrome": {
               "version_added": "39"
@@ -66,7 +66,7 @@
         "next": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Generator/next",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-generator.prototype.next",
+            "spec_url": "https://tc39.es/ecma262/#sec-generator.prototype.next",
             "support": {
               "chrome": {
                 "version_added": "39"
@@ -118,7 +118,7 @@
         "return": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Generator/return",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-generator.prototype.return",
+            "spec_url": "https://tc39.es/ecma262/#sec-generator.prototype.return",
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -170,7 +170,7 @@
         "throw": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Generator/throw",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-generator.prototype.throw",
+            "spec_url": "https://tc39.es/ecma262/#sec-generator.prototype.throw",
             "support": {
               "chrome": {
                 "version_added": "39"

--- a/javascript/builtins/GeneratorFunction.json
+++ b/javascript/builtins/GeneratorFunction.json
@@ -4,7 +4,7 @@
       "GeneratorFunction": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/GeneratorFunction",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-generatorfunction-objects",
+          "spec_url": "https://tc39.es/ecma262/#sec-generatorfunction-objects",
           "support": {
             "chrome": {
               "version_added": true
@@ -55,7 +55,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/GeneratorFunction/prototype",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-generatorfunction.prototype",
+            "spec_url": "https://tc39.es/ecma262/#sec-generatorfunction.prototype",
             "support": {
               "chrome": {
                 "version_added": true

--- a/javascript/builtins/Int16Array.json
+++ b/javascript/builtins/Int16Array.json
@@ -4,7 +4,7 @@
       "Int16Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int16Array",
-          "spec_url": "https://tc39.github.io/ecma262/#table-49",
+          "spec_url": "https://tc39.es/ecma262/#table-49",
           "support": {
             "chrome": {
               "version_added": "7"

--- a/javascript/builtins/Int32Array.json
+++ b/javascript/builtins/Int32Array.json
@@ -4,7 +4,7 @@
       "Int32Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int32Array",
-          "spec_url": "https://tc39.github.io/ecma262/#table-49",
+          "spec_url": "https://tc39.es/ecma262/#table-49",
           "support": {
             "chrome": {
               "version_added": "7"

--- a/javascript/builtins/Int8Array.json
+++ b/javascript/builtins/Int8Array.json
@@ -4,7 +4,7 @@
       "Int8Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int8Array",
-          "spec_url": "https://tc39.github.io/ecma262/#table-49",
+          "spec_url": "https://tc39.es/ecma262/#table-49",
           "support": {
             "chrome": {
               "version_added": "7"

--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -4,7 +4,7 @@
       "Intl": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl",
-          "spec_url": "https://tc39.github.io/ecma402/#intl-object",
+          "spec_url": "https://tc39.es/ecma402/#intl-object",
           "support": {
             "chrome": {
               "version_added": "24"
@@ -55,7 +55,7 @@
         "getCanonicalLocales": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/getCanonicalLocales",
-            "spec_url": "https://tc39.github.io/ecma402/#sec-intl.getcanonicallocales",
+            "spec_url": "https://tc39.es/ecma402/#sec-intl.getcanonicallocales",
             "support": {
               "chrome": {
                 "version_added": "54"
@@ -107,7 +107,7 @@
         "Collator": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Collator",
-            "spec_url": "https://tc39.github.io/ecma402/#collator-objects",
+            "spec_url": "https://tc39.es/ecma402/#collator-objects",
             "support": {
               "chrome": {
                 "version_added": "24"
@@ -209,7 +209,7 @@
           "prototype": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Collator/prototype",
-              "spec_url": "https://tc39.github.io/ecma402/#sec-Intl.Collator.prototype",
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.Collator.prototype",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -261,7 +261,7 @@
           "compare": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Collator/compare",
-              "spec_url": "https://tc39.github.io/ecma402/#sec-Intl.Collator.prototype.compare",
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.Collator.prototype.compare",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -313,7 +313,7 @@
           "resolvedOptions": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Collator/resolvedOptions",
-              "spec_url": "https://tc39.github.io/ecma402/#sec-Intl.Collator.prototype.resolvedOptions",
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.Collator.prototype.resolvedOptions",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -365,7 +365,7 @@
           "supportedLocalesOf": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Collator/supportedLocalesOf",
-              "spec_url": "https://tc39.github.io/ecma402/#sec-Intl.Collator.supportedLocalesOf",
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.Collator.supportedLocalesOf",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -418,7 +418,7 @@
         "DateTimeFormat": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat",
-            "spec_url": "https://tc39.github.io/ecma402/#datetimeformat-objects",
+            "spec_url": "https://tc39.es/ecma402/#datetimeformat-objects",
             "support": {
               "chrome": {
                 "version_added": "24"
@@ -570,7 +570,7 @@
           "prototype": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/prototype",
-              "spec_url": "https://tc39.github.io/ecma402/#sec-Intl.DateTimeFormat.prototype",
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.DateTimeFormat.prototype",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -622,7 +622,7 @@
           "format": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/format",
-              "spec_url": "https://tc39.github.io/ecma402/#sec-Intl.DateTimeFormat.prototype.format",
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.DateTimeFormat.prototype.format",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -674,7 +674,7 @@
           "formatToParts": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/formatToParts",
-              "spec_url": "https://tc39.github.io/ecma402/#sec-Intl.DateTimeFormat.prototype.formatToParts",
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.DateTimeFormat.prototype.formatToParts",
               "support": {
                 "chrome": {
                   "version_added": "57",
@@ -729,7 +729,7 @@
           "resolvedOptions": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/resolvedOptions",
-              "spec_url": "https://tc39.github.io/ecma402/#sec-Intl.DateTimeFormat.prototype.resolvedOptions",
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.DateTimeFormat.prototype.resolvedOptions",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -832,7 +832,7 @@
           "supportedLocalesOf": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Collator/supportedLocalesOf",
-              "spec_url": "https://tc39.github.io/ecma402/#sec-Intl.Collator.supportedLocalesOf",
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.Collator.supportedLocalesOf",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -885,7 +885,7 @@
         "ListFormat": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ListFormat",
-            "spec_url": "https://tc39.github.io/proposal-intl-list-format/#listformat-objects",
+            "spec_url": "https://tc39.es/proposal-intl-list-format/#listformat-objects",
             "support": {
               "chrome": {
                 "version_added": "72"
@@ -936,7 +936,7 @@
           "prototype": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ListFormat/prototype",
-              "spec_url": "https://tc39.github.io/proposal-intl-list-format/#sec-Intl.ListFormat.prototype",
+              "spec_url": "https://tc39.es/proposal-intl-list-format/#sec-Intl.ListFormat.prototype",
               "support": {
                 "chrome": {
                   "version_added": "72"
@@ -988,7 +988,7 @@
           "format": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ListFormat/format",
-              "spec_url": "https://tc39.github.io/proposal-intl-list-format/#sec-Intl.ListFormat.prototype.format",
+              "spec_url": "https://tc39.es/proposal-intl-list-format/#sec-Intl.ListFormat.prototype.format",
               "support": {
                 "chrome": {
                   "version_added": "72"
@@ -1040,7 +1040,7 @@
           "formatToParts": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ListFormat/formatToParts",
-              "spec_url": "https://tc39.github.io/proposal-intl-list-format/#sec-Intl.ListFormat.prototype.formatToParts",
+              "spec_url": "https://tc39.es/proposal-intl-list-format/#sec-Intl.ListFormat.prototype.formatToParts",
               "support": {
                 "chrome": {
                   "version_added": "72"
@@ -1092,7 +1092,7 @@
           "resolvedOptions": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ListFormat/resolvedOptions",
-              "spec_url": "https://tc39.github.io/proposal-intl-list-format/#sec-Intl.ListFormat.prototype.resolvedOptions",
+              "spec_url": "https://tc39.es/proposal-intl-list-format/#sec-Intl.ListFormat.prototype.resolvedOptions",
               "support": {
                 "chrome": {
                   "version_added": "72"
@@ -1144,7 +1144,7 @@
           "supportedLocalesOf": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ListFormat/supportedLocalesOf",
-              "spec_url": "https://tc39.github.io/proposal-intl-list-format/#sec-Intl.ListFormat.supportedLocalesOf",
+              "spec_url": "https://tc39.es/proposal-intl-list-format/#sec-Intl.ListFormat.supportedLocalesOf",
               "support": {
                 "chrome": {
                   "version_added": "72"
@@ -1197,7 +1197,7 @@
         "Locale": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale",
-            "spec_url": "https://tc39.github.io/proposal-intl-locale/#locale-objects",
+            "spec_url": "https://tc39.es/proposal-intl-locale/#locale-objects",
             "support": {
               "chrome": {
                 "version_added": "74"
@@ -1248,7 +1248,7 @@
           "prototype": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/prototype",
-              "spec_url": "https://tc39.github.io/proposal-intl-locale/#sec-Intl.Locale.prototype",
+              "spec_url": "https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype",
               "support": {
                 "chrome": {
                   "version_added": "74"
@@ -1300,7 +1300,7 @@
           "maximize": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/maximize",
-              "spec_url": "https://tc39.github.io/proposal-intl-locale/#sec-Intl.Locale.prototype.maximize",
+              "spec_url": "https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.maximize",
               "support": {
                 "chrome": {
                   "version_added": "74"
@@ -1352,7 +1352,7 @@
           "minimize": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/minimize",
-              "spec_url": "https://tc39.github.io/proposal-intl-locale/#sec-Intl.Locale.prototype.minimize",
+              "spec_url": "https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.minimize",
               "support": {
                 "chrome": {
                   "version_added": "74"
@@ -1404,7 +1404,7 @@
           "toString": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/toString",
-              "spec_url": "https://tc39.github.io/proposal-intl-locale/#sec-Intl.Locale.prototype.toString",
+              "spec_url": "https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.toString",
               "support": {
                 "chrome": {
                   "version_added": "74"
@@ -1456,7 +1456,7 @@
           "baseName": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/baseName",
-              "spec_url": "https://tc39.github.io/proposal-intl-locale/#sec-Intl.Locale.prototype.baseName",
+              "spec_url": "https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.baseName",
               "support": {
                 "chrome": {
                   "version_added": "74"
@@ -1508,7 +1508,7 @@
           "calendar": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/calendar",
-              "spec_url": "https://tc39.github.io/proposal-intl-locale/#sec-Intl.Locale.prototype.calendar",
+              "spec_url": "https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.calendar",
               "support": {
                 "chrome": {
                   "version_added": "74"
@@ -1560,7 +1560,7 @@
           "collation": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/collation",
-              "spec_url": "https://tc39.github.io/proposal-intl-locale/#sec-Intl.Locale.prototype.collation",
+              "spec_url": "https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.collation",
               "support": {
                 "chrome": {
                   "version_added": "74"
@@ -1612,7 +1612,7 @@
           "hourCycle": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/hourCycle",
-              "spec_url": "https://tc39.github.io/proposal-intl-locale/#sec-Intl.Locale.prototype.hourCycle",
+              "spec_url": "https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.hourCycle",
               "support": {
                 "chrome": {
                   "version_added": "74"
@@ -1664,7 +1664,7 @@
           "caseFirst": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/caseFirst",
-              "spec_url": "https://tc39.github.io/proposal-intl-locale/#sec-Intl.Locale.prototype.caseFirst",
+              "spec_url": "https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.caseFirst",
               "support": {
                 "chrome": {
                   "version_added": "74"
@@ -1716,7 +1716,7 @@
           "numeric": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/numeric",
-              "spec_url": "https://tc39.github.io/proposal-intl-locale/#sec-Intl.Locale.prototype.numeric",
+              "spec_url": "https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.numeric",
               "support": {
                 "chrome": {
                   "version_added": "74"
@@ -1768,7 +1768,7 @@
           "numberingSystem": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/numberingSystem",
-              "spec_url": "https://tc39.github.io/proposal-intl-locale/#sec-Intl.Locale.prototype.numberingSystem",
+              "spec_url": "https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.numberingSystem",
               "support": {
                 "chrome": {
                   "version_added": "74"
@@ -1820,7 +1820,7 @@
           "language": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/language",
-              "spec_url": "https://tc39.github.io/proposal-intl-locale/#sec-Intl.Locale.prototype.language",
+              "spec_url": "https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.language",
               "support": {
                 "chrome": {
                   "version_added": "74"
@@ -1872,7 +1872,7 @@
           "script": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/script",
-              "spec_url": "https://tc39.github.io/proposal-intl-locale/#sec-Intl.Locale.prototype.script",
+              "spec_url": "https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.script",
               "support": {
                 "chrome": {
                   "version_added": "74"
@@ -1924,7 +1924,7 @@
           "region": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/region",
-              "spec_url": "https://tc39.github.io/proposal-intl-locale/#sec-Intl.Locale.prototype.region",
+              "spec_url": "https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.region",
               "support": {
                 "chrome": {
                   "version_added": "74"
@@ -1977,7 +1977,7 @@
         "NumberFormat": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat",
-            "spec_url": "https://tc39.github.io/ecma402/#numberformat-objects",
+            "spec_url": "https://tc39.es/ecma402/#numberformat-objects",
             "support": {
               "chrome": {
                 "version_added": "24"
@@ -2028,7 +2028,7 @@
           "prototype": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat/prototype",
-              "spec_url": "https://tc39.github.io/ecma402/#sec-Intl.NumberFormat.prototype",
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.NumberFormat.prototype",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -2080,7 +2080,7 @@
           "format": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat/format",
-              "spec_url": "https://tc39.github.io/ecma402/#sec-Intl.NumberFormat.prototype.format",
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.NumberFormat.prototype.format",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -2132,7 +2132,7 @@
           "formatToParts": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat/formatToParts",
-              "spec_url": "https://tc39.github.io/ecma402/#sec-Intl.NumberFormat.prototype.formatToParts",
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.NumberFormat.prototype.formatToParts",
               "support": {
                 "chrome": {
                   "version_added": "64"
@@ -2184,7 +2184,7 @@
           "resolvedOptions": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat/resolvedOptions",
-              "spec_url": "https://tc39.github.io/ecma402/#sec-Intl.NumberFormat.prototype.resolvedOptions",
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.NumberFormat.prototype.resolvedOptions",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -2236,7 +2236,7 @@
           "supportedLocalesOf": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat/supportedLocalesOf",
-              "spec_url": "https://tc39.github.io/ecma402/#sec-Intl.NumberFormat.supportedLocalesOf",
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.NumberFormat.supportedLocalesOf",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -2289,7 +2289,7 @@
         "PluralRules": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/PluralRules",
-            "spec_url": "https://tc39.github.io/ecma402/#pluralrules-objects",
+            "spec_url": "https://tc39.es/ecma402/#pluralrules-objects",
             "support": {
               "chrome": {
                 "version_added": "63"
@@ -2340,7 +2340,7 @@
           "PluralRules": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/PluralRules",
-              "spec_url": "https://tc39.github.io/ecma402/#sec-intl-pluralrules-constructor",
+              "spec_url": "https://tc39.es/ecma402/#sec-intl-pluralrules-constructor",
               "description": "<code>PluralRules()</code> constructor",
               "support": {
                 "chrome": {
@@ -2598,7 +2598,7 @@
         "RelativeTimeFormat": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat",
-            "spec_url": "https://tc39.github.io/proposal-intl-relative-time/#relativetimeformat-objects",
+            "spec_url": "https://tc39.es/proposal-intl-relative-time/#relativetimeformat-objects",
             "support": {
               "chrome": {
                 "version_added": "71"
@@ -2649,7 +2649,7 @@
           "format": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/format",
-              "spec_url": "https://tc39.github.io/proposal-intl-relative-time/#sec-Intl.RelativeTimeFormat.prototype.format",
+              "spec_url": "https://tc39.es/proposal-intl-relative-time/#sec-Intl.RelativeTimeFormat.prototype.format",
               "support": {
                 "chrome": {
                   "version_added": "71"
@@ -2701,7 +2701,7 @@
           "formatToParts": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/formatToParts",
-              "spec_url": "https://tc39.github.io/proposal-intl-relative-time/#sec-Intl.RelativeTimeFormat.prototype.formatToParts",
+              "spec_url": "https://tc39.es/proposal-intl-relative-time/#sec-Intl.RelativeTimeFormat.prototype.formatToParts",
               "support": {
                 "chrome": {
                   "version_added": "71"
@@ -2753,7 +2753,7 @@
           "prototype": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/prototype",
-              "spec_url": "https://tc39.github.io/proposal-intl-relative-time/#sec-Intl.RelativeTimeFormat.prototype",
+              "spec_url": "https://tc39.es/proposal-intl-relative-time/#sec-Intl.RelativeTimeFormat.prototype",
               "support": {
                 "chrome": {
                   "version_added": "71"
@@ -2805,7 +2805,7 @@
           "resolvedOptions": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/resolvedOptions",
-              "spec_url": "https://tc39.github.io/proposal-intl-relative-time/#sec-intl.relativetimeformat.prototype.resolvedoptions",
+              "spec_url": "https://tc39.es/proposal-intl-relative-time/#sec-intl.relativetimeformat.prototype.resolvedoptions",
               "support": {
                 "chrome": {
                   "version_added": "71"
@@ -2857,7 +2857,7 @@
           "supportedLocalesOf": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/supportedLocalesOf",
-              "spec_url": "https://tc39.github.io/proposal-intl-relative-time/#sec-Intl.RelativeTimeFormat.supportedLocalesOf",
+              "spec_url": "https://tc39.es/proposal-intl-relative-time/#sec-Intl.RelativeTimeFormat.supportedLocalesOf",
               "support": {
                 "chrome": {
                   "version_added": "71"

--- a/javascript/builtins/JSON.json
+++ b/javascript/builtins/JSON.json
@@ -4,7 +4,7 @@
       "JSON": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/JSON",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-json-object",
+          "spec_url": "https://tc39.es/ecma262/#sec-json-object",
           "support": {
             "chrome": {
               "version_added": true
@@ -55,7 +55,7 @@
         "parse": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-json.parse",
+            "spec_url": "https://tc39.es/ecma262/#sec-json.parse",
             "support": {
               "chrome": {
                 "version_added": true
@@ -107,7 +107,7 @@
         "stringify": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-json.stringify",
+            "spec_url": "https://tc39.es/ecma262/#sec-json.stringify",
             "support": {
               "chrome": {
                 "version_added": true

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -4,7 +4,7 @@
       "Map": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-map-objects",
+          "spec_url": "https://tc39.es/ecma262/#sec-map-objects",
           "support": {
             "chrome": {
               "version_added": "38"
@@ -281,7 +281,7 @@
         "clear": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/clear",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-map.prototype.clear",
+            "spec_url": "https://tc39.es/ecma262/#sec-map.prototype.clear",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -333,7 +333,7 @@
         "delete": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/delete",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-map.prototype.delete",
+            "spec_url": "https://tc39.es/ecma262/#sec-map.prototype.delete",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -396,7 +396,7 @@
         "entries": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/entries",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-map.prototype.entries",
+            "spec_url": "https://tc39.es/ecma262/#sec-map.prototype.entries",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -448,7 +448,7 @@
         "forEach": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/forEach",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-map.prototype.foreach",
+            "spec_url": "https://tc39.es/ecma262/#sec-map.prototype.foreach",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -500,7 +500,7 @@
         "get": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/get",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-map.prototype.get",
+            "spec_url": "https://tc39.es/ecma262/#sec-map.prototype.get",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -552,7 +552,7 @@
         "has": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/has",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-map.prototype.has",
+            "spec_url": "https://tc39.es/ecma262/#sec-map.prototype.has",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -604,7 +604,7 @@
         "keys": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/keys",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-map.prototype.keys",
+            "spec_url": "https://tc39.es/ecma262/#sec-map.prototype.keys",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -656,7 +656,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/prototype",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-map.prototype",
+            "spec_url": "https://tc39.es/ecma262/#sec-map.prototype",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -708,7 +708,7 @@
         "set": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/set",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-map.prototype.set",
+            "spec_url": "https://tc39.es/ecma262/#sec-map.prototype.set",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -762,7 +762,7 @@
         "size": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/size",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-get-map.prototype.size",
+            "spec_url": "https://tc39.es/ecma262/#sec-get-map.prototype.size",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -816,7 +816,7 @@
         "values": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/values",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-map.prototype.values",
+            "spec_url": "https://tc39.es/ecma262/#sec-map.prototype.values",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -868,7 +868,7 @@
         "@@iterator": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/@@iterator",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-map.prototype-@@iterator",
+            "spec_url": "https://tc39.es/ecma262/#sec-map.prototype-@@iterator",
             "support": {
               "chrome": {
                 "version_added": true
@@ -948,7 +948,7 @@
         "@@species": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/@@species",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-get-map-@@species",
+            "spec_url": "https://tc39.es/ecma262/#sec-get-map-@@species",
             "support": {
               "chrome": {
                 "version_added": "51"
@@ -1011,7 +1011,7 @@
         "@@toStringTag": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/@@toStringTag",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-map.prototype-@@tostringtag",
+            "spec_url": "https://tc39.es/ecma262/#sec-map.prototype-@@tostringtag",
             "support": {
               "chrome": {
                 "version_added": "44"

--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -5,7 +5,7 @@
         "E": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/E",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.e",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.e",
             "support": {
               "chrome": {
                 "version_added": true
@@ -57,7 +57,7 @@
         "LN2": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/LN2",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.ln2",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.ln2",
             "support": {
               "chrome": {
                 "version_added": true
@@ -109,7 +109,7 @@
         "LN10": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/LN10",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.ln10",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.ln10",
             "support": {
               "chrome": {
                 "version_added": true
@@ -161,7 +161,7 @@
         "LOG2E": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/LOG2E",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.log2e",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.log2e",
             "support": {
               "chrome": {
                 "version_added": true
@@ -213,7 +213,7 @@
         "LOG10E": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/LOG10E",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.log10e",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.log10e",
             "support": {
               "chrome": {
                 "version_added": true
@@ -265,7 +265,7 @@
         "PI": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/PI",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.pi",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.pi",
             "support": {
               "chrome": {
                 "version_added": true
@@ -317,7 +317,7 @@
         "SQRT1_2": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/SQRT1_2",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.sqrt1_2",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.sqrt1_2",
             "support": {
               "chrome": {
                 "version_added": true
@@ -369,7 +369,7 @@
         "SQRT2": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/SQRT2",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.sqrt2",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.sqrt2",
             "support": {
               "chrome": {
                 "version_added": true
@@ -421,7 +421,7 @@
         "abs": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/abs",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.abs",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.abs",
             "support": {
               "chrome": {
                 "version_added": true
@@ -473,7 +473,7 @@
         "acos": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/acos",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.acos",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.acos",
             "support": {
               "chrome": {
                 "version_added": true
@@ -525,7 +525,7 @@
         "acosh": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/acosh",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.acosh",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.acosh",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -577,7 +577,7 @@
         "asin": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/asin",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.asin",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.asin",
             "support": {
               "chrome": {
                 "version_added": true
@@ -629,7 +629,7 @@
         "asinh": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/asinh",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.asinh",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.asinh",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -681,7 +681,7 @@
         "atan": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/atan",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.atan",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.atan",
             "support": {
               "chrome": {
                 "version_added": true
@@ -733,7 +733,7 @@
         "atan2": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/atan2",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.atan2",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.atan2",
             "support": {
               "chrome": {
                 "version_added": true
@@ -785,7 +785,7 @@
         "atanh": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/atanh",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.atanh",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.atanh",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -837,7 +837,7 @@
         "cbrt": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/cbrt",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.cbrt",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.cbrt",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -889,7 +889,7 @@
         "ceil": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/ceil",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.ceil",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.ceil",
             "support": {
               "chrome": {
                 "version_added": true
@@ -941,7 +941,7 @@
         "clz32": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/clz32",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.clz32",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.clz32",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -993,7 +993,7 @@
         "cos": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/cos",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.cos",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.cos",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1045,7 +1045,7 @@
         "cosh": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/cosh",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.cosh",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.cosh",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1097,7 +1097,7 @@
         "exp": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/exp",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.exp",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.exp",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1149,7 +1149,7 @@
         "expm1": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/expm1",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.expm1",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.expm1",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1201,7 +1201,7 @@
         "floor": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/floor",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.floor",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.floor",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1253,7 +1253,7 @@
         "fround": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/fround",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.fround",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.fround",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1305,7 +1305,7 @@
         "hypot": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/hypot",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.hypot",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.hypot",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1357,7 +1357,7 @@
         "imul": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/imul",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.imul",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.imul",
             "support": {
               "chrome": {
                 "version_added": "28"
@@ -1409,7 +1409,7 @@
         "log": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/log",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.log",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.log",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1461,7 +1461,7 @@
         "log1p": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/log1p",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.log1p",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.log1p",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1513,7 +1513,7 @@
         "log2": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/log2",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.log2",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.log2",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1565,7 +1565,7 @@
         "log10": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/log10",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.log10",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.log10",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1617,7 +1617,7 @@
         "max": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/max",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.max",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.max",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1669,7 +1669,7 @@
         "min": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/min",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.min",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.min",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1721,7 +1721,7 @@
         "pow": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/pow",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.pow",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.pow",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1773,7 +1773,7 @@
         "random": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/random",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.random",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.random",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1825,7 +1825,7 @@
         "round": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/round",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.round",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.round",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1877,7 +1877,7 @@
         "sign": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/sign",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.sign",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.sign",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1929,7 +1929,7 @@
         "sin": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/sin",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.sin",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.sin",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1981,7 +1981,7 @@
         "sinh": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/sinh",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.sinh",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.sinh",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -2033,7 +2033,7 @@
         "sqrt": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/sqrt",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.sqrt",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.sqrt",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2085,7 +2085,7 @@
         "tan": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/tan",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.tan",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.tan",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2137,7 +2137,7 @@
         "tanh": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/tanh",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.tanh",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.tanh",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -2189,7 +2189,7 @@
         "trunc": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/trunc",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-math.trunc",
+            "spec_url": "https://tc39.es/ecma262/#sec-math.trunc",
             "support": {
               "chrome": {
                 "version_added": "38"

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -4,7 +4,7 @@
       "Number": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-number-objects",
+          "spec_url": "https://tc39.es/ecma262/#sec-number-objects",
           "support": {
             "chrome": {
               "version_added": true
@@ -55,7 +55,7 @@
         "EPSILON": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/EPSILON",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-number.epsilon",
+            "spec_url": "https://tc39.es/ecma262/#sec-number.epsilon",
             "support": {
               "chrome": {
                 "version_added": true
@@ -107,7 +107,7 @@
         "MAX_SAFE_INTEGER": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-number.max_safe_integer",
+            "spec_url": "https://tc39.es/ecma262/#sec-number.max_safe_integer",
             "support": {
               "chrome": {
                 "version_added": "34"
@@ -159,7 +159,7 @@
         "MAX_VALUE": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_VALUE",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-number.max_value",
+            "spec_url": "https://tc39.es/ecma262/#sec-number.max_value",
             "support": {
               "chrome": {
                 "version_added": true
@@ -211,7 +211,7 @@
         "MIN_SAFE_INTEGER": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/MIN_SAFE_INTEGER",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-number.min_safe_integer",
+            "spec_url": "https://tc39.es/ecma262/#sec-number.min_safe_integer",
             "support": {
               "chrome": {
                 "version_added": "34"
@@ -263,7 +263,7 @@
         "MIN_VALUE": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/MIN_VALUE",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-number.min_value",
+            "spec_url": "https://tc39.es/ecma262/#sec-number.min_value",
             "support": {
               "chrome": {
                 "version_added": true
@@ -315,7 +315,7 @@
         "NEGATIVE_INFINITY": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/NEGATIVE_INFINITY",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-number.negative_infinity",
+            "spec_url": "https://tc39.es/ecma262/#sec-number.negative_infinity",
             "support": {
               "chrome": {
                 "version_added": true
@@ -367,7 +367,7 @@
         "NaN": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/NaN",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-number.nan",
+            "spec_url": "https://tc39.es/ecma262/#sec-number.nan",
             "support": {
               "chrome": {
                 "version_added": true
@@ -419,7 +419,7 @@
         "POSITIVE_INFINITY": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/POSITIVE_INFINITY",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-number.positive_infinity",
+            "spec_url": "https://tc39.es/ecma262/#sec-number.positive_infinity",
             "support": {
               "chrome": {
                 "version_added": true
@@ -471,7 +471,7 @@
         "isFinite": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-number.isfinite",
+            "spec_url": "https://tc39.es/ecma262/#sec-number.isfinite",
             "support": {
               "chrome": {
                 "version_added": "19"
@@ -523,7 +523,7 @@
         "isInteger": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-number.isinteger",
+            "spec_url": "https://tc39.es/ecma262/#sec-number.isinteger",
             "support": {
               "chrome": {
                 "version_added": true
@@ -575,7 +575,7 @@
         "isNaN": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-number.isnan",
+            "spec_url": "https://tc39.es/ecma262/#sec-number.isnan",
             "support": {
               "chrome": {
                 "version_added": "25"
@@ -627,7 +627,7 @@
         "isSafeInteger": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/isSafeInteger",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-number.issafeinteger",
+            "spec_url": "https://tc39.es/ecma262/#sec-number.issafeinteger",
             "support": {
               "chrome": {
                 "version_added": true
@@ -679,7 +679,7 @@
         "parseFloat": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/parseFloat",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-number.parsefloat",
+            "spec_url": "https://tc39.es/ecma262/#sec-number.parsefloat",
             "support": {
               "chrome": {
                 "version_added": true
@@ -731,7 +731,7 @@
         "parseInt": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/parseInt",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-number.parseint",
+            "spec_url": "https://tc39.es/ecma262/#sec-number.parseint",
             "support": {
               "chrome": {
                 "version_added": true
@@ -783,7 +783,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/prototype",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-properties-of-the-number-prototype-object",
+            "spec_url": "https://tc39.es/ecma262/#sec-properties-of-the-number-prototype-object",
             "support": {
               "chrome": {
                 "version_added": true
@@ -835,7 +835,7 @@
         "toExponential": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/toExponential",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-number.prototype.toexponential",
+            "spec_url": "https://tc39.es/ecma262/#sec-number.prototype.toexponential",
             "support": {
               "chrome": {
                 "version_added": true
@@ -887,7 +887,7 @@
         "toFixed": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-number.prototype.tofixed",
+            "spec_url": "https://tc39.es/ecma262/#sec-number.prototype.tofixed",
             "support": {
               "chrome": {
                 "version_added": true
@@ -993,8 +993,8 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString",
             "spec_url": [
-              "https://tc39.github.io/ecma262/#sec-number.prototype.tolocalestring",
-              "https://tc39.github.io/ecma402/#sec-Number.prototype.toLocaleString"
+              "https://tc39.es/ecma262/#sec-number.prototype.tolocalestring",
+              "https://tc39.es/ecma402/#sec-Number.prototype.toLocaleString"
             ],
             "support": {
               "chrome": {
@@ -1147,7 +1147,7 @@
         "toPrecision": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-number.prototype.toprecision",
+            "spec_url": "https://tc39.es/ecma262/#sec-number.prototype.toprecision",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1250,7 +1250,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/toString",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-number.prototype.tostring",
+            "spec_url": "https://tc39.es/ecma262/#sec-number.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1302,7 +1302,7 @@
         "valueOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/valueOf",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-number.prototype.valueof",
+            "spec_url": "https://tc39.es/ecma262/#sec-number.prototype.valueof",
             "support": {
               "chrome": {
                 "version_added": true

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -4,7 +4,7 @@
       "Object": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-object-objects",
+          "spec_url": "https://tc39.es/ecma262/#sec-object-objects",
           "support": {
             "chrome": {
               "version_added": true
@@ -55,7 +55,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/prototype",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.prototype",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.prototype",
             "support": {
               "chrome": {
                 "version_added": true
@@ -266,7 +266,7 @@
           "__compat": {
             "description": "<code>__proto__</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/proto",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-additional-properties-of-the-object.prototype-object",
+            "spec_url": "https://tc39.es/ecma262/#sec-additional-properties-of-the-object.prototype-object",
             "support": {
               "chrome": {
                 "version_added": true
@@ -318,7 +318,7 @@
         "constructor": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/constructor",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.prototype.constructor",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.constructor",
             "support": {
               "chrome": {
                 "version_added": true
@@ -370,7 +370,7 @@
         "assign": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/assign",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.assign",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.assign",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -422,7 +422,7 @@
         "create": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/create",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.create",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.create",
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -474,7 +474,7 @@
         "defineProperties": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperties",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.defineproperties",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.defineproperties",
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -526,7 +526,7 @@
         "defineProperty": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.defineproperty",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.defineproperty",
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -580,7 +580,7 @@
         "entries": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/entries",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.entries",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.entries",
             "support": {
               "chrome": {
                 "version_added": "54"
@@ -643,7 +643,7 @@
         "freeze": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.freeze",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.freeze",
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -695,7 +695,7 @@
         "fromEntries": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries",
-            "spec_url": "https://tc39.github.io/proposal-object-from-entries/#sec-object.fromentries",
+            "spec_url": "https://tc39.es/proposal-object-from-entries/#sec-object.fromentries",
             "support": {
               "chrome": {
                 "version_added": "73"
@@ -799,7 +799,7 @@
         "getOwnPropertyDescriptor": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.getownpropertydescriptor",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.getownpropertydescriptor",
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -851,7 +851,7 @@
         "getOwnPropertyDescriptors": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptors",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.getownpropertydescriptors",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.getownpropertydescriptors",
             "support": {
               "chrome": {
                 "version_added": "54"
@@ -914,7 +914,7 @@
         "getOwnPropertyNames": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.getownpropertynames",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.getownpropertynames",
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -966,7 +966,7 @@
         "getOwnPropertySymbols": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.getownpropertysymbols",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.getownpropertysymbols",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1018,7 +1018,7 @@
         "getPrototypeOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.getprototypeof",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.getprototypeof",
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -1070,7 +1070,7 @@
         "is": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/is",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.is",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.is",
             "support": {
               "chrome": {
                 "version_added": "30"
@@ -1122,7 +1122,7 @@
         "isExtensible": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/isExtensible",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.isextensible",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.isextensible",
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -1174,7 +1174,7 @@
         "isFrozen": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/isFrozen",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.isfrozen",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.isfrozen",
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -1226,7 +1226,7 @@
         "isSealed": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/isSealed",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.issealed",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.issealed",
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -1278,7 +1278,7 @@
         "keys": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/keys",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.keys",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.keys",
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -1382,7 +1382,7 @@
         "preventExtensions": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.preventextensions",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.preventextensions",
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -1486,7 +1486,7 @@
           "__compat": {
             "description": "<code>__defineGetter__</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineGetter__",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.__defineGetter__",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1540,7 +1540,7 @@
           "__compat": {
             "description": "<code>__defineSetter__</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineSetter__",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.prototype.__defineSetter__",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.__defineSetter__",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1594,7 +1594,7 @@
           "__compat": {
             "description": "<code>__lookupGetter__</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupGetter__",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.prototype.__lookupGetter__",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.__lookupGetter__",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1647,7 +1647,7 @@
           "__compat": {
             "description": "<code>__lookupSetter__</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupSetter__",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.prototype.__lookupSetter__",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.__lookupSetter__",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1750,7 +1750,7 @@
         "hasOwnProperty": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.prototype.hasownproperty",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.hasownproperty",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1802,7 +1802,7 @@
         "isPrototypeOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/isPrototypeOf",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.prototype.isprototypeof",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.isprototypeof",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1854,7 +1854,7 @@
         "propertyIsEnumerable": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/propertyIsEnumerable",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.prototype.propertyisenumerable",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.propertyisenumerable",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1906,7 +1906,7 @@
         "toLocaleString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/toLocaleString",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.prototype.tolocalestring",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.tolocalestring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2009,7 +2009,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/toString",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.prototype.tostring",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2114,7 +2114,7 @@
         "valueOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/valueOf",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.prototype.valueof",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.valueof",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2219,7 +2219,7 @@
         "seal": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/seal",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.seal",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.seal",
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -2271,7 +2271,7 @@
         "setPrototypeOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.setprototypeof",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.setprototypeof",
             "support": {
               "chrome": {
                 "version_added": "34"
@@ -2375,7 +2375,7 @@
         "values": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/values",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-object.values",
+            "spec_url": "https://tc39.es/ecma262/#sec-object.values",
             "support": {
               "chrome": {
                 "version_added": "54"

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -4,7 +4,7 @@
       "Promise": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-promise-objects",
+          "spec_url": "https://tc39.es/ecma262/#sec-promise-objects",
           "support": {
             "chrome": {
               "version_added": "32"
@@ -56,7 +56,7 @@
           "__compat": {
             "description": "<code>Promise()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-promise-objects",
+            "spec_url": "https://tc39.es/ecma262/#sec-promise-objects",
             "support": {
               "chrome": {
                 "version_added": "32"
@@ -113,7 +113,7 @@
         "all": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/all",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-promise.all",
+            "spec_url": "https://tc39.es/ecma262/#sec-promise.all",
             "support": {
               "chrome": {
                 "version_added": "32"
@@ -165,7 +165,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/prototype",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-promise.prototype",
+            "spec_url": "https://tc39.es/ecma262/#sec-promise.prototype",
             "support": {
               "chrome": {
                 "version_added": "32"
@@ -217,7 +217,7 @@
         "catch": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-promise.prototype.catch",
+            "spec_url": "https://tc39.es/ecma262/#sec-promise.prototype.catch",
             "support": {
               "chrome": {
                 "version_added": "32"
@@ -269,7 +269,7 @@
         "finally": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/finally",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-promise.prototype.finally",
+            "spec_url": "https://tc39.es/ecma262/#sec-promise.prototype.finally",
             "support": {
               "chrome": {
                 "version_added": "63"
@@ -321,7 +321,7 @@
         "then": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/then",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-promise.prototype.then",
+            "spec_url": "https://tc39.es/ecma262/#sec-promise.prototype.then",
             "support": {
               "chrome": {
                 "version_added": "32"
@@ -373,7 +373,7 @@
         "race": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/race",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-promise.race",
+            "spec_url": "https://tc39.es/ecma262/#sec-promise.race",
             "support": {
               "chrome": {
                 "version_added": "32"
@@ -425,7 +425,7 @@
         "reject": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/reject",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-promise.reject",
+            "spec_url": "https://tc39.es/ecma262/#sec-promise.reject",
             "support": {
               "chrome": {
                 "version_added": "32"
@@ -477,7 +477,7 @@
         "resolve": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-promise.resolve",
+            "spec_url": "https://tc39.es/ecma262/#sec-promise.resolve",
             "support": {
               "chrome": {
                 "version_added": "32"

--- a/javascript/builtins/Proxy.json
+++ b/javascript/builtins/Proxy.json
@@ -4,7 +4,7 @@
       "Proxy": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-proxy-objects",
+          "spec_url": "https://tc39.es/ecma262/#sec-proxy-objects",
           "support": {
             "chrome": {
               "version_added": "49"
@@ -55,7 +55,7 @@
         "revocable": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/revocable",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-proxy.revocable",
+            "spec_url": "https://tc39.es/ecma262/#sec-proxy.revocable",
             "support": {
               "chrome": {
                 "version_added": "63"
@@ -108,7 +108,7 @@
           "apply": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/apply",
-              "spec_url": "https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist",
+              "spec_url": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -160,7 +160,7 @@
           "construct": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/construct",
-              "spec_url": "https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget",
+              "spec_url": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -212,7 +212,7 @@
           "defineProperty": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/defineProperty",
-              "spec_url": "https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc",
+              "spec_url": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -264,7 +264,7 @@
           "deleteProperty": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/deleteProperty",
-              "spec_url": "https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-delete-p",
+              "spec_url": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-delete-p",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -369,7 +369,7 @@
           "get": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/get",
-              "spec_url": "https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver",
+              "spec_url": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -421,7 +421,7 @@
           "getOwnPropertyDescriptor": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/getOwnPropertyDescriptor",
-              "spec_url": "https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getownproperty-p",
+              "spec_url": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getownproperty-p",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -473,7 +473,7 @@
           "getPrototypeOf": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/getPrototypeOf",
-              "spec_url": "https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getprototypeof",
+              "spec_url": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getprototypeof",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -525,7 +525,7 @@
           "has": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/has",
-              "spec_url": "https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-hasproperty-p",
+              "spec_url": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-hasproperty-p",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -577,7 +577,7 @@
           "isExtensible": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/isExtensible",
-              "spec_url": "https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-isextensible",
+              "spec_url": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-isextensible",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -629,7 +629,7 @@
           "ownKeys": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/ownKeys",
-              "spec_url": "https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys",
+              "spec_url": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -683,7 +683,7 @@
           "preventExtensions": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/preventExtensions",
-              "spec_url": "https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-preventextensions",
+              "spec_url": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-preventextensions",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -735,7 +735,7 @@
           "set": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/set",
-              "spec_url": "https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-set-p-v-receiver",
+              "spec_url": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-set-p-v-receiver",
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -787,7 +787,7 @@
           "setPrototypeOf": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/setPrototypeOf",
-              "spec_url": "https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-setprototypeof-v",
+              "spec_url": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-setprototypeof-v",
               "support": {
                 "chrome": {
                   "version_added": "49"

--- a/javascript/builtins/RangeError.json
+++ b/javascript/builtins/RangeError.json
@@ -4,7 +4,7 @@
       "RangeError": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RangeError",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-rangeerror",
+          "spec_url": "https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-rangeerror",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/builtins/ReferenceError.json
+++ b/javascript/builtins/ReferenceError.json
@@ -4,7 +4,7 @@
       "ReferenceError": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ReferenceError",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-referenceerror",
+          "spec_url": "https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-referenceerror",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/builtins/Reflect.json
+++ b/javascript/builtins/Reflect.json
@@ -4,7 +4,7 @@
       "Reflect": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-reflect-object",
+          "spec_url": "https://tc39.es/ecma262/#sec-reflect-object",
           "support": {
             "chrome": {
               "version_added": "49"
@@ -55,7 +55,7 @@
         "apply": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/apply",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-reflect.apply",
+            "spec_url": "https://tc39.es/ecma262/#sec-reflect.apply",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -107,7 +107,7 @@
         "construct": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/construct",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-reflect.construct",
+            "spec_url": "https://tc39.es/ecma262/#sec-reflect.construct",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -159,7 +159,7 @@
         "defineProperty": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/defineProperty",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-reflect.defineproperty",
+            "spec_url": "https://tc39.es/ecma262/#sec-reflect.defineproperty",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -211,7 +211,7 @@
         "deleteProperty": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/deleteProperty",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-reflect.deleteproperty",
+            "spec_url": "https://tc39.es/ecma262/#sec-reflect.deleteproperty",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -315,7 +315,7 @@
         "get": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/get",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-reflect.get",
+            "spec_url": "https://tc39.es/ecma262/#sec-reflect.get",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -367,7 +367,7 @@
         "getOwnPropertyDescriptor": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/getOwnPropertyDescriptor",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-reflect.getownpropertydescriptor",
+            "spec_url": "https://tc39.es/ecma262/#sec-reflect.getownpropertydescriptor",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -419,7 +419,7 @@
         "getPrototypeOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/getPrototypeOf",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-reflect.getprototypeof",
+            "spec_url": "https://tc39.es/ecma262/#sec-reflect.getprototypeof",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -471,7 +471,7 @@
         "has": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/has",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-reflect.has",
+            "spec_url": "https://tc39.es/ecma262/#sec-reflect.has",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -523,7 +523,7 @@
         "isExtensible": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/isExtensible",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-reflect.isextensible",
+            "spec_url": "https://tc39.es/ecma262/#sec-reflect.isextensible",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -575,7 +575,7 @@
         "ownKeys": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/ownKeys",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-reflect.ownkeys",
+            "spec_url": "https://tc39.es/ecma262/#sec-reflect.ownkeys",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -627,7 +627,7 @@
         "preventExtensions": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/preventExtensions",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-reflect.preventextensions",
+            "spec_url": "https://tc39.es/ecma262/#sec-reflect.preventextensions",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -679,7 +679,7 @@
         "set": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/set",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-reflect.set",
+            "spec_url": "https://tc39.es/ecma262/#sec-reflect.set",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -731,7 +731,7 @@
         "setPrototypeOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/setPrototypeOf",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-reflect.setprototypeof",
+            "spec_url": "https://tc39.es/ecma262/#sec-reflect.setprototypeof",
             "support": {
               "chrome": {
                 "version_added": "49"

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -4,7 +4,7 @@
       "RegExp": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-regexp-regular-expression-objects",
+          "spec_url": "https://tc39.es/ecma262/#sec-regexp-regular-expression-objects",
           "support": {
             "chrome": {
               "version_added": true
@@ -55,7 +55,7 @@
         "compile": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/compile",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-regexp.prototype.compile",
+            "spec_url": "https://tc39.es/ecma262/#sec-regexp.prototype.compile",
             "support": {
               "chrome": {
                 "version_added": true
@@ -169,7 +169,7 @@
         "exec": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-regexp.prototype.exec",
+            "spec_url": "https://tc39.es/ecma262/#sec-regexp.prototype.exec",
             "support": {
               "chrome": {
                 "version_added": true
@@ -221,7 +221,7 @@
         "flags": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/flags",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-get-regexp.prototype.flags",
+            "spec_url": "https://tc39.es/ecma262/#sec-get-regexp.prototype.flags",
             "support": {
               "chrome": {
                 "version_added": true
@@ -279,7 +279,7 @@
         "global": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/global",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-get-regexp.prototype.global",
+            "spec_url": "https://tc39.es/ecma262/#sec-get-regexp.prototype.global",
             "support": {
               "chrome": {
                 "version_added": true
@@ -382,7 +382,7 @@
         "ignoreCase": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/ignoreCase",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-get-regexp.prototype.ignorecase",
+            "spec_url": "https://tc39.es/ecma262/#sec-get-regexp.prototype.ignorecase",
             "support": {
               "chrome": {
                 "version_added": true
@@ -537,7 +537,7 @@
         "lastIndex": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-properties-of-regexp-instances",
+            "spec_url": "https://tc39.es/ecma262/#sec-properties-of-regexp-instances",
             "support": {
               "chrome": {
                 "version_added": true
@@ -798,7 +798,7 @@
         "multiline": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/multiline",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-get-regexp.prototype.multiline",
+            "spec_url": "https://tc39.es/ecma262/#sec-get-regexp.prototype.multiline",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1004,7 +1004,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/prototype",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-regexp.prototype",
+            "spec_url": "https://tc39.es/ecma262/#sec-regexp.prototype",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1108,7 +1108,7 @@
         "source": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/source",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-get-regexp.prototype.source",
+            "spec_url": "https://tc39.es/ecma262/#sec-get-regexp.prototype.source",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1313,7 +1313,7 @@
         "sticky": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/sticky",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-get-regexp.prototype.sticky",
+            "spec_url": "https://tc39.es/ecma262/#sec-get-regexp.prototype.sticky",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -1467,7 +1467,7 @@
         "test": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-regexp.prototype.test",
+            "spec_url": "https://tc39.es/ecma262/#sec-regexp.prototype.test",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1570,7 +1570,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/toString",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-regexp.prototype.tostring",
+            "spec_url": "https://tc39.es/ecma262/#sec-regexp.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1724,7 +1724,7 @@
         "unicode": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-get-regexp.prototype.unicode",
+            "spec_url": "https://tc39.es/ecma262/#sec-get-regexp.prototype.unicode",
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -1777,7 +1777,7 @@
         "@@match": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@match",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-regexp.prototype-@@match",
+            "spec_url": "https://tc39.es/ecma262/#sec-regexp.prototype-@@match",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1829,7 +1829,7 @@
         "@@matchAll": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@matchAll",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-regexp-prototype-matchall",
+            "spec_url": "https://tc39.es/ecma262/#sec-regexp-prototype-matchall",
             "support": {
               "chrome": {
                 "version_added": "73"
@@ -1881,7 +1881,7 @@
         "@@replace": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@replace",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-regexp.prototype-@@replace",
+            "spec_url": "https://tc39.es/ecma262/#sec-regexp.prototype-@@replace",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1933,7 +1933,7 @@
         "@@search": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@search",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-regexp.prototype-@@search",
+            "spec_url": "https://tc39.es/ecma262/#sec-regexp.prototype-@@search",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1985,7 +1985,7 @@
         "@@species": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@species",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-get-regexp-@@species",
+            "spec_url": "https://tc39.es/ecma262/#sec-get-regexp-@@species",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2048,7 +2048,7 @@
         "@@split": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@split",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-regexp.prototype-@@split",
+            "spec_url": "https://tc39.es/ecma262/#sec-regexp.prototype-@@split",
             "support": {
               "chrome": {
                 "version_added": true

--- a/javascript/builtins/Set.json
+++ b/javascript/builtins/Set.json
@@ -4,7 +4,7 @@
       "Set": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-set-objects",
+          "spec_url": "https://tc39.es/ecma262/#sec-set-objects",
           "support": {
             "chrome": {
               "version_added": "38"
@@ -281,7 +281,7 @@
         "add": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/add",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-set.prototype.add",
+            "spec_url": "https://tc39.es/ecma262/#sec-set.prototype.add",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -335,7 +335,7 @@
         "clear": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/clear",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-set.prototype.clear",
+            "spec_url": "https://tc39.es/ecma262/#sec-set.prototype.clear",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -387,7 +387,7 @@
         "delete": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/delete",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-set.prototype.delete",
+            "spec_url": "https://tc39.es/ecma262/#sec-set.prototype.delete",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -450,7 +450,7 @@
         "entries": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/entries",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-set.prototype.entries",
+            "spec_url": "https://tc39.es/ecma262/#sec-set.prototype.entries",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -502,7 +502,7 @@
         "forEach": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/forEach",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-set.prototype.foreach",
+            "spec_url": "https://tc39.es/ecma262/#sec-set.prototype.foreach",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -554,7 +554,7 @@
         "has": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/has",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-set.prototype.has",
+            "spec_url": "https://tc39.es/ecma262/#sec-set.prototype.has",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -606,7 +606,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/prototype",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-set.prototype",
+            "spec_url": "https://tc39.es/ecma262/#sec-set.prototype",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -658,7 +658,7 @@
         "size": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/size",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-get-set.prototype.size",
+            "spec_url": "https://tc39.es/ecma262/#sec-get-set.prototype.size",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -712,7 +712,7 @@
         "values": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/values",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-set.prototype.values",
+            "spec_url": "https://tc39.es/ecma262/#sec-set.prototype.values",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -764,7 +764,7 @@
         "@@iterator": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/@@iterator",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-set.prototype-@@iterator",
+            "spec_url": "https://tc39.es/ecma262/#sec-set.prototype-@@iterator",
             "support": {
               "chrome": {
                 "version_added": true
@@ -844,7 +844,7 @@
         "@@species": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/@@species",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-get-set-@@species",
+            "spec_url": "https://tc39.es/ecma262/#sec-get-set-@@species",
             "support": {
               "chrome": {
                 "version_added": "51"

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -4,7 +4,7 @@
       "SharedArrayBuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-sharedarraybuffer-objects",
+          "spec_url": "https://tc39.es/ecma262/#sec-sharedarraybuffer-objects",
           "support": {
             "chrome": [
               {
@@ -232,7 +232,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/prototype",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-sharedarraybuffer.prototype",
+            "spec_url": "https://tc39.es/ecma262/#sec-sharedarraybuffer.prototype",
             "support": {
               "chrome": [
                 {
@@ -348,7 +348,7 @@
         "byteLength": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/byteLength",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-get-sharedarraybuffer.prototype.bytelength",
+            "spec_url": "https://tc39.es/ecma262/#sec-get-sharedarraybuffer.prototype.bytelength",
             "support": {
               "chrome": [
                 {
@@ -464,7 +464,7 @@
         "slice": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/slice",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-sharedarraybuffer.prototype.slice",
+            "spec_url": "https://tc39.es/ecma262/#sec-sharedarraybuffer.prototype.slice",
             "support": {
               "chrome": [
                 {

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -4,7 +4,7 @@
       "String": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-string-objects",
+          "spec_url": "https://tc39.es/ecma262/#sec-string-objects",
           "support": {
             "chrome": {
               "version_added": true
@@ -55,7 +55,7 @@
         "@@iterator": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/@@iterator",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype-@@iterator",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype-@@iterator",
             "support": {
               "chrome": {
                 "version_added": true
@@ -238,7 +238,7 @@
         "big": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/big",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.big",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.big",
             "support": {
               "chrome": {
                 "version_added": true
@@ -290,7 +290,7 @@
         "blink": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/blink",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.blink",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.blink",
             "support": {
               "chrome": {
                 "version_added": true
@@ -342,7 +342,7 @@
         "bold": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/bold",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.bold",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.bold",
             "support": {
               "chrome": {
                 "version_added": true
@@ -394,7 +394,7 @@
         "charAt": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/charAt",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.charat",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.charat",
             "support": {
               "chrome": {
                 "version_added": true
@@ -446,7 +446,7 @@
         "charCodeAt": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/charCodeAt",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.charcodeat",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.charcodeat",
             "support": {
               "chrome": {
                 "version_added": true
@@ -498,7 +498,7 @@
         "codePointAt": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/codePointAt",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.codepointat",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.codepointat",
             "support": {
               "chrome": {
                 "version_added": "41"
@@ -561,7 +561,7 @@
         "concat": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/concat",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.concat",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.concat",
             "support": {
               "chrome": {
                 "version_added": true
@@ -613,7 +613,7 @@
         "endsWith": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.endswith",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.endswith",
             "support": {
               "chrome": {
                 "version_added": "41"
@@ -676,7 +676,7 @@
         "fixed": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/fixed",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.fixed",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.fixed",
             "support": {
               "chrome": {
                 "version_added": true
@@ -728,7 +728,7 @@
         "fontcolor": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/fontcolor",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.fontcolor",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.fontcolor",
             "support": {
               "chrome": {
                 "version_added": true
@@ -780,7 +780,7 @@
         "fontsize": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/fontsize",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.fontsize",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.fontsize",
             "support": {
               "chrome": {
                 "version_added": true
@@ -832,7 +832,7 @@
         "fromCharCode": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/fromCharCode",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.fromcharcodes",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.fromcharcodes",
             "support": {
               "chrome": {
                 "version_added": true
@@ -884,7 +884,7 @@
         "fromCodePoint": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/fromCodePoint",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.fromcodepoint",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.fromcodepoint",
             "support": {
               "chrome": {
                 "version_added": "41"
@@ -947,7 +947,7 @@
         "includes": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/includes",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.includes",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.includes",
             "support": {
               "chrome": {
                 "version_added": "41"
@@ -1013,7 +1013,7 @@
         "indexOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/indexOf",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.indexof",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.indexof",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1065,7 +1065,7 @@
         "italics": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/italics",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.italics",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.italics",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1117,7 +1117,7 @@
         "lastIndexOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/lastIndexOf",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.lastindexof",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.lastindexof",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1169,7 +1169,7 @@
         "length": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/length",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-properties-of-string-instances-length",
+            "spec_url": "https://tc39.es/ecma262/#sec-properties-of-string-instances-length",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1221,7 +1221,7 @@
         "link": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/link",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.link",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.link",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1274,8 +1274,8 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare",
             "spec_url": [
-              "https://tc39.github.io/ecma262/#sec-string.prototype.localecompare",
-              "https://tc39.github.io/ecma402/#sec-String.prototype.localeCompare"
+              "https://tc39.es/ecma262/#sec-string.prototype.localecompare",
+              "https://tc39.es/ecma402/#sec-String.prototype.localeCompare"
             ],
             "support": {
               "chrome": {
@@ -1428,7 +1428,7 @@
         "match": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/match",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.match",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.match",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1532,7 +1532,7 @@
         "matchAll": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.matchall",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.matchall",
             "support": {
               "chrome": {
                 "version_added": "73"
@@ -1584,7 +1584,7 @@
         "normalize": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/normalize",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.normalize",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.normalize",
             "support": {
               "chrome": {
                 "version_added": "34"
@@ -1636,7 +1636,7 @@
         "padEnd": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/padEnd",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.padend",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.padend",
             "support": {
               "chrome": {
                 "version_added": "57"
@@ -1699,7 +1699,7 @@
         "padStart": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/padStart",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.padstart",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.padstart",
             "support": {
               "chrome": {
                 "version_added": "57"
@@ -1762,7 +1762,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/prototype",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1867,7 +1867,7 @@
         "raw": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/raw",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.raw",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.raw",
             "support": {
               "chrome": {
                 "version_added": "41"
@@ -1919,7 +1919,7 @@
         "repeat": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/repeat",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.repeat",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.repeat",
             "support": {
               "chrome": {
                 "version_added": "41"
@@ -1982,7 +1982,7 @@
         "replace": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/replace",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.replace",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.replace",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2086,7 +2086,7 @@
         "search": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/search",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.search",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.search",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2190,7 +2190,7 @@
         "slice": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/slice",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.slice",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.slice",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2242,7 +2242,7 @@
         "small": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/small",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.small",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.small",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2294,7 +2294,7 @@
         "split": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/split",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.split",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.split",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2346,7 +2346,7 @@
         "startsWith": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.startswith",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.startswith",
             "support": {
               "chrome": {
                 "version_added": "41"
@@ -2409,7 +2409,7 @@
         "strike": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/strike",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.strike",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.strike",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2461,7 +2461,7 @@
         "sub": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/sub",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.sub",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.sub",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2513,7 +2513,7 @@
         "substr": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/substr",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.substr",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.substr",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2565,7 +2565,7 @@
         "substring": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/substring",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.substring",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.substring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2617,7 +2617,7 @@
         "sup": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/sup",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.sup",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.sup",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2670,8 +2670,8 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleLowerCase",
             "spec_url": [
-              "https://tc39.github.io/ecma262/#sec-string.prototype.tolocalelowercase",
-              "https://tc39.github.io/ecma402/#sup-string.prototype.tolocalelowercase"
+              "https://tc39.es/ecma262/#sec-string.prototype.tolocalelowercase",
+              "https://tc39.es/ecma402/#sup-string.prototype.tolocalelowercase"
             ],
             "support": {
               "chrome": {
@@ -2775,8 +2775,8 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleUpperCase",
             "spec_url": [
-              "https://tc39.github.io/ecma262/#sec-string.prototype.tolocaleuppercase",
-              "https://tc39.github.io/ecma402/#sup-string.prototype.tolocaleuppercase"
+              "https://tc39.es/ecma262/#sec-string.prototype.tolocaleuppercase",
+              "https://tc39.es/ecma402/#sup-string.prototype.tolocaleuppercase"
             ],
             "support": {
               "chrome": {
@@ -2879,7 +2879,7 @@
         "toLowerCase": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/toLowerCase",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.tolowercase",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.tolowercase",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2982,7 +2982,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/toString",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.tostring",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -3034,7 +3034,7 @@
         "toUpperCase": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/toUpperCase",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.touppercase",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.touppercase",
             "support": {
               "chrome": {
                 "version_added": true
@@ -3086,7 +3086,7 @@
         "trim": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/trim",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.trim",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.trim",
             "support": {
               "chrome": {
                 "version_added": true
@@ -3314,7 +3314,7 @@
         "valueOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/valueOf",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-string.prototype.valueof",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.valueof",
             "support": {
               "chrome": {
                 "version_added": true

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -4,7 +4,7 @@
       "Symbol": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-symbol-objects",
+          "spec_url": "https://tc39.es/ecma262/#sec-symbol-objects",
           "support": {
             "chrome": {
               "version_added": "38"
@@ -106,7 +106,7 @@
         "description": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/description",
-            "spec_url": "https://tc39.github.io/proposal-Symbol-description/#sec-symbol.prototype.description",
+            "spec_url": "https://tc39.es/proposal-Symbol-description/#sec-symbol.prototype.description",
             "support": {
               "chrome": {
                 "version_added": "70"
@@ -172,7 +172,7 @@
         "for": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/for",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.for",
+            "spec_url": "https://tc39.es/ecma262/#sec-symbol.for",
             "support": {
               "chrome": {
                 "version_added": "40"
@@ -224,7 +224,7 @@
         "hasInstance": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/hasInstance",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.hasinstance",
+            "spec_url": "https://tc39.es/ecma262/#sec-symbol.hasinstance",
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -287,7 +287,7 @@
         "isConcatSpreadable": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/isConcatSpreadable",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.isconcatspreadable",
+            "spec_url": "https://tc39.es/ecma262/#sec-symbol.isconcatspreadable",
             "support": {
               "chrome": {
                 "version_added": "48"
@@ -339,7 +339,7 @@
         "iterator": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/iterator",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.iterator",
+            "spec_url": "https://tc39.es/ecma262/#sec-symbol.iterator",
             "support": {
               "chrome": {
                 "version_added": "43"
@@ -391,7 +391,7 @@
         "keyFor": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/keyFor",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.keyfor",
+            "spec_url": "https://tc39.es/ecma262/#sec-symbol.keyfor",
             "support": {
               "chrome": {
                 "version_added": "40"
@@ -443,7 +443,7 @@
         "match": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/match",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.match",
+            "spec_url": "https://tc39.es/ecma262/#sec-symbol.match",
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -495,7 +495,7 @@
         "matchAll": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/matchAll",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.matchall",
+            "spec_url": "https://tc39.es/ecma262/#sec-symbol.matchall",
             "support": {
               "chrome": {
                 "version_added": "73"
@@ -547,7 +547,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/prototype",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.prototype",
+            "spec_url": "https://tc39.es/ecma262/#sec-symbol.prototype",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -599,7 +599,7 @@
         "replace": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/replace",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.replace",
+            "spec_url": "https://tc39.es/ecma262/#sec-symbol.replace",
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -651,7 +651,7 @@
         "search": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/search",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.search",
+            "spec_url": "https://tc39.es/ecma262/#sec-symbol.search",
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -703,7 +703,7 @@
         "species": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/species",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.species",
+            "spec_url": "https://tc39.es/ecma262/#sec-symbol.species",
             "support": {
               "chrome": {
                 "version_added": "51"
@@ -766,7 +766,7 @@
         "split": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/split",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.split",
+            "spec_url": "https://tc39.es/ecma262/#sec-symbol.split",
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -818,7 +818,7 @@
         "toPrimitive": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toPrimitive",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.toprimitive",
+            "spec_url": "https://tc39.es/ecma262/#sec-symbol.toprimitive",
             "support": {
               "chrome": {
                 "version_added": "47"
@@ -921,7 +921,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toString",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.prototype.tostring",
+            "spec_url": "https://tc39.es/ecma262/#sec-symbol.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -973,7 +973,7 @@
         "toStringTag": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.tostringtag",
+            "spec_url": "https://tc39.es/ecma262/#sec-symbol.tostringtag",
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -1036,7 +1036,7 @@
         "unscopables": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/unscopables",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.unscopables",
+            "spec_url": "https://tc39.es/ecma262/#sec-symbol.unscopables",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1088,7 +1088,7 @@
         "valueOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/valueOf",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.prototype.valueof",
+            "spec_url": "https://tc39.es/ecma262/#sec-symbol.prototype.valueof",
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1140,7 +1140,7 @@
         "@@toPrimitive": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/@@toPrimitive",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-symbol.prototype-@@toprimitive",
+            "spec_url": "https://tc39.es/ecma262/#sec-symbol.prototype-@@toprimitive",
             "support": {
               "chrome": {
                 "version_added": null

--- a/javascript/builtins/SyntaxError.json
+++ b/javascript/builtins/SyntaxError.json
@@ -4,7 +4,7 @@
       "SyntaxError": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-syntaxerror",
+          "spec_url": "https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-syntaxerror",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/builtins/TypeError.json
+++ b/javascript/builtins/TypeError.json
@@ -4,7 +4,7 @@
       "TypeError": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypeError",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror",
+          "spec_url": "https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-typeerror",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -4,7 +4,7 @@
       "TypedArray": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-typedarray-objects",
+          "spec_url": "https://tc39.es/ecma262/#sec-typedarray-objects",
           "support": {
             "chrome": {
               "version_added": "7"
@@ -316,7 +316,7 @@
         "BYTES_PER_ELEMENT": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/BYTES_PER_ELEMENT",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-typedarray.bytes_per_element",
+            "spec_url": "https://tc39.es/ecma262/#sec-typedarray.bytes_per_element",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -368,7 +368,7 @@
         "buffer": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/buffer",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-get-%typedarray%.prototype.buffer",
+            "spec_url": "https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.buffer",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -420,7 +420,7 @@
         "byteLength": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/byteLength",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-get-%typedarray%.prototype.bytelength",
+            "spec_url": "https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.bytelength",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -472,7 +472,7 @@
         "byteOffset": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/byteOffset",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-get-%typedarray%.prototype.byteoffset",
+            "spec_url": "https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.byteoffset",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -524,7 +524,7 @@
         "copyWithin": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/copyWithin",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.copywithin",
+            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.copywithin",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -576,7 +576,7 @@
         "entries": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/entries",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.entries",
+            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.entries",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -628,7 +628,7 @@
         "every": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/every",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.every",
+            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.every",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -680,7 +680,7 @@
         "fill": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.fill",
+            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.fill",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -732,7 +732,7 @@
         "filter": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/filter",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.filter",
+            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.filter",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -784,7 +784,7 @@
         "find": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/find",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.find",
+            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.find",
             "support": {
               "chrome": {
                 "version_added": true
@@ -836,7 +836,7 @@
         "findIndex": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/findIndex",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.findindex",
+            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.findindex",
             "support": {
               "chrome": {
                 "version_added": true
@@ -888,7 +888,7 @@
         "forEach": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/forEach",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.foreach",
+            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.foreach",
             "support": {
               "chrome": {
                 "version_added": true
@@ -940,7 +940,7 @@
         "from": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.from",
+            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.from",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -992,7 +992,7 @@
         "includes": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/includes",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.includes",
+            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.includes",
             "support": {
               "chrome": {
                 "version_added": "47"
@@ -1055,7 +1055,7 @@
         "indexOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/indexOf",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.indexof",
+            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.indexof",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1109,7 +1109,7 @@
         "join": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/join",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.join",
+            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.join",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1161,7 +1161,7 @@
         "keys": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/keys",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.keys",
+            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.keys",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1213,7 +1213,7 @@
         "lastIndexOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/lastIndexOf",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.lastindexof",
+            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.lastindexof",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1267,7 +1267,7 @@
         "length": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/length",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-get-%typedarray%.prototype.length",
+            "spec_url": "https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.length",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -1319,7 +1319,7 @@
         "map": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/map",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.map",
+            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.map",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1426,7 +1426,7 @@
         "name": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/name",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-properties-of-the-typedarray-constructors",
+            "spec_url": "https://tc39.es/ecma262/#sec-properties-of-the-typedarray-constructors",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -1478,7 +1478,7 @@
         "of": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/of",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.of",
+            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.of",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1530,7 +1530,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/prototype",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-properties-of-the-%typedarrayprototype%-object",
+            "spec_url": "https://tc39.es/ecma262/#sec-properties-of-the-%typedarrayprototype%-object",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -1582,7 +1582,7 @@
         "reduce": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/reduce",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.reduce",
+            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.reduce",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1634,7 +1634,7 @@
         "reduceRight": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/reduceRight",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.reduceRight",
+            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.reduceRight",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1686,7 +1686,7 @@
         "reverse": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/reverse",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.reverse",
+            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.reverse",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1738,7 +1738,7 @@
         "set": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/set",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.set-array-offset",
+            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.set-array-offset",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -1790,7 +1790,7 @@
         "slice": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/slice",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.slice",
+            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.slice",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1842,7 +1842,7 @@
         "some": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/some",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.some",
+            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.some",
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -1894,7 +1894,7 @@
         "sort": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/sort",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.sort",
+            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.sort",
             "support": {
               "chrome": {
                 "version_added": true
@@ -1946,7 +1946,7 @@
         "subarray": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/subarray",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.subarray",
+            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.subarray",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -1998,7 +1998,7 @@
         "toLocaleString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toLocaleString",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.tolocalestring",
+            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.tolocalestring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2050,7 +2050,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toString",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.tostring",
+            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2102,7 +2102,7 @@
         "values": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/values",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.values",
+            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.values",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2154,7 +2154,7 @@
         "@@iterator": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/@@iterator",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-%typedarray%.prototype-@@iterator",
+            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype-@@iterator",
             "support": {
               "chrome": {
                 "version_added": true
@@ -2234,7 +2234,7 @@
         "@@species": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/@@species",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-get-%typedarray%-@@species",
+            "spec_url": "https://tc39.es/ecma262/#sec-get-%typedarray%-@@species",
             "support": {
               "chrome": {
                 "version_added": true

--- a/javascript/builtins/URIError.json
+++ b/javascript/builtins/URIError.json
@@ -4,7 +4,7 @@
       "URIError": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/URIError",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-urierror",
+          "spec_url": "https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-urierror",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/builtins/Uint16Array.json
+++ b/javascript/builtins/Uint16Array.json
@@ -4,7 +4,7 @@
       "Uint16Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint16Array",
-          "spec_url": "https://tc39.github.io/ecma262/#table-49",
+          "spec_url": "https://tc39.es/ecma262/#table-49",
           "support": {
             "chrome": {
               "version_added": "7"

--- a/javascript/builtins/Uint32Array.json
+++ b/javascript/builtins/Uint32Array.json
@@ -4,7 +4,7 @@
       "Uint32Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint32Array",
-          "spec_url": "https://tc39.github.io/ecma262/#table-49",
+          "spec_url": "https://tc39.es/ecma262/#table-49",
           "support": {
             "chrome": {
               "version_added": "7"

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -4,7 +4,7 @@
       "Uint8Array": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array",
-          "spec_url": "https://tc39.github.io/ecma262/#table-49",
+          "spec_url": "https://tc39.es/ecma262/#table-49",
           "support": {
             "chrome": {
               "version_added": "7"

--- a/javascript/builtins/Uint8ClampedArray.json
+++ b/javascript/builtins/Uint8ClampedArray.json
@@ -4,7 +4,7 @@
       "Uint8ClampedArray": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray",
-          "spec_url": "https://tc39.github.io/ecma262/#table-49",
+          "spec_url": "https://tc39.es/ecma262/#table-49",
           "support": {
             "chrome": {
               "version_added": "7"

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -4,7 +4,7 @@
       "WeakMap": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-weakmap-objects",
+          "spec_url": "https://tc39.es/ecma262/#sec-weakmap-objects",
           "support": {
             "chrome": {
               "version_added": "36"
@@ -290,7 +290,7 @@
         "delete": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/delete",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-weakmap.prototype.delete",
+            "spec_url": "https://tc39.es/ecma262/#sec-weakmap.prototype.delete",
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -355,7 +355,7 @@
         "get": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/get",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-weakmap.prototype.get",
+            "spec_url": "https://tc39.es/ecma262/#sec-weakmap.prototype.get",
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -420,7 +420,7 @@
         "has": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/has",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-weakmap.prototype.has",
+            "spec_url": "https://tc39.es/ecma262/#sec-weakmap.prototype.has",
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -485,7 +485,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/prototype",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-weakmap.prototype",
+            "spec_url": "https://tc39.es/ecma262/#sec-weakmap.prototype",
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -548,7 +548,7 @@
         "set": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/set",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-weakmap.prototype.set",
+            "spec_url": "https://tc39.es/ecma262/#sec-weakmap.prototype.set",
             "support": {
               "chrome": {
                 "version_added": "36"

--- a/javascript/builtins/WeakSet.json
+++ b/javascript/builtins/WeakSet.json
@@ -4,7 +4,7 @@
       "WeakSet": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-weakset-objects",
+          "spec_url": "https://tc39.es/ecma262/#sec-weakset-objects",
           "support": {
             "chrome": {
               "version_added": "36"
@@ -157,7 +157,7 @@
         "add": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/add",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-weakset.prototype.add",
+            "spec_url": "https://tc39.es/ecma262/#sec-weakset.prototype.add",
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -267,7 +267,7 @@
         "delete": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/delete",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-weakset.prototype.delete",
+            "spec_url": "https://tc39.es/ecma262/#sec-weakset.prototype.delete",
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -319,7 +319,7 @@
         "has": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/has",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-weakset.prototype.has",
+            "spec_url": "https://tc39.es/ecma262/#sec-weakset.prototype.has",
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -371,7 +371,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/prototype",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-weakset.prototype",
+            "spec_url": "https://tc39.es/ecma262/#sec-weakset.prototype",
             "support": {
               "chrome": {
                 "version_added": "36"

--- a/javascript/builtins/WebAssembly.json
+++ b/javascript/builtins/WebAssembly.json
@@ -59,7 +59,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/CompileError",
             "spec_url": [
               "https://webassembly.github.io/spec/js-api/#constructor-properties-of-the-webassembly-object",
-              "https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard"
+              "https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard"
             ],
             "support": {
               "chrome": {
@@ -432,7 +432,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/LinkError",
             "spec_url": [
               "https://webassembly.github.io/spec/js-api/#constructor-properties-of-the-webassembly-object",
-              "https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard"
+              "https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard"
             ],
             "support": {
               "chrome": {
@@ -975,7 +975,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/RuntimeError",
             "spec_url": [
               "https://webassembly.github.io/spec/js-api/#constructor-properties-of-the-webassembly-object",
-              "https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard"
+              "https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard"
             ],
             "support": {
               "chrome": {

--- a/javascript/builtins/globals.json
+++ b/javascript/builtins/globals.json
@@ -4,7 +4,7 @@
       "Infinity": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Infinity",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-value-properties-of-the-global-object-infinity",
+          "spec_url": "https://tc39.es/ecma262/#sec-value-properties-of-the-global-object-infinity",
           "support": {
             "chrome": {
               "version_added": true
@@ -56,7 +56,7 @@
       "NaN": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NaN",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-value-properties-of-the-global-object-nan",
+          "spec_url": "https://tc39.es/ecma262/#sec-value-properties-of-the-global-object-nan",
           "support": {
             "chrome": {
               "version_added": true
@@ -108,7 +108,7 @@
       "decodeURI": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/decodeURI",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-decodeuri-encodeduri",
+          "spec_url": "https://tc39.es/ecma262/#sec-decodeuri-encodeduri",
           "support": {
             "chrome": {
               "version_added": true
@@ -160,7 +160,7 @@
       "decodeURIComponent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-decodeuricomponent-encodeduricomponent",
+          "spec_url": "https://tc39.es/ecma262/#sec-decodeuricomponent-encodeduricomponent",
           "support": {
             "chrome": {
               "version_added": true
@@ -212,7 +212,7 @@
       "encodeURI": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/encodeURI",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-encodeuri-uri",
+          "spec_url": "https://tc39.es/ecma262/#sec-encodeuri-uri",
           "support": {
             "chrome": {
               "version_added": true
@@ -264,7 +264,7 @@
       "encodeURIComponent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-encodeuricomponent-uricomponent",
+          "spec_url": "https://tc39.es/ecma262/#sec-encodeuricomponent-uricomponent",
           "support": {
             "chrome": {
               "version_added": true
@@ -316,7 +316,7 @@
       "escape": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/escape",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-escape-string",
+          "spec_url": "https://tc39.es/ecma262/#sec-escape-string",
           "support": {
             "chrome": {
               "version_added": true
@@ -368,7 +368,7 @@
       "eval": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/eval",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-eval-x",
+          "spec_url": "https://tc39.es/ecma262/#sec-eval-x",
           "support": {
             "chrome": {
               "version_added": true
@@ -420,7 +420,7 @@
       "globalThis": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/globalThis",
-          "spec_url": "https://tc39.github.io/proposal-global/#sec-other-properties-of-the-global-object-global",
+          "spec_url": "https://tc39.es/proposal-global/#sec-other-properties-of-the-global-object-global",
           "support": {
             "chrome": {
               "version_added": "71"
@@ -472,7 +472,7 @@
       "isFinite": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/isFinite",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-isfinite-number",
+          "spec_url": "https://tc39.es/ecma262/#sec-isfinite-number",
           "support": {
             "chrome": {
               "version_added": true
@@ -524,7 +524,7 @@
       "isNaN": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/isNaN",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-isnan-number",
+          "spec_url": "https://tc39.es/ecma262/#sec-isnan-number",
           "support": {
             "chrome": {
               "version_added": true
@@ -576,7 +576,7 @@
       "null": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/null",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-null-value",
+          "spec_url": "https://tc39.es/ecma262/#sec-null-value",
           "support": {
             "chrome": {
               "version_added": true
@@ -628,7 +628,7 @@
       "parseFloat": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/parseFloat",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-parsefloat-string",
+          "spec_url": "https://tc39.es/ecma262/#sec-parsefloat-string",
           "support": {
             "chrome": {
               "version_added": true
@@ -680,7 +680,7 @@
       "parseInt": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/parseInt",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-parseint-string-radix",
+          "spec_url": "https://tc39.es/ecma262/#sec-parseint-string-radix",
           "support": {
             "chrome": {
               "version_added": true
@@ -783,7 +783,7 @@
       "undefined": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-undefined",
+          "spec_url": "https://tc39.es/ecma262/#sec-undefined",
           "support": {
             "chrome": {
               "version_added": true
@@ -835,7 +835,7 @@
       "unescape": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/unescape",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-unescape-string",
+          "spec_url": "https://tc39.es/ecma262/#sec-unescape-string",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -3,7 +3,7 @@
     "classes": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes",
-        "spec_url": "https://tc39.github.io/ecma262/#sec-class-definitions",
+        "spec_url": "https://tc39.es/ecma262/#sec-class-definitions",
         "support": {
           "chrome": {
             "version_added": "49",
@@ -76,7 +76,7 @@
       "constructor": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/constructor",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-static-semantics-constructormethod",
+          "spec_url": "https://tc39.es/ecma262/#sec-static-semantics-constructormethod",
           "support": {
             "chrome": {
               "version_added": "49",
@@ -150,7 +150,7 @@
       "extends": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/extends",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-class-definitions",
+          "spec_url": "https://tc39.es/ecma262/#sec-class-definitions",
           "support": {
             "chrome": {
               "version_added": "49",
@@ -224,7 +224,7 @@
       "static": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/static",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-class-definitions",
+          "spec_url": "https://tc39.es/ecma262/#sec-class-definitions",
           "support": {
             "chrome": {
               "version_added": "49",

--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -3,7 +3,7 @@
     "functions": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions",
-        "spec_url": "https://tc39.github.io/ecma262/#sec-function-definitions",
+        "spec_url": "https://tc39.es/ecma262/#sec-function-definitions",
         "support": {
           "chrome": {
             "version_added": true
@@ -54,7 +54,7 @@
       "arguments": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/arguments",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-arguments-exotic-objects",
+          "spec_url": "https://tc39.es/ecma262/#sec-arguments-exotic-objects",
           "support": {
             "chrome": {
               "version_added": true
@@ -105,7 +105,7 @@
         "callee": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/arguments/callee",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-arguments-exotic-objects",
+            "spec_url": "https://tc39.es/ecma262/#sec-arguments-exotic-objects",
             "support": {
               "chrome": {
                 "version_added": true
@@ -209,7 +209,7 @@
         "length": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/arguments/length",
-            "spec_url": "https://tc39.github.io/ecma262/#sec-arguments-exotic-objects",
+            "spec_url": "https://tc39.es/ecma262/#sec-arguments-exotic-objects",
             "support": {
               "chrome": {
                 "version_added": true
@@ -262,8 +262,8 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/arguments/@@iterator",
             "spec_url": [
-              "https://tc39.github.io/ecma262/#sec-createunmappedargumentsobject",
-              "https://tc39.github.io/ecma262/#sec-createmappedargumentsobject"
+              "https://tc39.es/ecma262/#sec-createunmappedargumentsobject",
+              "https://tc39.es/ecma262/#sec-createmappedargumentsobject"
             ],
             "support": {
               "chrome": {
@@ -318,7 +318,7 @@
         "__compat": {
           "description": "Arrow functions",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/Arrow_functions",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-arrow-function-definitions",
+          "spec_url": "https://tc39.es/ecma262/#sec-arrow-function-definitions",
           "support": {
             "chrome": {
               "version_added": "45"
@@ -481,7 +481,7 @@
         "__compat": {
           "description": "Default parameters",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/Default_parameters",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-function-definitions",
+          "spec_url": "https://tc39.es/ecma262/#sec-function-definitions",
           "support": {
             "chrome": {
               "version_added": "49"
@@ -636,7 +636,7 @@
         "__compat": {
           "description": "Method definitions",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/Method_definitions",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-method-definitions",
+          "spec_url": "https://tc39.es/ecma262/#sec-method-definitions",
           "support": {
             "chrome": {
               "version_added": "39"
@@ -864,7 +864,7 @@
         "__compat": {
           "description": "Rest parameters",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/rest_parameters",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-function-definitions",
+          "spec_url": "https://tc39.es/ecma262/#sec-function-definitions",
           "support": {
             "chrome": {
               "version_added": "47"
@@ -978,7 +978,7 @@
       "get": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/get",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-method-definitions",
+          "spec_url": "https://tc39.es/ecma262/#sec-method-definitions",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -1081,7 +1081,7 @@
       "set": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/set",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-method-definitions",
+          "spec_url": "https://tc39.es/ecma262/#sec-method-definitions",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -743,7 +743,7 @@
         "__compat": {
           "description": "Template literals",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Template_literals",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-template-literals",
+          "spec_url": "https://tc39.es/ecma262/#sec-template-literals",
           "support": {
             "chrome": {
               "version_added": "41"

--- a/javascript/operators/async_function_expression.json
+++ b/javascript/operators/async_function_expression.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>async function</code> expression",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/async_function",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-async-function-definitions",
+          "spec_url": "https://tc39.es/ecma262/#sec-async-function-definitions",
           "support": {
             "chrome": {
               "version_added": "55"

--- a/javascript/operators/await.json
+++ b/javascript/operators/await.json
@@ -4,7 +4,7 @@
       "await": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/await",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-async-function-definitions",
+          "spec_url": "https://tc39.es/ecma262/#sec-async-function-definitions",
           "support": {
             "chrome": {
               "version_added": "55"

--- a/javascript/operators/class.json
+++ b/javascript/operators/class.json
@@ -4,7 +4,7 @@
       "class": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/class",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-class-definitions",
+          "spec_url": "https://tc39.es/ecma262/#sec-class-definitions",
           "support": {
             "chrome": {
               "version_added": "42"

--- a/javascript/operators/comma.json
+++ b/javascript/operators/comma.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Comma operator",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Comma_operator",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-comma-operator",
+          "spec_url": "https://tc39.es/ecma262/#sec-comma-operator",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/operators/conditional.json
+++ b/javascript/operators/conditional.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Conditional operator (<code>c ? t : f</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Conditional_Operator",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-conditional-operator",
+          "spec_url": "https://tc39.es/ecma262/#sec-conditional-operator",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/operators/delete.json
+++ b/javascript/operators/delete.json
@@ -4,7 +4,7 @@
       "delete": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/delete",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-delete-operator",
+          "spec_url": "https://tc39.es/ecma262/#sec-delete-operator",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/operators/destructuring.json
+++ b/javascript/operators/destructuring.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Destructuring assignment",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-destructuring-assignment",
+          "spec_url": "https://tc39.es/ecma262/#sec-destructuring-assignment",
           "support": {
             "chrome": {
               "version_added": "49"

--- a/javascript/operators/function.json
+++ b/javascript/operators/function.json
@@ -4,7 +4,7 @@
       "function": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/function",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-function-definitions",
+          "spec_url": "https://tc39.es/ecma262/#sec-function-definitions",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/operators/function_star.json
+++ b/javascript/operators/function_star.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>function*</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/function*",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-generator-function-definitions",
+          "spec_url": "https://tc39.es/ecma262/#sec-generator-function-definitions",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/operators/grouping.json
+++ b/javascript/operators/grouping.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Grouping operator <code>()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Grouping",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-grouping-operator",
+          "spec_url": "https://tc39.es/ecma262/#sec-grouping-operator",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/operators/in.json
+++ b/javascript/operators/in.json
@@ -4,7 +4,7 @@
       "in": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/in",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-relational-operators",
+          "spec_url": "https://tc39.es/ecma262/#sec-relational-operators",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/operators/instanceof.json
+++ b/javascript/operators/instanceof.json
@@ -4,7 +4,7 @@
       "instanceof": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/instanceof",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-relational-operators",
+          "spec_url": "https://tc39.es/ecma262/#sec-relational-operators",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/operators/new.json
+++ b/javascript/operators/new.json
@@ -4,7 +4,7 @@
       "new": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/new",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-new-operator",
+          "spec_url": "https://tc39.es/ecma262/#sec-new-operator",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/operators/new_target.json
+++ b/javascript/operators/new_target.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>new.target</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/new.target",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-built-in-function-objects",
+          "spec_url": "https://tc39.es/ecma262/#sec-built-in-function-objects",
           "support": {
             "chrome": {
               "version_added": "46"

--- a/javascript/operators/object_initializer.json
+++ b/javascript/operators/object_initializer.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Object initializer",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Object_initializer",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-object-initializer",
+          "spec_url": "https://tc39.es/ecma262/#sec-object-initializer",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/pipeline.json
+++ b/javascript/operators/pipeline.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Pipeline operator (<code>|></code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Pipeline_operator",
-          "spec_url": "https://tc39.github.io/proposal-pipeline-operator/#sec-intro",
+          "spec_url": "https://tc39.es/proposal-pipeline-operator/#sec-intro",
           "support": {
             "chrome": {
               "version_added": false

--- a/javascript/operators/property_accessors.json
+++ b/javascript/operators/property_accessors.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Property accessors",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Property_Accessors",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-property-accessors",
+          "spec_url": "https://tc39.es/ecma262/#sec-property-accessors",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/operators/super.json
+++ b/javascript/operators/super.json
@@ -4,7 +4,7 @@
       "super": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/super",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-super-keyword",
+          "spec_url": "https://tc39.es/ecma262/#sec-super-keyword",
           "support": {
             "chrome": {
               "version_added": "42"

--- a/javascript/operators/this.json
+++ b/javascript/operators/this.json
@@ -4,7 +4,7 @@
       "this": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/this",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-this-keyword",
+          "spec_url": "https://tc39.es/ecma262/#sec-this-keyword",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/operators/typeof.json
+++ b/javascript/operators/typeof.json
@@ -4,7 +4,7 @@
       "typeof": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/typeof",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-typeof-operator",
+          "spec_url": "https://tc39.es/ecma262/#sec-typeof-operator",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/operators/void.json
+++ b/javascript/operators/void.json
@@ -4,7 +4,7 @@
       "void": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/void",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-void-operator",
+          "spec_url": "https://tc39.es/ecma262/#sec-void-operator",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/operators/yield.json
+++ b/javascript/operators/yield.json
@@ -4,7 +4,7 @@
       "yield": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/yield",
-          "spec_url": "https://tc39.github.io/ecma262/#prod-YieldExpression",
+          "spec_url": "https://tc39.es/ecma262/#prod-YieldExpression",
           "support": {
             "chrome": {
               "version_added": "39"

--- a/javascript/operators/yield_star.json
+++ b/javascript/operators/yield_star.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>yield*</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/yield*",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-generator-function-definitions-runtime-semantics-evaluation",
+          "spec_url": "https://tc39.es/ecma262/#sec-generator-function-definitions-runtime-semantics-evaluation",
           "support": {
             "chrome": {
               "version_added": true

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -59,7 +59,7 @@
         "__compat": {
           "description": "<code>async function</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/async_function",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-async-function-definitions",
+          "spec_url": "https://tc39.es/ecma262/#sec-async-function-definitions",
           "support": {
             "chrome": {
               "version_added": "55"
@@ -122,7 +122,7 @@
       "block": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/block",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-block",
+          "spec_url": "https://tc39.es/ecma262/#sec-block",
           "support": {
             "chrome": {
               "version_added": true
@@ -174,7 +174,7 @@
       "break": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/break",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-break-statement",
+          "spec_url": "https://tc39.es/ecma262/#sec-break-statement",
           "support": {
             "chrome": {
               "version_added": true
@@ -226,7 +226,7 @@
       "class": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/class",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-class-definitions",
+          "spec_url": "https://tc39.es/ecma262/#sec-class-definitions",
           "support": {
             "chrome": {
               "version_added": "49",
@@ -281,7 +281,7 @@
       "const": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/const",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-let-and-const-declarations",
+          "spec_url": "https://tc39.es/ecma262/#sec-let-and-const-declarations",
           "support": {
             "chrome": {
               "version_added": "21"
@@ -341,7 +341,7 @@
       "continue": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/continue",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-continue-statement",
+          "spec_url": "https://tc39.es/ecma262/#sec-continue-statement",
           "support": {
             "chrome": {
               "version_added": true
@@ -393,7 +393,7 @@
       "debugger": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/debugger",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-debugger-statement",
+          "spec_url": "https://tc39.es/ecma262/#sec-debugger-statement",
           "support": {
             "chrome": {
               "version_added": true
@@ -448,8 +448,8 @@
             "description": "<code>default</code> keyword in <code>switch</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/default",
             "spec_url": [
-              "https://tc39.github.io/ecma262/#sec-switch-statement",
-              "https://tc39.github.io/ecma262/#sec-exports"
+              "https://tc39.es/ecma262/#sec-switch-statement",
+              "https://tc39.es/ecma262/#sec-exports"
             ],
             "support": {
               "chrome": {
@@ -504,8 +504,8 @@
             "description": "<code>default</code> keyword with <code>export</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/default",
             "spec_url": [
-              "https://tc39.github.io/ecma262/#sec-switch-statement",
-              "https://tc39.github.io/ecma262/#sec-exports"
+              "https://tc39.es/ecma262/#sec-switch-statement",
+              "https://tc39.es/ecma262/#sec-exports"
             ],
             "support": {
               "chrome": {
@@ -595,7 +595,7 @@
         "__compat": {
           "description": "<code>do...while</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/do...while",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-do-while-statement",
+          "spec_url": "https://tc39.es/ecma262/#sec-do-while-statement",
           "support": {
             "chrome": {
               "version_added": true
@@ -648,7 +648,7 @@
         "__compat": {
           "description": "Empty statement (<code>;</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/Empty",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-empty-statement",
+          "spec_url": "https://tc39.es/ecma262/#sec-empty-statement",
           "support": {
             "chrome": {
               "version_added": true
@@ -700,7 +700,7 @@
       "export": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/export",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-exports",
+          "spec_url": "https://tc39.es/ecma262/#sec-exports",
           "support": {
             "chrome": {
               "version_added": "61"
@@ -787,7 +787,7 @@
       "for": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/for",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-for-statement",
+          "spec_url": "https://tc39.es/ecma262/#sec-for-statement",
           "support": {
             "chrome": {
               "version_added": true
@@ -840,7 +840,7 @@
         "__compat": {
           "description": "<code>for await...of</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/for-await...of",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-for-in-and-for-of-statements",
+          "spec_url": "https://tc39.es/ecma262/#sec-for-in-and-for-of-statements",
           "support": {
             "chrome": {
               "version_added": "63"
@@ -959,7 +959,7 @@
         "__compat": {
           "description": "<code>for...in</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/for...in",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-for-in-and-for-of-statements",
+          "spec_url": "https://tc39.es/ecma262/#sec-for-in-and-for-of-statements",
           "support": {
             "chrome": {
               "version_added": true
@@ -1012,7 +1012,7 @@
         "__compat": {
           "description": "<code>for...of</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/for...of",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-for-in-and-for-of-statements",
+          "spec_url": "https://tc39.es/ecma262/#sec-for-in-and-for-of-statements",
           "support": {
             "chrome": {
               "version_added": "38"
@@ -1168,7 +1168,7 @@
       "function": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-function-definitions",
+          "spec_url": "https://tc39.es/ecma262/#sec-function-definitions",
           "support": {
             "chrome": {
               "version_added": true
@@ -1272,7 +1272,7 @@
         "__compat": {
           "description": "<code>function*</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function*",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-generator-function-definitions",
+          "spec_url": "https://tc39.es/ecma262/#sec-generator-function-definitions",
           "support": {
             "chrome": {
               "version_added": "39"
@@ -1489,7 +1489,7 @@
         "__compat": {
           "description": "<code>if...else</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/if...else",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-if-statement",
+          "spec_url": "https://tc39.es/ecma262/#sec-if-statement",
           "support": {
             "chrome": {
               "version_added": true
@@ -1543,7 +1543,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/import",
           "spec_url": [
             "https://github.com/tc39/proposal-dynamic-import/#import",
-            "https://tc39.github.io/ecma262/#sec-imports"
+            "https://tc39.es/ecma262/#sec-imports"
           ],
           "support": {
             "chrome": {
@@ -1769,7 +1769,7 @@
       "label": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/label",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-labelled-statements",
+          "spec_url": "https://tc39.es/ecma262/#sec-labelled-statements",
           "support": {
             "chrome": {
               "version_added": true
@@ -1821,7 +1821,7 @@
       "let": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/let",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-let-and-const-declarations",
+          "spec_url": "https://tc39.es/ecma262/#sec-let-and-const-declarations",
           "support": {
             "chrome": [
               {
@@ -1929,7 +1929,7 @@
       "return": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/return",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-return-statement",
+          "spec_url": "https://tc39.es/ecma262/#sec-return-statement",
           "support": {
             "chrome": {
               "version_added": true
@@ -1981,7 +1981,7 @@
       "switch": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/switch",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-switch-statement",
+          "spec_url": "https://tc39.es/ecma262/#sec-switch-statement",
           "support": {
             "chrome": {
               "version_added": true
@@ -2033,7 +2033,7 @@
       "throw": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/throw",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-throw-statement",
+          "spec_url": "https://tc39.es/ecma262/#sec-throw-statement",
           "support": {
             "chrome": {
               "version_added": true
@@ -2086,7 +2086,7 @@
         "__compat": {
           "description": "<code>try...catch</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/try...catch",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-try-statement",
+          "spec_url": "https://tc39.es/ecma262/#sec-try-statement",
           "support": {
             "chrome": {
               "version_added": true
@@ -2242,7 +2242,7 @@
       "var": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/var",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-variable-statement",
+          "spec_url": "https://tc39.es/ecma262/#sec-variable-statement",
           "support": {
             "chrome": {
               "version_added": true
@@ -2294,7 +2294,7 @@
       "while": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/while",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-while-statement",
+          "spec_url": "https://tc39.es/ecma262/#sec-while-statement",
           "support": {
             "chrome": {
               "version_added": true
@@ -2346,7 +2346,7 @@
       "with": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/with",
-          "spec_url": "https://tc39.github.io/ecma262/#sec-with-statement",
+          "spec_url": "https://tc39.es/ecma262/#sec-with-statement",
           "support": {
             "chrome": {
               "version_added": true


### PR DESCRIPTION
All https://tc39.github.io URLs now redirect to corresponding https://tc39.es URLs.