### PR TITLE
Remove edge_mobile from javascript/*

### DIFF
--- a/javascript/builtins/BigInt.json
+++ b/javascript/builtins/BigInt.json
@@ -65,9 +65,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "68"
               },
@@ -118,9 +115,6 @@
                 "version_added": "67"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -175,9 +169,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "68"
               },
@@ -228,9 +219,6 @@
                 "version_added": "67"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -285,9 +273,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "68"
               },
@@ -338,9 +323,6 @@
                 "version_added": "67"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/javascript/builtins/BigInt64Array.json
+++ b/javascript/builtins/BigInt64Array.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "68"
             },

--- a/javascript/builtins/BigUint64Array.json
+++ b/javascript/builtins/BigUint64Array.json
@@ -14,9 +14,6 @@
             "edge": {
               "version_added": false
             },
-            "edge_mobile": {
-              "version_added": false
-            },
             "firefox": {
               "version_added": "68"
             },

--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -375,9 +375,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "68"
               },
@@ -428,9 +425,6 @@
                 "version_added": "67"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -901,9 +895,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "68"
               },
@@ -954,9 +945,6 @@
                 "version_added": "67"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -374,9 +374,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": "1"
               },


### PR DESCRIPTION
This is a PR based off of #3888.  Since the Windows Phone OS is deprecated platform, Edge Mobile is as well.  It was mentioned that Microsoft suggested we drop Edge Mobile.