### PR TITLE
Update Navigator to note secure context needed for getUserMedia()

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1385,6 +1385,59 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "secure_context_required": {
+          "__compat": {
+            "description": "Secure context required",
+            "support": {
+              "chrome": {
+                "version_added": "74"
+              },
+              "chrome_android": {
+                "version_added": "74"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": "Release, Beta, and Developer Edition builds of Firefox do not require a secure context by default; however, Nightly builds do."
+              },
+              "firefox_android": {
+                "version_added": false,
+                "notes": "Release, Beta, and Developer Edition builds of Firefox do not require a secure context by default; however, Nightly builds do."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": "74"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "mediaSession": {


### PR DESCRIPTION
The Media Capture and Streams spec has been updated to require the use
of a secure context -- one loaded using HTTPs, `localhost`, or `file:///` --
in order to access `navigator.mediaDevices.getUserMedia()`. This updates
the data accordingly. Currently this is only enforced in Chrome. Firefox
will begin to do so soon, but is currently doing so on Nightly builds.

Sources:
* [Disable getUserMedia on non-secure origins](https://bugzilla.mozilla.org/show_bug.cgi?id=1335740)
* [intent to deprecate](https://groups.google.com/forum/#!topic/mozilla.dev.platform/vmO0NRM46l8)
