### PR TITLE
Update Firefox compat for api.performanceResourceTiming

### DIFF
--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -157,10 +157,10 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "45"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "45"
             },
             "ie": {
               "version_added": false
@@ -301,10 +301,10 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "45"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "45"
             },
             "ie": {
               "version_added": false
@@ -445,10 +445,10 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "51"
+              "version_added": "45"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "45"
             },
             "ie": {
               "version_added": false
@@ -829,10 +829,10 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "45"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "45"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Fixes #4289 by setting the Firefox versions for four properties (nextHopProtocol, transferSize, encodedBodySize, decodedBodySize) to "45", as reflected by the bug in Bugzilla.