### PR TITLE
Set Chrome/Safari versions for various CSS font/text properties

### DIFF
--- a/css/properties/text-combine-upright.json
+++ b/css/properties/text-combine-upright.json
@@ -12,13 +12,21 @@
               {
                 "partial_implementation": true,
                 "alternative_name": "-webkit-text-combine",
-                "version_added": true,
+                "version_added": "9",
                 "notes": "This property was initially named <code>-webkit-text-combine</code> according to a <a href='http://www.w3.org/TR/2011/WD-css3-writing-modes-20110531/#text-combine'>2011 version of the CSS3 Writing Modes specification</a>, supporting the values <code>none</code> and <code>horizontal</code> without <code>digits</code>."
               }
             ],
-            "chrome_android": {
-              "version_added": "48"
-            },
+            "chrome_android": [
+              {
+                "version_added": "48"
+              },
+              {
+                "partial_implementation": true,
+                "alternative_name": "-webkit-text-combine",
+                "version_added": "18",
+                "notes": "This property was initially named <code>-webkit-text-combine</code> according to a <a href='http://www.w3.org/TR/2011/WD-css3-writing-modes-20110531/#text-combine'>2011 version of the CSS3 Writing Modes specification</a>, supporting the values <code>none</code> and <code>horizontal</code> without <code>digits</code>."
+              }
+            ],
             "edge": {
               "version_added": "12",
               "alternative_name": "-ms-text-combine-horizontal"
@@ -107,41 +115,60 @@
             },
             "opera": [
               {
-                "version_added": true
+                "version_added": "35"
               },
               {
                 "partial_implementation": true,
                 "alternative_name": "-webkit-text-combine",
-                "version_added": true,
+                "version_added": "15",
                 "notes": "This property was initially named <code>-webkit-text-combine</code> according to a <a href='http://www.w3.org/TR/2011/WD-css3-writing-modes-20110531/#text-combine'>2011 version of the CSS3 Writing Modes specification</a>, supporting the values <code>none</code> and <code>horizontal</code> without digits."
               }
             ],
             "opera_android": [
               {
-                "version_added": true
+                "version_added": "35"
               },
               {
                 "partial_implementation": true,
                 "alternative_name": "-webkit-text-combine",
-                "version_added": true,
+                "version_added": "14",
                 "notes": "This property was initially named <code>-webkit-text-combine</code> according to a <a href='http://www.w3.org/TR/2011/WD-css3-writing-modes-20110531/#text-combine'>2011 version of the CSS3 Writing Modes specification</a>, supporting the values <code>none</code> and <code>horizontal</code> without digits."
               }
             ],
             "safari": {
               "partial_implementation": true,
               "alternative_name": "-webkit-text-combine",
-              "version_added": true,
+              "version_added": "5.1",
               "notes": "This property was initially named <code>-webkit-text-combine</code> according to a <a href='http://www.w3.org/TR/2011/WD-css3-writing-modes-20110531/#text-combine'>2011 version of the CSS3 Writing Modes specification</a>, supporting the values <code>none</code> and <code>horizontal</code> without digits."
             },
             "safari_ios": {
-              "version_added": false
+              "partial_implementation": true,
+              "alternative_name": "-webkit-text-combine",
+              "version_added": "5",
+              "notes": "This property was initially named <code>-webkit-text-combine</code> according to a <a href='http://www.w3.org/TR/2011/WD-css3-writing-modes-20110531/#text-combine'>2011 version of the CSS3 Writing Modes specification</a>, supporting the values <code>none</code> and <code>horizontal</code> without digits."
             },
-            "samsunginternet_android": {
-              "version_added": "5.0"
-            },
-            "webview_android": {
-              "version_added": "48"
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "5.0"
+              },
+              {
+                "partial_implementation": true,
+                "alternative_name": "-webkit-text-combine",
+                "version_added": "1.0",
+                "notes": "This property was initially named <code>-webkit-text-combine</code> according to a <a href='http://www.w3.org/TR/2011/WD-css3-writing-modes-20110531/#text-combine'>2011 version of the CSS3 Writing Modes specification</a>, supporting the values <code>none</code> and <code>horizontal</code> without <code>digits</code>."
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "48"
+              },
+              {
+                "partial_implementation": true,
+                "alternative_name": "-webkit-text-combine",
+                "version_added": true,
+                "notes": "This property was initially named <code>-webkit-text-combine</code> according to a <a href='http://www.w3.org/TR/2011/WD-css3-writing-modes-20110531/#text-combine'>2011 version of the CSS3 Writing Modes specification</a>, supporting the values <code>none</code> and <code>horizontal</code> without <code>digits</code>."
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -194,7 +221,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
                 "version_added": false

--- a/css/properties/text-decoration-color.json
+++ b/css/properties/text-decoration-color.json
@@ -49,7 +49,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "8"
               }
             ],
             "safari_ios": [

--- a/css/properties/text-decoration-line.json
+++ b/css/properties/text-decoration-line.json
@@ -49,7 +49,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "8"
               }
             ],
             "safari_ios": [
@@ -107,10 +107,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": null
+                "version_added": "8"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "8"
               },
               "samsunginternet_android": {
                 "version_added": "7.0"

--- a/css/properties/text-decoration-style.json
+++ b/css/properties/text-decoration-style.json
@@ -49,7 +49,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "8"
               }
             ],
             "safari_ios": [
@@ -58,7 +58,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "8"
               }
             ],
             "samsunginternet_android": {
@@ -103,10 +103,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": true
+                "version_added": "8"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "8"
               },
               "samsunginternet_android": {
                 "version_added": "7.0"

--- a/css/properties/text-emphasis-color.json
+++ b/css/properties/text-emphasis-color.json
@@ -5,14 +5,24 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-emphasis-color",
           "support": {
-            "chrome": {
-              "prefix": "-webkit-",
-              "version_added": "25"
-            },
-            "chrome_android": {
-              "prefix": "-webkit-",
-              "version_added": "25"
-            },
+            "chrome": [
+              {
+                "version_added": "25"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "25"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "25"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "25"
+              }
+            ],
             "edge": {
               "version_added": false
             },
@@ -51,33 +61,60 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "prefix": "-webkit-",
-              "version_added": "15"
-            },
-            "opera_android": {
-              "prefix": "-webkit-",
-              "version_added": "14"
-            },
+            "opera": [
+              {
+                "version_added": "15"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "14"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "14"
+              }
+            ],
             "safari": [
               {
-                "version_added": true
+                "version_added": "6.1"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": "6.1"
               }
             ],
-            "safari_ios": {
-              "version_added": "7.1"
-            },
-            "samsunginternet_android": {
-              "version_added": null
-            },
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "4.4"
-            }
+            "safari_ios": [
+              {
+                "version_added": "7"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "7"
+              }
+            ],
+            "samsunginternet_android": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1.5"
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "4.4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "4.4"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/text-emphasis-position.json
+++ b/css/properties/text-emphasis-position.json
@@ -5,18 +5,25 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-emphasis-position",
           "support": {
+            "support": {
             "chrome": [
               {
-                "version_added": true
+                "version_added": "25"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": "25"
               }
             ],
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": [
+              {
+                "version_added": "25"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "25"
+              }
+            ],
             "edge": {
               "version_added": false
             },
@@ -57,7 +64,7 @@
             },
             "opera": [
               {
-                "version_added": true
+                "version_added": "15"
               },
               {
                 "prefix": "-webkit-",
@@ -66,7 +73,7 @@
             ],
             "opera_android": [
               {
-                "version_added": true
+                "version_added": "14"
               },
               {
                 "prefix": "-webkit-",
@@ -75,22 +82,34 @@
             ],
             "safari": [
               {
-                "version_added": true
+                "version_added": "6.1"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": "6.1"
               }
             ],
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "safari_ios": [
+              {
+                "version_added": "7"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "7"
+              }
+            ],
+            "samsunginternet_android": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1.5"
+              }
+            ],
             "webview_android": [
               {
-                "version_added": true
+                "version_added": "4.4"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/text-emphasis-position.json
+++ b/css/properties/text-emphasis-position.json
@@ -5,7 +5,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-emphasis-position",
           "support": {
-            "support": {
             "chrome": [
               {
                 "version_added": "25"

--- a/css/properties/text-emphasis-style.json
+++ b/css/properties/text-emphasis-style.json
@@ -5,14 +5,24 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-emphasis-style",
           "support": {
-            "chrome": {
-              "prefix": "-webkit-",
-              "version_added": "25"
-            },
-            "chrome_android": {
-              "prefix": "-webkit-",
-              "version_added": "25"
-            },
+            "chrome": [
+              {
+                "version_added": "25"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "25"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "25"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "25"
+              }
+            ],
             "edge": {
               "version_added": false
             },
@@ -51,33 +61,60 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "prefix": "-webkit-",
-              "version_added": "15"
-            },
-            "opera_android": {
-              "prefix": "-webkit-",
-              "version_added": "14"
-            },
+            "opera": [
+              {
+                "version_added": "15"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "14"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "14"
+              }
+            ],
             "safari": [
               {
-                "version_added": true
+                "version_added": "6.1"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": "6.1"
               }
             ],
-            "safari_ios": {
-              "version_added": "7.1"
-            },
-            "samsunginternet_android": {
-              "version_added": null
-            },
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "4.4"
-            }
+            "safari_ios": [
+              {
+                "version_added": "7"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "7"
+              }
+            ],
+            "samsunginternet_android": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1.5"
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "4.4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "4.4"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/text-emphasis.json
+++ b/css/properties/text-emphasis.json
@@ -5,14 +5,24 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-emphasis",
           "support": {
-            "chrome": {
-              "prefix": "-webkit-",
-              "version_added": "25"
-            },
-            "chrome_android": {
-              "prefix": "-webkit-",
-              "version_added": "25"
-            },
+            "chrome": [
+              {
+                "version_added": "25"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "25"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "25"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "25"
+              }
+            ],
             "edge": {
               "version_added": false
             },
@@ -51,33 +61,60 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "prefix": "-webkit-",
-              "version_added": "15"
-            },
-            "opera_android": {
-              "prefix": "-webkit-",
-              "version_added": "14"
-            },
+            "opera": [
+              {
+                "version_added": "15"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "14"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "14"
+              }
+            ],
             "safari": [
               {
-                "version_added": true
+                "version_added": "6.1"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": "6.1"
               }
             ],
-            "safari_ios": {
-              "version_added": "7.1"
-            },
-            "samsunginternet_android": {
-              "version_added": null
-            },
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "4.4"
-            }
+            "safari_ios": [
+              {
+                "version_added": "7"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "7"
+              }
+            ],
+            "samsunginternet_android": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1.5"
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "4.4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "4.4"
+              }
+            ]
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
This PR sets Chromium and Safari versions for font and text CSS properties, as to aid in #4301.

<details>
	<summary>css.properties.text-combine-upright</summary>
	<ol>
		<li>Implemented in 643496f0a5af9e819ef949eb49be94158e0fe7e3</li>
		<li>Implemented in WebKit 534.12</li>
		<li><strong>Safari 5.1, Chrome 9</strong></li>
	</ol>
</details>

<details>
	<summary>css.properties.text-combine-upright.digits</summary>
	<ol>
		<li>Safari iOS already has "false" in data</li>
		<li><strong>Mirrored onto Safari Desktop</strong></li>
	</ol>
</details>

<details>
	<summary>css.properties.text-decoration-color (-webkit- prefix), css.properties.text-decoration-line (-webkit- prefix)</summary>
	<ol>
		<li>Safari iOS already has "8" in data</li>
		<li>Mirrored onto Safari Desktop (Safari 8)</li>
		<li><strong>Confirmed via manual testing</strong></li>
	</ol>
</details>

<details>
	<summary>css.properties.text-decoration-style (-webkit- prefix), css.properties.text-decoration-line.blink, css.properties.text-decoration-style.wavy</summary>
	<ol>
		<li><strong>Supported in Safari 8 (manual testing)</strong></li>
	</ol>
</details>

<details>
	<summary>css.properties.text-emphasis-color, css.properties.text-emphasis-style, css.properties.text-emphasis, css.properties.text-emphasis-position</summary>
	<ol>
		<li>Implemented in af6c0f3f3d087e837cd7d501807fca8e35392b7a</li>
		<li>Same commit that implemented the -webkit- prefixes</li>
		<li>Safari already has "6.1" for prefixed version</li>
		<li>Chrome already has "25" for prefixed version</li>
		<li><strong>Safari 6.1, Chrome 25</strong></li>
	</ol>
</details>