### PR TITLE
HTMLImageElement.decode() added to Firefox 68

### DIFF
--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -411,10 +411,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
Source:
* https://bugzilla.mozilla.org/show_bug.cgi?id=1501794

A checklist to help your pull request get merged faster:
- [ ] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
