### PR TITLE
Set Chromium/Safari versions for various CSS selectors (part 2)

### DIFF
--- a/css/selectors/host.json
+++ b/css/selectors/host.json
@@ -58,10 +58,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/css/selectors/host.json
+++ b/css/selectors/host.json
@@ -58,13 +58,13 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "54"

--- a/css/selectors/in-range.json
+++ b/css/selectors/in-range.json
@@ -32,19 +32,20 @@
               "notes": "Before Opera 39, <code>:in-range</code> matched disabled and read-only inputs (see <a href='https://crbug.com/602568'>Chromium bug 602568</a>). In Opera 39, it was changed to only match enabled read-write inputs."
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "11",
               "notes": "Before Opera 39, <code>:in-range</code> matched disabled and read-only inputs (see <a href='https://crbug.com/602568'>Chromium bug 602568</a>). In Opera 39, it was changed to only match enabled read-write inputs."
             },
             "safari": {
-              "version_added": true,
+              "version_added": "5.1",
               "notes": "In Safari, <code>:in-range</code> matched disabled and read-only inputs (see <a href='https://webkit.org/b/156530'>bug 156530</a>). It was later changed to only match enabled read-write inputs."
             },
             "safari_ios": {
-              "version_added": true,
+              "version_added": "5",
               "notes": "In Safari, <code>:in-range</code> matched disabled and read-only inputs (see <a href='https://webkit.org/b/156530'>bug 156530</a>). It was later changed to only match enabled read-write inputs."
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0",
+              "notes": "Before version 6.0, <code>:in-range</code> matched disabled and read-only inputs (see <a href='https://crbug.com/602568'>Chromium bug 602568</a>). In version 6.0, it was changed to only match enabled read-write inputs."
             },
             "webview_android": {
               "version_added": "2.3",

--- a/css/selectors/indeterminate.json
+++ b/css/selectors/indeterminate.json
@@ -75,7 +75,7 @@
                 "version_added": "10.6"
               },
               "opera_android": {
-                "version_added": "10.6"
+                "version_added": "11"
               },
               "safari": {
                 "version_added": "3"

--- a/css/selectors/indeterminate.json
+++ b/css/selectors/indeterminate.json
@@ -7,10 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:indeterminate",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -28,16 +28,16 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": null
-            },
-            "safari": {
               "version_added": true
             },
+            "safari": {
+              "version_added": "3"
+            },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -54,10 +54,10 @@
             "description": "<code>type=&quot;checkbox&quot;</code>",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -75,19 +75,19 @@
                 "version_added": "10.6"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "10.6"
               },
               "safari": {
                 "version_added": "3"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": true
               }
             },
             "status": {
@@ -174,16 +174,16 @@
                 "version_added": "15"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "14"
               },
               "safari": {
-                "version_added": true
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "37"

--- a/css/selectors/invalid.json
+++ b/css/selectors/invalid.json
@@ -78,13 +78,13 @@
                 "version_added": "27"
               },
               "safari": {
-                "version_added": null
+                "version_added": "9"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "9"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "webview_android": {
                 "version_added": "40"

--- a/css/selectors/left.json
+++ b/css/selectors/left.json
@@ -7,10 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:left",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "6"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -25,24 +25,22 @@
               "version_added": "8"
             },
             "opera": {
-              "version_added": "9.2",
-              "version_removed": "15"
+              "version_added": "9.2"
             },
             "opera_android": {
-              "version_added": "10.1",
-              "version_removed": "14"
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": null
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {

--- a/css/selectors/out-of-range.json
+++ b/css/selectors/out-of-range.json
@@ -28,16 +28,16 @@
               "version_added": "11"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
-              "version_added": true
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "2.3"

--- a/css/selectors/placeholder-shown.json
+++ b/css/selectors/placeholder-shown.json
@@ -94,13 +94,13 @@
                 "version_added": "34"
               },
               "safari": {
-                "version_added": true
+                "version_added": "9"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "9"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "47"

--- a/css/selectors/placeholder.json
+++ b/css/selectors/placeholder.json
@@ -12,7 +12,7 @@
               },
               {
                 "prefix": "-webkit-input-",
-                "version_added": true
+                "version_added": "6"
               }
             ],
             "chrome_android": [
@@ -21,7 +21,7 @@
               },
               {
                 "prefix": "-webkit-input-",
-                "version_added": true
+                "version_added": "18"
               }
             ],
             "edge": [
@@ -61,7 +61,7 @@
               },
               {
                 "prefix": "-webkit-input-",
-                "version_added": true
+                "version_added": "15"
               }
             ],
             "opera_android": [
@@ -70,7 +70,7 @@
               },
               {
                 "prefix": "-webkit-input-",
-                "version_added": "37"
+                "version_added": "14"
               }
             ],
             "safari": [
@@ -97,7 +97,7 @@
               },
               {
                 "prefix": "-webkit-input-",
-                "version_added": true
+                "version_added": "1.0"
               }
             ],
             "webview_android": [

--- a/css/selectors/read-only.json
+++ b/css/selectors/read-only.json
@@ -7,10 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:read-only",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "13"
@@ -32,16 +32,16 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/selectors/read-write.json
+++ b/css/selectors/read-write.json
@@ -7,10 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:read-write",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "13"
@@ -32,16 +32,16 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/selectors/right.json
+++ b/css/selectors/right.json
@@ -7,10 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:right",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "6"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -33,16 +33,16 @@
               "version_removed": "14"
             },
             "safari": {
-              "version_added": null
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {

--- a/css/selectors/slotted.json
+++ b/css/selectors/slotted.json
@@ -57,10 +57,10 @@
               "version_added": "37"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/css/selectors/slotted.json
+++ b/css/selectors/slotted.json
@@ -57,10 +57,10 @@
               "version_added": "37"
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/css/selectors/type.json
+++ b/css/selectors/type.json
@@ -75,7 +75,7 @@
                 "version_added": "8"
               },
               "opera_android": {
-                "version_added": "8"
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1.3"

--- a/css/selectors/type.json
+++ b/css/selectors/type.json
@@ -10,7 +10,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -31,13 +31,13 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -54,10 +54,10 @@
             "description": "Namespaces (<code>ns|elementName</code>)",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -75,16 +75,16 @@
                 "version_added": "8"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "8"
               },
               "safari": {
                 "version_added": "1.3"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true

--- a/css/selectors/universal.json
+++ b/css/selectors/universal.json
@@ -75,7 +75,7 @@
                 "version_added": "8"
               },
               "opera_android": {
-                "version_added": "8"
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1.3"

--- a/css/selectors/universal.json
+++ b/css/selectors/universal.json
@@ -10,7 +10,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -31,13 +31,13 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -54,10 +54,10 @@
             "description": "Namespaces (<code>*|*</code>)",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -75,16 +75,16 @@
                 "version_added": "8"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "8"
               },
               "safari": {
                 "version_added": "1.3"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true

--- a/css/selectors/valid.json
+++ b/css/selectors/valid.json
@@ -78,13 +78,13 @@
                 "version_added": "27"
               },
               "safari": {
-                "version_added": null
+                "version_added": "9"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "9"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "webview_android": {
                 "version_added": "40"


### PR DESCRIPTION
This sets Chromium and Safari versions for various CSS selectors within spec, as to aid #4303.

<details>
	<summary>css.selectors.host</summary>
	<ol>
		<li>Implemented in 6d9e2418d7d7310dcc0d59dd7abb0641d21406c8</li>
		<li>Implemented in WebKit 602.1.7</li>
		<li>Chrome already has "54" in data</li>
		<li><strong>Safari 10, Chrome 54</strong></li>
	</ol>
</details>

<details>
	<summary>css.selectors.in-range, css.selectors.out-of-range</summary>
	<ol>
		<li>Implemented in f55645df30dfadef723a4c727f8b6ad5ba05caa3</li>
		<li>Implemented in WebKit 534.16</li>
		<li><strong>Safari 5.1, Chrome 10</strong></li>
	</ol>
</details>

<details>
	<summary>css.selectors.indeterminate, css.selectors.indeterminate.checkbox</summary>
	<ol>
		<li>Implemented in f3fd7741eece9d277e7ecb9b165b8ce14513e273</li>
		<li>Safari already has "3" in data for checkbox</li>
		<li><strong>Mirrored onto parent and Chrome (Safari 3, Chrome 1)</strong></li>
	</ol>
</details>

<details>
	<summary>css.selectors.indeterminate.progress</summary>
	<ol>
		<li>Chrome already has "6" in data</li>
		<li><strong>Mirrored onto Safari (Safari 5.1)</strong></li>
	</ol>
</details>

<details>
	<summary>css.selectors.invalid.form, css.selectors.valid.form</summary>
	<ol>
		<li>Supported in Safari 9 (manual testing)</li>
		<li>Chrome already has "40" in data</li>
		<li><strong>Safari 9, Chrome 40</strong></li>
	</ol>
</details>

<details>
	<summary>css.selectors.left, css.selectors.right</summary>
	<ol>
		<li>Implemented in 1fcfaa5241a51365843a2c422fa2187ec5c3848a</li>
		<li>Implemented in WebKit 533.7</li>
		<li><strong>Safari 5.1, Chrome 6</strong></li>
	</ol>
</details>

<details>
	<summary>css.selectors.placeholder-shown.non_text_types</summary>
	<ol>
		<li>Supported in Safari 9 (manual testing)</li>
		<li>Chrome already has "47" in data</li>
		<li><strong>Safari 9, Chrome 47</strong></li>
	</ol>
</details>

<details>
	<summary>css.selectors.placeholder (-webkit-input- prefix)</summary>
	<ol>
		<li>Safari already has "5" in data</li>
		<li><strong>Mirrored onto Chrome (Chrome 6)</strong></li>
	</ol>
</details>

<details>
	<summary>css.selectors.read-only, css.selectors.read-write</summary>
	<ol>
		<li>Implemented in fdf354c68ce91a3cc3ef2e5a19c4a4d7cb7f2c56</li>
		<li>Implemented in WebKit 528</li>
		<li><strong>Safari 4, Chrome 1</strong></li>
	</ol>
</details>

<details>
	<summary>css.selectors.slotted</summary>
	<ol>
		<li>Implemented in 8c4fa4ead4f81456ffde3a3f28476f8c46417569</li>
		<li>Implemented in WebKit 602.1.21</li>
		<li>Chrome already has "50" in data</li>
		<li><strong>Safari 10, Chrome 50</strong></li>
	</ol>
</details>

<details>
	<summary>css.selectors.type</summary>
	<ol>
		<li><strong>Basic CSS1, assuming Safari 1, Chrome 1</strong></li>
	</ol>
</details>

<details>
	<summary>css.selectors.universal</summary>
	<ol>
		<li>Part of the CSS 2.1 spec</li>
		<li>Other selectors (:active, :hover, :focus) show support in KHTML before fork</li>
		<li><strong>Assuming Safari 1, Chrome 2</strong></li>
	</ol>
</details>

<details>
	<summary>css.selectors.type.namespaces, css.selectors.universal.namespaces</summary>
	<ol>
		<li>Safari already has "1.3" in data</li>
		<li><strong>Mirrored onto Chrome (Chrome 1)</strong></li>
	</ol>
</details>