### PR TITLE
Fix URLs in api.PaintWorkletGlobalScope

### DIFF
--- a/api/PaintWorkletGlobalScope.json
+++ b/api/PaintWorkletGlobalScope.json
@@ -2,7 +2,7 @@
   "api": {
     "PaintWorkletGlobalScope": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaintWorkletGlobalScope",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaintWorklet",
         "support": {
           "chrome": {
             "version_added": "65"
@@ -49,7 +49,7 @@
       },
       "devicePixelRatio": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaintWorkletGlobalScope/devicePixelRatio",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaintWorklet/devicePixelRatio",
           "support": {
             "chrome": {
               "version_added": "65"
@@ -97,7 +97,7 @@
       },
       "registerPaint": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaintWorkletGlobalScope/registerPaint",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaintWorklet/registerPaint",
           "support": {
             "chrome": {
               "version_added": "65"


### PR DESCRIPTION
This PR supersedes #4285.  The MDN URLs in this file point to non-existent pages.  As such, this PR points them to the correct pages.