### PR TITLE
Fix opera support for CSS.escape

### DIFF
--- a/api/CSS.json
+++ b/api/CSS.json
@@ -458,7 +458,7 @@
               "version_added": "33"
             },
             "opera_android": {
-               "version_added": "33"
+              "version_added": "33"
             },
             "safari": {
               "version_added": "10"

--- a/api/CSS.json
+++ b/api/CSS.json
@@ -455,7 +455,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "33"
             },
             "opera_android": {
               "version_added": false

--- a/api/CSS.json
+++ b/api/CSS.json
@@ -458,7 +458,7 @@
               "version_added": "33"
             },
             "opera_android": {
-              "version_added": false
+               "version_added": "33"
             },
             "safari": {
               "version_added": "10"


### PR DESCRIPTION
see https://dev.opera.com/blog/opera-33/

I also manually checked in opera 62
