### PR TITLE
Object.entries support in iOS Safari

### DIFF
--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -624,7 +624,7 @@
                 "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": "10.1"
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": "6.0"


### PR DESCRIPTION
Based on this official announcement: https://webkit.org/blog/7477/new-web-features-in-safari-10-1/
Object.entries is supported in iOS Safari by version 10.3. Version 10.1 is for desktop version.
