### PR TITLE
Add RelativeTimeFormat constructor

### DIFF
--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -2289,7 +2289,7 @@
         "PluralRules": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/PluralRules",
-            "spec_url": "https://tc39.es/ecma402/#pluralrules-objects",
+            "spec_url": "https://tc39.es/ecma402/#sec-intl-pluralrules-constructor",
             "support": {
               "chrome": {
                 "version_added": "63"

--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -2289,7 +2289,7 @@
         "PluralRules": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/PluralRules",
-            "spec_url": "https://tc39.es/ecma402/#sec-intl-pluralrules-constructor",
+            "spec_url": "https://tc39.es/ecma402/#pluralrules-objects",
             "support": {
               "chrome": {
                 "version_added": "63"
@@ -2644,6 +2644,59 @@
               "experimental": false,
               "standard_track": true,
               "deprecated": false
+            }
+          },
+          "RelativeTimeFormat": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat",
+              "spec_url": "https://tc39.es/proposal-intl-relative-time/#sec-intl-relativetimeformat-constructor",
+              "description": "<code>RelativeTimeFormat()</code> constructor",
+              "support": {
+                "chrome": {
+                  "version_added": "71"
+                },
+                "chrome_android": {
+                  "version_added": "71"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "65"
+                },
+                "firefox_android": {
+                  "version_added": "65"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "12.0.0"
+                },
+                "opera": {
+                  "version_added": "58"
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": true
+                },
+                "webview_android": {
+                  "version_added": "71"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           },
           "format": {


### PR DESCRIPTION
This change updates the spec URL for the Intl.PluralRules constructor (subfeature of the Intl.PluralRules object), to point to the specific section of the Ecma 402 spec about the constructor itself.

Otherwise, without this change, the spec URL instead points to the general section introduction for the Intl.PluralRules object. But in the BCD content, we already have a spec URL for the Intl.PluralRules objects itself (the parent feature of the subfeature this patch changes).