### PR TITLE
Chrome shipped api.AudioContext[Options].sampleRate in 74

### DIFF
--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -204,11 +204,10 @@
             "description": "<code>sampleRate</code> option",
             "support": {
               "chrome": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/432248'>issue 432248</a> for Chrome support."
+                "version_added": "74"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "74"
               },
               "edge": {
                 "version_added": false
@@ -241,7 +240,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "74"
               }
             },
             "status": {

--- a/api/AudioContextOptions.json
+++ b/api/AudioContextOptions.json
@@ -100,11 +100,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioContextOptions/sampleRate",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/432248'>issue 432248</a> for Chrome support."
+              "version_added": "74"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "74"
             },
             "edge": {
               "version_added": false
@@ -134,7 +133,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "74"
             }
           },
           "status": {


### PR DESCRIPTION
Cherry-picked from https://github.com/mdn/browser-compat-data/pull/3826#discussion_r298312178.  Already confirmed supported by Google.