### PR TITLE
Make parameter for addIceCandidate() optional

### DIFF
--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -52,7 +52,7 @@
       },
       "RTCIceCandidate": {
         "__compat": {
-          "description": "RTCIceCandidate()",
+          "description": "<code>RTCIceCandidate()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidate/RTCIceCandidate",
           "support": {
             "chrome": {
@@ -68,10 +68,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": "22",
+              "notes": "Beginning in Firefox 68, the constructor's <code>options</code> parameter is optional."
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true,
+              "notes": "Beginning in Firefox 68, the constructor's <code>options</code> parameter is optional."
             },
             "ie": {
               "version_added": false

--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -69,11 +69,11 @@
             },
             "firefox": {
               "version_added": "22",
-              "notes": "Beginning in Firefox 68, the constructor's <code>options</code> parameter is optional."
+              "notes": "Before Firefox 68, the constructor's <code>options</code> parameter was required."
             },
             "firefox_android": {
               "version_added": true,
-              "notes": "Beginning in Firefox 68, the constructor's <code>options</code> parameter is optional."
+              "notes": "Before Firefox 68, the constructor's <code>options</code> parameter was required."
             },
             "ie": {
               "version_added": false

--- a/api/RTCIceCandidateInit.json
+++ b/api/RTCIceCandidateInit.json
@@ -67,10 +67,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": "22",
+              "notes": "The <code>candidate</code> property became optional in a mid-2017 specification update. Firefox implements this change in version 68."
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "The <code>candidate</code> property became optional in a mid-2017 specification update. Firefox implements this change in version 68."
             },
             "ie": {
               "version_added": false

--- a/api/RTCIceCandidateInit.json
+++ b/api/RTCIceCandidateInit.json
@@ -68,11 +68,11 @@
             },
             "firefox": {
               "version_added": "22",
-              "notes": "The <code>candidate</code> property became optional in a mid-2017 specification update. Firefox implements this change in version 68."
+              "notes": "In Firefox 68, the <code>candidate</code> property became optional per mid-2017 specification update."
             },
             "firefox_android": {
               "version_added": true,
-              "notes": "The <code>candidate</code> property became optional in a mid-2017 specification update. Firefox implements this change in version 68."
+              "notes": "In Firefox 68, the <code>candidate</code> property became optional per mid-2017 specification update."
             },
             "ie": {
               "version_added": false

--- a/api/RTCIceCandidateInit.json
+++ b/api/RTCIceCandidateInit.json
@@ -68,11 +68,11 @@
             },
             "firefox": {
               "version_added": "22",
-              "notes": "In Firefox 68, the <code>candidate</code> property became optional per mid-2017 specification update."
+              "notes": "Prior to Firefox 68, the <code>candidate</code> property was required; Firefox 68 and later make it optional per a mid-2017 specification update."
             },
             "firefox_android": {
               "version_added": true,
-              "notes": "In Firefox 68, the <code>candidate</code> property became optional per mid-2017 specification update."
+              "notes": "Prior to Firefox 68, the <code>candidate</code> property was required; Firefox 68 and later make it optional per a mid-2017 specification update."
             },
             "ie": {
               "version_added": false

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -176,10 +176,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": "22",
+              "notes": "Starting in Firefox 68, the <code>candidate</code> parameter is optional when calling the constructor. A <code>null</code> value for <code>candidate</code> indicates no more candidates will be sent, while an empty <code>candidate</code> string indicates that no more candidates will be sent for the current generation of candidates."
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": "44",
+              "notes": "Starting in Firefox 68, the <code>candidate</code> parameter is optional when calling the constructor. A <code>null</code> value for <code>candidate</code> indicates no more candidates will be sent, while an empty <code>candidate</code> string indicates that no more candidates will be sent for the current generation of candidates."
             },
             "ie": {
               "version_added": false

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -177,11 +177,11 @@
             },
             "firefox": {
               "version_added": "22",
-              "notes": "Starting in Firefox 68, the <code>candidate</code> parameter is optional when calling the constructor. A <code>null</code> value for <code>candidate</code> indicates no more candidates will be sent, while an empty <code>candidate</code> string indicates that no more candidates will be sent for the current generation of candidates."
+              "notes": "Starting in Firefox 68, the <code>candidate</code> parameter is optional when calling <code>addIceCandidate()</code>. A <code>null</code> value for <code>candidate</code> indicates no more candidates will be sent, while an empty <code>candidate</code> string indicates that no more candidates will be sent for the current generation of candidates."
             },
             "firefox_android": {
               "version_added": "44",
-              "notes": "Starting in Firefox 68, the <code>candidate</code> parameter is optional when calling the constructor. A <code>null</code> value for <code>candidate</code> indicates no more candidates will be sent, while an empty <code>candidate</code> string indicates that no more candidates will be sent for the current generation of candidates."
+              "notes": "Starting in Firefox 68, the <code>candidate</code> parameter is optional when calling <code>addIceCandidate()</code>. A <code>null</code> value for <code>candidate</code> indicates no more candidates will be sent, while an empty <code>candidate</code> string indicates that no more candidates will be sent for the current generation of candidates."
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This implements fuller support for the end-of-candidates notification by
making the candidate optional. These changes also add notes about the
meaning changes of the candidate parameter/property over time.

Sources:
* https://bugzilla.mozilla.org/show_bug.cgi?id=1318167
* https://github.com/w3c/webrtc-pc/issues/2125