### PR TITLE
Update background-blend-mode

### DIFF
--- a/css/properties/background-blend-mode.json
+++ b/css/properties/background-blend-mode.json
@@ -34,7 +34,7 @@
               "version_added": "22"
             },
             "safari": {
-              "version_added": true
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": "8"
@@ -43,7 +43,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {


### PR DESCRIPTION
For #4295:

* Safari to version 8.

  WebKit added this feature in early 2014: https://trac.webkit.org/changeset/163633/webkit Many sources (including caniuse) claim that this shipped in 7.1. I couldn't directly confirm that (the only Apple documentation for 7.1 mentions security fixes), but we don't have 7.1 in our data set anyway. Version 8 is consistent with the WebKit engine number for Safari for iOS.
* WebView to `true`.

  I suspect we'll change this to "37" once we deal with the whole WebView issue. It seems to have landed around then anyway.