### PR TITLE
Mark the http-equiv value set-cookie as deprecated

### DIFF
--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -391,10 +391,12 @@
                   "version_added": true
                 },
                 "firefox": {
-                  "version_added": "1"
+                  "version_added": "1",
+                  "version_removed": "68"
                 },
                 "firefox_android": {
-                  "version_added": "4"
+                  "version_added": "4",
+                  "version_removed": "68"
                 },
                 "ie": {
                   "version_added": true


### PR DESCRIPTION
This is not supported anymore in Firefox 68

Source:
* https://bugzilla.mozilla.org/show_bug.cgi?id=1457503
* https://github.com/whatwg/html/pull/3649
