### PR TITLE
Add CSS counter()

### DIFF
--- a/css/types/counter.json
+++ b/css/types/counter.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "types": {
+      "counter": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/counter",
+          "description": "<code>counter()</code>",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "8"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/types/counter.json
+++ b/css/types/counter.json
@@ -31,10 +31,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
Supersedes and closes #4230 due to lack of response from the PR author and changes requested.  This PR adds the `counter()` CSS type (as per https://github.com/mdn/sprints/issues/1188), and addresses all of the changes requested in the original PR, along with a couple of additional updates (i.e. removing Edge Mobile and adding a version number to Samsung Internet).