### PR TITLE
Location API: Added notes for pathname for Internet Explorer

### DIFF
--- a/api/Location.json
+++ b/api/Location.json
@@ -407,7 +407,7 @@
             },
             "ie": {
               "version_added": true,
-              "notes": "IE11 does not provide the leading slash char."
+              "notes": "Internet Explorer does not provide the leading slash character in the <code>pathname</code> (<code>docs/Web/API/Location</code> instead of <code>/docs/Web/API/Location</code>)."
             },
             "opera": {
               "version_added": true

--- a/api/Location.json
+++ b/api/Location.json
@@ -406,7 +406,8 @@
               "notes": "Before Firefox 53, the <code>pathname</code> property returned wrong parts of the URL. For example, for a URL of http://z.com/x?a=true&b=false, <code>pathname</code> would return \"/x?a=true&b=false\" rather than \"/x\"."
             },
             "ie": {
-              "version_added": true
+              "version_added": true,
+              "notes": "IE11 does not provide the leading slash char."
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
Internet Explorer 11 does not provide the leading `/` char for pathname.
I added this information to the browser compatibility table.

![ie11](https://user-images.githubusercontent.com/7441419/60775261-ac1b3380-a120-11e9-852e-1c0073a87cf0.png)
