### PR TITLE
Fix consistency of versions in CSS files

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -40,7 +40,7 @@
               "version_added": "3.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -135,9 +135,20 @@
                 "prefix": "-webkit-",
                 "version_added": "7"
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": [
+                {
+                  "version_added": "6.0"
+                },
+                {
+                  "version_added": "2.0",
+                  "partial_implementation": true,
+                  "notes": "Older versions of the specification treat absolute positioned children as though they are a 0 by 0 flex item. Later specification versions take the children out of the flow and set their positions based on align and justify properties. Chrome implements the new behavior beginning with Samsung Internet 6.0."
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "1.5"
+                }
+              ],
               "webview_android": [
                 {
                   "version_added": "52"

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -120,7 +120,6 @@
               "opera_android": {
                 "version_added": false
               },
-
               "safari": [
                 {
                   "version_added": "9"

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -126,9 +126,20 @@
               "safari_ios": {
                 "version_added": false
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": [
+                {
+                  "version_added": "3.0"
+                },
+                {
+                  "version_added": "2.0",
+                  "partial_implementation": true,
+                  "notes": "Older versions of the specification treat absolute positioned children as though they are a 0 by 0 flex item. Later specification versions take the children out of the flow and set their positions based on align and justify properties. Chrome implements the new behavior beginning with Samsung Internet 6.0."
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "1.5"
+                }
+              ],
               "webview_android": [
                 {
                   "version_added": "37"

--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -87,7 +87,7 @@
               "prefix": "-webkit-"
             },
             "samsunginternet_android": {
-              "version_added": "4.0",
+              "version_added": "1.0",
               "partial_implementation": true,
               "prefix": "-webkit-"
             },

--- a/css/properties/background-repeat.json
+++ b/css/properties/background-repeat.json
@@ -80,7 +80,7 @@
                 "version_added": "10.5"
               },
               "opera_android": {
-                "version_added": "10.5"
+                "version_added": "11"
               },
               "safari": {
                 "version_added": "1.3"

--- a/css/properties/background-repeat.json
+++ b/css/properties/background-repeat.json
@@ -30,7 +30,7 @@
               "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -80,7 +80,7 @@
                 "version_added": "10.5"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "10.5"
               },
               "safari": {
                 "version_added": "1.3"
@@ -131,7 +131,7 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
                 "version_added": "4.1"

--- a/css/properties/background.json
+++ b/css/properties/background.json
@@ -36,7 +36,7 @@
               "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -86,7 +86,7 @@
                 "version_added": "1.3"
               },
               "safari_ios": {
-                "version_added": "3.2"
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -138,7 +138,7 @@
             ],
             "samsunginternet_android": {
               "prefix": "-webkit-",
-              "version_added": "1.0" 
+              "version_added": "1.0"
             },
             "webview_android": {
               "prefix": "-webkit-",

--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -137,7 +137,8 @@
               }
             ],
             "samsunginternet_android": {
-              "version_added": null
+              "prefix": "-webkit-",
+              "version_added": "1.0" 
             },
             "webview_android": {
               "prefix": "-webkit-",
@@ -250,7 +251,7 @@
             "description": "<code>&lt;gradient&gt;</code>",
             "support": {
               "chrome": {
-                "version_added": "2"
+                "version_added": "7"
               },
               "chrome_android": {
                 "version_added": "18"

--- a/css/properties/image-rendering.json
+++ b/css/properties/image-rendering.json
@@ -39,7 +39,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "41"

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -42,7 +42,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -43,7 +43,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -42,7 +42,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/css/properties/outline-style.json
+++ b/css/properties/outline-style.json
@@ -28,7 +28,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": "46"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "8"

--- a/css/selectors/invalid.json
+++ b/css/selectors/invalid.json
@@ -40,7 +40,7 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/css/selectors/placeholder-shown.json
+++ b/css/selectors/placeholder-shown.json
@@ -57,7 +57,7 @@
               "version_added": "9.2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "51"

--- a/css/selectors/valid.json
+++ b/css/selectors/valid.json
@@ -40,7 +40,7 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -72,11 +72,11 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "16",
+                "version_added": "3.6",
                 "notes": "Gradients are limited to <a href='https://developer.mozilla.org/docs/Web/CSS/background-image'><code>background-image</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/border-image'><code>border-image</code></a>, and <a href='https://developer.mozilla.org/docs/Web/CSS/mask-image'><code>mask-image</code></a>."
               },
               "firefox_android": {
-                "version_added": "16",
+                "version_added": "4",
                 "notes": "Gradients are limited to <a href='https://developer.mozilla.org/docs/Web/CSS/background-image'><code>background-image</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/border-image'><code>border-image</code></a>, and <a href='https://developer.mozilla.org/docs/Web/CSS/mask-image'><code>mask-image</code></a>."
               },
               "ie": {

--- a/css/types/timing-function.json
+++ b/css/types/timing-function.json
@@ -40,7 +40,7 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4"


### PR DESCRIPTION
This PR is intended to fix a couple of version inconsistencies that arose within the API files overtime.  Below is a list of the exact changes in this PR.

-----

css.at-rules.media:
    → No support known in samsunginternet_android, but support declared in the following sub-feature(s): any-hover, any-pointer, aspect-ratio, calc, hover, pointer, prefers-color-scheme, prefers-reduced-motion
      - Set parent to "1.0"

css.properties.align-items.flex_context:
    → No support known in samsunginternet_android, but support declared in the following sub-feature(s): first_last_baseline, start_end
      - Set parent to a copy of Chrome Android

css.properties.align-self.flex_context:
    → No support known in samsunginternet_android, but support declared in the following sub-feature(s): start_end, baseline, stretch
      - Set parent to a copy of Chrome Android

css.properties.appearance:
    → Basic support in samsunginternet_android was declared implemented in a later version than the following sub-feature(s): button, textfield
      - Parent was marked as "4.0", changed to "1.0" to match Chrome Android

css.properties.background-repeat:
    → No support known in opera_android, but support declared in the following sub-feature(s): round_space
      - Set subfeature to "11"

css.properties.background:
    → Basic support in safari_ios was declared implemented in a later version than the following sub-feature(s): SVG_image_as_background
      - Safari iOS looks to be set to the Safari versions, not iOS versions, fixed

css.properties.border-image:
    → No support known in samsunginternet_android, but support declared in the following sub-feature(s): optional_border_image_slice, fill, gradient
      - Set parent to "1.0"
    → Basic support in chrome was declared implemented in a later version than the following sub-feature(s): gradient
      - Set subfeature to later version

css.properties.image-rendering:
    → No support known in samsunginternet_android, but support declared in the following sub-feature(s): pixelated
      - Set parent to true

css.properties.max-width:
    → No support known in samsunginternet_android, but support declared in the following sub-feature(s): fit-content, max-content, min-content
      - Set parent to "1.0"

css.properties.min-height:
    → No support known in samsunginternet_android, but support declared in the following sub-feature(s): max-content, min-content, stretch, fit-content
      - Set parent to "1.0"

css.properties.min-width:
    → No support known in samsunginternet_android, but support declared in the following sub-feature(s): max-content, min-content, fit-content
      - Set parent to "1.0"

css.properties.outline-style:
    → Basic support in firefox_android was declared implemented in a later version than the following sub-feature(s): auto
      - Possible typo in parent, changed to "4"

css.selectors.invalid:
    → No support known in samsunginternet_android, but support declared in the following sub-feature(s): form
      - Set parent to "1.0"

css.selectors.placeholder-shown:
    → No support known in samsunginternet_android, but support declared in the following sub-feature(s): non_text_types
      - Set parent to "5.0"

css.selectors.valid:
    → No support known in samsunginternet_android, but support declared in the following sub-feature(s): form
      - Set parent to "1.0"

css.types.image.gradient:
    → Basic support in firefox was declared implemented in a later version than the following sub-feature(s): linear-gradient, radial-gradient, repeating-linear-gradient, repeating-radial-gradient
      - Parent was set to "16", but there is evidence of use back from 3.6, set parent to "3.6"
    → Basic support in firefox_android was declared implemented in a later version than the following sub-feature(s): linear-gradient, radial-gradient, repeating-linear-gradient, repeating-radial-gradient
      - Parent was set to "16", but there is evidence of use back from 3.6, set parent to "4"

css.types.timing-function:
    → No support known in samsunginternet_android, but support declared in the following sub-feature(s): cubic-bezier, steps
      - Set parent to "1.0"
