### PR TITLE
Fix consistency of IE/Edge in API files

### DIFF
--- a/api/ANGLE_instanced_arrays.json
+++ b/api/ANGLE_instanced_arrays.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": null
+            "version_added": "12"
           },
           "edge_mobile": {
             "version_added": null

--- a/api/CSSStyleDeclaration.json
+++ b/api/CSSStyleDeclaration.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "12"
           },
           "edge_mobile": {
             "version_added": null
@@ -23,7 +23,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": null
+            "version_added": true
           },
           "opera": {
             "version_added": true

--- a/api/Console.json
+++ b/api/Console.json
@@ -300,7 +300,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": null
@@ -312,7 +312,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": null

--- a/api/ExtendableMessageEvent.json
+++ b/api/ExtendableMessageEvent.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -23,7 +23,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": null
+            "version_added": true
           },
           "opera": {
             "version_added": true

--- a/api/HTMLHyperlinkElementUtils.json
+++ b/api/HTMLHyperlinkElementUtils.json
@@ -13,7 +13,7 @@
             "notes": "Starting in Chrome 52, the members of this interface were moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "firefox": {
             "version_added": "22",

--- a/api/MediaEncryptedEvent.json
+++ b/api/MediaEncryptedEvent.json
@@ -11,7 +11,7 @@
             "version_added": "42"
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/NavigatorLanguage.json
+++ b/api/NavigatorLanguage.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/NavigatorOnLine.json
+++ b/api/NavigatorOnLine.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/SVGPoint.json
+++ b/api/SVGPoint.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/Screen.json
+++ b/api/Screen.json
@@ -23,7 +23,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": null
+            "version_added": true
           },
           "opera": {
             "version_added": true

--- a/api/TextTrackList.json
+++ b/api/TextTrackList.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/UIEvent.json
+++ b/api/UIEvent.json
@@ -23,7 +23,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": null
+            "version_added": true
           },
           "opera": {
             "version_added": true

--- a/api/URL.json
+++ b/api/URL.json
@@ -43,7 +43,7 @@
             ]
           },
           "ie": {
-            "version_added": null
+            "version_added": true
           },
           "opera": [
             {

--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -46,7 +46,7 @@
             }
           ],
           "ie": {
-            "version_added": null
+            "version_added": true
           },
           "opera": {
             "version_added": true

--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null
@@ -23,7 +23,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": null
+            "version_added": true
           },
           "opera": {
             "version_added": true

--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null
@@ -23,7 +23,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": null
+            "version_added": true
           },
           "opera": {
             "version_added": null

--- a/api/XPathExpression.json
+++ b/api/XPathExpression.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null

--- a/api/XPathResult.json
+++ b/api/XPathResult.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": null
+            "version_added": true
           },
           "edge_mobile": {
             "version_added": null


### PR DESCRIPTION
Cherry-picked from #4083 for specifically updates to IE and Edge.  This PR is intended to fix the version consistency within files, providing higher accuracy.  Changes are as follows:

api.ANGLE_instanced_arrays - Subfeatures show Edge support, mark Edge as "12"
api.CSSStyleDeclaration - Subfeatures show IE support, mark IE as true (and Edge as "12")
api.Console.debug - Subfeatures show IE support, marked IE as true (and Edge as "12")
api.ExtendableMessageEvent - Subfeatures show Edge support, mark Edge as true
api.HTMLElement - Based upon age, IE obviously supports this API
api.HTMLHyperlinkElementUtils - Subfeatures show Edge support, mark Edge as true
api.MediaEncryptedEvent - Subfeatures had versions for Edge, mark Edge as true
api.NavigatorLanguage - Subfeatures show Edge support, mark Edge as true
api.NavigatorOnLine - Subfeatures show Edge support, mark Edge as true
api.SVGPoint - Subfeatures show Edge support, mark Edge as true
api.Screen - Subfeatures show Edge support, mark Edge as true
api.TextTrackList - Subfeatures show support, mark Edge as true
api.UIEvent - Subfeatures show IE support, mark IE as true
api.URL - Based upon age, IE obviously supports this API
api.WebSocket - Subfeatures show IE support, mark IE as true
api.WindowEventHandlers - Subfeatures show support, mark Edge as true
api.WindowEventHandlers - Subfeatures show support, mark Edge as true
api.XPathExpression - Subfeatures show Edge support, mark Edge as true
api.XPathResult - Subfeatures show Edge support, mark Edge as true