### PR TITLE
Mention a couple of WebExtension API polyfills

### DIFF
--- a/webextensions/api/contentScripts.json
+++ b/webextensions/api/contentScripts.json
@@ -7,7 +7,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/contentScripts/RegisteredContentScript",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "notes": "There is a <a href='https://github.com/bfred-it/content-scripts-register-polyfill'>polyfill available</a>."
               },
               "edge": {
                 "version_added": false
@@ -28,7 +29,8 @@
               "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/contentScripts/RegisteredContentScript/unregister",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": false,
+                "notes": "There is a <a href='https://github.com/bfred-it/content-scripts-register-polyfill'>polyfill available</a>."
                 },
                 "edge": {
                   "version_added": false
@@ -51,7 +53,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/contentScripts/register",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "notes": "There is a <a href='https://github.com/bfred-it/content-scripts-register-polyfill'>polyfill available</a>."
               },
               "edge": {
                 "version_added": false

--- a/webextensions/api/contentScripts.json
+++ b/webextensions/api/contentScripts.json
@@ -30,7 +30,7 @@
               "support": {
                 "chrome": {
                   "version_added": false,
-                "notes": "There is a <a href='https://github.com/bfred-it/content-scripts-register-polyfill'>polyfill available</a>."
+                  "notes": "There is a <a href='https://github.com/bfred-it/content-scripts-register-polyfill'>polyfill available</a>."
                 },
                 "edge": {
                   "version_added": false

--- a/webextensions/api/permissions.json
+++ b/webextensions/api/permissions.json
@@ -57,7 +57,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "notes": "There is a <a href='https://github.com/bfred-it/chrome-permissions-events-polyfill'>polyfill available</a>."
               },
               "firefox_android": {
                 "version_added": false
@@ -79,7 +80,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "notes": "There is a <a href='https://github.com/bfred-it/chrome-permissions-events-polyfill'>polyfill available</a>."
               },
               "firefox_android": {
                 "version_added": false


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
> - [x] Summarize your changes

- the Permissions API event is missing from firefox
- contentScripts.register is missing from Chrome

So I added these two polyfills to the table

> - [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)

[bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1444294) for the missing events

> - [x] Data: if you tested something, describe how you tested with details like browser and version

- [chrome-permissions-events-polyfill](https://github.com/bfred-it/chrome-permissions-events-polyfill) was tested in Firefox 67
- [content-scripts-register-polyfill](https://github.com/bfred-it/content-scripts-register-polyfill) was tested in Chrome 75

Both were tested in [Refined GitHub](https://github.com/sindresorhus/refined-github/pull/2181) to register existing content scripts on new hosts.

> - [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)

> - [x] Link to related issues or pull requests, if any

This follows the existing mentions of polyfills: https://github.com/mdn/browser-compat-data/search?q=polyfill&unscoped_q=polyfill
