### PR TITLE
In Firefox 69 {document,iframe}.policy renamed *.featurePolicy

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -7835,17 +7835,30 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "65",
-              "alternative_name": "policy",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.security.featurePolicy.webidl.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.featurePolicy.webidl.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "65",
+                "version_removed": "69",
+                "alternative_name": "policy",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.featurePolicy.webidl.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": "65",
               "alternative_name": "policy",

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -724,17 +724,30 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "65",
-              "alternative_name": "policy",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.security.featurePolicy.webidl.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.featurePolicy.webidl.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "65",
+                "version_removed": "69",
+                "alternative_name": "policy",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.featurePolicy.webidl.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": "65",
               "alternative_name": "policy",


### PR DESCRIPTION
## Summary
In Firefox 69 `document.policy` became `document.featurePolicy` and `HTMLIFrameElement.policy` became `HTMLIFrameElement.featurePolicy`. This is a follow up to issue #4367 and PR #4381 with data that was not available at the time.

## Data
[Bugilla bug 1514296](https://bugzil.la/1514296)

## Tests
The mentoned Bugzilla bug contains a lot of information abut performed WPTs, but I also checked existence of `*.policy` and `*.featurePolicy` in Nightly.

## Related issues
Issue: #4367
PR: #4381

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
