### PR TITLE
Update border-image data

### DIFF
--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -247,7 +247,8 @@
             "description": "<code>&lt;gradient&gt;</code>",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "2"
+              },
               },
               "edge": {
                 "version_added": "12"

--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -157,6 +157,9 @@
               "chrome": {
                 "version_added": "16"
               },
+              "chrome_android": {
+                "version_added": "18"
+              },
               "edge": {
                 "version_added": "12"
               },
@@ -172,11 +175,17 @@
               "opera": {
                 "version_added": "15"
               },
+              "opera_android": {
+                "version_added": "14"
+              },
               "safari": {
                 "version_added": "6"
               },
               "safari_ios": {
                 "version_added": "6"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0"
               }
             },
             "status": {

--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -268,10 +268,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "4"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "3.2"
               },
               "webview_android": {
                 "version_added": true

--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -195,9 +195,8 @@
             }
           }
         },
-        "fill_keyword": {
+        "fill": {
           "__compat": {
-            "description": "<code>fill</code> keyword",
             "support": {
               "chrome": {
                 "version_added": true

--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -201,6 +201,8 @@
               "chrome": {
                 "version_added": "16"
               },
+              "chrome_android": {
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -217,11 +219,17 @@
               "opera": {
                 "version_added": true
               },
+              "opera_android": {
+                "version_added": true
+              },
               "safari": {
                 "version_added": "6"
               },
               "safari_ios": {
                 "version_added": "6"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true

--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -173,7 +173,10 @@
                 "version_added": "15"
               },
               "safari": {
-                "version_added": null
+                "version_added": "6"
+              },
+              "safari_ios": {
+                "version_added": "6"
               }
             },
             "status": {

--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -249,6 +249,8 @@
               "chrome": {
                 "version_added": "2"
               },
+              "chrome_android": {
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -273,6 +275,9 @@
               },
               "safari_ios": {
                 "version_added": "3.2"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true

--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -199,7 +199,8 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "16"
+              },
               },
               "edge": {
                 "version_added": "12"

--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -186,6 +186,9 @@
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
+              },
+              "webview_android": {
+                "version_added": true
               }
             },
             "status": {


### PR DESCRIPTION
For #4295, I took a closer look at `border-image`'s subfeatures.

* `optional_border_image_slice`
   * chrome_android: was missing, mirrored from Chrome.
   * opera_android: was missing, mirrored from Opera.
   * safari: I couldn't find the implementation change, but I found a changeset adding tests and a bunch of bugs relating to making `border-image` follow the spec. Overall, it looks like this feature first appears at the same time as its unprefixing: [changset 95031](https://trac.webkit.org/changeset/95031/webkit).
   * safari_ios: was missing, mirrored from Safari's WebKit engine number.
   * samsung_internet: was missing, mirrored from Chrome.
* `fill`
   * **Changed feature name and dropped description**, for consistency with other CSS keyword features.
   * chrome: The discussion on [bug 101311](https://bugs.chromium.org/p/chromium/issues/detail?id=101311) suggests Chrome started following the spec when the unprefixed version landed in Chrome (like Safari). This looks like 16 (based on the parent feature).
   * chrome_android: was missing, mirrored from Chrome.
   * opera_android: was missing, mirrored from Opera.
   * samsung_internet: was missing, mirrored from Chrome.
* `<gradient>`
   * chrome: I couldn't track this down directly. I based the number on the WebKit engine version and release dates.
   * chrome_android: mirrored from Chrome.
   * safari: [This commit](https://github.com/WebKit/webkit/commit/805aaf43ff7e093834182e8c306567de03c150a8#diff-8d8d95e51b8e21f82a9f2cc3df2a9ade) added it and the [Safari 4 release notes](https://developer.apple.com/library/archive/releasenotes/General/WhatsNewInSafari/Articles/Safari_4_0.html) mention it.
   * safari_ios: mirrored from Safari, based on WebKit version number.
   * samsung_internet: was missing, mirrored from Chrome.