### PR TITLE
HTMLElement/SVGElement focus() options in Firefox 68

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -893,7 +893,7 @@
         },
         "preventScroll_option": {
           "__compat": {
-            "description": "<code>preventScroll</code> boolean option",
+            "description": "<code>preventScroll</code> Boolean option",
             "support": {
               "chrome": {
                 "version_added": "64"
@@ -908,10 +908,10 @@
                 "version_added": null
               },
               "firefox": {
-                "version_added": null
+                "version_added": "68"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "68"
               },
               "ie": {
                 "version_added": null

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -199,6 +199,105 @@
           }
         }
       },
+      "focus": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGElement/focus",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "edge_mobile": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "51"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "preventScroll_option": {
+          "__compat": {
+            "description": "<code>preventScroll</code> Boolean option",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": "68"
+              },
+              "firefox_android": {
+                "version_added": "68"
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      },
       "load_event": {
         "__compat": {
           "description": "<code>load</code> event",


### PR DESCRIPTION
* Adds the focus() method and options to SVGElement, with data
for Blink and Firefox.
* Updated the information about focus() options for Firefox 68

Sources:
* https://bugzilla.mozilla.org/show_bug.cgi?id=778654 (SVGElement.focus() added to Firefox
* https://bugzilla.mozilla.org/show_bug.cgi?id=1374045
