### PR TITLE
Add Safari status for CSS clip-path

### DIFF
--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -47,14 +47,24 @@
             "opera_android": {
               "version_added": "42"
             },
-            "safari": {
-              "prefix": "-webkit-",
-              "version_added": "7"
-            },
-            "safari_ios": {
-              "prefix": "-webkit-",
-              "version_added": "7"
-            },
+            "safari": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "7"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": true
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "7"
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -105,14 +115,24 @@
               "opera_android": {
                 "version_added": "42"
               },
-              "safari": {
-                "prefix": "-webkit-",
-                "version_added": "7"
-              },
-              "safari_ios": {
-                "prefix": "-webkit-",
-                "version_added": "7"
-              },
+              "safari": [
+                {
+                  "version_added": true
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "7"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": true
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "7"
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": "6.0"
               },
@@ -170,14 +190,24 @@
               "opera_android": {
                 "version_added": "42"
               },
-              "safari": {
-                "prefix": "-webkit-",
-                "version_added": "7"
-              },
-              "safari_ios": {
-                "prefix": "-webkit-",
-                "version_added": "7"
-              },
+              "safari": [
+                {
+                  "version_added": true
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "7"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": true
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "7"
+                }
+              ],
               "samsunginternet_android": [
                 {
                   "version_added": "6.0"
@@ -255,14 +285,24 @@
               "opera_android": {
                 "version_added": "42"
               },
-              "safari": {
-                "prefix": "-webkit-",
-                "version_added": "7"
-              },
-              "safari_ios": {
-                "prefix": "-webkit-",
-                "version_added": "7"
-              },
+              "safari": [
+                {
+                  "version_added": true
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "7"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": true
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "7"
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": "6.0"
               },

--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -48,10 +48,12 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": false
+              "prefix": "-webkit-",
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": false
+              "prefix": "-webkit-",
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -104,10 +106,12 @@
                 "version_added": "42"
               },
               "safari": {
-                "version_added": false
+                "prefix": "-webkit-",
+                "version_added": "7"
               },
               "safari_ios": {
-                "version_added": false
+                "prefix": "-webkit-",
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": "6.0"
@@ -167,10 +171,12 @@
                 "version_added": "42"
               },
               "safari": {
-                "version_added": false
+                "prefix": "-webkit-",
+                "version_added": "7"
               },
               "safari_ios": {
-                "version_added": false
+                "prefix": "-webkit-",
+                "version_added": "7"
               },
               "samsunginternet_android": [
                 {
@@ -250,10 +256,12 @@
                 "version_added": "42"
               },
               "safari": {
-                "version_added": false
+                "prefix": "-webkit-",
+                "version_added": "7"
               },
               "safari_ios": {
-                "version_added": false
+                "prefix": "-webkit-",
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": "6.0"


### PR DESCRIPTION
Added to Safari as part of [bug 95474](https://bugs.webkit.org/show_bug.cgi?id=95474) and linked [changeset](https://trac.webkit.org/changeset/127327/webkit). Safari 7 seems likely to be the first major release, but it's a bit hard to be sure without a good archive of Safari versions.

I also tested compatibility in the current version of Safari to verify it works as expected there.

A checklist to help your pull request get merged faster:
- [X] Summarize your changes
- [X] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [X] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
