### PR TITLE
Remove redundant prefix properties from subfeatures of mask property

### DIFF
--- a/css/properties/mask.json
+++ b/css/properties/mask.json
@@ -127,11 +127,9 @@
             "description": "Applies to HTML elements",
             "support": {
               "chrome": {
-                "prefix": "-webkit-",
                 "version_added": true
               },
               "chrome_android": {
-                "prefix": "-webkit-",
                 "version_added": true
               },
               "edge": {
@@ -147,7 +145,6 @@
                 "version_added": false
               },
               "opera": {
-                "prefix": "-webkit-",
                 "version_added": true
               },
               "opera_android": {
@@ -163,7 +160,6 @@
                 "version_added": null
               },
               "webview_android": {
-                "prefix": "-webkit-",
                 "version_added": true
               }
             },
@@ -179,11 +175,9 @@
             "description": "Shorthand for <code>mask-*</code> properties",
             "support": {
               "chrome": {
-                "prefix": "-webkit-",
                 "version_added": true
               },
               "chrome_android": {
-                "prefix": "-webkit-",
                 "version_added": true
               },
               "edge": {
@@ -199,7 +193,6 @@
                 "version_added": false
               },
               "opera": {
-                "prefix": "-webkit-",
                 "version_added": true
               },
               "opera_android": {
@@ -215,7 +208,6 @@
                 "version_added": null
               },
               "webview_android": {
-                "prefix": "-webkit-",
                 "version_added": true
               }
             },


### PR DESCRIPTION
While working on the 2019 KR, I found that there were prefixes applied to the subfeatures of the `mask` CSS property.  Obviously, it seems a little weird to have prefixes on a subfeature reading "Applies to HTML elements".  This PR removes those odd prefixes.