### PR TITLE
Set real values for various Chromium + Safari CSS @rules

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -207,11 +207,11 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true,
+                "version_added": "15",
                 "version_removed": "25"
               },
               "opera_android": {
-                "version_added": true,
+                "version_added": "14",
                 "version_removed": "25"
               },
               "safari": {

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -184,10 +184,12 @@
             "description": "SVG fonts",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "1",
+                "version_removed": "38"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "18",
+                "version_removed": "38"
               },
               "edge": {
                 "version_added": false
@@ -205,22 +207,26 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": true,
+                "version_removed": "25"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": true,
+                "version_removed": "25"
               },
               "safari": {
-                "version_added": true
+                "version_added": "3.2"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "3"
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "1.0",
+                "version_removed": "3.0"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": true,
+                "version_removed": "38"
               }
             },
             "status": {
@@ -235,10 +241,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-face/font-display",
             "support": {
               "chrome": {
-                "version_added": "60"
+                "version_added": "72"
               },
               "chrome_android": {
-                "version_added": "60"
+                "version_added": "72"
               },
               "edge": {
                 "version_added": false
@@ -256,22 +262,22 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "47"
+                "version_added": "60"
               },
               "opera_android": {
-                "version_added": "44"
+                "version_added": "51"
               },
               "safari": {
-                "version_added": true
+                "version_added": "11.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "11.1"
               },
               "samsunginternet_android": {
                 "version_added": false
               },
               "webview_android": {
-                "version_added": "60"
+                "version_added": "72"
               }
             },
             "status": {
@@ -620,10 +626,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-face/unicode-range",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -644,16 +650,16 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": "3.1"
+                "version_added": "3.2"
               },
               "safari_ios": {
-                "version_added": "2"
+                "version_added": "3"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true

--- a/css/at-rules/import.json
+++ b/css/at-rules/import.json
@@ -7,10 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@import",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "2"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -34,13 +34,13 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "4"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/at-rules/import.json
+++ b/css/at-rules/import.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@import",
           "support": {
             "chrome": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -34,10 +34,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -12,7 +12,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "2"
               }
             ],
             "chrome_android": [
@@ -21,7 +21,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "18"
               }
             ],
             "edge": {
@@ -129,11 +129,11 @@
             ],
             "safari_ios": [
               {
-                "version_added": true
+                "version_added": "9"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "4"
               }
             ],
             "samsunginternet_android": [
@@ -142,7 +142,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "1.0"
               }
             ],
             "webview_android": [
@@ -193,13 +193,13 @@
                 "version_added": "32"
               },
               "safari": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "45"

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1699,16 +1699,16 @@
                 "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": false

--- a/css/at-rules/page.json
+++ b/css/at-rules/page.json
@@ -162,10 +162,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@page/size",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
                 "version_added": false
@@ -183,22 +183,22 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
-                "version_added": null
+                "version_added": false
               }
             },
             "status": {


### PR DESCRIPTION
This PR is to assist in the efforts of #3710, or more specifically, #4294.  I've browsed through WebKit and Blink to identify the exact versions where features were added/removed (if supported at all).  Based on the following data, this sets versions within Chrome, Chrome Android, Safari, Safari iOS, Opera, Opera Android, Samsung Internet, and WebView:

<details>
	<summary>css.at-rules.font-face.SVG_fonts</summary>
	<ol>
		<li>Having a hard time finding the exact source code</li>
		<li>CanIUse lists Safari 3.2</li>
		<li>Chrome had support, but was removed in Chrome 38: <a href="http://www.chromestatus.com/feature/5930075908210688">http://www.chromestatus.com/feature/5930075908210688</a></li>
		<li><strong>Safari 3.2, Chrome 1-38</strong></li>
	</ol>
</details>

<details>
	<summary>css.at-rules.font-face.font-display</summary>
	<ol>
		<li>Safari implemented in WebKit bb5b5cf8885540d1e1370247da6ddd4bdf75ec48, Tue Aug 15 00:03:56 2017 +0000</li>
		<li>Commit not present in 11.0.3 or earlier, exists in 11.1</li>
		<li>CanIUse lists Safari 11.1</li>
		<li>Chrome implemented in <a href="https://chromium.googlesource.com/chromium/src/+/5d39943cf7bd8db8aa1f874f3444affca39e408f/third_party/blink/renderer/core/css/font_display.h">https://chromium.googlesource.com/chromium/src/+/5d39943cf7bd8db8aa1f874f3444affca39e408f/third_party/blink/renderer/core/css/font_display.h</a>, initially landed in 72</li>
		<li><strong>Safari 11.1, Chrome 72</strong></li>
	</ol>
</details>

<details>
	<summary>css.at-rules.font-face.unicode-range</summary>
	<ol>
		<li>Implemented in WebKit 648b73b1f8f531ff5a7d7b390e5391abeb7660c3, Mon Jan 7 23:32:55 2008 +0000</li>
		<li>File WebCore/css/CSSUnicodeRangeValue.cpp defines property, first introduced in WebKit 525.3</li>
		<li><strong>Safari 3.2, Chrome 1</strong></li>
	</ol>
</details>

<details>
	<summary>css.at-rules.import</summary>
	<ol>
		<li>CSSImportRule.cpp created in WebKit 13a64221676d62dba11dd220a03d7dca35609fc3</li>
		<li>Initial definition in WebCore/css/css_ruleimpl.cpp</li>
		<li>css_ruleimpl.cpp defined in WebKit bb0c24b55183dc12fee06166f24714471286db70, Fri Aug 24 14:24:40 2001 +0000</li>
		<li><strong>Commit was before Safari 1.0, defaulting to Safari + Chrome 1</strong></li>
	</ol>
</details>

<details>
	<summary>css.at-rules.keyframes (-webkit- prefix)</summary>
	<ol>
		<li>CSSKeyframesRule.cpp created in WebKit a001d32fd3d96bcb4368e91b892622edebbdc333, commit message states the implementation of the property, Tue Aug 5 23:01:41 2008 +0000</li>
		<li>https://bugs.webkit.org/show_bug.cgi?id=20088</li>
		<li>File does not exist in Safari 3.2.1 (<a href="https://trac.webkit.org/browser/webkit/releases/Apple/Safari%203.2.1/WebCore/css">https://trac.webkit.org/browser/webkit/releases/Apple/Safari%203.2.1/WebCore/css</a>), but exists in Safari 4.0 (<a href="https://trac.webkit.org/browser/webkit/releases/Apple/Safari%204.0/WebCore/css/WebKitCSSKeyframesRule.cpp">https://trac.webkit.org/browser/webkit/releases/Apple/Safari%204.0/WebCore/css/WebKitCSSKeyframesRule.cpp</a>).</li>
		<li><strong>Safari 4, Chrome 2</strong></li>
	</ol>
</details>

<details>
	<summary>css.at-rules.keyframes.ignore_important_declarations</summary>
	<ol>
		<li>Chrome 45 already specified in BCD, Safari is null</li>
		<li>Safari is true</li>
		<li>SauceLabs testing: 9.1 + 10 do not ignore !important, 10.1 does</li>
		<li><strong>Safari 10.1, Chrome 45</strong></li>
	</ol>
</details>

<details>
	<summary>css.at-rules.media.-moz-device-pixel-ratio</summary>
	<ol>
		<li><strong>Implied `false` as it's a Firefox-based prefix</strong></li>
	</ol>
</details>

<details>
	<summary>css.at-rules.page.size</summary>
	<ol>
		<li>Manually tested in latest browsers (native OS)</li>
		<li><strong>No Support in Chrome or Safari</strong></li>
	</ol>
</details>

_Note: all commit hashes are for the WebKit Git mirror._

I have requested @jpmedley’s review on all the Chrome versions, but any and all reviews are welcome!