### PR TITLE
Firefox only supports one repeated column in grid layout

### DIFF
--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -284,7 +284,9 @@
               },
               "firefox": [
                 {
-                  "version_added": "57"
+                  "version_added": "57",
+                  "notes": "<code>repeat(auto-fill, ...)</code> and <code>repeat(auto-fit, ...)</code> only support one repeated column (see <a href='https://bugzil.la/1341507'>bug 1341507</a>).",
+                  "partial_implementation": true
                 },
                 {
                   "version_added": "52",

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -284,7 +284,9 @@
               },
               "firefox": [
                 {
-                  "version_added": "57"
+                  "version_added": "57",
+                  "notes": "<code>repeat(auto-fill, ...)</code> and <code>repeat(auto-fit, ...)</code> only support one repeated column (see <a href='https://bugzil.la/1341507'>bug 1341507</a>).",
+                  "partial_implementation": true
                 },
                 {
                   "version_added": "52",


### PR DESCRIPTION
As per bug [1341507][1], `repeat(auto-fill, ...)`, Firefox is missing support for multiple track lengths, which is defined in the spec draft [CSS Grid Layout Module Level 1][0]

[0]: https://drafts.csswg.org/css-grid/#auto-repeat
[1]: https://bugzil.la/1341507
