### PR TITLE
Set real values for Chromium + Safari CSS @media properties

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -990,10 +990,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/monochrome",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": false
@@ -1017,13 +1017,13 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "3"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -613,7 +613,7 @@
                 "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": "46"
+                "version_added": "45"
               }
             },
             "status": {
@@ -1395,7 +1395,7 @@
                 "version_added": "1.5"
               },
               "webview_android": {
-                "version_added": "37"
+                "version_added": true
               }
             },
             "status": {

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -159,7 +159,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/aspect-ratio",
             "support": {
               "chrome": {
-                "version_added": "4"
+                "version_added": "3"
               },
               "chrome_android": {
                 "version_added": "18"
@@ -180,19 +180,19 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": "53"
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "4.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true
@@ -263,10 +263,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/color",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -287,16 +287,16 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
-              },
-              "safari": {
                 "version_added": true
               },
+              "safari": {
+                "version_added": "3"
+              },
               "safari_ios": {
-                "version_added": null
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true
@@ -342,13 +342,13 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "7.0"
               },
               "webview_android": {
                 "version_added": "58"
@@ -367,10 +367,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/color-index",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "29"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "29"
               },
               "edge": {
                 "version_added": false
@@ -388,22 +388,22 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "16"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "16"
               },
               "safari": {
-                "version_added": null
+                "version_added": "8"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "8"
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "2.0"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": true
               }
             },
             "status": {
@@ -419,10 +419,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/device-aspect-ratio",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -443,16 +443,16 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "3"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true
@@ -471,10 +471,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/device-height",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -495,16 +495,16 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "3"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true
@@ -523,10 +523,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/device-width",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -547,16 +547,16 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "3"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true
@@ -575,10 +575,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/display-mode",
             "support": {
               "chrome": {
-                "version_added": "46"
+                "version_added": "45"
               },
               "chrome_android": {
-                "version_added": "46"
+                "version_added": "45"
               },
               "edge": {
                 "version_added": false
@@ -598,19 +598,19 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "33"
+                "version_added": "32"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "32"
               },
               "safari": {
-                "version_added": null
+                "version_added": "13"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "13"
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "46"
@@ -629,10 +629,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/grid",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -653,16 +653,16 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
-              },
-              "safari": {
                 "version_added": true
               },
+              "safari": {
+                "version_added": "3"
+              },
               "safari_ios": {
-                "version_added": null
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true
@@ -681,10 +681,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/height",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -702,22 +702,22 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "3"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": true
               }
             },
             "status": {
@@ -811,13 +811,13 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": true
+                "version_added": "9.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "10"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": false
@@ -1014,16 +1014,16 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
                 "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true
@@ -1042,10 +1042,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/orientation",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "3"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1066,16 +1066,16 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
-              },
-              "safari": {
                 "version_added": true
               },
+              "safari": {
+                "version_added": "4.1"
+              },
               "safari_ios": {
-                "version_added": null
+                "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true
@@ -1345,10 +1345,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/resolution",
             "support": {
               "chrome": {
-                "version_added": "29"
+                "version_added": "27"
               },
               "chrome_android": {
-                "version_added": "29"
+                "version_added": "27"
               },
               "edge": {
                 "version_added": "12"
@@ -1383,16 +1383,16 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "6.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "7"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.5"
               },
               "webview_android": {
                 "version_added": "37"
@@ -1623,10 +1623,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/width",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1647,16 +1647,16 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
-              },
-              "safari": {
                 "version_added": true
               },
+              "safari": {
+                "version_added": "3"
+              },
               "safari_ios": {
-                "version_added": null
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true
@@ -1727,11 +1727,11 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/-webkit-animation",
             "support": {
               "chrome": {
-                "version_added": true,
+                "version_added": "2",
                 "version_removed": "36"
               },
               "chrome_android": {
-                "version_added": true,
+                "version_added": "18",
                 "version_removed": "36"
               },
               "edge": {
@@ -1758,14 +1758,14 @@
                 "version_removed": "24"
               },
               "safari": {
-                "version_added": null
+                "version_added": "4"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "3.2"
               },
               "samsunginternet_android": {
-                "version_added": true,
-                "version_removed": true
+                "version_added": "1.0",
+                "version_removed": "3.0"
               },
               "webview_android": {
                 "version_added": true,
@@ -1785,10 +1785,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/-webkit-device-pixel-ratio",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1869,16 +1869,16 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "3"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true
@@ -1897,10 +1897,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/-webkit-device-pixel-ratio",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1981,16 +1981,16 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "3"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true
@@ -2009,10 +2009,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/-webkit-device-pixel-ratio",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -2093,16 +2093,16 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "3"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true
@@ -2121,10 +2121,12 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/-webkit-transform-2d",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "2",
+                "version_removed": "36"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "18",
+                "version_removed": "36"
               },
               "edge": {
                 "version_added": false
@@ -2142,22 +2144,26 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "23"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true,
+                "version_removed": "24"
               },
               "safari": {
-                "version_added": "1.3"
+                "version_added": "4"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "3.2"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0",
+                "version_removed": "3.0"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": true,
+                "version_removed": "37"
               }
             },
             "status": {
@@ -2173,10 +2179,12 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/-webkit-transform-3d",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "2",
+                "version_removed": "36"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18",
+                "version_removed": "36"
               },
               "edge": {
                 "version_added": "12"
@@ -2218,22 +2226,26 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "23"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true,
+                "version_removed": "24"
               },
               "safari": {
-                "version_added": "1.3"
+                "version_added": "4"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "3.2"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0",
+                "version_removed": "3.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "37"
               }
             },
             "status": {
@@ -2249,10 +2261,12 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/-webkit-transition",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "2",
+                "version_removed": "36"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "18",
+                "version_removed": "36"
               },
               "edge": {
                 "version_added": false
@@ -2270,22 +2284,26 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "23"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true,
+                "version_removed": "24"
               },
               "safari": {
-                "version_added": "1.3"
+                "version_added": "4"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "3.2"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0",
+                "version_removed": "3.0"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": true,
+                "version_removed": "37"
               }
             },
             "status": {


### PR DESCRIPTION
This PR is to assist in the efforts of #3710, or more specifically, #4294.  I've browsed through WebKit and Blink to identify the exact versions where features were added/removed (if supported at all).  Based on the following data, this sets versions within Chrome, Chrome Android, Safari, Safari iOS, Opera, Opera Android, Samsung Internet, and WebView:

<details>
	<summary>css.at-rules.media.color, css.at-rules.media.device-aspect-ratio, css.at-rules.media.device-height, css.at-rules.media.device-width, css.at-rules.media.grid, css.at-rules.media.height, css.at-rules.media.width</summary>
	<ol>
		<li>CSS3 Media Queries implementation in WebKit 1f63b91e8004c50e4ab184a522913cadf5866ddd</li>
		<li>Commit defines WebCore/css/MediaQueryEvaluator.cpp</li>
		<li>Parsing script found in file in commit</li>
		<li>File initially found in 521.13, contains parseAspectRatio function</li>
		<li><strong>Safari 3, Chrome 1</strong></li>
	</ol>
</details>

<details>
	<summary>css.at-rules.media.aspect-ratio, css.at-rules.media.orientation</summary>
	<ol>
		<li>Support added in WebKit 9476eb7cbc7ca31b649e1a54ea3ecf69f00f1a76</li>
		<li><a href="https://bugs.webkit.org/show_bug.cgi?id=25197">https://bugs.webkit.org/show_bug.cgi?id=25197</a></li>
		<li>Introduced in 532.0</li>
		<li><strong>Safari 4.1, Chrome 3</strong></li>
		<li>Note: Opera was set to "53" for some odd reason.  This was changed to "true" to leave room for pre-15 Opera implementation.</li>
	</ol>
</details>

<details>
	<summary>css.at-rules.media.color-gamut</summary>
	<ol>
		<li>Support added in WebKit 1452c11ffcad445fd8a4b631cd4bdd6d167cec99</li>
		<li><a href="https://bugs.webkit.org/show_bug.cgi?id=155994">https://bugs.webkit.org/show_bug.cgi?id=155994</a></li>
		<li>Introduced in 602.1.30</li>
		<li>Chrome landed in <a href="https://storage.googleapis.com/chromium-find-releases-static/257.html#2575c4f8b8a7172537a762d069486d906bed1076">https://storage.googleapis.com/chromium-find-releases-static/257.html#2575c4f8b8a7172537a762d069486d906bed1076</a></li>
		<li><strong>Safari 10.1, Chrome 58</strong></li>
	</ol>
</details>

<details>
	<summary>css.at-rules.media.color-index</summary>
	<ol>
		<li>Support added in WebKit 53473ee6dda3543bb8ec6d38bc6af7c000fdef1b</li>
		<li><a href="https://bugs.webkit.org/show_bug.cgi?id=114468">https://bugs.webkit.org/show_bug.cgi?id=114468</a></li>
		<li>Introduced in 538.10</li>
		<li>Implemented in Chrome in <a href="https://chromium.googlesource.com/chromium/src/+/2f8a10bf0814821e9ae41103f0fbf0bb8c39c0cf/third_party/WebKit/Source/core/css/MediaQueryEvaluator.cpp">https://chromium.googlesource.com/chromium/src/+/2f8a10bf0814821e9ae41103f0fbf0bb8c39c0cf/third_party/WebKit/Source/core/css/MediaQueryEvaluator.cpp</a>, version estimated by date (Sat May 11 00:26:16 2013)</li>
		<li><strong>Safari 8, Chrome 29</strong></li>
	</ol>
</details>

<details>
	<summary>css.at-rules.media.display-mode</summary>
	<ol>
		<li>Support added in WebKit c02dfcfb7cccb993614517f79560342e72a9d142</li>
		<li><a href="https://bugs.webkit.org/show_bug.cgi?id=180376">https://bugs.webkit.org/show_bug.cgi?id=180376</a></li>
		<li>Introduced in 606.1.1</li>
		<li>Chrome landed in <a href="https://storage.googleapis.com/chromium-find-releases-static/02b.html#02b80e73d179e8b87d007b197766fa5fca1a80ee">https://storage.googleapis.com/chromium-find-releases-static/02b.html#02b80e73d179e8b87d007b197766fa5fca1a80ee</a></li>
		<li><strong>Safari 13, Chrome 45</strong></li>
	</ol>
</details>

<details>
	<summary>css.at-rules.media.inverted-colors</summary>
	<ol>
		<li>Support added in WebKit a8a0da2b8e64f7dd4337b4062a46de32efd8f38a</li>
		<li><a href="https://bugs.webkit.org/show_bug.cgi?id=137535">https://bugs.webkit.org/show_bug.cgi?id=137535</a></li>
		<li>Introduced in 601.1.10</li>
		<li>No Chrome support</li>
		<li><strong>Safari 9.1, Chrome False</strong></li>
	</ol>
</details>

<details>
	<summary>css.at-rules.media.monochrome</summary>
	<ol>
		<li>CSS3 Media Queries implementation in WebKit 1f63b91e8004c50e4ab184a522913cadf5866ddd</li>
		<li>Commit defines WebCore/css/MediaQueryEvaluator.cpp</li>
		<li>Parsing script found in file in commit</li>
		<li>File initially found in 521.13, contains parseAspectRatio function</li>
		<li><strong>Safari 3, Chrome 1</strong></li>
		<li>Note: The commit for inverted-colors states that it also implements monochrome support, though this commit shows the monochrome property being added.</li>
	</ol>
</details>

<details>
	<summary>css.at-rules.media.resolution</summary>
	<ol>
		<li>Support added in WebKit 2a707b5341589180996070918e4f390c4ba32883</li>
		<li><a href="https://bugs.webkit.org/show_bug.cgi?id=99077">https://bugs.webkit.org/show_bug.cgi?id=99077</a></li>
		<li>Introduced in 537.30</li>
		<li><strong>Safari 6.1, Chrome 27</strong></li>
	</ol>
</details>

<details>
	<summary>css.at-rules.media.-webkit-animation, css.at-rules.media.-webkit-transition, css.at-rules.media.-webkit-transform-2d, css.at-rules.media.-webkit-transform-3d</summary>
	<ol>
		<li>Support added in WebKit 301b3b21c60c97c0a08d797d0da1718048988410</li>
		<li>Introduced in 528.10</li>
		<li><strong>Safari 4, Chrome 2</strong></li>
	</ol>
</details>

<details>
	<summary>css.at-rules.media.-webkit-device-pixel-ratio, css.at-rules.media.-webkit-max-device-pixel-ratio, css.at-rules.media.-webkit-min-device-pixel-ratio</summary>
	<ol>
		<li>Support added in WebKit 0b5dc49f66efad69156404f1adff88ccce602a83</li>
		<li>Introduced in 521.14</li>
		<li><strong>Safari 3, Chrome 1</strong></li>
	</ol>
</details>

_Note: all commit hashes are for the WebKit Git mirror._

I have requested @jpmedley’s review on all the Chrome versions, but any and all reviews are welcome!