### PR TITLE
Add NodeJS version to property escapes in RegExp

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -972,9 +972,20 @@
               "ie": {
                 "version_added": null
               },
-              "nodejs": {
-                "version_added": null
-              },
+              "nodejs": [
+                {
+                  "version_added": "10.0.0"
+                },
+                {
+                  "version_added": "8.3.0",
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--harmony"
+                    }
+                  ]
+                }
+              ],
               "opera": {
                 "version_added": "51"
               },


### PR DESCRIPTION
Supersedes #4424 due to lack of response from the original PR author (rebase and data updates needed).  Source for data: https://node.green/#ES2018-features--RegExp-Unicode-Property-Escapes