### PR TITLE
Safari 12.1 dropped Do Not Track header

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -694,8 +694,7 @@
               "notes": "Safari 7.1.3+ uses <code>window.doNotTrack</code> rather than <code>navigator.doNotTrack</code>."
             },
             "safari_ios": {
-              "version_added": null,
-              "version_removed": true
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -694,7 +694,8 @@
               "notes": "Safari 7.1.3+ uses <code>window.doNotTrack</code> rather than <code>navigator.doNotTrack</code>."
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": null,
+              "version_removed": true
             },
             "samsunginternet_android": {
               "version_added": null

--- a/http/headers/dnt.json
+++ b/http/headers/dnt.json
@@ -30,10 +30,12 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "6",
+              "version_removed": "12.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "12.1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -44,7 +46,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/http/headers/dnt.json
+++ b/http/headers/dnt.json
@@ -35,7 +35,7 @@
             },
             "safari_ios": {
               "version_added": true,
-              "version_removed": "12.1"
+              "version_removed": "12.2"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/http/headers/dnt.json
+++ b/http/headers/dnt.json
@@ -46,7 +46,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
# Summary
1. Safari 12.1 dropped support for DNT.
2. Do Not Track header standard is no longer actively developed, the document was published as a "note" before being fully implemented and reaching "Technical Recommendation" status.

# Data
1. Safari 12.1 release notes: https://developer.apple.com/documentation/safari_release_notes/safari_12_1_release_notes

2. The "Tracking Preference Expression (DNT)" document:
https://w3c.github.io/dnt/drafts/tracking-dnt.html
It has status "Working Group Note" and all work on the standard ended. Also, there does not seem to be any interest in implementing the whole standard or even determining what `DNT: 1` actually means (all tracking or cross-site tracking or third-party tracking, etc.).

I believe this means `standard_track` should be set to `false`, especially since only a tiny subset of the standard was ever implemented.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] N/A - Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] N/A - Link to related issues or pull requests, if any

Edit: changed `safari_ios` to `12.2` because it has the same release URL int the [JSON](https://github.com/mdn/browser-compat-data/blob/master/browsers/safari_ios.json).