### PR TITLE
Add Chrome/Safari versions for column-span/column-fill

### DIFF
--- a/css/properties/column-fill.json
+++ b/css/properties/column-fill.json
@@ -9,7 +9,7 @@
               "version_added": "50"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "50"
             },
             "edge": {
               "version_added": "12"
@@ -44,7 +44,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "8"
               }
             ],
             "safari_ios": [
@@ -53,14 +53,14 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "8"
               }
             ],
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "50"
             }
           },
           "status": {

--- a/css/properties/column-span.json
+++ b/css/properties/column-span.json
@@ -11,7 +11,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "6"
               }
             ],
             "chrome_android": [
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "18"
               }
             ],
             "edge": [
@@ -72,7 +72,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "5.1"
               }
             ],
             "safari_ios": [
@@ -81,7 +81,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "5"
               }
             ],
             "samsunginternet_android": [
@@ -90,7 +90,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "1.0"
               }
             ],
             "webview_android": [


### PR DESCRIPTION
This PR adds Chrome and Safari versions to the `column-span` and `column-fill` properties.

## css.properties.column-fill (-webkit- prefix)
Implemented in 5e0c945afb51b75aed2bfe431f1b7e0fdc27f139
Implemented in WebKit 538.2
Chrome already has "50" set
Safari 8

## css.properties.column-span (-webkit- prefix)
Implemented in 87be1fe8ece215f8e075729135c416969cffdf41
Implemented in WebKit 534.1
Safari 5.1, Chrome 6

_Note: all commit hashes are Git hashes of the Git mirror of WebKit._