### PR TITLE
Add negotiated to RTCDataChannel in Firefox 68

### DIFF
--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -702,10 +702,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
FX 68 added the `negotiated` property to `RTCDataChannel`.

References:
* https://bugzilla.mozilla.org/show_bug.cgi?id=1529695