### PR TITLE
Safari doesn't support jump- syntax for animation-timing-function

### DIFF
--- a/css/properties/animation-timing-function.json
+++ b/css/properties/animation-timing-function.json
@@ -191,10 +191,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
Based upon manual testing in Safari 12.1.  It seems that Firefox is the only browser that supports this syntax.