### PR TITLE
HTMLDocument.cookie -> Document.cookie in Firefox 68

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -1394,10 +1394,12 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Prior to Firefox 68, <code>cookie</code> was available only on HTML documents; it is now available on all documents, such as XML and SVG."
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Prior to Firefox 68, <code>cookie</code> was available only on HTML documents; it is now available on all documents, such as XML and SVG."
             },
             "ie": {
               "version_added": true


### PR DESCRIPTION
Note that Document.cookie works for non-HTML documents in
Firefox 68 and later.

Source:
* https://bugzilla.mozilla.org/show_bug.cgi?id=144795
