### PR TITLE
Add meta name="color-scheme"

### DIFF
--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -473,6 +473,53 @@
               "deprecated": false
             }
           },
+          "color-scheme": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": "12.1"
+                },
+                "safari_ios": {
+                  "version_added": "12.2"
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "referer": {
             "__compat": {
               "description": "referrer value",


### PR DESCRIPTION
Added this value for the `name` property on the `<meta>` element.
Currently supported only in Safari 12.1 for Mac and 12.2 for iOS.

https://github.com/whatwg/html/issues/4504

