### PR TITLE
Fix consistency of Chromium in API files

### DIFF
--- a/api/Coordinates.json
+++ b/api/Coordinates.json
@@ -8,7 +8,7 @@
             "version_added": "5"
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": "18"
           },
           "edge": {
             "version_added": true
@@ -50,10 +50,10 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": null
+            "version_added": true
           }
         },
         "status": {

--- a/api/DedicatedWorkerGlobalScope.json
+++ b/api/DedicatedWorkerGlobalScope.json
@@ -8,7 +8,7 @@
             "version_added": "4"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": null
@@ -38,10 +38,10 @@
             "version_added": "5.1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": null
+            "version_added": true
           }
         },
         "status": {

--- a/api/EffectTiming.json
+++ b/api/EffectTiming.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/EffectTiming",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": true
           },
           "chrome_android": {
-            "version_added": null
+            "version_added": true
           },
           "edge": {
             "version_added": null
@@ -26,10 +26,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": null
@@ -38,10 +38,10 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
-            "version_added": null
+            "version_added": true
           }
         },
         "status": {

--- a/api/External.json
+++ b/api/External.json
@@ -26,7 +26,7 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": null

--- a/api/FontFaceSet.json
+++ b/api/FontFaceSet.json
@@ -26,10 +26,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": "10"

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -38,7 +38,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true

--- a/api/NavigatorStorage.json
+++ b/api/NavigatorStorage.json
@@ -111,7 +111,7 @@
               "version_added": null
             },
             "opera": {
-              "version_added": "42"
+              "version_added": null
             },
             "opera_android": {
               "version_added": null

--- a/api/PublicKeyCredentialCreationOptions.json
+++ b/api/PublicKeyCredentialCreationOptions.json
@@ -26,10 +26,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": null

--- a/api/PublicKeyCredentialRequestOptions.json
+++ b/api/PublicKeyCredentialRequestOptions.json
@@ -26,10 +26,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": null

--- a/api/SpeechGrammarList.json
+++ b/api/SpeechGrammarList.json
@@ -42,7 +42,8 @@
             "version_added": false
           },
           "webview_android": {
-            "version_added": null
+            "prefix": "webkit",
+            "version_added": true
           }
         },
         "status": {

--- a/api/SpeechRecognition.json
+++ b/api/SpeechRecognition.json
@@ -42,7 +42,8 @@
             "version_added": false
           },
           "webview_android": {
-            "version_added": null
+            "prefix": "webkit",
+            "version_added": true
           }
         },
         "status": {

--- a/api/TextTrackList.json
+++ b/api/TextTrackList.json
@@ -26,10 +26,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": null

--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -26,10 +26,10 @@
             "version_added": null
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": null

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -41,7 +41,7 @@
             "version_added": true
           },
           "webview_android": {
-            "version_added": null
+            "version_added": true
           }
         },
         "status": {


### PR DESCRIPTION
Cherry-picked from #4083 for specifically updates to Chromium-based browsers. This PR is intended to fix the version consistency within files, providing higher accuracy. Changes are as follows:

api.Coordinates - Mirror Chrome onto Chrome Android, Samsung Internet, and WebView
api.DedicatedWorkerGlobalScope - Mirror Chrome onto Chrome Android, Samsung Internet, and WebView
api.EffectTiming - Subfeatures show Chromium support, mark Chromium as true
api.External - Mirror Chrome onto Opera
api.FontFaceSet - Mirror Chrome onto Opera, Opera Android
api.GlobalEventHandlers - Mirror Chrome onto Samsung Internet
api.NavigatorStorage - Stray Opera version number in subfeature, removed
api.PublicKeyCredentialCreationOptions - Mirror Chrome onto Opera, Opera Android
api.PublicKeyCredentialRequestOptions - Mirror Chrome onto Opera, Opera Android
api.SpeechGrammarList - Mirror Chrome onto WebView
api.SpeechRecognition - Mirror Chrome onto WebView
api.TextTrackList - Subfeatures show support, mark Opera, Opera Android as true
api.WindowEventHandlers - Subfeatures show support, mark Opera, Opera Android as true
api.WorkerGlobalScope - Mirror Chrome onto Chrome Android, Samsung Internet, and WebView