### PR TITLE
Mirror Chrome (1-27) + Safari (1-6.1) for CSS properties

### DIFF
--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -117,7 +117,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": true
+                  "version_added": "6.1"
                 }
               ],
               "safari_ios": [
@@ -126,7 +126,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": true
+                  "version_added": "6.1"
                 }
               ],
               "samsunginternet_android": {

--- a/css/properties/flex-wrap.json
+++ b/css/properties/flex-wrap.json
@@ -49,7 +49,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "6.1"
               }
             ],
             "safari_ios": [
@@ -58,7 +58,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "6.1"
               }
             ],
             "webview_android": [

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -123,7 +123,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": true
+                  "version_added": "6.1"
                 }
               ],
               "safari_ios": [
@@ -132,7 +132,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": true
+                  "version_added": "6.1"
                 }
               ],
               "samsunginternet_android": {

--- a/css/properties/text-decoration-line.json
+++ b/css/properties/text-decoration-line.json
@@ -49,7 +49,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "8"
               }
             ],
             "safari_ios": [

--- a/css/properties/text-rendering.json
+++ b/css/properties/text-rendering.json
@@ -150,10 +150,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": "6"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "6"
               },
               "samsunginternet_android": {
                 "version_added": null

--- a/css/properties/unicode-bidi.json
+++ b/css/properties/unicode-bidi.json
@@ -104,11 +104,13 @@
               },
               "safari": {
                 "prefix": "-webkit-",
-                "version_added": true,
+                "version_added": "6",
                 "notes": "Avoiding using <code>-webkit-isolate</code>. It can lock up older versions of Safari (up to version 9) and Chrome (up to version 47)."
               },
               "safari_ios": {
-                "version_added": false
+                "prefix": "-webkit-",
+                "version_added": "6",
+                "notes": "Avoiding using <code>-webkit-isolate</code>. It can lock up older versions of Safari (up to version 9) and Chrome (up to version 47)."
               },
               "samsunginternet_android": {
                 "version_added": "5.0"

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -77,10 +77,10 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": null
+                "version_added": "6.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "6.1"
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -211,12 +211,10 @@
                     "version_added": false
                   },
                   "safari": {
-                    "version_added": null,
-                    "notes": "In Safari Technology Preview Release 66"
+                    "version_added": "12.1"
                   },
                   "safari_ios": {
-                    "version_added": null,
-                    "notes": "In Safari Technology Preview Release 66"
+                    "version_added": "12.1"
                   },
                   "samsunginternet_android": {
                     "version_added": false
@@ -465,12 +463,10 @@
                     "version_added": "50"
                   },
                   "safari": {
-                    "version_added": null,
-                    "notes": "In Safari Technology Preview Release 66"
+                    "version_added": "12.1"
                   },
                   "safari_ios": {
-                    "version_added": null,
-                    "notes": "In Safari Technology Preview Release 66"
+                    "version_added": "12.1"
                   },
                   "samsunginternet_android": {
                     "version_added": true
@@ -608,7 +604,7 @@
                   },
                   {
                     "prefix": "-webkit-",
-                    "version_added": true
+                    "version_added": "13"
                   }
                 ],
                 "chrome_android": [
@@ -859,12 +855,10 @@
                     "version_added": "50"
                   },
                   "safari": {
-                    "version_added": null,
-                    "notes": "In Safari Technology Preview Release 66"
+                    "version_added": "12.1"
                   },
                   "safari_ios": {
-                    "version_added": null,
-                    "notes": "In Safari Technology Preview Release 66"
+                    "version_added": "12.1"
                   },
                   "samsunginternet_android": {
                     "version_added": true
@@ -1161,12 +1155,10 @@
                     "version_added": "50"
                   },
                   "safari": {
-                    "version_added": null,
-                    "notes": "In Safari Technology Preview Release 66"
+                    "version_added": "12.1"
                   },
                   "safari_ios": {
-                    "version_added": null,
-                    "notes": "In Safari Technology Preview Release 66"
+                    "version_added": "12.1"
                   },
                   "samsunginternet_android": {
                     "version_added": true
@@ -1571,12 +1563,10 @@
                     "version_added": "50"
                   },
                   "safari": {
-                    "version_added": null,
-                    "notes": "In Safari Technology Preview Release 66"
+                    "version_added": "12.1"
                   },
                   "safari_ios": {
-                    "version_added": null,
-                    "notes": "In Safari Technology Preview Release 66"
+                    "version_added": "12.1"
                   },
                   "samsunginternet_android": {
                     "version_added": true

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -214,7 +214,7 @@
                     "version_added": "12.1"
                   },
                   "safari_ios": {
-                    "version_added": "12.1"
+                    "version_added": "12.2"
                   },
                   "samsunginternet_android": {
                     "version_added": false
@@ -466,7 +466,7 @@
                     "version_added": "12.1"
                   },
                   "safari_ios": {
-                    "version_added": "12.1"
+                    "version_added": "12.2"
                   },
                   "samsunginternet_android": {
                     "version_added": true
@@ -858,7 +858,7 @@
                     "version_added": "12.1"
                   },
                   "safari_ios": {
-                    "version_added": "12.1"
+                    "version_added": "12.2"
                   },
                   "samsunginternet_android": {
                     "version_added": true
@@ -1158,7 +1158,7 @@
                     "version_added": "12.1"
                   },
                   "safari_ios": {
-                    "version_added": "12.1"
+                    "version_added": "12.2"
                   },
                   "samsunginternet_android": {
                     "version_added": true
@@ -1566,7 +1566,7 @@
                     "version_added": "12.1"
                   },
                   "safari_ios": {
-                    "version_added": "12.1"
+                    "version_added": "12.2"
                   },
                   "samsunginternet_android": {
                     "version_added": true

--- a/css/types/integer.json
+++ b/css/types/integer.json
@@ -10,7 +10,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -31,13 +31,13 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/css/types/length-percentage.json
+++ b/css/types/length-percentage.json
@@ -662,10 +662,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": true
+                "version_added": "6.1"
               },
               "safari_ios": {
-                "version_added": "4"
+                "version_added": "6.1"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -686,7 +686,7 @@
             "description": "<code>vmin</code> unit",
             "support": {
               "chrome": {
-                "version_added": "20"
+                "version_added": "26"
               },
               "chrome_android": {
                 "version_added": true
@@ -724,10 +724,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": true
+                "version_added": "6.1"
               },
               "safari_ios": {
-                "version_added": "6"
+                "version_added": "6.1"
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/css/types/length-percentage.json
+++ b/css/types/length-percentage.json
@@ -689,7 +689,7 @@
                 "version_added": "26"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "26"
               },
               "edge": [
                 {

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -664,10 +664,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": true
+                "version_added": "6.1"
               },
               "safari_ios": {
-                "version_added": "4"
+                "version_added": "6.1"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -688,7 +688,7 @@
             "description": "<code>vmin</code> unit",
             "support": {
               "chrome": {
-                "version_added": "20"
+                "version_added": "26"
               },
               "chrome_android": {
                 "version_added": true
@@ -726,10 +726,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": true
+                "version_added": "6.1"
               },
               "safari_ios": {
-                "version_added": "6"
+                "version_added": "6.1"
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/css/types/timing-function.json
+++ b/css/types/timing-function.json
@@ -78,10 +78,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "6"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "6"
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/css/types/transform-function.json
+++ b/css/types/transform-function.json
@@ -7,10 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -42,7 +42,7 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "2"


### PR DESCRIPTION
This pull request mirrors versions of Chrome based upon WebKit and versions of Safari between each other to eliminate null and true values that already have answers in our data.  Changes are as follows:

<details>
	<summary>css.properties.align-self.flex_context (-webkit- prefix)</summary>
	<ol>
		<li>Chrome already has "21" in data</li>
		<li><strong>Mirrored onto Safari (Safari 6.1)</strong></li>
	</ol>
</details>

<details>
	<summary>css.properties.flex-wrap (-webkit- prefix)</summary>
	<ol>
		<li>Chrome already has "21" in data</li>
		<li><strong>Mirrored onto Safari (Safari 6.1)</strong></li>
	</ol>
</details>

<details>
	<summary>css.properties.justify-content.flex_context (-webkit- prefix)</summary>
	<ol>
		<li>Chrome already has "21" in data</li>
		<li><strong>Mirrored onto Safari (Safari 6.1)</strong></li>
	</ol>
</details>

<details>
	<summary>css.properties.text-decoration.shorthand</summary>
	<ol>
		<li>Safari iOS already has "8" in data</li>
		<li><strong>Mirrored onto Safari Desktop (Safari 8)</strong></li>
	</ol>
</details>

<details>
	<summary>css.properties.text-rendering.geometricPrecision</summary>
	<ol>
		<li>Chrome already has "13" in data</li>
		<li><strong>Mirrored onto Safari (Safari 6)</strong></li>
	</ol>
</details>

<details>
	<summary>css.types.image.gradient.radial-gradient (-webkit- prefix)</summary>
	<ol>
		<li>Safari already has "5.1" in data</li>
		<li><strong>Mirrored onto Chrome (Chrome 13)</strong></li>
	</ol>
</details>

<details>
	<summary>css.types.integer</summary>
	<ol>
		<li><strong>Basic CSS1, assuming Safari 1, Chrome 1</strong></li>
	</ol>
</details>

<details>
	<summary>css.types.length-percentage.vmax, css.types.length-percentage.vmin</summary>
	<ol>
		<li>Chrome already has "26" in data</li>
		<li><strong>Mirrored onto Safari (Safari 6.1)</strong></li>
	</ol>
</details>

<details>
	<summary>css.types.length.vmax, css.types.length.vmin</summary>
	<ol>
		<li>Chrome already has "26" in data</li>
		<li><strong>Mirrored onto Safari (Safari 6.1)</strong></li>
	</ol>
</details>

<details>
	<summary>css.types.transform-function</summary>
	<ol>
		<li>Safari already has "3.1" in data</li>
		<li><strong>Mirrored onto Chrome (Chrome 1)</strong></li>
	</ol>
</details>

<details>
	<summary>css.types.timing-function.cubic-bezier</summary>
	<ol>
		<li>Chrome already has "16" in data</li>
		<li><strong>Mirrored onto Safari (Safari 6)</strong></li>
	</ol>
</details>

<details>
	<summary>css.types.image.gradient.conic-gradient.doubleposition, css.types.image.gradient.linear-gradient.doubleposition, css.	types.image.gradient.radial-gradient.doubleposition, css.types.image.gradient.repeating-linear-gradient.doubleposition, css.types.image.gradient.repeating-radial-gradient.doubleposition</summary>
	<ol>
		<li>Safari has mention of exact Technology Preview 66</li>
		<li>Safari TP 66 matches 12.1</li>
		<li><strong>Safari 12.1</strong></li>
	</ol>
</details>

<details>
	<summary>css.properties.unicode-bidi.isolate (-webkit- prefix)</summary>
	<ol>
		<li>Chrome already has "16" in data</li>
		<li><strong>Mirrored onto Safari (Safari 6)</strong></li>
	</ol>
</details>

<details>
	<summary>css.properties.width.animatable</summary>
	<ol>
		<li>Chrome already has "26" in data</li>
		<li><strong>Mirrored onto Safari (Safari 6.1)</strong></li>
	</ol>
</details>