### PR TITLE
Set Chromium/Safari versions for misc. CSS properties

### DIFF
--- a/css/properties/alt.json
+++ b/css/properties/alt.json
@@ -35,7 +35,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "8"
               }
             ],
             "safari_ios": [
@@ -44,7 +44,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "8"
               }
             ],
             "samsunginternet_android": {

--- a/css/properties/backface-visibility.json
+++ b/css/properties/backface-visibility.json
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "15"
+                "version_added": "18"
               }
             ],
             "edge": [
@@ -94,7 +94,7 @@
             ],
             "opera_android": [
               {
-                "version_added": "23"
+                "version_added": "24"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/backface-visibility.json
+++ b/css/properties/backface-visibility.json
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "15"
               }
             ],
             "edge": [
@@ -83,25 +83,41 @@
             "ie": {
               "version_added": "10"
             },
-            "opera": {
-              "prefix": "-webkit-",
-              "version_added": "15"
-            },
-            "opera_android": {
-              "prefix": "-webkit-",
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "23"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "23"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "14"
+              }
+            ],
             "safari": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "5.1"
             },
             "safari_ios": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "5"
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "3.0"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1.0"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "37"

--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -11,7 +11,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "24"
+                "version_added": "23"
               }
             ],
             "chrome_android": [
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "25"
               }
             ],
             "edge": {
@@ -37,28 +37,40 @@
               "version_added": "10",
               "notes": "Internet Explorer only supports clip paths defined by <code>url()</code>."
             },
-            "opera": {
-              "version_added": "42"
-            },
-            "opera_android": {
-              "version_added": "42"
-            },
-            "safari": [
+            "opera": [
               {
-                "version_added": true
+                "version_added": "42"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "7"
+                "version_added": "15"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "42"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "14"
+              }
+            ],
+            "safari": [
+              {
+                "version_added": "9.1"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "6.1"
               }
             ],
             "safari_ios": [
               {
-                "version_added": true
+                "version_added": "9.1"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "7"
+                "version_added": "6.1"
               }
             ],
             "samsunginternet_android": {
@@ -85,10 +97,10 @@
             "description": "On SVG elements",
             "support": {
               "chrome": {
-                "version_added": "55"
+                "version_added": "23"
               },
               "chrome_android": {
-                "version_added": "55"
+                "version_added": "25"
               },
               "edge": {
                 "version_added": "12"
@@ -103,34 +115,22 @@
                 "version_added": "10"
               },
               "opera": {
-                "version_added": "42"
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": "42"
+                "version_added": "14"
               },
-              "safari": [
-                {
-                  "version_added": true
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "7"
-                }
-              ],
-              "safari_ios": [
-                {
-                  "version_added": true
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "7"
-                }
-              ],
+              "safari": {
+                "version_added": "6.1"
+              },
+              "safari_ios": {
+                "version_added": "6.1"
+              },
               "samsunginternet_android": {
-                "version_added": "6.0"
+                "version_added": "1.5"
               },
               "webview_android": {
-                "version_added": "55"
+                "version_added": "4.4"
               }
             },
             "status": {
@@ -144,24 +144,12 @@
           "__compat": {
             "description": "On HTML elements",
             "support": {
-              "chrome": [
-                {
-                  "version_added": "55"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "24"
-                }
-              ],
-              "chrome_android": [
-                {
-                  "version_added": "55"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": true
-                }
-              ],
+              "chrome": {
+                "version_added": "23"
+              },
+              "chrome_android": {
+                "version_added": "25"
+              },
               "edge": {
                 "version_added": false
               },
@@ -175,40 +163,22 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "42"
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": "42"
+                "version_added": "14"
               },
-              "safari": [
-                {
-                  "version_added": true
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "7"
-                }
-              ],
-              "safari_ios": [
-                {
-                  "version_added": true
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "7"
-                }
-              ],
-              "samsunginternet_android": [
-                {
-                  "version_added": "6.0"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": true
-                }
-              ],
+              "safari": {
+                "version_added": "6.1"
+              },
+              "safari_ios": {
+                "version_added": "6.1"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.5"
+              },
               "webview_android": {
-                "version_added": "55"
+                "version_added": "4.4"
               }
             },
             "status": {
@@ -223,10 +193,10 @@
             "description": "<code>&lt;basic-shape&gt;</code>",
             "support": {
               "chrome": {
-                "version_added": "55"
+                "version_added": "23"
               },
               "chrome_android": {
-                "version_added": "55"
+                "version_added": "25"
               },
               "edge": {
                 "version_added": false
@@ -267,34 +237,22 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "42"
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": "42"
+                "version_added": "14"
               },
-              "safari": [
-                {
-                  "version_added": true
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "7"
-                }
-              ],
-              "safari_ios": [
-                {
-                  "version_added": true
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "7"
-                }
-              ],
+              "safari": {
+                "version_added": "6.1"
+              },
+              "safari_ios": {
+                "version_added": "6.1"
+              },
               "samsunginternet_android": {
-                "version_added": "6.0"
+                "version_added": "1.5"
               },
               "webview_android": {
-                "version_added": "55"
+                "version_added": "4.4"
               }
             },
             "status": {

--- a/css/properties/color.json
+++ b/css/properties/color.json
@@ -30,13 +30,13 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -418,19 +418,19 @@
                 "version_added": "25"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "25"
               },
               "safari": {
-                "version_added": true
+                "version_added": "9"
               },
               "safari_ios": {
                 "version_added": "8"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "3.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "38"
               }
             },
             "status": {

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -922,10 +922,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -1169,11 +1169,11 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true,
+                "version_added": "1",
                 "notes": "Chrome 65 stopped creating layout objects for elements inside an <code>&lt;iframe&gt;</code> with <code>display:none</code> applied."
               },
               "chrome_android": {
-                "version_added": true,
+                "version_added": "18",
                 "notes": "Chrome 65 stopped creating layout objects for elements inside an <code>&lt;iframe&gt;</code> with <code>display:none</code> applied."
               },
               "edge": {
@@ -1189,19 +1189,21 @@
                 "version_added": "4"
               },
               "opera": {
-                "version_added": "7"
+                "version_added": "7",
+                "notes": "Opera 52 stopped creating layout objects for elements inside an <code>&lt;iframe&gt;</code> with <code>display:none</code> applied."
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1",
+                "notes": "Opera Android 47 stopped creating layout objects for elements inside an <code>&lt;iframe&gt;</code> with <code>display:none</code> applied."
               },
               "safari": {
                 "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": true,

--- a/css/properties/image-rendering.json
+++ b/css/properties/image-rendering.json
@@ -6,10 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image-rendering",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "13"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": false
@@ -24,19 +24,19 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "41"
@@ -53,11 +53,11 @@
             "support": {
               "chrome": {
                 "alternative_name": "-webkit-optimize-contrast",
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
                 "alternative_name": "-webkit-optimize-contrast",
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": false
@@ -83,22 +83,39 @@
               "ie": {
                 "version_added": false
               },
-              "opera": {
-                "prefix": "-o-",
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": null
-              },
+              "opera": [
+                {
+                  "alternative_name": "-webkit-optimize-contrast",
+                  "version_added": "15"
+                },
+                {
+                  "prefix": "-o-",
+                  "version_added": true,
+                  "version_removed": "15"
+                }
+              ],
+              "opera_android": [
+                {
+                  "alternative_name": "-webkit-optimize-contrast",
+                  "version_added": "14"
+                },
+                {
+                  "prefix": "-o-",
+                  "version_added": true,
+                  "version_removed": "14"
+                }
+              ],
               "safari": {
                 "alternative_name": "-webkit-optimize-contrast",
-                "version_added": true
+                "version_added": "6"
               },
               "safari_ios": {
-                "version_added": null
+                "alternative_name": "-webkit-optimize-contrast",
+                "version_added": "6"
               },
               "samsunginternet_android": {
-                "version_added": false
+                "alternative_name": "-webkit-optimize-contrast",
+                "version_added": "1.0"
               },
               "webview_android": {
                 "alternative_name": "-webkit-optimize-contrast",

--- a/css/properties/isolation.json
+++ b/css/properties/isolation.json
@@ -27,16 +27,16 @@
               "version_added": "30"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "30"
             },
             "safari": {
-              "version_added": true
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "41"

--- a/css/properties/paint-order.json
+++ b/css/properties/paint-order.json
@@ -9,7 +9,7 @@
               "version_added": "35"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "35"
             },
             "edge": {
               "version_added": "17"
@@ -24,22 +24,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "22"
             },
             "safari": {
-              "version_added": true
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "37"
             }
           },
           "status": {

--- a/css/properties/transform-box.json
+++ b/css/properties/transform-box.json
@@ -76,13 +76,13 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "64"

--- a/css/properties/transform-box.json
+++ b/css/properties/transform-box.json
@@ -76,10 +76,10 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": "12"
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "12"
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "9.0"

--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -108,7 +108,7 @@
             ],
             "opera_android": [
               {
-                "version_added": "23"
+                "version_added": "24"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -11,7 +11,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "1"
               }
             ],
             "chrome_android": [
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "18"
               }
             ],
             "edge": [
@@ -91,7 +91,15 @@
             ],
             "opera": [
               {
-                "version_added": "12.1"
+                "version_added": "23"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
               },
               {
                 "prefix": "-o-",
@@ -100,7 +108,15 @@
             ],
             "opera_android": [
               {
-                "version_added": "12.1"
+                "version_added": "23"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
               },
               {
                 "prefix": "-o-",
@@ -113,7 +129,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "3.1"
+                "version_added": "2"
               }
             ],
             "safari_ios": [
@@ -122,12 +138,18 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "1"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "3.0"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1.0"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "37"

--- a/css/properties/transform.json
+++ b/css/properties/transform.json
@@ -11,7 +11,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "1"
               }
             ],
             "chrome_android": [
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "18"
               }
             ],
             "edge": [
@@ -141,9 +141,15 @@
                 "version_added": "3.2"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "3.0"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1.0"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "37"

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -6,10 +6,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/width",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -27,19 +27,19 @@
               "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {

--- a/css/properties/word-wrap.json
+++ b/css/properties/word-wrap.json
@@ -8,7 +8,7 @@
             "chrome": [
               {
                 "alternative_name": "overflow-wrap",
-                "version_added": true
+                "version_added": "23"
               },
               {
                 "version_added": "1"
@@ -17,7 +17,7 @@
             "chrome_android": [
               {
                 "alternative_name": "overflow-wrap",
-                "version_added": true
+                "version_added": "25"
               },
               {
                 "version_added": "18"
@@ -50,7 +50,7 @@
             "opera": [
               {
                 "alternative_name": "overflow-wrap",
-                "version_added": true
+                "version_added": "15"
               },
               {
                 "version_added": "10.5"
@@ -59,7 +59,7 @@
             "opera_android": [
               {
                 "alternative_name": "overflow-wrap",
-                "version_added": true
+                "version_added": "14"
               },
               {
                 "version_added": "11"
@@ -68,7 +68,7 @@
             "safari": [
               {
                 "alternative_name": "overflow-wrap",
-                "version_added": true
+                "version_added": "6.1"
               },
               {
                 "version_added": "2"
@@ -77,15 +77,21 @@
             "safari_ios": [
               {
                 "alternative_name": "overflow-wrap",
-                "version_added": true
+                "version_added": "7"
               },
               {
                 "version_added": "1"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "alternative_name": "overflow-wrap",
+                "version_added": "1.5"
+              },
+              {
+                "version_added": "1.0"
+              }
+            ],
             "webview_android": [
               {
                 "alternative_name": "overflow-wrap",

--- a/css/properties/writing-mode.json
+++ b/css/properties/writing-mode.json
@@ -7,7 +7,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": true
+                "version_added": "48"
               },
               {
                 "prefix": "-webkit-",
@@ -16,11 +16,11 @@
             ],
             "chrome_android": [
               {
-                "version_added": true
+                "version_added": "48"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "47"
+                "version_added": "15"
               }
             ],
             "edge": [
@@ -71,33 +71,54 @@
               "version_added": "9",
               "notes": "Internet Explorer's implementation differs from the specification."
             },
-            "opera": {
-              "prefix": "-webkit-",
-              "version_added": "15"
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "prefix": "-webkit-",
-              "version_added": "5.1"
-            },
-            "safari_ios": {
-              "prefix": "-webkit-",
-              "version_added": "5.1"
-            },
-            "samsunginternet_android": [
+            "opera": [
               {
-                "version_added": true
+                "version_added": "35"
               },
               {
                 "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "35"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "14"
+              }
+            ],
+            "safari": [
+              {
+                "version_added": "11"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "5.1"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "11"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "5.1"
+              }
+            ],
+            "samsunginternet_android": [
+              {
                 "version_added": "5.0"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1.0"
               }
             ],
             "webview_android": [
               {
-                "version_added": true
+                "version_added": "48"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/writing-mode.json
+++ b/css/properties/writing-mode.json
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "15"
+                "version_added": "18"
               }
             ],
             "edge": [

--- a/css/properties/writing-mode.json
+++ b/css/properties/writing-mode.json
@@ -91,7 +91,7 @@
             ],
             "safari": [
               {
-                "version_added": "11"
+                "version_added": "10.1"
               },
               {
                 "prefix": "-webkit-",
@@ -100,7 +100,7 @@
             ],
             "safari_ios": [
               {
-                "version_added": "11"
+                "version_added": "10.3"
               },
               {
                 "prefix": "-webkit-",


### PR DESCRIPTION
This PR sets Chromium and Safari versions for several CSS properties not mentioned by the Q2 of the 2019 KR.  This aims to increase the percentage of real values within the repository.  Changes are as follows:

<details>
	<summary>css.properties.color, css.properties.width</summary>
	<ol>
		<li><strong>Basic CSS1, assuming Safari 1, Chrome 1</strong></li>
	</ol>
</details>

<details>
	<summary>css.properties.display.ruby_values</summary>
	<ol>
		<li><strong>Unsupported in Safari and Chrome</strong></li>
	</ol>
</details>

<details>
	<summary>css.properties.backface-visibility (-webkit- prefix)</summary>
	<ol>
		<li>Chrome already has "12" in data</li>
		<li><strong>Mirrored onto Safari (Safari 5.1)</strong></li>
	</ol>
</details>

<details>
	<summary>css.properties.display.none</summary>
	<ol>
		<li>Safari already has "1" in data</li>
		<li><strong>Mirrored onto Chrome (Chrome 1)</strong></li>
	</ol>
</details>

<details>
	<summary>css.properties.isolation</summary>
	<ol>
		<li>Safari iOS already has "8" in data</li>
		<li><strong>Mirrored onto Safari Desktop (Safari 8)</strong></li>
	</ol>
</details>

<details>
	<summary>css.properties.transform (-webkit- prefix)</summary>
	<ol>
		<li>Safari already has "3.1" in data</li>
		<li><strong>Mirrored onto Chrome (Chrome 1)</strong></li>
	</ol>
</details>

<details>
	<summary>css.properties.transform-origin (-webkit- prefix)</summary>
	<ol>
		<li>Safari already has "3.1" in data</li>
		<li><strong>Mirrored onto Chrome (Chrome 1)</strong></li>
	</ol>
</details>

<details>
	<summary>css.properties.alt (-webkit- prefix)</summary>
	<ol>
		<li>Implemented in a171d862b649859553a81202920a507997b7f1f5</li>
		<li>Implemented in WebKit 538.8</li>
		<li>No support in Chrome</li>
		<li><strong>Safari 8</strong></li>
	</ol>
</details>

<details>
	<summary>css.properties.clip-path</summary>
	<ol>
		<li>Implemented in 2e2bf43ce4954df7f28e9d3bb3aa08830cdaffd1</li>
		<li>Implemented in WebKit 601.1.14</li>
		<li>Chrome already has "55" in data</li>
		<li><strong>Safari 9.1, Chrome 55</strong></li>
	</ol>
</details>

<details>
	<summary>css.properties.clip-path (-webkit- prefix), css.properties.clip-path.basic_shape</summary>
	<ol>
		<li>Implemented in 60c867ae86d206910c7d761fa7be2e2d0ec8c4dc</li>
		<li>Implemented in WebKit 537.9</li>
		<li><strong>Safari 6.1, Chrome 23</strong></li>
	</ol>
</details>

<details>
	<summary>css.properties.clip-path.html</summary>
	<ol>
		<li>Implemented in 49391c0f036e6cf0dd6bab5a40538282a8e29d95</li>
		<li>Implemented in WebKit 537.9</li>
		<li><strong>Safari 6.1, Chrome 23</strong></li>
	</ol>
</details>

<details>
	<summary>css.properties.clip-path.svg</summary>
	<ol>
		<li>Implemented in 7c931bd470bf0cab2468b5f652866882ff41dc24</li>
		<li>Implemented in WebKit 537.9</li>
		<li><strong>Safari 6.1, Chrome 23</strong></li>
	</ol>
</details>

<details>
	<summary>css.properties.color.rebeccapurple</summary>
	<ol>
		<li>Implemented in a917830d9420fd43170b41d53824cc172e9d9d95</li>
		<li>Implemented in WebKit 538.42</li>
		<li>Chrome already has "38" in data</li>
		<li><strong>Safari 9, Chrome 38</strong></li>
	</ol>
</details>

<details>
	<summary>css.properties.image-rendering, css.properties.image-rendering.crisp-edges</summary>
	<ol>
		<li>Implemented in 01e47492ea620efd8a6f02f965298e85d2e4017c</li>
		<li>Implemented in WebKit 535.1</li>
		<li><strong>Safari 6, Chrome 13</strong></li>
	</ol>
</details>

<details>
	<summary>css.properties.paint-order</summary>
	<ol>
		<li>Implemented in c6037a225c508a518684f6070552f819f24bcdc3</li>
		<li>Implemented in WebKit 538.24</li>
		<li>Chrome already has "35" in data</li>
		<li><strong>Safari 8, Chrome 35</strong></li>
	</ol>
</details>

<details>
	<summary>css.properties.transform-box</summary>
	<ol>
		<li>Implemented in 23372cf48189784ac167086b6779c974206190c2</li>
		<li>Implemented in 604.1.23</li>
		<li>Chrome already has "64" in data</li>
		<li><strong>Safari 11, Chrome 64</strong></li>
	</ol>
</details>

<details>
	<summary>css.properties.word-wrap (as "overflow-wrap")</summary>
	<ol>
		<li>Implemented in a1db8488af59100de1ff690b47f7e19fe3ad857b</li>
		<li>Implemented in WebKit 537.9</li>
		<li><strong>Safari 6.1, Chrome 23</strong></li>
	</ol>
</details>

<details>
	<summary>css.properties.writing-mode</summary>
	<ol>
		<li>Supported in Safari</li>
		<li>Implemented in 951fb0fdb922540b1c64e4556f3b1f65b5125f4d</li>
		<li>Unprefixed in 0dcaabd652503c80590b9c6af294f4ad24ae36f4</li>
		<li>Unprefixed in WebKit 603.1.11</li>
		<li>CanIUse Suggests Chrome 48 for unprefixing (https://caniuse.com/#feat=css-writing-mode)</li>
		<li><strong>Safari 10.1, Chrome 48</strong></li>
	</ol>
</details>