### PR TITLE
Updating Chrome support for backdrop-filter

### DIFF
--- a/css/properties/backdrop-filter.json
+++ b/css/properties/backdrop-filter.json
@@ -5,12 +5,34 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/backdrop-filter",
           "support": {
-            "chrome": {
-              "version_added": "76"
-            },
-            "chrome_android": {
-              "version_added": "76"
-            },
+            "chrome": [
+              {
+                "version_added": "76"
+              },
+              {
+                "version_added": "47",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "76"
+              },
+              {
+                "version_added": "47",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": "17"
             },

--- a/css/properties/backdrop-filter.json
+++ b/css/properties/backdrop-filter.json
@@ -6,22 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/backdrop-filter",
           "support": {
             "chrome": {
-              "version_added": "47",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Enable Experimental Web Platform Features"
-                }
-              ]
+              "version_added": "76"
             },
             "chrome_android": {
-              "version_added": "47",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Enable Experimental Web Platform Features"
-                }
-              ]
+              "version_added": "76"
             },
             "edge": {
               "version_added": "17"

--- a/css/properties/backdrop-filter.json
+++ b/css/properties/backdrop-filter.json
@@ -52,7 +52,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "76"
             }
           },
           "status": {


### PR DESCRIPTION
This feature is in M76 Beta, [enabled by default](https://chromium.googlesource.com/chromium/src/+/5ff2d1bef3dd93aaf97ee01aff46719d3bb7114a#).
