### PR TITLE
Fix consistency of Firefox and Safari in API files

### DIFF
--- a/api/AnimationEvent.json
+++ b/api/AnimationEvent.json
@@ -72,10 +72,15 @@
               "version_added": "4"
             }
           ],
-          "safari_ios": {
-            "prefix": "webkit",
-            "version_added": null
-          },
+          "safari_ios": [
+            {
+              "version_added": "9.3"
+            },
+            {
+              "prefix": "webkit",
+              "version_added": "3.2"
+            }
+          ],
           "samsunginternet_android": [
             {
               "version_added": "4.0"

--- a/api/Coordinates.json
+++ b/api/Coordinates.json
@@ -47,7 +47,7 @@
             "version_added": "5"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "4.2"
           },
           "samsunginternet_android": {
             "version_added": null

--- a/api/ImageBitmap.json
+++ b/api/ImageBitmap.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "5.0"
@@ -85,7 +85,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true
@@ -136,7 +136,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/MediaEncryptedEvent.json
+++ b/api/MediaEncryptedEvent.json
@@ -17,7 +17,7 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
             "version_added": null

--- a/api/MediaTrackConstraints.json
+++ b/api/MediaTrackConstraints.json
@@ -17,7 +17,7 @@
             "version_added": true
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
             "version_added": true

--- a/api/TextTrackList.json
+++ b/api/TextTrackList.json
@@ -17,7 +17,7 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": true
           },
           "firefox_android": {
             "version_added": null
@@ -32,7 +32,7 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
             "version_added": null

--- a/api/Window.json
+++ b/api/Window.json
@@ -538,7 +538,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": "4"

--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -32,10 +32,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true

--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true


### PR DESCRIPTION
Cherry-picked from #4083 for specifically updates to Firefox and Safari.  This PR is intended to fix the version consistency within files, providing higher accuracy. Changes are as follows:

api.AnimationEvent - Mirrored Safari onto Safari iOS
api.Coordinates - Mirror Safari onto Safari iOS
api.ImageBitmap - Safari marked as false, Safari iOS was null, set subfeatures as false for Safari iOS
api.MediaEncryptedEvent - Subfeatures show Firefox support, mark Firefox as true
api.MediaTrackConstraints - Subfeatures show Firefox support, mark Firefox as true
api.TextTrackList - Subfeatures show support, mark Firefox, Safari as true
api.UIEvent - Mirror Firefox onto Firefox Android
api.WindowEventHandlers - Subfeatures show support, mark Safari, Safari iOS as true
api.WindowEventHandlers - Subfeatures show support, mark Safari, Safari iOS as true