### PR TITLE
Add trimLeft and trimRight javascript String aliases in NodeJS

### DIFF
--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -3187,7 +3187,7 @@
                   "version_added": "10.0.0"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "0.12",
                   "alternative_name": "trimRight"
                 }
               ],
@@ -3281,7 +3281,7 @@
                   "version_added": "10.0.0"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "0.12",
                   "alternative_name": "trimLeft"
                 }
               ],

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -3182,9 +3182,15 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": "10.0.0"
-              },
+              "nodejs": [
+                {
+                  "version_added": "10.0.0"
+                },
+                {
+                  "version_added": true,
+                  "alternative_name": "trimRight"
+                }
+              ],
               "opera": {
                 "version_added": "53"
               },
@@ -3270,9 +3276,15 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": "10.0.0"
-              },
+              "nodejs": [
+                {
+                  "version_added": "10.0.0"
+                },
+                {
+                  "version_added": true,
+                  "alternative_name": "trimLeft"
+                }
+              ],
               "opera": {
                 "version_added": "53"
               },


### PR DESCRIPTION
Fixes #2554 by adding the `trimLeft` and `trimRight` aliases supported within NodeJS.