### PR TITLE
Add Safari version for Payment Request API

### DIFF
--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -58,10 +58,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": true
+            "version_added": "11.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "11.3"
           },
           "samsunginternet_android": {
             "version_added": "6.0"
@@ -125,10 +125,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -196,7 +196,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -264,7 +264,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -331,7 +331,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -600,7 +600,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -667,7 +667,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -939,7 +939,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -1006,7 +1006,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -1074,7 +1074,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -1141,7 +1141,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -1208,7 +1208,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"


### PR DESCRIPTION
This is a follow-up to #4236 that adds Safari version that implements the Payment Request API.  This also closes #4236 as it supersedes the changes.