### PR TITLE
MediaStreamTrackAudioSourceNode implemented in Firefox 68

### DIFF
--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -658,10 +658,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "68"
+              "version_added": "68",
+              "notes": "Firefox 68 implements the updated standard's definition of the \"first\" audio track; now the first track is the one whose ID comes first lexicographically."
             },
             "firefox_android": {
-              "version_added": "68"
+              "version_added": "68",
+              "notes": "Firefox 68 implements the updated standard's definition of the \"first\" audio track; now the first track is the one whose ID comes first lexicographically."
             },
             "ie": {
               "version_added": false

--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -649,28 +649,28 @@
               "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "edge_mobile": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -679,14 +679,14 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/MediaStreamTrackAudioSourceNode.json
+++ b/api/MediaStreamTrackAudioSourceNode.json
@@ -5,49 +5,152 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrackAudioSourceNode",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": false
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": false
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "edge_mobile": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
-            "version_added": null
+            "version_added": "68"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "68"
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": false
           },
           "opera_android": {
-            "version_added": null
+            "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
-            "version_added": null
+            "version_added": false
           }
         },
         "status": {
           "experimental": false,
           "standard_track": true,
           "deprecated": false
+        }
+      },
+      "MediaStreamTrackAudioSourceNode": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrackAudioSourceNode/MediaStreamTrackAudioSourceNode",
+          "description": "<code>MediaStreamTrackAudioSourceNode()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "68"
+            },
+            "firefox_android": {
+              "version_added": "68"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mediaStreamTrack": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrackAudioSourceNode/mediaStreamTrack",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "edge_mobile": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "68"
+            },
+            "firefox_android": {
+              "version_added": "68"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
         }
       }
     }

--- a/api/MediaStreamTrackAudioSourceOptions.json
+++ b/api/MediaStreamTrackAudioSourceOptions.json
@@ -1,8 +1,8 @@
 {
   "api": {
-    "MediaStreamTrackAudioSourceNode": {
+    "MediaStreamTrackAudioSourceOptions": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrackAudioSourceNode",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/falseMediaStreamTrackAudioSourceOptions",
         "support": {
           "chrome": {
             "version_added": false
@@ -50,63 +50,9 @@
           "deprecated": false
         }
       },
-      "MediaStreamTrackAudioSourceNode": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrackAudioSourceNode/MediaStreamTrackAudioSourceNode",
-          "description": "<code>MediaStreamTrackAudioSourceNode()</code> constructor",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "edge_mobile": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": "68",
-              "notes": "Firefox 68 implements the updated standard's definition of the \"first\" audio track; now the first track is the one whose ID comes first lexicographically."
-            },
-            "firefox_android": {
-              "version_added": "68",
-              "notes": "Firefox 68 implements the updated standard's definition of the \"first\" audio track; now the first track is the one whose ID comes first lexicographically."
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "mediaStreamTrack": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrackAudioSourceNode/mediaStreamTrack",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/falseMediaStreamTrackAudioSourceOptions/mediaStreamTrack",
           "support": {
             "chrome": {
               "version_added": false


### PR DESCRIPTION
This updates `AudioContext.json` and `MediaStreamTrackAudioSourceNode.json`
to indicate that Firefox 68 implements `MediaStreamTrackAudioSourceNode`.
This includes the `createMediaStreamTrackSource()` method on the audio
context. Also updated: Firefox is currently the only browser to support
this interface at all.

Sources:
* https://bugzilla.mozilla.org/show_bug.cgi?id=1324548
* https://cs.chromium.org/search/?q=MediaStreamTrackAudioSourceNode&sq=package:chromium&type=cs
* https://developer.microsoft.com/en-us/microsoft-edge/platform/catalog/?page=1&q=MediaStreamTrackAudioSourceNode