### PR TITLE
Update SVG-as-backgrounds data

### DIFF
--- a/css/properties/background-size.json
+++ b/css/properties/background-size.json
@@ -172,57 +172,6 @@
               "deprecated": false
             }
           }
-        },
-        "SVG_image_as_background": {
-          "__compat": {
-            "description": "SVG image as background",
-            "support": {
-              "chrome": {
-                "version_added": "44"
-              },
-              "chrome_android": {
-                "version_added": "44"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "edge_mobile": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": "8"
-              },
-              "firefox_android": {
-                "version_added": "8"
-              },
-              "ie": {
-                "version_added": "9"
-              },
-              "opera": {
-                "version_added": "31"
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": null
-              },
-              "webview_android": {
-                "version_added": "44"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       }
     }

--- a/css/properties/background.json
+++ b/css/properties/background.json
@@ -107,10 +107,10 @@
             "description": "SVG image as background",
             "support": {
               "chrome": {
-                "version_added": "31"
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "31"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -119,7 +119,7 @@
                 "version_added": true
               },
               "firefox": {
-                "version_added": "9"
+                "version_added": "4"
               },
               "firefox_android": {
                 "version_added": "4"
@@ -128,22 +128,22 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": "21"
+                "version_added": true
               },
               "opera_android": {
                 "version_added": true
               },
               "safari": {
-                "version_added": "5.1"
+                "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": "4.2"
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": null
               },
               "webview_android": {
-                "version_added": "3"
+                "version_added": true
               }
             },
             "status": {


### PR DESCRIPTION
For #4295, I tried to figure out what was meant by `css.properties.background-size.SVG_image_as_background`. After some digging, I decided to clean up the data in `css.properties.background.SVG_image_as_background` instead and remove `css.properties.background-size.SVG_image_as_background`.

First, the removal: the short version of the story seems to be that SVG images as backgrounds is quirky, particularly because SVGs don't _necessarily_ have an intrinsic size and this causes surprising behavior. Since we haven't really updated this data since it was originally migrated from the wiki to BCD, I suspect whomever originally added the info to the wiki was trying to cope with those surprises.

In the process of researching `background-size`, I learned a bit about the history of the feature represented by `css.properties.background-size.SVG_image_as_background`. Again, because of various surprises and bugs, I found a lot of that data to be unreliable. It's a very old feature, but I tried my best to introduce more realistic version numbers:

* Chrome: there are several bugs (such as [49096](https://bugs.chromium.org/p/chromium/issues/detail?id=49096) or [104701](https://bugs.chromium.org/p/chromium/issues/detail?id=104701)) fighting with SVG in early versions of Chrome. Given that WebKit appears to have landed SVG in CSS backgrounds some time before Chrome's first release, I've made the educated guess that Chrome has always supported SVGs in backgrounds.
* Firefox: the [Firefox 4 release notes](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/4) explicitly mentions support.
* Opera: I wasn't able to pin down the version, but there are Stack Overflow questions talking about Opera's support in 10- and 12-series releases. I set this to `true`.
* Safari: the [Safari 3.1 release notes](https://web.archive.org/web/20080902030001/http://docs.info.apple.com/article.html?artnum=307467) explicitly mentions support. There are [very old WebKit bugs](https://bugs.webkit.org/show_bug.cgi?id=5971) discussing it. This predates iOS v1.
* WebView: set to `true`. I suspect this is also v1, but early WebView is still a thing we need to sort out.
