### PR TITLE
Support for prefers-color-scheme in Safari for iOS

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1277,7 +1277,7 @@
                 "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "13"
               },
               "webview_android": {
                 "version_added": "76"


### PR DESCRIPTION
iOS 13 adds support for `prefers-color-scheme` as a part of its new Dark Mode feature. Apple stated this [in their release notes for Safari 13](https://developer.apple.com/documentation/safari_release_notes/safari_13_beta_release_notes) as "Added opt-in dark mode support for websites in Safari for iOS."

This can be tested by loading [https://skitty.xyz/dark/](https://skitty.xyz/dark/) on any device running the iOS 13 Beta. The web page will be black when iOS's Dark Mode is enabled and white when it is disabled. This was tested on the version of Safari shipped in both iOS 13 Developer Beta 1 and iOS 13 Developer Beta 2.

There were no errors during data validation (running `npm test`):
```sh
✔ css/at-rules/media.json
```