### PR TITLE
Update scroll-behavior.json with Samsung Internet

### DIFF
--- a/css/properties/scroll-behavior.json
+++ b/css/properties/scroll-behavior.json
@@ -39,7 +39,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.2"
             },
             "webview_android": {
               "version_added": "61"

--- a/css/properties/scroll-behavior.json
+++ b/css/properties/scroll-behavior.json
@@ -39,7 +39,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "8.2"
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "61"


### PR DESCRIPTION
Sets the version_added of scroll-behavior for Samsung Internet to 8.2

Was able to test it in 9.2 and found that worked with the scrolling tag set to smooth. Also saw that it works in 8.2 according to https://caniuse.com/#feat=css-overscroll-behavior. Wasn't able to find any changelogs that showed this change. 