### PR TITLE
Update background-position-*

### DIFF
--- a/css/properties/background-position-x.json
+++ b/css/properties/background-position-x.json
@@ -6,10 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/background-position-x",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -27,19 +27,19 @@
               "version_added": "6"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "18"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/properties/background-position-y.json
+++ b/css/properties/background-position-y.json
@@ -6,10 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/background-position-y",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -27,19 +27,19 @@
               "version_added": "6"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true


### PR DESCRIPTION
For #4295. Updating `background-position-x` and `background-position-y` for WebKit derivatives.

I did a bunch of digging and it appears that `background-position-x` and `background-position-y` are extremely old properties in the WebKit lineage. [There are tests for them committed to WebKit in 2003](https://github.com/chromium/chromium/search?o=asc&q=%22background-position-x%22&s=committer-date&type=Commits), but I couldn't find an original implementation changeset. I suspect that they're both from KHTML. (The features themselves seem to have originated with IE 6—it's practically primordial.)

Given that, I've set `background-position-x` and `background-position-y` to the first release for all of the WebKit-derived browsers. I also set the Operas to their first Chromium releases (caniuse and others report it first being supported with Opera 15).