### PR TITLE
[Firefox] Bug 1513643: Enable `@supports selector(…)` by default

### DIFF
--- a/css/at-rules/supports.json
+++ b/css/at-rules/supports.json
@@ -88,16 +88,21 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "64",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.supports-selector.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "69"
+                },
+                {
+                  "version_added": "64",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.supports-selector.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": {
                 "version_added": "64",
                 "flags": [


### PR DESCRIPTION
See [bug 1513643][bmo‑1513643] for details.

[bmo‑1513643]: https://bugzilla.mozilla.org/show_bug.cgi?id=1513643
