### PR TITLE
Set Safari support based upon Chrome support for CSS animation-direction

### DIFF
--- a/css/properties/animation-direction.json
+++ b/css/properties/animation-direction.json
@@ -188,10 +188,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "6"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "6"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -233,7 +233,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "6"
+              },
+              "safari_ios": {
+                "version_added": "6"
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
Safari version numbers were derived by obtaining the Chrome version and matching WebKit version numbers.  This PR is to help the efforts of #4299.