### PR TITLE
Updates to CSSStyleRule for Firefox 68

### DIFF
--- a/api/CSSStyleSheet.json
+++ b/api/CSSStyleSheet.json
@@ -47,6 +47,55 @@
           "deprecated": false
         }
       },
+      "addRule": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/addRule",
+          "description": "<code>addRule()</code>",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "68"
+            },
+            "firefox_android": {
+              "version_added": "68"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
       "cssRules": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/cssRules",
@@ -146,6 +195,7 @@
       "deleteRule": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/deleteRule",
+          "description": "<code>deleteRule()</code>",
           "support": {
             "chrome": {
               "version_added": true
@@ -194,6 +244,7 @@
       "insertRule": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/insertRule",
+          "description": "<code>insertRule()</code>",
           "support": {
             "chrome": {
               "version_added": true
@@ -284,6 +335,103 @@
               "standard_track": true,
               "deprecated": false
             }
+          }
+        }
+      },
+      "removeRule": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/removeRule",
+          "description": "<code>removeRule()</code>",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "68"
+            },
+            "firefox_android": {
+              "version_added": "68"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "rules": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/addRule",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "edge_mobile": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "68"
+            },
+            "firefox_android": {
+              "version_added": "68"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
Firefox 68 adds the finally-surrendered-and-added-to-the-spec legacy
items that were introduced by IE 9 way back when, which refuse to die:
addRule(), removeRule(), and the rule property.

Sources:
* https://bugzilla.mozilla.org/show_bug.cgi?id=1545823
* https://developer.microsoft.com/en-us/microsoft-edge/platform/catalog/?page=1&q=CSSStyleSheet
