### PR TITLE
Set Chrome/Safari versions for css transition-property/timing-function

### DIFF
--- a/css/properties/transition-property.json
+++ b/css/properties/transition-property.json
@@ -11,7 +11,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "1"
               }
             ],
             "chrome_android": [
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "18"
               }
             ],
             "edge": [
@@ -123,7 +123,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "3.1"
               }
             ],
             "safari_ios": [
@@ -137,11 +137,11 @@
             ],
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "1.5"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "1.0"
               }
             ],
             "webview_android": [
@@ -165,10 +165,10 @@
             "description": "<code>IDENT</code> value",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -189,13 +189,13 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": false
+                "version_added": "4"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "3"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true

--- a/css/properties/transition-timing-function.json
+++ b/css/properties/transition-timing-function.json
@@ -11,7 +11,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "1"
               }
             ],
             "chrome_android": [
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "18"
               }
             ],
             "edge": [
@@ -137,11 +137,11 @@
             ],
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "1.5"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "1.0"
               }
             ],
             "webview_android": [
@@ -165,10 +165,10 @@
             "description": "<code>jump-</code> keywords for <code>steps()</code>",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": false
               },
               "edge": {
                 "version_added": false
@@ -183,22 +183,22 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": false
               },
               "opera_android": {
-                "version_added": true
+                "version_added": false
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": false
               },
               "webview_android": {
-                "version_added": true
+                "version_added": false
               }
             },
             "status": {


### PR DESCRIPTION
This PR is intended to finish the final values within #4300.  It sets Chromium and Safari versions based upon the following findings:

## css.properties.transition-property (-webkit- prefix), css.properties.transition-timing-function (-webkit- prefix)
Introduced in 02b766f2d2c8d7a93f7ccaf79d49fe8997783f42
Introduced in WebKit 525.1
Safari 3.1, Chrome 1

## css.properties.transition-property.IDENT_value
Introduced in 166f251275e975b64dde76959d9f78a34083c475
Introduced in WebKit 527
Safari 4, Chrome 1

## css.properties.transition-timing-function.jump
Not supported in Safari or Chrome (based upon manual testing)
