### PR TITLE
Firefox 68: resize event no longer sent before first paint

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -7569,11 +7569,11 @@
             },
             "firefox": {
               "version_added": true,
-              "notes": "Firefox emits a <code>resize</code> event on page load."
+              "notes": "Prior to Firefox 68, Firefox emitted a <code>resize</code> event on page load. This is no longer the case."
             },
             "firefox_android": {
               "version_added": true,
-              "notes": "Firefox emits a <code>resize</code> event on page load."
+              "notes": "Prior to Firefox 68, Firefox emitted a <code>resize</code> event on page load. This is no longer the case."
             },
             "ie": {
               "version_added": true


### PR DESCRIPTION
Prior to Firefox 68, a resize event would be sent before the first
window paint, which was against the spec. This has been corrected.

Source:
* https://bugzilla.mozilla.org/show_bug.cgi?id=1528052

