### PR TITLE
Clean up border-radius

### DIFF
--- a/css/properties/border-radius.json
+++ b/css/properties/border-radius.json
@@ -103,11 +103,11 @@
             "description": "Elliptical borders",
             "support": {
               "chrome": {
-                "version_added": true,
+                "version_added": "1",
                 "notes": "Before Chrome 4, the slash <code>/</code> notation is unsupported. If two values are specified, then an elliptical border is drawn on all four corners. <code>-webkit-border-radius: 40px 10px;</code> is equivalent to <code>border-radius: 40px / 10px;</code>."
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -131,14 +131,14 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true,
+                "version_added": "3",
                 "notes": "Before Safari 4.1, the slash <code>/</code> notation is unsupported. If two values are specified, then an elliptical border is drawn on all four corners. <code>-webkit-border-radius: 40px 10px;</code> is equivalent to <code>border-radius: 40px / 10px;</code>."
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true

--- a/css/properties/border-radius.json
+++ b/css/properties/border-radius.json
@@ -8,7 +8,7 @@
             "chrome": [
               {
                 "version_added": "4",
-                "notes": "Current Chrome and Safari versions ignore border-radius on <code>&lt;select&gt;</code> elements unless <code>-webkit-appearance</code> is overridden to an appropriate value."
+                "notes": "Chrome ignores <code>border-radius</code> on <code>&lt;select&gt;</code> elements unless <code>-webkit-appearance</code> is overridden to an appropriate value."
               },
               {
                 "prefix": "-webkit-",
@@ -66,7 +66,7 @@
             },
             "opera": {
               "version_added": "10.5",
-              "notes": "In Opera prior to version 11.60, replaced elements with <code>border-radius</code> will not have rounded corners."
+              "notes": "Before Opera 11.60, replaced elements with <code>border-radius</code> do not have rounded corners."
             },
             "opera_android": {
               "version_added": "11"
@@ -74,7 +74,7 @@
             "safari": [
               {
                 "version_added": "5",
-                "notes": "Current Chrome and Safari versions ignore border-radius on <code>&lt;select&gt;</code> elements unless <code>-webkit-appearance</code> is overridden to an appropriate value."
+                "notes": "Safari ignores <code>border-radius</code> on <code>&lt;select&gt;</code> elements unless <code>-webkit-appearance</code> is overridden to an appropriate value."
               },
               {
                 "prefix": "-webkit-",
@@ -104,7 +104,7 @@
             "support": {
               "chrome": {
                 "version_added": true,
-                "notes": "Prior to Chrome 4, the slash <code>/</code> notation is unsupported. If two values are specified, an elliptical border is drawn on all four corners. <code>-webkit-border-radius: 40px 10px;</code> is equivalent to <code>border-radius: 40px/10px;</code>."
+                "notes": "Before Chrome 4, the slash <code>/</code> notation is unsupported. If two values are specified, then an elliptical border is drawn on all four corners. <code>-webkit-border-radius: 40px 10px;</code> is equivalent to <code>border-radius: 40px / 10px;</code>."
               },
               "chrome_android": {
                 "version_added": true
@@ -132,7 +132,7 @@
               },
               "safari": {
                 "version_added": true,
-                "notes": "Prior to Safari 4.1, the slash <code>/</code> notation is unsupported. If two values are specified, an elliptical border is drawn on all four corners. <code>-webkit-border-radius: 40px 10px;</code> is equivalent to <code>border-radius: 40px/10px;</code>."
+                "notes": "Before Safari 4.1, the slash <code>/</code> notation is unsupported. If two values are specified, then an elliptical border is drawn on all four corners. <code>-webkit-border-radius: 40px 10px;</code> is equivalent to <code>border-radius: 40px / 10px;</code>."
               },
               "safari_ios": {
                 "version_added": true

--- a/css/properties/border-radius.json
+++ b/css/properties/border-radius.json
@@ -159,7 +159,7 @@
                 "version_added": "4"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -183,13 +183,13 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": "5"
+                "version_added": "4.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true


### PR DESCRIPTION
For #4295, I looked at `border-radius` data. It was kinda messy.

First, I cleaned up all the notes for consistency and style.

* `elliptical_borders`:
   * chrome: support predates Chrome (through the `-webkit-` prefix), though I did confirm the accuracy of the note.
   * chrome_android: mirrored from Chrome.
   * safari: WebKit [change 46508](https://trac.webkit.org/changeset/46508/webkit) seems to confirm that Safari added the slash notation with 4.1. An earlier change seems to show slash-less elliptical support at the time the `-webkit-` prefixed property was introduced, in Safari 3. It's unclear to me whether elliptical support was available on the previous WebKit `-khtml-` prefix, but I also don't know whether Safari ever supported the `-khtml-` prefixes. Either way, it seemed way too historical to bother with.
  * safari_ios: mirrored from Safari, based on WebKit engine number.
  * samsung_internet: mirrored from Chrome.
* `4_values_for_4_corners`
   * I didn't really set out to update this, but I learned about it incidentally and thought it was worth updating.
   * chrome_android: mirrored from Chrome.
   * safari: It got this at the same time as the unprefixed `border-radius` feature ([change 46508](https://trac.webkit.org/changeset/46508/webkit)) and the slash notation.
   * safari_ios: mirrored from Safari's WebKit engine number.
   * samsung_internet: mirrored from Chrome.