### PR TITLE
Set Chrome versions for CSS box-* based upon Safari versions

### DIFF
--- a/css/properties/box-align.json
+++ b/css/properties/box-align.json
@@ -6,11 +6,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/box-align",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "prefix": "-webkit-"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "prefix": "-webkit-"
             },
             "edge": {
@@ -64,7 +64,8 @@
               "prefix": "-webkit-"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0",
+              "prefix": "-webkit-"
             },
             "webview_android": {
               "version_added": true,

--- a/css/properties/box-direction.json
+++ b/css/properties/box-direction.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "prefix": "-webkit-",
@@ -67,7 +67,8 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "prefix": "-webkit-",
+              "version_added": true
             },
             "safari": [
               {
@@ -85,7 +86,8 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0",
+              "prefix": "-webkit-"
             },
             "webview_android": {
               "prefix": "-webkit-",

--- a/css/properties/box-flex-group.json
+++ b/css/properties/box-flex-group.json
@@ -6,12 +6,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/box-flex-group",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "67",
               "prefix": "-webkit-"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "67",
               "prefix": "-webkit-"
             },
@@ -53,7 +53,9 @@
               "prefix": "-webkit-"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0",
+              "version_removed": "9.0",
+              "prefix": "-webkit-"
             },
             "webview_android": {
               "version_added": true,

--- a/css/properties/box-flex.json
+++ b/css/properties/box-flex.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "prefix": "-webkit-",
@@ -67,7 +67,8 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "prefix": "-webkit-",
+              "version_added": true
             },
             "safari": [
               {
@@ -85,7 +86,8 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0",
+              "prefix": "-webkit-"
             },
             "webview_android": {
               "prefix": "-webkit-",

--- a/css/properties/box-lines.json
+++ b/css/properties/box-lines.json
@@ -6,12 +6,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/box-lines",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "67",
               "prefix": "-webkit-"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "67",
               "prefix": "-webkit-"
             },
@@ -53,7 +53,9 @@
               "prefix": "-webkit-"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0",
+              "version_removed": "9.0",
+              "prefix": "-webkit-"
             },
             "webview_android": {
               "version_added": true,

--- a/css/properties/box-ordinal-group.json
+++ b/css/properties/box-ordinal-group.json
@@ -6,11 +6,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/box-ordinal-group",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "prefix": "-webkit-"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "prefix": "-webkit-"
             },
             "edge": {
@@ -86,7 +86,8 @@
               "prefix": "-webkit-"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0",
+              "prefix": "-webkit-"
             },
             "webview_android": {
               "version_added": true,

--- a/css/properties/box-orient.json
+++ b/css/properties/box-orient.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "prefix": "-webkit-",
@@ -67,7 +67,8 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "prefix": "-webkit-",
+              "version_added": true
             },
             "safari": [
               {
@@ -85,7 +86,8 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "prefix": "-webkit-",
+              "version_added": "1.0"
             },
             "webview_android": {
               "prefix": "-webkit-",

--- a/css/properties/box-pack.json
+++ b/css/properties/box-pack.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "prefix": "-webkit-",
@@ -67,7 +67,8 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "prefix": "-webkit-",
+              "version_added": true
             },
             "safari": [
               {
@@ -85,7 +86,8 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "prefix": "-webkit-",
+              "version_added": "1.0"
             },
             "webview_android": {
               "prefix": "-webkit-",


### PR DESCRIPTION
Since Chrome 1 was based off of WebKit 528, anything listed as Safari 3.2 or older automatically defaults to Chrome 1.  I noticed that all of the properties listed in #4296 (except for box-sizing) had Safari 3 listed as the first version to implement support.  This PR sets all eight properties as the following:

Chrome = 1
Chrome Android = 18
Opera = True
Opera Android = True
Samsung Internet = 1.0
WebView = True