### PR TITLE
Update Clear-Site-Data to list directives and to indicate Fx68 changes

### DIFF
--- a/http/headers/clear-site-data.json
+++ b/http/headers/clear-site-data.json
@@ -71,6 +71,296 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "cache": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Clear-Site-Data",
+            "support": {
+              "chrome": {
+                "version_added": "61"
+              },
+              "chrome_android": {
+                "version_added": "61"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "firefox": [
+                {
+                  "version_added": "63"
+                },
+                {
+                  "version_added": "62",
+                  "flags": [
+                    {
+                      "name": "dom.clearSiteData.enabled",
+                      "type": "preference",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "63"
+                },
+                {
+                  "version_added": "62",
+                  "flags": [
+                    {
+                      "name": "dom.clearSiteData.enabled",
+                      "type": "preference",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "48"
+              },
+              "opera_android": {
+                "version_added": "45"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": "61"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "cookies": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Clear-Site-Data",
+            "support": {
+              "chrome": {
+                "version_added": "61"
+              },
+              "chrome_android": {
+                "version_added": "61"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "firefox": [
+                {
+                  "version_added": "63"
+                },
+                {
+                  "version_added": "62",
+                  "flags": [
+                    {
+                      "name": "dom.clearSiteData.enabled",
+                      "type": "preference",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "63"
+                },
+                {
+                  "version_added": "62",
+                  "flags": [
+                    {
+                      "name": "dom.clearSiteData.enabled",
+                      "type": "preference",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "48"
+              },
+              "opera_android": {
+                "version_added": "45"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": "61"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "executionContexts": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Clear-Site-Data",
+            "support": {
+              "chrome": {
+                "version_added": "61"
+              },
+              "chrome_android": {
+                "version_added": "61"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "firefox": [
+                {
+                  "version_added": "63",
+                  "version_removed": "68"
+                },
+                {
+                  "version_added": "62",
+                  "flags": [
+                    {
+                      "name": "dom.clearSiteData.enabled",
+                      "type": "preference",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "63",
+                  "version_removed": "68"
+                },
+                {
+                  "version_added": "62",
+                  "flags": [
+                    {
+                      "name": "dom.clearSiteData.enabled",
+                      "type": "preference",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "48"
+              },
+              "opera_android": {
+                "version_added": "45"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": "61"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "storage": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Clear-Site-Data",
+            "support": {
+              "chrome": {
+                "version_added": "61"
+              },
+              "chrome_android": {
+                "version_added": "61"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "firefox": [
+                {
+                  "version_added": "63"
+                },
+                {
+                  "version_added": "62",
+                  "flags": [
+                    {
+                      "name": "dom.clearSiteData.enabled",
+                      "type": "preference",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "63"
+                },
+                {
+                  "version_added": "62",
+                  "flags": [
+                    {
+                      "name": "dom.clearSiteData.enabled",
+                      "type": "preference",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "48"
+              },
+              "opera_android": {
+                "version_added": "45"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": "61"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Firefox 68 removes the `executionContexts` directive from the
`Clear-Site-Data` header. This patch adds entries into BCD for each of
the headers' directives, with the `executionContexts` entry noting this
change for Firefox 68.

Sources:
* https://bugzilla.mozilla.org/show_bug.cgi?id=1548034
* https://bugs.chromium.org/p/chromium/issues/detail?id=607897#c32
