### PR TITLE
Update for link element's disabled attribute being added back

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -146,19 +146,23 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": true,
+                "notes": "Chrome does not include stylesheets which have the HTML <code>disabled</code> attribute in <code>document.styleSheets</code>."
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": true,
+                "notes": "Chrome does not include stylesheets which have the HTML <code>disabled</code> attribute in <code>document.styleSheets</code>."
               },
               "edge": {
                 "version_added": true
               },
               "firefox": {
-                "version_added": false
+                "version_added": "68",
+                "notes": "Prior to Firefox 68, the HTML <code>disabled</code> attribute worked but could not be changed using JavaScript code."
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "68",
+                "notes": "Prior to Firefox 68, the HTML <code>disabled</code> attribute worked but could not be changed using JavaScript code."
               },
               "ie": {
                 "version_added": true
@@ -179,7 +183,8 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": true,
+                "notes": "Chrome does not include stylesheets which have the HTML <code>disabled</code> attribute in <code>document.styleSheets</code>."
               }
             },
             "status": {

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -157,12 +157,10 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "68",
-                "notes": "Prior to Firefox 68, the HTML <code>disabled</code> attribute worked but could not be changed using JavaScript code."
+                "version_added": "68"
               },
               "firefox_android": {
-                "version_added": "68",
-                "notes": "Prior to Firefox 68, the HTML <code>disabled</code> attribute worked but could not be changed using JavaScript code."
+                "version_added": "68"
               },
               "ie": {
                 "version_added": true
@@ -184,7 +182,7 @@
               },
               "webview_android": {
                 "version_added": true,
-                "notes": "Chrome does not include stylesheets which have the HTML <code>disabled</code> attribute in <code>document.styleSheets</code>."
+                "notes": "Chrome does not include stylesheets which have the HTML <code>disabled</code> attribute in <code>document.styleSheets</code>, but"
               }
             },
             "status": {

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -147,11 +147,11 @@
             "support": {
               "chrome": {
                 "version_added": true,
-                "notes": "Chrome does not include stylesheets which have the HTML <code>disabled</code> attribute in <code>document.styleSheets</code>."
+                "notes": "In Chrome, adding the <code>disabled</code> attribute using JavaScript does not remove the stylesheet from <code>document.styleSheets</code>."
               },
               "chrome_android": {
                 "version_added": true,
-                "notes": "Chrome does not include stylesheets which have the HTML <code>disabled</code> attribute in <code>document.styleSheets</code>."
+                "notes": "In Chrome, adding the <code>disabled</code> attribute using JavaScript does not remove the stylesheet from <code>document.styleSheets</code>."
               },
               "edge": {
                 "version_added": true

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -147,11 +147,11 @@
             "support": {
               "chrome": {
                 "version_added": true,
-                "notes": "In Chrome, adding the <code>disabled</code> attribute using JavaScript does not remove the stylesheet from <code>document.styleSheets</code>."
+                "notes": "In Chrome and other Blink-based browsers, adding the <code>disabled</code> attribute using JavaScript does not remove the stylesheet from <code>document.styleSheets</code>."
               },
               "chrome_android": {
                 "version_added": true,
-                "notes": "In Chrome, adding the <code>disabled</code> attribute using JavaScript does not remove the stylesheet from <code>document.styleSheets</code>."
+                "notes": "In Chrome and other Blink-based browsers, adding the <code>disabled</code> attribute using JavaScript does not remove the stylesheet from <code>document.styleSheets</code>."
               },
               "edge": {
                 "version_added": true
@@ -166,10 +166,12 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": false
+                "version_added": true,
+                "notes": "In Chrome and other Blink-based browsers, adding the <code>disabled</code> attribute using JavaScript does not remove the stylesheet from <code>document.styleSheets</code>."
               },
               "opera_android": {
-                "version_added": false
+                "version_added": true,
+                "notes": "In Chrome and other Blink-based browsers, adding the <code>disabled</code> attribute using JavaScript does not remove the stylesheet from <code>document.styleSheets</code>."
               },
               "safari": {
                 "version_added": false
@@ -178,11 +180,12 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": true,
+                "notes": "In Chrome and other Blink-based browsers, adding the <code>disabled</code> attribute using JavaScript does not remove the stylesheet from <code>document.styleSheets</code>."
               },
               "webview_android": {
                 "version_added": true,
-                "notes": "Chrome does not include stylesheets which have the HTML <code>disabled</code> attribute in <code>document.styleSheets</code>, but"
+                "notes": "In Chrome and other Blink-based browsers, adding the <code>disabled</code> attribute using JavaScript does not remove the stylesheet from <code>document.styleSheets</code>."
               }
             },
             "status": {


### PR DESCRIPTION
At some point, the link element's disabled attribute was removed
from the spec. It has since been restored but was not linked to
the stylesheet's disabled attribute.

In https://github.com/whatwg/html/issues/3840, the two are being
revised to reflect one another. This BCD update adds data to
indicate this.

Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1281135
Firefox intent to implement: https://groups.google.com/forum/#!topic/mozilla.dev.platform/BdgNaChHnpY