### PR TITLE
Set Chromium/Safari versions for various CSS selectors

### DIFF
--- a/css/selectors/adjacent_sibling.json
+++ b/css/selectors/adjacent_sibling.json
@@ -10,7 +10,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -35,13 +35,13 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/selectors/after.json
+++ b/css/selectors/after.json
@@ -8,20 +8,20 @@
           "support": {
             "chrome": [
               {
-                "version_added": true
+                "version_added": "1"
               },
               {
                 "alternative_name": ":after",
-                "version_added": true
+                "version_added": "1"
               }
             ],
             "chrome_android": [
               {
-                "version_added": true
+                "version_added": "18"
               },
               {
                 "alternative_name": ":after",
-                "version_added": true
+                "version_added": "18"
               }
             ],
             "edge": [
@@ -95,12 +95,24 @@
                 "version_added": "4"
               }
             ],
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "safari_ios": [
+              {
+                "version_added": "3.2"
+              },
+              {
+                "alternative_name": ":after",
+                "version_added": "3.2"
+              }
+            ],
+            "samsunginternet_android": [
+              {
+                "version_added": "1.0"
+              },
+              {
+                "alternative_name": ":after",
+                "version_added": "1.0"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": true

--- a/css/selectors/any-link.json
+++ b/css/selectors/any-link.json
@@ -12,7 +12,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "1"
               }
             ],
             "chrome_android": [
@@ -21,7 +21,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "18"
               }
             ],
             "edge": {
@@ -50,21 +50,36 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
-            "opera_android": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "52"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "47"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "14"
+              }
+            ],
             "safari": [
               {
                 "version_added": "9"
               },
               {
-                "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "3",
+                "prefix": "-webkit-"
+              },
+              {
+                "version_added": "1.2",
+                "version_removed": "3",
+                "prefix": "-khtml-"
               }
             ],
             "safari_ios": [
@@ -73,12 +88,18 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "1"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "9.0"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1.0"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "65"

--- a/css/selectors/before.json
+++ b/css/selectors/before.json
@@ -8,20 +8,20 @@
           "support": {
             "chrome": [
               {
-                "version_added": true
+                "version_added": "1"
               },
               {
                 "alternative_name": ":before",
-                "version_added": true
+                "version_added": "1"
               }
             ],
             "chrome_android": [
               {
-                "version_added": true
+                "version_added": "18"
               },
               {
                 "alternative_name": ":before",
-                "version_added": true
+                "version_added": "18"
               }
             ],
             "edge": [
@@ -95,9 +95,15 @@
             "safari_ios": {
               "version_added": "5.1"
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "1.0"
+              },
+              {
+                "alternative_name": ":before",
+                "version_added": "1.0"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": true

--- a/css/selectors/child.json
+++ b/css/selectors/child.json
@@ -10,7 +10,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -31,13 +31,13 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/selectors/class.json
+++ b/css/selectors/class.json
@@ -10,7 +10,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -31,13 +31,13 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/selectors/cue.json
+++ b/css/selectors/cue.json
@@ -7,10 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::cue",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "26"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "26"
             },
             "edge": {
               "version_added": false
@@ -26,19 +26,19 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "14"
             },
             "safari": {
-              "version_added": null
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "6.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true

--- a/css/selectors/defined.json
+++ b/css/selectors/defined.json
@@ -31,13 +31,13 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "54"

--- a/css/selectors/defined.json
+++ b/css/selectors/defined.json
@@ -31,10 +31,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/css/selectors/descendant.json
+++ b/css/selectors/descendant.json
@@ -8,7 +8,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": true
+                "version_added": "1"
               },
               {
                 "version_added": "61",
@@ -17,7 +17,7 @@
             ],
             "chrome_android": [
               {
-                "version_added": true
+                "version_added": "18"
               },
               {
                 "version_added": "61",
@@ -43,13 +43,13 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/selectors/first.json
+++ b/css/selectors/first.json
@@ -31,10 +31,10 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": null
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/css/selectors/id.json
+++ b/css/selectors/id.json
@@ -10,7 +10,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -31,13 +31,13 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true


### PR DESCRIPTION
This sets the Chromium and Safari versions for various standard CSS selectors, to directly assist #4303.

<details>
	<summary>css.selectors.class, css.selectors.descendant, css.selectors.id</summary>
	<ol>
		<li><strong>Basic CSS1, assuming Safari 1, Chrome 1</strong></li>
	</ol>
</details>

<details>
	<summary>css.selectors.after, css.selectors.before</summary>
	<ol>
		<li>Already has Safari 4 set in data</li>
		<li><strong>Mirrored onto Chrome (Chrome 1)</strong></li>
	</ol>
</details>

<details>
	<summary>css.selectors.first</summary>
	<ol>
		<li>Already has Chrome 18 set in data</li>
		<li><strong>Mirrored onto Safari (Safari 6)</strong></li>
	</ol>
</details>

<details>
	<summary>css.selectors.adjacent_sibling</summary>
	<ol>
		<li>Evidence of implementation within KHTML</li>
		<li>Commit bb0c24b55183dc12fee06166f24714471286db70 (on Fri Aug 24 14:24:40 2001)</li>
		<li><strong>Safari 1, Chrome 1</strong></li>
	</ol>
</details>

<details>
	<summary>css.selectors.any-link (-webkit- prefix)</summary>
	<ol>
		<li>Implemented in 157cb8a6ad02f4d3d459f0c39211bba6899f603d with the -khtml- prefix (Safari 1.2 by date)</li>
		<li>Changed from -khtml- to -webkit- in 21d3140fb8ed411bc01cefa0d376f2a6c2db12c5 (Safari 3 by date)</li>
		<li><strong>Safari 3, Chrome 1</strong></li>
	</ol>
</details>

<details>
	<summary>css.selectors.child</summary>
	<ol>
		<li>Evidence of implementation within KHTML</li>
		<li>Commit 3905c48acb7062ce1df8b9a4be3e9b68fe2ad935 (Tue Feb 25 20:00:16 2003)</li>
		<li><strong>Safari 1, Chrome 1</strong></li>
	</ol>
</details>

<details>
	<summary>css.selectors.cue</summary>
	<ol>
		<li>Implemented in 324b098556299e3f8a9a2bad5adaf4bd83e4eec1</li>
		<li>Implemented in WebKit 537.25</li>
		<li><strong>Safari 6.1, Chrome 26</strong></li>
	</ol>
</details>

<details>
	<summary>css.selectors.defined</summary>
	<ol>
		<li>Already has Chrome 54 set in data</li>
		<li>Implemented in ecad4648d09b759f950fc7bd76d140a854d9cda1</li>
		<li>Implemented in WebKit 602.1.22</li>
		<li><strong>Safari 10, Chrome 54</strong></li>
	</ol>
</details>