### PR TITLE
Remove superfluous version_added: false lines for PointerEvent

### DIFF
--- a/api/PointerEvent.json
+++ b/api/PointerEvent.json
@@ -31,21 +31,16 @@
               ]
             }
           ],
-          "firefox_android": [
-            {
-              "version_added": false
-            },
-            {
-              "version_added": "41",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.w3c_pointer_events.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox_android": {
+            "version_added": "41",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.w3c_pointer_events.enabled",
+                "value_to_set": "true"
+              }
+            ]
+          },
           "ie": [
             {
               "version_added": "11"
@@ -114,21 +109,16 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": false
-              },
-              {
-                "version_added": "41",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.w3c_pointer_events.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "41",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.w3c_pointer_events.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "ie": [
               {
                 "version_added": "11"
@@ -197,21 +187,16 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": false
-              },
-              {
-                "version_added": "41",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.w3c_pointer_events.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "41",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.w3c_pointer_events.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "ie": {
               "version_added": "10"
             },
@@ -272,21 +257,16 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": false
-              },
-              {
-                "version_added": "41",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.w3c_pointer_events.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "41",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.w3c_pointer_events.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "ie": [
               {
                 "version_added": "11"
@@ -354,21 +334,16 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": false
-              },
-              {
-                "version_added": "41",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.w3c_pointer_events.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "41",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.w3c_pointer_events.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "ie": [
               {
                 "version_added": "11"
@@ -436,21 +411,16 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": false
-              },
-              {
-                "version_added": "41",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.w3c_pointer_events.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "41",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.w3c_pointer_events.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "ie": [
               {
                 "version_added": "11"
@@ -518,21 +488,16 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": false
-              },
-              {
-                "version_added": "54",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.w3c_pointer_events.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "54",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.w3c_pointer_events.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "ie": {
               "version_added": false
             },
@@ -593,21 +558,16 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": false
-              },
-              {
-                "version_added": "41",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.w3c_pointer_events.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "41",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.w3c_pointer_events.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "ie": {
               "version_added": "10"
             },
@@ -668,21 +628,16 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": false
-              },
-              {
-                "version_added": "41",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.w3c_pointer_events.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "41",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.w3c_pointer_events.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "ie": {
               "version_added": "10"
             },
@@ -743,21 +698,16 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": false
-              },
-              {
-                "version_added": "54",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.w3c_pointer_events.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "54",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.w3c_pointer_events.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "ie": {
               "version_added": false
             },
@@ -818,21 +768,16 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": false
-              },
-              {
-                "version_added": "41",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.w3c_pointer_events.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "41",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.w3c_pointer_events.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "ie": [
               {
                 "version_added": "11"
@@ -951,21 +896,16 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": false
-              },
-              {
-                "version_added": "41",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.w3c_pointer_events.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "41",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.w3c_pointer_events.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "ie": {
               "version_added": "10"
             },


### PR DESCRIPTION
This is split from https://github.com/mdn/browser-compat-data/pull/4314. It tidies existing Firefox  for Android data without making any significant data changes.