### PR TITLE
Firefox for Android does not support tabs.duplicate

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1220,7 +1220,7 @@
                 "version_added": "47"
               },
               "firefox_android": {
-                "version_added": "54"
+                "version_added": false
               },
               "opera": {
                 "version_added": true


### PR DESCRIPTION
Fennec does not implement the `tabs.duplicate` method, so the table should not list it as such.

https://searchfox.org/mozilla-central/rev/2487eaaf066a087786e0bcc05301863d1ae08645/mobile/android/components/extensions/schemas/tabs.json#447-448