### PR TITLE
Fix Chrome/Opera Android versions in css.properties.mask-size

### DIFF
--- a/css/properties/mask-size.json
+++ b/css/properties/mask-size.json
@@ -11,7 +11,7 @@
             },
             "chrome_android": {
               "prefix": "-webkit-",
-              "version_added": "28"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "17"
@@ -34,7 +34,7 @@
             },
             "opera_android": {
               "prefix": "-webkit-",
-              "version_added": "15"
+              "version_added": "14"
             },
             "safari": {
               "prefix": "-webkit-",


### PR DESCRIPTION
Follow-up to a review in #4360 that was originally dismissed due to a version confusion.  This PR fixes the Chrome/Opera Android version numbers to better accommodate the data.