### PR TITLE
Add Promise.allSettled()

### DIFF
--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -166,6 +166,7 @@
         "allSettled": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled",
+            "spec_url": "https://tc39.es/proposal-promise-allSettled/#sec-promise.allsettled",
             "description": "<code>allSettled()</code>",
             "support": {
               "chrome": {
@@ -178,10 +179,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "68"
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": "68"
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -114,6 +114,7 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/all",
             "spec_url": "https://tc39.es/ecma262/#sec-promise.all",
+            "description": "<code>all()</code>",
             "support": {
               "chrome": {
                 "version_added": "32"
@@ -153,6 +154,58 @@
               },
               "webview_android": {
                 "version_added": "4.4.3"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "allSettled": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled",
+            "description": "<code>allSettled()</code>",
+            "support": {
+              "chrome": {
+                "version_added": "76"
+              },
+              "chrome_android": {
+                "version_added": "76"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "68"
+              },
+              "firefox_android": {
+                "version_added": "68"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": "76"
               }
             },
             "status": {
@@ -218,6 +271,7 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch",
             "spec_url": "https://tc39.es/ecma262/#sec-promise.prototype.catch",
+            "description": "<code>catch()</code>",
             "support": {
               "chrome": {
                 "version_added": "32"
@@ -270,6 +324,7 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/finally",
             "spec_url": "https://tc39.es/ecma262/#sec-promise.prototype.finally",
+            "description": "<code>finally()</code>",
             "support": {
               "chrome": {
                 "version_added": "63"
@@ -322,6 +377,7 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/then",
             "spec_url": "https://tc39.es/ecma262/#sec-promise.prototype.then",
+            "description": "<code>then()</code>",
             "support": {
               "chrome": {
                 "version_added": "32"
@@ -374,6 +430,7 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/race",
             "spec_url": "https://tc39.es/ecma262/#sec-promise.race",
+            "description": "<code>race()</code>",
             "support": {
               "chrome": {
                 "version_added": "32"
@@ -426,6 +483,7 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/reject",
             "spec_url": "https://tc39.es/ecma262/#sec-promise.reject",
+            "description": "<code>reject()</code>",
             "support": {
               "chrome": {
                 "version_added": "32"
@@ -478,6 +536,7 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve",
             "spec_url": "https://tc39.es/ecma262/#sec-promise.resolve",
+            "description": "<code>resolve()</code>",
             "support": {
               "chrome": {
                 "version_added": "32"


### PR DESCRIPTION
This patch adds this method to the Promise.json data with what should be
correct version information for Chrome, Edge, and Firefox. There is no
specification URL because currently `allSettled()` is not yet part of the
spec, and the schema rejects the URL of the proposal.

Sources:
* https://tc39.es/proposal-promise-allSettled/
* Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1539694
* Chrome status: https://www.chromestatus.com/features/5547381053456384
* Edge: https://developer.microsoft.com/en-us/microsoft-edge/platform/catalog/?page=1&q=allSettled
