### PR TITLE
Object.fromEntries is supported on Opera60

### DIFF
--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -719,7 +719,7 @@
                 "version_added": "12.0.0"
               },
               "opera": {
-                "version_added": false
+                "version_added": "60"
               },
               "opera_android": {
                 "version_added": false


### PR DESCRIPTION
Based on [offical document](https://help.opera.com/en/opera-version-history/) and my test, Object.fromEntries is supported on Opera60.

![image](https://user-images.githubusercontent.com/19589659/59842183-94a22380-9388-11e9-8e9f-5aa7a259453c.png)
