### PR TITLE
DOMMatrix: add Safari support data

### DIFF
--- a/api/DOMMatrix.json
+++ b/api/DOMMatrix.json
@@ -29,10 +29,10 @@
             "version_added": "45"
           },
           "safari": {
-            "version_added": false
+            "version_added": "5"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "5"
           },
           "webview_android": {
             "version_added": "61"
@@ -73,10 +73,10 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": false
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "5"
             },
             "webview_android": {
               "version_added": "61"
@@ -119,10 +119,10 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": false
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "5"
             },
             "webview_android": {
               "version_added": "61"

--- a/api/DOMMatrix.json
+++ b/api/DOMMatrix.json
@@ -29,10 +29,10 @@
             "version_added": "45"
           },
           "safari": {
-            "version_added": "5"
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": "5"
+            "version_added": "11"
           },
           "webview_android": {
             "version_added": "61"
@@ -73,10 +73,10 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"
@@ -119,10 +119,10 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "11"
             },
             "webview_android": {
               "version_added": "61"


### PR DESCRIPTION
Per https://caniuse.com/#search=dommatrix, DOMMatrix is supported since Safari 11.
