### PR TITLE
Update background-repeat data

### DIFF
--- a/css/properties/background-repeat.json
+++ b/css/properties/background-repeat.json
@@ -107,10 +107,10 @@
             "description": "Two-value syntax (different values for x & y directions)",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "3"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"

--- a/css/properties/background-repeat.json
+++ b/css/properties/background-repeat.json
@@ -178,11 +178,17 @@
               "ie": {
                 "version_added": "9"
               },
-              "opera": {
-                "version_added": "10.5"
-              },
+              "opera": [
+                {
+                  "version_added": "17"
+                },
+                {
+                  "version_added": "10.5",
+                  "version_removed": "15"
+                }
+              ],
               "opera_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "safari": {
                 "version_added": "7"
@@ -191,7 +197,7 @@
                 "version_added": "8"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "2.0"
               },
               "webview_android": {
                 "version_added": true

--- a/css/properties/background-repeat.json
+++ b/css/properties/background-repeat.json
@@ -134,10 +134,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": true
+                "version_added": "4.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "4"
               },
               "samsunginternet_android": {
                 "version_added": null

--- a/css/properties/background-repeat.json
+++ b/css/properties/background-repeat.json
@@ -140,7 +140,7 @@
                 "version_added": "4"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true

--- a/css/properties/background-repeat.json
+++ b/css/properties/background-repeat.json
@@ -158,10 +158,10 @@
             "description": "<code>round</code> and <code>space</code> keywords",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "30"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "30"
               },
               "edge": {
                 "version_added": "12"

--- a/css/properties/background-repeat.json
+++ b/css/properties/background-repeat.json
@@ -36,10 +36,10 @@
               "version_added": "1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/css/properties/background-repeat.json
+++ b/css/properties/background-repeat.json
@@ -185,10 +185,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": true
+                "version_added": "7"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "8"
               },
               "samsunginternet_android": {
                 "version_added": null


### PR DESCRIPTION
For #4295, I researched `background-repeat`. This was a complicated one!

## `background-repeat`

Since I was here making a bunch of other changes, I mirrored from `background-repeat` from Safari to Safari for iOS and from Chrome to Samsung Internet. A rather old feature, so I figured this was reasonable.

## `2-value`

* Chrome: https://chromium.googlesource.com/chromium/src.git/+/5ea3d8d2563187f1d17ed850a9373a3dda42a606 Inferred v3 based on release date; Omaha Proxy doesn't seem to work this far back.
* Safaris: https://bugs.webkit.org/show_bug.cgi?id=28635 Inferred versions based on release date and WebKit engine.
* Samsung Internet: mirrored from Chrome

## `round_space`

Maybe we should split these in two? I decided not to for a cleaner diff, but I could add that change too.

* Chrome

   [caniuse says 32](https://caniuse.com/#feat=background-repeat-round-space) without citation. I went digging.

   This bug shows `round` was added no later than 31: https://bugs.chromium.org/p/chromium/issues/detail?id=331683

   This bug shows it wasn't working in 28: https://bugs.chromium.org/p/chromium/issues/detail?id=263310

   This comment on a Firefox bug suggests it still wasn't working in Chrome in 29: https://bugzilla.mozilla.org/show_bug.cgi?id=913153#c11

   By process of elimination, that leaves us with Chrome 30.

* Opera: mirrored from Chrome.
* Safaris

   The dates on a bunch of bugs and change sets seem to show that it was added to WebKit in August, 2013, meaning no earlier than Safari 7 by release date:

   * https://bugs.webkit.org/show_bug.cgi?id=27570
   * https://bugs.webkit.org/show_bug.cgi?id=119080
   * https://trac.webkit.org/changeset/154875/webkit
   * https://trac.webkit.org/changeset/153582/webkit

   caniuse also reports version 7. I inferred iOS 8 based on the WebKit versions in our data set.

* Samsung Internet: mirrored from Chrome.