### PR TITLE
Fix Samsung version (resolve build failure)

### DIFF
--- a/css/properties/background-origin.json
+++ b/css/properties/background-origin.json
@@ -103,7 +103,7 @@
               }
             ],
             "samsunginternet_android": {
-              "version_added": "1"
+              "version_added": "1.0"
             },
             "webview_android": [
               {
@@ -161,7 +161,7 @@
                 "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": "1"
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4.1"


### PR DESCRIPTION
Don't know how I missed this in https://github.com/mdn/browser-compat-data/pull/4326, but apparently that PR got the Samsung version wrong and so master fails currently.