### PR TITLE
Add release date for Safari iOS 12.2

### DIFF
--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -151,6 +151,7 @@
           "engine_version": "605.1"
         },
         "12.2": {
+          "release_date": "2019-03-25",
           "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_12_1_release_notes",
           "status": "current",
           "engine": "WebKit",


### PR DESCRIPTION
This PR adds the release date for Safari iOS 12.2 based upon Safari Desktop 12.1.
