### PR TITLE
Add audio/video track support data to RTCRtpReceiver source get…

### DIFF
--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -425,10 +425,10 @@
             "description": "Video tracks supported",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "73"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "73"
               },
               "edge": {
                 "version_added": null
@@ -468,7 +468,7 @@
                 "version_added": null
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "73"
               }
             },
             "status": {
@@ -484,10 +484,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpReceiver/getSynchronizationSources",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "73"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "73"
             },
             "edge": {
               "version_added": null
@@ -527,7 +527,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "73"
             }
           },
           "status": {
@@ -541,10 +541,10 @@
             "description": "Audio tracks supported",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "73"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "73"
               },
               "edge": {
                 "version_added": false
@@ -584,7 +584,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "73"
               }
             },
             "status": {
@@ -599,10 +599,10 @@
             "description": "Video tracks supported",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "73"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "73"
               },
               "edge": {
                 "version_added": null
@@ -642,7 +642,7 @@
                 "version_added": null
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "73"
               }
             },
             "status": {

--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -361,6 +361,122 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "audio_tracks_supported": {
+          "__compat": {
+            "description": "Audio tracks supported",
+            "support": {
+              "chrome": {
+                "version_added": "59"
+              },
+              "chrome_android": {
+                "version_added": "59"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "59"
+              },
+              "firefox_android": {
+                "version_added": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.peerconnection.rtpsourcesapi.enable",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "46"
+              },
+              "opera_android": {
+                "version_added": "43"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": "7.0"
+              },
+              "webview_android": {
+                "version_added": "59"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "video_tracks_supported": {
+          "__compat": {
+            "description": "Video tracks supported",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "68"
+              },
+              "firefox_android": {
+                "version_added": "68",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.peerconnection.rtpsourcesapi.enable",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "getSynchronizationSources": {
@@ -418,6 +534,122 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "audio_tracks_supported": {
+          "__compat": {
+            "description": "Audio tracks supported",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "59"
+              },
+              "firefox_android": {
+                "version_added": "59",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.peerconnection.rtpsourcesapi.enable",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "video_tracks_supported": {
+          "__compat": {
+            "description": "Video tracks supported",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "68"
+              },
+              "firefox_android": {
+                "version_added": "68",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.peerconnection.rtpsourcesapi.enable",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },


### PR DESCRIPTION
Firefox 68 adds support for video tracks to `RTCRtpReceiver`'s methods
`getContributingSources()` and `getSynchronousSources()`. This patch
adds all the data needed to present this.

Source:
* https://bugzilla.mozilla.org/show_bug.cgi?id=1534466
