### PR TITLE
Set Chromium versions from Safari versions for several column properties

### DIFF
--- a/css/properties/column-count.json
+++ b/css/properties/column-count.json
@@ -11,12 +11,18 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "1"
               }
             ],
-            "chrome_android": {
-              "version_added": "50"
-            },
+            "chrome_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "18"
+              }
+            ],
             "edge": [
               {
                 "version_added": "12"
@@ -58,11 +64,11 @@
             ],
             "opera_android": [
               {
-                "version_added": true
+                "version_added": "11.1"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "14"
               }
             ],
             "safari": [
@@ -80,15 +86,27 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "1"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": "5.0"
-            },
-            "webview_android": {
-              "version_added": true
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "5.0"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1.0"
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/column-rule-color.json
+++ b/css/properties/column-rule-color.json
@@ -11,7 +11,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "1"
               }
             ],
             "chrome_android": [
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "18"
               }
             ],
             "edge": [
@@ -62,6 +62,15 @@
                 "version_added": "15"
               }
             ],
+            "opera_android": [
+              {
+                "version_added": "11.1"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "14"
+              }
+            ],
             "safari": [
               {
                 "version_added": "9"
@@ -77,7 +86,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "1"
               }
             ],
             "samsunginternet_android": [
@@ -86,12 +95,18 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "1.0"
               }
             ],
-            "webview_android": {
-              "version_added": true
-            }
+            "webview_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/column-rule-style.json
+++ b/css/properties/column-rule-style.json
@@ -11,7 +11,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "1"
               }
             ],
             "chrome_android": [
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "18"
               }
             ],
             "edge": [
@@ -62,6 +62,15 @@
                 "version_added": "15"
               }
             ],
+            "opera_android": [
+              {
+                "version_added": "11.1"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "14"
+              }
+            ],
             "safari": [
               {
                 "version_added": "9"
@@ -77,7 +86,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "3"
+                "version_added": "1"
               }
             ],
             "samsunginternet_android": [
@@ -86,12 +95,18 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "1.0"
               }
             ],
-            "webview_android": {
-              "version_added": true
-            }
+            "webview_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/column-rule-width.json
+++ b/css/properties/column-rule-width.json
@@ -11,7 +11,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "1"
               }
             ],
             "chrome_android": [
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "18"
               }
             ],
             "edge": [
@@ -34,7 +34,7 @@
             ],
             "firefox": [
               {
-                "version_added": "50"
+                "version_added": "52"
               },
               {
                 "prefix": "-moz-",
@@ -43,7 +43,7 @@
             ],
             "firefox_android": [
               {
-                "version_added": "50"
+                "version_added": "52"
               },
               {
                 "prefix": "-moz-",
@@ -62,6 +62,15 @@
                 "version_added": "15"
               }
             ],
+            "opera_android": [
+              {
+                "version_added": "11.1"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "14"
+              }
+            ],
             "safari": [
               {
                 "version_added": "9"
@@ -77,7 +86,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "1"
               }
             ],
             "samsunginternet_android": [
@@ -86,12 +95,18 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "1.0"
               }
             ],
-            "webview_android": {
-              "version_added": true
-            }
+            "webview_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/column-rule.json
+++ b/css/properties/column-rule.json
@@ -11,7 +11,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "1"
               }
             ],
             "chrome_android": [
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "18"
               }
             ],
             "edge": [
@@ -63,6 +63,15 @@
                 "version_added": "15"
               }
             ],
+            "opera_android": [
+              {
+                "version_added": "11.1"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "14"
+              }
+            ],
             "safari": [
               {
                 "version_added": "9"
@@ -78,7 +87,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "1"
               }
             ],
             "samsunginternet_android": [
@@ -87,12 +96,18 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "1.0"
               }
             ],
-            "webview_android": {
-              "version_added": true
-            }
+            "webview_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/column-width.json
+++ b/css/properties/column-width.json
@@ -11,7 +11,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "1"
               }
             ],
             "chrome_android": [
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "18"
               }
             ],
             "edge": [
@@ -53,12 +53,24 @@
             "ie": {
               "version_added": "10"
             },
-            "opera": {
-              "version_added": "11.1"
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "11.1"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "11.1"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
             "safari": [
               {
                 "version_added": "9"
@@ -74,7 +86,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "1"
               }
             ],
             "samsunginternet_android": [
@@ -83,12 +95,18 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "1.0"
               }
             ],
-            "webview_android": {
-              "version_added": true
-            }
+            "webview_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": true
+              }
+            ]
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
This PR adds version numbers to Chrome (and Chrome-based browsers) based upon data from Safari to six different CSS column properties.