### PR TITLE
Add Safari support for javascript.functions.method_definitions

### DIFF
--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -666,10 +666,10 @@
               "version_added": "26"
             },
             "safari": {
-              "version_added": false
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "4.0"


### PR DESCRIPTION
Due to lack of response from the original PR author, this supersedes and closes #4312.  I was able to test this feature out in Safari 9.0, and found that it was supported.