### PR TITLE
Update chrome in console.timeLog() compat

### DIFF
--- a/api/Console.json
+++ b/api/Console.json
@@ -1194,11 +1194,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/timeLog",
           "support": {
             "chrome": {
-              "version_added": "70",
-              "notes": "See <a href='https://crbug.com/854474'>bug 854474</a>."
+              "version_added": "72"
             },
             "chrome_android": {
-              "version_added": "70"
+              "version_added": "72"
             },
             "edge": {
               "version_added": false
@@ -1213,7 +1212,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "60"
             },
             "safari": {
               "version_added": false,
@@ -1226,7 +1225,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "72"
             }
           },
           "status": {

--- a/api/Console.json
+++ b/api/Console.json
@@ -1194,11 +1194,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/timeLog",
           "support": {
             "chrome": {
-              "version_added": false,
+              "version_added": "70",
               "notes": "See <a href='https://crbug.com/854474'>bug 854474</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "70"
             },
             "edge": {
               "version_added": false


### PR DESCRIPTION
As I just discovered this, I don't know exactly when it was added, but the bug report says it got fixed on 'Tue, Oct 2, 2018, 10:06 PM GMT+2'. So this looks like to be Chrome 70. Also tested this in Chrome on Android with the remove devices tool.
(see https://bugs.chromium.org/p/chromium/issues/detail?id=854474#c8)