### PR TITLE
Update canvas captureStream support on Safari

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -78,10 +78,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": true
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"


### PR DESCRIPTION
canvas captureStream is not supported on Safari or Safari iOS. See https://stackoverflow.com/questions/56879151/cannot-bind-mediastream-from-canvas-capturestream-to-player-element-on-safari for an example.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
