### PR TITLE
Set Chrome/Safari values for CSS mask properties

### DIFF
--- a/css/properties/mask-origin.json
+++ b/css/properties/mask-origin.json
@@ -119,10 +119,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -167,10 +167,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -215,10 +215,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/css/properties/mask-type.json
+++ b/css/properties/mask-type.json
@@ -56,13 +56,13 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": null
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "37"
@@ -103,10 +103,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
This PR sets version numbers for Chromium and Safari for various mask properties, to aid in #4305.

<details>
	<summary>css.properties.mask-origin.fill-box, css.properties.mask-origin.stroke-box, css.properties.mask-origin.view-box</summary>
	<ul>
		<li>False in Chrome and Safari (manual testing)</li>
	</ul>
</details>

<details>
	<summary>css.properties.mask-type</summary>
	<ul>
		<li>Implemented in f0db4b40ffcfc3e206427165cc7f66e14a8f78f4</li>
		<li>Chrome already has "24" in data</li>
		<li>Mirrored onto Safari (Safari 6.1)</li>
	</ul>
</details>

<details>
	<summary>css.properties.mask-type.applies_to_html</summary>
	<ul>
		<li>False for Chrome and Safari (manual testing)</li>
	</ul>
</details>