### PR TITLE
Safari still supports box-sizing with -webkit- prefix

### DIFF
--- a/css/properties/box-sizing.json
+++ b/css/properties/box-sizing.json
@@ -100,8 +100,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "3",
-                "version_removed": true
+                "version_added": "3"
               }
             ],
             "safari_ios": {


### PR DESCRIPTION
It looks like a `version_removed: true` line was added to the `box-sizing` property for Safari for `-webkit-` prefix support.  After some tracking down, I found out this data was imported from the old MDN tables.  However, that line is inaccurate.  I tested both the prefixed and non-prefixed versions of the property in Safari 12.1, and both were recognized by the browser.