### PR TITLE
fix(4336) location.hostname is supported on IE

### DIFF
--- a/api/Location.json
+++ b/api/Location.json
@@ -223,7 +223,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": false
+              "version_added": true
             },
             "opera": {
               "version_added": false


### PR DESCRIPTION
https://github.com/mdn/browser-compat-data/issues/4336