### PR TITLE
Add unprefixed CSS filter support for Safari

### DIFF
--- a/css/properties/filter.json
+++ b/css/properties/filter.json
@@ -120,14 +120,24 @@
                 "version_added": "14"
               }
             ],
-            "safari": {
-              "prefix": "-webkit-",
-              "version_added": "6"
-            },
-            "safari_ios": {
-              "prefix": "-webkit-",
-              "version_added": "6"
-            },
+            "safari": [
+              {
+                "version_added": "9.1"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "6"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "9.3"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "6"
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "6.0"
             },


### PR DESCRIPTION
Version derived from the release notes for Safari 9.1:
https://developer.apple.com/library/archive/releasenotes/General/WhatsNewInSafari/Articles/Safari_9_1.html#//apple_ref/doc/uid/TP40014305-CH10-SW15

I couldn't find an official reference for Safari on iOS so I aligned with caniuse which lists 9.3 as the version where filter became unprefixed.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
