### PR TITLE
Firefox 68 adds support for rejectionhandled/unhandledrejection

### DIFF
--- a/api/PromiseRejectionEvent.json
+++ b/api/PromiseRejectionEvent.json
@@ -17,26 +17,10 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": false,
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.promise_rejection_events.enabled",
-                "value_to_set": "true"
-              }
-            ],
-            "notes": "Firefox doesn't yet send the <code><a href='https://developer.mozilla.org/docs/Web/API/Window/unhandledrejection_event'>unhandledrejection</a></code> or understand <code><a href='https://developer.mozilla.org/docs/Web/API/Window/rejectionhandled_event'>rejectionhandled<a></code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+            "version_added": "68"
           },
           "firefox_android": {
-            "version_added": false,
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.promise_rejection_events.enabled",
-                "value_to_set": "true"
-              }
-            ],
-            "notes": "Firefox doesn't yet send the <code><a href='https://developer.mozilla.org/docs/Web/API/Window/unhandledrejection_event'>unhandledrejection</a></code> or understand <code><a href='https://developer.mozilla.org/docs/Web/API/Window/rejectionhandled_event'>rejectionhandled<a></code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+            "version_added": "68"
           },
           "ie": {
             "version_added": false
@@ -84,24 +68,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.promise_rejection_events.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.promise_rejection_events.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "68"
             },
             "ie": {
               "version_added": false
@@ -149,24 +119,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.promise_rejection_events.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.promise_rejection_events.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "68"
             },
             "ie": {
               "version_added": false
@@ -214,24 +170,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.promise_rejection_events.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.promise_rejection_events.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "68"
             },
             "ie": {
               "version_added": false

--- a/api/PromiseRejectionEvent.json
+++ b/api/PromiseRejectionEvent.json
@@ -16,11 +16,30 @@
           "edge_mobile": {
             "version_added": null
           },
-          "firefox": {
-            "version_added": "68"
-          },
+          "firefox": [
+            {
+              "version_added": "69"
+            },
+            {
+              "version_added": "68",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.promise_rejection_events.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": {
-            "version_added": "68"
+            "version_added": "68",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.promise_rejection_events.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "ie": {
             "version_added": false
@@ -67,11 +86,30 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": "68"
-            },
+            "firefox": [
+              {
+                "version_added": "69"
+              },
+              {
+                "version_added": "68",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.promise_rejection_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": "68"
+              "version_added": "68",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.promise_rejection_events.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": false
@@ -118,11 +156,30 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": "68"
-            },
+            "firefox": [
+              {
+                "version_added": "69"
+              },
+              {
+                "version_added": "68",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.promise_rejection_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": "68"
+              "version_added": "68",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.promise_rejection_events.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": false
@@ -169,11 +226,30 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": "68"
-            },
+            "firefox": [
+              {
+                "version_added": "69"
+              },
+              {
+                "version_added": "68",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.promise_rejection_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": "68"
+              "version_added": "68",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.promise_rejection_events.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": false

--- a/api/Window.json
+++ b/api/Window.json
@@ -2553,11 +2553,30 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": "68"
-            },
+            "firefox": [
+              {
+                "version_added": "69"
+              },
+              {
+                "version_added": "68",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.promise_rejection_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": "68"
+              "version_added": "68",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.promise_rejection_events.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": false
@@ -2601,11 +2620,30 @@
             "edge_mobile": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "68"
-            },
+            "firefox": [
+              {
+                "version_added": "69"
+              },
+              {
+                "version_added": "68",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.promise_rejection_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": "68"
+              "version_added": "68",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.promise_rejection_events.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": false
@@ -7125,11 +7163,30 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": "68"
-            },
+            "firefox": [
+              {
+                "version_added": "69"
+              },
+              {
+                "version_added": "68",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.promise_rejection_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": "68"
+              "version_added": "68",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.promise_rejection_events.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": false
@@ -9989,11 +10046,30 @@
             "edge_mobile": {
               "version_added": true
             },
-            "firefox": {
-              "version_added": "68"
-            },
+            "firefox": [
+              {
+                "version_added": "69"
+              },
+              {
+                "version_added": "68",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.promise_rejection_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": "68"
+              "version_added": "68",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.promise_rejection_events.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": false

--- a/api/Window.json
+++ b/api/Window.json
@@ -2554,12 +2554,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false,
-              "notes": "Firefox implements the <code>PromiseRejectionEvent</code> interface if you go to <code>about:config</code> and set the <code>dom.promise_rejection_events.enabled</code> pref to <code>true</code>. However, Firefox doesn't yet actually send the <code>unhandledrejection</code> or understand <code>rejectionhandled</code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "Firefox implements the <code>PromiseRejectionEvent</code> interface if you go to <code>about:config</code> and set the <code>dom.promise_rejection_events.enabled</code> pref to <code>true</code>. However, Firefox doesn't yet actually send the <code>unhandledrejection</code> or understand <code>rejectionhandled</code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+              "version_added": "68"
             },
             "ie": {
               "version_added": false
@@ -2604,12 +2602,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": false,
-              "notes": "Firefox implements the <code>PromiseRejectionEvent</code> interface if you go to <code>about:config</code> and set the <code>dom.promise_rejection_events.enabled</code> preference to <code>true</code>. However, Firefox doesn't yet actually send <code>unhandledrejection</code> or understand <code>rejectionhandled</code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "Firefox implements the <code>PromiseRejectionEvent</code> interface if you go to <code>about:config</code> and set the <code>dom.promise_rejection_events.enabled</code> preference to <code>true</code>. However, Firefox doesn't yet actually send <code>unhandledrejection</code> or understand <code>rejectionhandled</code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+              "version_added": "68"
             },
             "ie": {
               "version_added": false
@@ -7130,12 +7126,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false,
-              "notes": "Firefox implements the <code>PromiseRejectionEvent</code> interface if you go to <code>about:config</code> and set the <code>dom.promise_rejection_events.enabled</code> pref to <code>true</code>. However, Firefox doesn't yet actually send the <code>unhandledrejection</code> or understand <code>rejectionhandled</code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "Firefox implements the <code>PromiseRejectionEvent</code> interface if you go to <code>about:config</code> and set the <code>dom.promise_rejection_events.enabled</code> pref to <code>true</code>. However, Firefox doesn't yet actually send the <code>unhandledrejection</code> or understand <code>rejectionhandled</code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+              "version_added": "68"
             },
             "ie": {
               "version_added": false
@@ -9996,12 +9990,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": false,
-              "notes": "Firefox implements the <code>PromiseRejectionEvent</code> interface if you go to <code>about:config</code> and set the <code>dom.promise_rejection_events.enabled</code> preference to <code>true</code>. However, Firefox doesn't yet actually send <code>unhandledrejection</code> or understand <code>rejectionhandled</code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "Firefox implements the <code>PromiseRejectionEvent</code> interface if you go to <code>about:config</code> and set the <code>dom.promise_rejection_events.enabled</code> preference to <code>true</code>. However, Firefox doesn't yet actually send <code>unhandledrejection</code> or understand <code>rejectionhandled</code> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
+              "version_added": "68"
             },
             "ie": {
               "version_added": false

--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -553,7 +553,17 @@
             },
             "firefox": [
               {
-                "version_added": "68"
+                "version_added": "69"
+              },
+              {
+                "version_added": "68",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.promise_rejection_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "55",
@@ -565,12 +575,19 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "This event handler was added in Firefox 55 but was not functional. It was therefore disabled by default."
+                "notes": "This event handler was added in Firefox 55 but was disabled since it wasn't fully implemented. It was fully implemented in Firefox 68 and enabled by default in Firefox 69."
               }
             ],
             "firefox_android": [
               {
-                "version_added": "68"
+                "version_added": "68",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.promise_rejection_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "55",
@@ -582,7 +599,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "This event handler was added in Firefox 55 but was not functional. It was therefore disabled by default."
+                "notes": "This event handler was added in Firefox 55 but was disabled since it wasn't fully implemented. It was fully implemented in Firefox 68 but not enabled by default."
               }
             ],
             "ie": {
@@ -680,7 +697,17 @@
             },
             "firefox": [
               {
-                "version_added": "68"
+                "version_added": "69"
+              },
+              {
+                "version_added": "68",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.promise_rejection_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "55",
@@ -692,12 +719,19 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "This event handler was added in Firefox 55 but was not functional. It was therefore disabled by default."
+                "notes": "This event handler was added in Firefox 55 but was disabled since it wasn't fully implemented. It was fully implemented in Firefox 68 and enabled by default in Firefox 69."
               }
             ],
             "firefox_android": [
               {
-                "version_added": "68"
+                "version_added": "68",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.promise_rejection_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               {
                 "version_added": "55",
@@ -709,7 +743,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "This event handler was added in Firefox 55 but was not functional. It was therefore disabled by default."
+                "notes": "This event handler was added in Firefox 55 but was disabled since it wasn't fully implemented. It was fully implemented in Firefox 68 but not enabled by default."
               }
             ],
             "ie": {

--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -551,30 +551,40 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": "55",
-              "partial_implementation": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.promise_rejection_events.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "Firefox doesn't yet send the <a href='https://developer.mozilla.org/docs/Web/Events/unhandledrejection'>unhandledrejection</a> or understand <a href='https://developer.mozilla.org/docs/Web/Events/rejectionhandled'>rejectionhandled<a> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
-            },
-            "firefox_android": {
-              "version_added": "55",
-              "partial_implementation": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.promise_rejection_events.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "Firefox doesn't yet send the <a href='https://developer.mozilla.org/docs/Web/Events/unhandledrejection'>unhandledrejection</a> or understand <a href='https://developer.mozilla.org/docs/Web/Events/rejectionhandled'>rejectionhandled<a> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "68"
+              },
+              {
+                "version_added": "55",
+                "partial_implementation": true,
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.promise_rejection_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "This event handler was added in Firefox 55 but was not functional. It was therefore disabled by default."
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "68"
+              },
+              {
+                "version_added": "55",
+                "partial_implementation": true,
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.promise_rejection_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "This event handler was added in Firefox 55 but was not functional. It was therefore disabled by default."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -668,30 +678,40 @@
             "edge_mobile": {
               "version_added": null
             },
-            "firefox": {
-              "version_added": "55",
-              "partial_implementation": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.promise_rejection_events.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "Firefox doesn't yet send the <a href='https://developer.mozilla.org/docs/Web/Events/unhandledrejection'>unhandledrejection</a> or understand <a href='https://developer.mozilla.org/docs/Web/Events/rejectionhandled'>rejectionhandled<a> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
-            },
-            "firefox_android": {
-              "version_added": "55",
-              "partial_implementation": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.promise_rejection_events.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "Firefox doesn't yet send the <a href='https://developer.mozilla.org/docs/Web/Events/unhandledrejection'>unhandledrejection</a> or understand <a href='https://developer.mozilla.org/docs/Web/Events/rejectionhandled'>rejectionhandled<a> events. Completing the implementation will be addressed in <a href='https://bugzil.la/1362272'>bug 1362272</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "68"
+              },
+              {
+                "version_added": "55",
+                "partial_implementation": true,
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.promise_rejection_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "This event handler was added in Firefox 55 but was not functional. It was therefore disabled by default."
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "68"
+              },
+              {
+                "version_added": "55",
+                "partial_implementation": true,
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.promise_rejection_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "This event handler was added in Firefox 55 but was not functional. It was therefore disabled by default."
+              }
+            ],
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
As well as the interface and handlers for these events.

Source:
* https://bugzilla.mozilla.org/show_bug.cgi?id=1362272
