### PR TITLE
Edge Support on Console.timeStamp

### DIFF
--- a/api/Console.json
+++ b/api/Console.json
@@ -1321,7 +1321,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "edge_mobile": {
               "version_added": null

--- a/api/Console.json
+++ b/api/Console.json
@@ -1321,7 +1321,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "edge_mobile": {
               "version_added": null
@@ -1333,7 +1333,7 @@
               "version_added": "10"
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
Tested `console.timeStamp` on Edge *(Windows 10 build 18895)*: **it worked.**
![image](https://user-images.githubusercontent.com/5672451/60234255-eff57980-9892-11e9-9ae8-8b88dbaebe33.png)
.