### PR TITLE
Use an unambiguous date format in the stats script

### DIFF
--- a/scripts/statistics.js
+++ b/scripts/statistics.js
@@ -76,5 +76,5 @@ const printTable = () => {
   console.log(table);
 }
 
-console.log('Status as of version 0.0.xx (released on xx/xx/2019) for web platform features: \n')
+console.log('Status as of version 0.0.xx (released on 2019-MM-DD) for web platform features: \n')
 printTable();


### PR DESCRIPTION
As an American living in Europe, I've lost the ability to make sense of dates. This updates the stats script to ~accommodate my deficiency~ suggest a less ambiguous date format.