### PR TITLE
Set IE version for api.History

### DIFF
--- a/api/History.json
+++ b/api/History.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "12"
           },
           "edge_mobile": {
             "version_added": true
@@ -23,7 +23,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": true
+            "version_added": "10"
           },
           "opera": {
             "version_added": true


### PR DESCRIPTION
Follow-up to #4261 that adds the IE version where the History API was implemented.  Based upon manual testing via SauceLabs.