### PR TITLE
Set Chromium/Safari versions for column properties

### DIFF
--- a/css/properties/break-before.json
+++ b/css/properties/break-before.json
@@ -67,10 +67,10 @@
               "description": "<code>column</code>",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "51"
                 },
                 "chrome_android": {
-                  "version_added": true
+                  "version_added": "51"
                 },
                 "edge": {
                   "version_added": "12"
@@ -85,10 +85,10 @@
                   "version_added": "10"
                 },
                 "opera": {
-                  "version_added": true
+                  "version_added": "38"
                 },
                 "opera_android": {
-                  "version_added": true
+                  "version_added": "41"
                 },
                 "safari": {
                   "version_added": false
@@ -97,10 +97,10 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "5.0"
                 },
                 "webview_android": {
-                  "version_added": true
+                  "version_added": "51"
                 }
               },
               "status": {

--- a/css/properties/break-inside.json
+++ b/css/properties/break-inside.json
@@ -67,10 +67,10 @@
               "description": "<code>column</code> and <code>avoid-column</code>",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "50"
                 },
                 "chrome_android": {
-                  "version_added": true
+                  "version_added": "50"
                 },
                 "edge": {
                   "version_added": "12"
@@ -85,22 +85,22 @@
                   "version_added": "10"
                 },
                 "opera": {
-                  "version_added": true
+                  "version_added": "37"
                 },
                 "opera_android": {
-                  "version_added": true
+                  "version_added": "37"
                 },
                 "safari": {
-                  "version_added": true
+                  "version_added": "10"
                 },
                 "safari_ios": {
-                  "version_added": true
+                  "version_added": "10"
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "5.0"
                 },
                 "webview_android": {
-                  "version_added": true
+                  "version_added": "50"
                 }
               },
               "status": {
@@ -176,10 +176,10 @@
               "description": "<code>page</code> and <code>avoid-page</code>",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "51"
                 },
                 "chrome_android": {
-                  "version_added": true
+                  "version_added": "51"
                 },
                 "edge": {
                   "version_added": "12"
@@ -193,13 +193,24 @@
                 "ie": {
                   "version_added": false
                 },
-                "opera": {
-                  "version_added": "11.1",
-                  "version_removed": "12.1"
-                },
-                "opera_android": {
-                  "version_added": null
-                },
+                "opera": [
+                  {
+                    "version_added": "38"
+                  },
+                  {
+                    "version_added": "11.1",
+                    "version_removed": "12.1"
+                  }
+                ],
+                "opera_android": [
+                  {
+                    "version_added": "41"
+                  },
+                  {
+                    "version_added": "11.1",
+                    "version_removed": "12.1"
+                  }
+                ],
                 "safari": {
                   "version_added": false
                 },
@@ -207,10 +218,10 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "5.0"
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "51"
                 }
               },
               "status": {

--- a/css/properties/column-gap.json
+++ b/css/properties/column-gap.json
@@ -256,7 +256,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": true
+                  "version_added": "1"
                 }
               ],
               "chrome_android": [
@@ -265,7 +265,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": true
+                  "version_added": "18"
                 }
               ],
               "edge": [
@@ -352,7 +352,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": true
+                  "version_added": "1.0"
                 }
               ],
               "uc_android": {


### PR DESCRIPTION
This PR sets version numbers for various column properties based upon manual testing.  Intended to help the efforts of #4297.

<details>
	<summary>css.properties.break-before.multicol_context.column</summary>
	<ul>
		<li>Safari has no support</li>
		<li>Chrome 51 (manual testing)</li>
	</ul>
</details>

<details>
	<summary>css.properties.break-inside.multicol_context.column</summary>
	<ul>
		<li>Safari 10 (manual testing)</li>
		<li>Chrome 50 (manual testing)</li>
	</ul>
</details>

<details>
	<summary>css.properties.break-inside.paged_context.page</summary>
	<ul>
		<li>Safari has no support</li>
		<li>Chrome 51 (manual testing)</li>
	</ul>
</details>

<details>
	<summary>css.properties.column-gap.multicol_context (-webkit- prefix)</summary>
	<ul>
		<li>Safari already has "3" in data</li>
		<li>Mirrored onto Chrome (Chrome 1)</li>
	</ul>
</details>