### PR TITLE
Correct AudioWorkletNode processorerror event handler

### DIFF
--- a/api/AudioWorkletNode.json
+++ b/api/AudioWorkletNode.json
@@ -102,6 +102,57 @@
           }
         }
       },
+      "onprocessorerror": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletNode/onprocessorerror",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "parameters": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletNode/parameters",
@@ -153,9 +204,9 @@
           }
         }
       },
-      "onprocessorerror": {
+      "port": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletNode/onprocessorerror",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletNode/port",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -179,10 +230,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -191,7 +242,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "66"
@@ -244,57 +295,6 @@
             },
             "samsunginternet_android": {
               "version_added": null
-            },
-            "webview_android": {
-              "version_added": "66"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "port": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletNode/port",
-          "support": {
-            "chrome": {
-              "version_added": "66"
-            },
-            "chrome_android": {
-              "version_added": "66"
-            },
-            "edge": {
-              "version_added": null
-            },
-            "edge_mobile": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": true
             },
             "webview_android": {
               "version_added": "66"

--- a/api/AudioWorkletNode.json
+++ b/api/AudioWorkletNode.json
@@ -204,6 +204,58 @@
           }
         }
       },
+      "processorerror_event": {
+        "__compat": {
+          "description": "<code>processorerror</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletNode/processorerror_event",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "port": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletNode/port",

--- a/api/AudioWorkletNode.json
+++ b/api/AudioWorkletNode.json
@@ -153,9 +153,9 @@
           }
         }
       },
-      "processorerror_event": {
+      "onprocessorerror": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletNode/processorerror_event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletNode/onprocessorerror",
           "support": {
             "chrome": {
               "version_added": "66"


### PR DESCRIPTION
Rename `processorerror_event` to `onprocessorerror` because that's how the property is called on the AudioWorkletNode interface.
- [Link to the current spec](https://webaudio.github.io/web-audio-api/#audioworkletnode)

Maybe I should add separate `processorerror event`, so that we have `onprocessorerror` as an event handler property on AudioWorkletNode, and `processorerror event` as an event itself? Similarly to how it's done on OfflineAudioContext with `complete` event.