### PR TITLE
Remove remaining edge_mobile data

### DIFF
--- a/api/HTMLTrackElement.json
+++ b/api/HTMLTrackElement.json
@@ -86,9 +86,6 @@
             "edge": {
               "version_added": null
             },
-            "edge_mobile": {
-              "version_added": null
-            },
             "firefox": {
               "version_added": "68"
             },

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -122,9 +122,6 @@
               "edge": {
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "version_added": true
-              },
               "firefox": {
                 "version_added": "4"
               },

--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -231,9 +231,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": [
                 {
                   "version_added": "54"

--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -171,9 +171,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },
@@ -224,9 +221,6 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": [
@@ -2033,9 +2027,6 @@
                 "version_removed": "45"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {
@@ -5144,9 +5135,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "prefix": "-moz-",
                 "version_added": "33"
@@ -5197,9 +5185,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": "39"
               },
@@ -5246,9 +5231,6 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/css/properties/text-align.json
+++ b/css/properties/text-align.json
@@ -266,9 +266,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "version_added": false
               },

--- a/css/properties/user-select.json
+++ b/css/properties/user-select.json
@@ -344,10 +344,6 @@
                 "alternative_name": "element",
                 "version_added": "12"
               },
-              "edge_mobile": {
-                "alternative_name": "element",
-                "version_added": "12"
-              },
               "firefox": {
                 "version_added": false
               },

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -255,9 +255,6 @@
               "edge": {
                 "version_added": false
               },
-              "edge_mobile": {
-                "version_added": false
-              },
               "firefox": {
                 "alternative_name": "-moz-available",
                 "version_added": "3"
@@ -469,9 +466,6 @@
                 "version_added": "46"
               },
               "edge": {
-                "version_added": false
-              },
-              "edge_mobile": {
                 "version_added": false
               },
               "firefox": {

--- a/html/elements/track.json
+++ b/html/elements/track.json
@@ -90,9 +90,6 @@
               "edge": {
                 "version_added": null
               },
-              "edge_mobile": {
-                "version_added": null
-              },
               "firefox": {
                 "version_added": "68"
               },


### PR DESCRIPTION
There is some Edge Mobile data remaining in the repository.

# Summary
This removes [remaining `edge_mobile` information](https://github.com/mdn/browser-compat-data/search?q=edge_mobile&type=Code).

# Data
This removes data seen if you run `grep -r "edge_mobile" ./`.
This happens to be a super set of #4280.

# Details
Remove all remaining edge_mobile data and references to edge_mobile:
 - remove remaining data in api/HTMLTrackElement.json
 - remove remaining data in css/properties/*
 - remove remaining data in html/elements/track.json
 - delete browsers/edge_mobile.json
 - remove edge_mobile from schemas/*
 - remove edge_mobile from scripts/render.js, test/test-browsers.js,
   types.d.ts, and .vscode/snippets.code-snippets

# Related issues
#3888 and all issues and commits mentioned there.

# Tests
Linter tests pass normally.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
