### PR TITLE
Update support of optional try/catch bindings

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -2219,10 +2219,10 @@
                 "version_added": "47"
               },
               "safari": {
-                "version_added": false
+                "version_added": "11.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "11.3"
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
I noticed that optional catch bindings are supported in recent Edge/Safari and added these. :) 

I took the support information for Safari from [kangax compat table](https://kangax.github.io/compat-table/es2016plus/#test-optional_catch_binding). 

For Edge it's supported since the move to Chromium which makes `76`. :) You can verify this by opening the new Edge and try it in the console. :) 

<img width="298" alt="Screenshot 2019-06-30 at 13 49 36" src="https://user-images.githubusercontent.com/962099/60396143-ee031300-9b3d-11e9-8103-e1e99478f392.png">

Thanks for the good work. :)

------

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
