### PR TITLE
Remove moz-chunked-arraybuffer in Firefox 68

### DIFF
--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -1303,7 +1303,7 @@
             "status": {
               "experimental": false,
               "standard_track": false,
-              "deprecated": false
+              "deprecated": true
             }
           }
         }

--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -1253,6 +1253,59 @@
               "deprecated": false
             }
           }
+        },
+        "moz-chunked-arraybuffer": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/responseType",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "edge_mobile": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "14",
+                "version_removed": "68"
+              },
+              "firefox_android": {
+                "version_added": "14",
+                "version_removed": "68"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
         }
       },
       "responseURL": {


### PR DESCRIPTION
Added this entry to the list of values for `XMLHttpRequest.responseType`,
indicating it was added in Firefox 14 and removed in 68.

Source:
* https://bugzilla.mozilla.org/show_bug.cgi?id=1120171

