### PR TITLE
Update background-origin

### DIFF
--- a/css/properties/background-origin.json
+++ b/css/properties/background-origin.json
@@ -10,7 +10,7 @@
                 "version_added": "1"
               },
               {
-                "version_added": true,
+                "version_added": "1",
                 "prefix": "-webkit-",
                 "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
@@ -20,7 +20,7 @@
                 "version_added": true
               },
               {
-                "version_added": true,
+                "version_added": "18",
                 "prefix": "-webkit-",
                 "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
@@ -110,7 +110,7 @@
                 "version_added": "4.1"
               },
               {
-                "version_added": true,
+                "version_added": "4.1",
                 "prefix": "-webkit-",
                 "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
@@ -130,7 +130,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -158,7 +158,7 @@
                 "version_added": "3"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/css/properties/background-origin.json
+++ b/css/properties/background-origin.json
@@ -103,7 +103,7 @@
               }
             ],
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1"
             },
             "webview_android": [
               {
@@ -161,7 +161,7 @@
                 "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1"
               },
               "webview_android": {
                 "version_added": "4.1"


### PR DESCRIPTION
For #4295, updates to `background-origin` for WebKit and derivatives:

For `-webkit-background-origin` itself:

* Chrome to 1 and Chrome for Android to 18.

   This changeset shows that WebKit prefix predates Chrome's existence by quite a long time: https://trac.webkit.org/changeset/13874/webkit

* WebView to 4.1

  For consistency with the unprefixed version (I realize this value may change when we sort out the WebView question).

For the `content-box` value:

* Chrome for Android to 18 and Safari for iOS to version 1

  It was included in the original implementation of `background-origin`, according to this post on the WebKit blog https://webkit.org/blog/22/css3-goodies-borders-and-backgrounds/