### PR TITLE
Support for -webkit-mask-size in Chrome

### DIFF
--- a/css/properties/mask-size.json
+++ b/css/properties/mask-size.json
@@ -37,12 +37,12 @@
               "version_added": "15"
             },
             "safari": {
-              "version_added": "4",
-              "prefix": "-webkit"
+              "prefix": "-webkit-",
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "2",
-              "prefix": "-webkit"
+              "prefix": "-webkit-",
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": null

--- a/css/properties/mask-size.json
+++ b/css/properties/mask-size.json
@@ -29,10 +29,12 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "prefix": "-webkit-",
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": null
+              "prefix": "-webkit-",
+              "version_added": "15"
             },
             "safari": {
               "version_added": "4",
@@ -46,7 +48,8 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": false
+              "prefix": "-webkit-",
+              "version_added": "4.4"
             }
           },
           "status": {

--- a/css/properties/mask-size.json
+++ b/css/properties/mask-size.json
@@ -6,10 +6,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-size",
           "support": {
             "chrome": {
-              "version_added": false
+              "prefix": "-webkit-",
+              "version_added": "4"
             },
             "chrome_android": {
-              "version_added": false
+              "prefix": "-webkit-",
+              "version_added": "28"
             },
             "edge": {
               "version_added": "17"


### PR DESCRIPTION
Tested in Chrome 75 on desktop and Chrome 72 on Android.

Using version numbers for -webkit-mask-* properties from https://www.chromestatus.com/features/6500037865504768.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
