### PR TITLE
Fix consistency of versions in API files

### DIFF
--- a/api/InputEvent.json
+++ b/api/InputEvent.json
@@ -316,7 +316,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "edge_mobile": {
                 "version_added": null

--- a/api/PerformanceNavigation.json
+++ b/api/PerformanceNavigation.json
@@ -41,7 +41,7 @@
             "version_added": true
           },
           "webview_android": {
-            "version_added": false
+            "version_added": true
           }
         },
         "status": {

--- a/api/PerformanceNavigationTiming.json
+++ b/api/PerformanceNavigationTiming.json
@@ -34,10 +34,10 @@
             "version_added": "43"
           },
           "safari": {
-            "version_added": false
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "11"
           },
           "samsunginternet_android": {
             "version_added": "7.0"

--- a/api/PerformanceNavigationTiming.json
+++ b/api/PerformanceNavigationTiming.json
@@ -34,10 +34,10 @@
             "version_added": "43"
           },
           "safari": {
-            "version_added": "11"
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": "11"
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "7.0"
@@ -84,10 +84,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -135,10 +135,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -186,10 +186,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -237,10 +237,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -288,10 +288,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -339,10 +339,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -492,10 +492,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -543,10 +543,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "7.0"

--- a/api/PerformanceObserver.json
+++ b/api/PerformanceObserver.json
@@ -245,7 +245,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true

--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -22,7 +22,7 @@
             },
             {
               "alternative_name": "DataChannel",
-              "version_added": "22",
+              "version_added": "18",
               "version_removed": "60"
             }
           ],
@@ -32,7 +32,7 @@
             },
             {
               "alternative_name": "DataChannel",
-              "version_added": "22",
+              "version_added": "18",
               "version_removed": "60"
             }
           ],
@@ -81,10 +81,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": "18"
             },
             "firefox_android": {
-              "version_added": "22"
+              "version_added": "18"
             },
             "ie": {
               "version_added": false
@@ -135,7 +135,7 @@
               "version_added": "18"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "ie": {
               "version_added": false

--- a/api/RTCIceCredentialType.json
+++ b/api/RTCIceCredentialType.json
@@ -127,7 +127,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
               "version_added": false

--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -697,7 +697,7 @@
                 "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": "10.1"
+                "version_added": "10.3"
               },
               "webview_android": {
                 "version_added": "43"

--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -1275,7 +1275,7 @@
                 "version_removed": "68"
               },
               "firefox_android": {
-                "version_added": "14",
+                "version_added": "50",
                 "version_removed": "68"
               },
               "ie": {


### PR DESCRIPTION
This PR is intended to fix a couple of version inconsistencies that arose within the API files overtime.  Below is a list of the exact changes in this PR.

-----

api.InputEvent.inputType: No support in edge, but this is not declared for sub-feature(s): insertFromPasteAsQuotation
- Sub-feature was null, marked as false

api.PerformanceNavigation: No support in webview_android, but this is not declared for sub-feature(s): type, redirectCount, toJSON
- Chrome Android was changed to true but WebView was not, changed parent to true

api.PerformanceNavigationTiming: No support in safari or safari_ios, but this is not declared for sub-feature(s): domComplete, domContentLoadedEventEnd, domContentLoadedEventStart, domInteractive, loadEventEnd, loadEventStart, unloadEventEnd, unloadEventStart
- ~~Changes to a parent feature were left out of a PR, changed parent to "11"~~ Subfeatures marked as false

api.PerformanceObserver: No support in ie, but this is not declared for sub-feature(s): supportedEntryTypes
- Sub-feature was null, marked as false

api.RTCDataChannel: Basic support in firefox was declared implemented in a later version than the following sub-feature(s): bufferedAmount
- https://bugzilla.mozilla.org/show_bug.cgi?id=729512 shows RTCDataChannel ("DataChannel") was implemented in Firefox 18, changed parent and sub-features with "22"

api.RTCIceCredentialType: No support in opera, but this is not declared for sub-feature(s): password
- Sub-feature was null, marked as false

api.WindowOrWorkerGlobalScope.fetch: Basic support in safari_ios was declared implemented in a later version than the following sub-feature(s): streaming_response_body
- Suspected misuse of Safari / iOS versions, changed subfeature to "10.3" to match parent

api.XMLHttpRequest.responseType: Basic support in firefox_android was declared implemented in a later version than the following sub-feature(s): moz-chunked-arraybuffer
- Bumped subfeature version number up