### PR TITLE
[Firefox] Bug 1470695: Implement `overflow‑*` logical properties

### DIFF
--- a/css/properties/overflow-block.json
+++ b/css/properties/overflow-block.json
@@ -18,7 +18,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "69"
             },
             "firefox_android": {
               "version_added": false

--- a/css/properties/overflow-inline.json
+++ b/css/properties/overflow-inline.json
@@ -18,7 +18,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "69"
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
See [bug 1470695][bmo‑1470695] for details.

[bmo‑1470695]: https://bugzilla.mozilla.org/show_bug.cgi?id=1470695