### PR TITLE
Document data conventions

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -25,7 +25,7 @@ The repository is made available under the terms the [Creative Commons CC0 Publi
 
 There are many ways you can help improve this repository! For example:
 
-* **Add new compat data**: familiarize yourself with the [schema](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data.schema.json) and read the [schema docs](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md) to add new files.
+* **Add new compat data**: familiarize yourself with the [schema](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data.schema.json) and read the [schema docs](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md) and [data guidelines](data-guidelines.md) to add new files.
 * **Fix existing compat data**: maybe a browser now supports a certain feature. Yay! If you open a PR to fix a browser's data, it would be most helpful if you include a link to a bug report or similar so that we can double-check the good news.
 * **Fix a bug:** we have a list of [issues](https://github.com/mdn/browser-compat-data/issues),
 or maybe you found your own.

--- a/docs/data-guidelines.md
+++ b/docs/data-guidelines.md
@@ -20,6 +20,28 @@ If it's helpful to understanding the rule, summarize the rationale. Definitely c
 
 -- END TEMPLATE -->
 
+## Constructor features
+
+A constructor for an API feature should have the same name as the parent feature (unless the constructor doesn't share the name of its parent feature) and have a description with text in the form of `<code>Name()</code> constructor`.
+
+For example, the `ImageData` constructor, `ImageData()`, is represented as `api.ImageData.ImageData`. It has the description `<code>ImageData()</code> constructor`, like this:
+
+```json
+{
+  "api": {
+    "ImageData": {
+      "__compat": {},
+      "ImageData": {
+        "__compat": {
+          "description": "<code>ImageData()</code> constructor",
+          "support": {}
+        }
+      }
+    }
+  }
+}
+```
+
 ## Worker support
 
 Data for an API's support for Web Workers should be in a subfeature named `worker_support` and have a description with the text `Available in workers`.

--- a/docs/data-guidelines.md
+++ b/docs/data-guidelines.md
@@ -144,13 +144,6 @@ For example, if the current release of browser X is version 10.2, but a new feat
 This decision was made in [#3953, under the expectation that most users are likely to run the latest minor version of their browser](https://github.com/mdn/browser-compat-data/pull/3953#issuecomment-485847399), but not necessarily the latest version overall.
 
 
-## Node.js releases before 1.0
-
-Unlike other browsers, use pre-1.0 releases of Node.js because Node did not use major version numbers during its early history. BCD permits including any Node.js release that introduces a feature (typically, these are `major.minor.0` releases).
-
-See [#3160](https://github.com/mdn/browser-compat-data/pull/3160) for a discussion of this approach.
-
-
 ## Safari for iOS versioning
 
 For Safari for iOS, use the iOS version number, not the Safari version number or WebKit version number.

--- a/docs/data-guidelines.md
+++ b/docs/data-guidelines.md
@@ -3,6 +3,7 @@
 This file contains recommendations to help you record data in a consistent and understandable way. It covers the project's preferences for the way features should be represented, rather than hard requirements encoded in the schema definitions or linter logic.
 
 - [Data guidelines](#data-guidelines)
+  * [Secure context required](#secure-context-required)
   * [Naming event features: `eventname_event`](#naming-event-features---eventname-event-)
   * [Defined names without behaviors imply `partial_implementation`](#defined-names-without-behaviors-imply--partial-implementation-)
   * [Release lines and backported features](#release-lines-and-backported-features)
@@ -18,6 +19,57 @@ A description of what to do, preferable in the imperative. If applicable, includ
 If it's helpful to understanding the rule, summarize the rationale. Definitely cite the issue or pull request where this was decided (it may be the PR that merges the policy).
 
 -- END TEMPLATE -->
+
+## Secure context required
+
+An API that requires HTTPS should contain a subfeature named `secure_context_required` and have a description with the text `Secure context required`, like this:
+
+```json
+{
+  "api": {
+    "ImageData": {
+      "__compat": {},
+      "secure_context_required": {
+        "__compat": {
+          "description": "Secure context required",
+          "support": {}
+        }
+      }
+    }
+  }
+}
+```
+
+For example, if the `ImageData` feature requires a secure context from version 60 in Chrome, version 55 in Firefox, and not at all in Safari, we could represent that as follows:
+
+```json
+{
+  "api": {
+    "ImageData": {
+      "__compat": {},
+      "secure_context_required": {
+        "__compat": {
+          "description": "Secure context required",
+          "support": {
+            "chrome": {
+              "version_added": "60"
+            },
+            "firefox": {
+              "version_added": "55"
+            },
+            "safari": {
+              "version_added": false
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Discussed in more detail in [#190](https://github.com/mdn/browser-compat-data/issues/190).
+
 
 ## Naming event features: `eventname_event`
 

--- a/docs/data-guidelines.md
+++ b/docs/data-guidelines.md
@@ -3,26 +3,28 @@
 This file contains recommendations to help you record data in a consistent and understandable way. It covers the project's preferences for the way features should be represented, rather than hard requirements encoded in the schema definitions or linter logic.
 
 - [Data guidelines](#data-guidelines)
-  * [Secure context required](#secure-context-required)
-  * [Naming event features: `eventname_event`](#naming-event-features---eventname-event-)
-  * [Defined names without behaviors imply `partial_implementation`](#defined-names-without-behaviors-imply--partial-implementation-)
+  * [Constructors](#constructors)
+  * [DOM events (`eventname_event`)](#dom-events---eventname-event--)
+  * [Secure context required (`secure_context_required`)](#secure-context-required---secure-context-required--)
+  * [Web Workers (`worker_support`)](#web-workers---worker-support--)
+  * [Non-functional defined names imply `partial_implementation`](#non-functional-defined-names-imply--partial-implementation-)
   * [Release lines and backported features](#release-lines-and-backported-features)
-  * [Node.js versioning](#nodejs-versioning)
+  * [Node.js releases before 1.0](#nodejs-releases-before-10)
   * [Safari for iOS versioning](#safari-for-ios-versioning)
 
 <!-- BEGIN TEMPLATE
 
 ## Short title in sentence case
 
-A description of what to do, preferable in the imperative. If applicable, include an example to illustrate the rule.
+A description of what to do, preferably in the imperative. If applicable, include an example to illustrate the rule.
 
 If it's helpful to understanding the rule, summarize the rationale. Definitely cite the issue or pull request where this was decided (it may be the PR that merges the policy).
 
 -- END TEMPLATE -->
 
-## Constructor features
+## Constructors
 
-A constructor for an API feature should have the same name as the parent feature (unless the constructor doesn't share the name of its parent feature) and have a description with text in the form of `<code>Name()</code> constructor`.
+Name a constructor for an API feature the same as the parent feature (unless the constructor doesn't share the name of its parent feature) and have a description with text in the form of `<code>Name()</code> constructor`.
 
 For example, the `ImageData` constructor, `ImageData()`, is represented as `api.ImageData.ImageData`. It has the description `<code>ImageData()</code> constructor`, like this:
 
@@ -42,11 +44,67 @@ For example, the `ImageData` constructor, `ImageData()`, is represented as `api.
 }
 ```
 
-## Worker support
 
-Data for an API's support for Web Workers should be in a subfeature named `worker_support` and have a description with the text `Available in workers`.
+## DOM events (`eventname_event`)
 
-For example, if the `ImageData` API has worker support, then it would be recorded like this:
+Name DOM event features in the form _eventname_\_event with description text `<code>eventname</code> event`.
+
+For example, the feature for a `focus` event would be named `focus_event` with the description text `<code>focus</code> event`, like this:
+
+```json
+{
+  "api": {
+    "Element": {
+      "__compat": {},
+      ...
+      "focus_event": {
+        "__compat": {
+          "description": "<code>focus</code> event",
+          "support": {}
+        }
+      }
+    }
+  }
+}
+```
+
+This rule applies to the event features themselves, not the features for the event handlers. For example, `focus_event` and `onfocus` are two separate features.
+
+This practice emerged through several discussions:
+
+* [#935](https://github.com/mdn/browser-compat-data/issues/935#issuecomment-464691417)
+* [#3420](https://github.com/mdn/browser-compat-data/pull/3420)
+* [#3469](https://github.com/mdn/browser-compat-data/pull/3469)
+
+
+## Secure context required (`secure_context_required`)
+
+Use a subfeature named `secure_context_required` with the description text `Secure context required` to record data about whether a feature requires HTTPS. For example, the `ImageData` API requires a secure context, recorded like this:
+
+```json
+{
+  "api": {
+    "ImageData": {
+      "__compat": {},
+      "secure_context_required": {
+        "__compat": {
+          "description": "Secure context required",
+          "support": {}
+        }
+      }
+    }
+  }
+}
+```
+
+This convention is discussed in more detail in [#190](https://github.com/mdn/browser-compat-data/issues/190).
+
+
+## Web Workers (`worker_support`)
+
+Use a subfeature named `worker_support` with description text `Available in workers` to record data about an API's support for Web Workers.
+
+For example, the `ImageData` API has worker support, recorded like this:
 
 ```json
 {
@@ -66,71 +124,8 @@ For example, if the `ImageData` API has worker support, then it would be recorde
 
 Formerly named `available_in_workers`, this policy was set in [#2362](https://github.com/mdn/browser-compat-data/pull/2362).
 
-## Secure context required
 
-An API that requires HTTPS should contain a subfeature named `secure_context_required` and have a description with the text `Secure context required`, like this:
-
-```json
-{
-  "api": {
-    "ImageData": {
-      "__compat": {},
-      "secure_context_required": {
-        "__compat": {
-          "description": "Secure context required",
-          "support": {}
-        }
-      }
-    }
-  }
-}
-```
-
-For example, if the `ImageData` feature requires a secure context from version 60 in Chrome, version 55 in Firefox, and not at all in Safari, we could represent that as follows:
-
-```json
-{
-  "api": {
-    "ImageData": {
-      "__compat": {},
-      "secure_context_required": {
-        "__compat": {
-          "description": "Secure context required",
-          "support": {
-            "chrome": {
-              "version_added": "60"
-            },
-            "firefox": {
-              "version_added": "55"
-            },
-            "safari": {
-              "version_added": false
-            }
-          }
-        }
-      }
-    }
-  }
-}
-```
-
-Discussed in more detail in [#190](https://github.com/mdn/browser-compat-data/issues/190).
-
-
-## Naming event features: `eventname_event`
-
-Name DOM event features in the form _eventname_\_event. For example, the feature for a `focus` event would be named `focus_event`.
-
-Note: this rule applies to the event features themselves, not the features for their handlers. For example, `onfocus` and `focus_event` are two separate features.
-
-This practice emerged through several discussions:
-
-* [#935](https://github.com/mdn/browser-compat-data/issues/935#issuecomment-464691417)
-* [#3420](https://github.com/mdn/browser-compat-data/pull/3420)
-* [#3469](https://github.com/mdn/browser-compat-data/pull/3469)
-
-
-## Defined names without behaviors imply `partial_implementation`
+## Non-functional defined names imply `partial_implementation`
 
 If a browser recognizes an API name, but the API doesn’t have any discernable behavior, use `"partial_implementation": true` instead of `"version_added": false`, as if the feature has non-standard support, rather than no support.
 
@@ -141,20 +136,24 @@ See [#3904](https://github.com/mdn/browser-compat-data/pull/3904#issuecomment-48
 
 ## Release lines and backported features
 
-BCD does not record absolute version numbers; instead, BCD follows release lines (generally, major and minor, but not patch-level releases). Use the earliest applicable release line for recording support for a given feature, even when that support change was backported to a previous release of the browser.
+Use version numbers to reflect which _release line_ (major or minor but not patch-level releases) first supported a feature, rather than absolute version numbers.
+
+Typically, BCD does not record absolute version numbers (such as Chrome 76.0.3809.46; instead BCD records significant releases (such as Chrome 76). Use the earliest applicable release line for recording support for a given feature, even when that support change was backported to a previous release of the browser.
 
 For example, if the current release of browser X is version 10.2, but a new feature was backported to previous versions including a new 9.7.1 release, then the supported version is 9.7 (not 10.2 or 9.7.1).
 
 This decision was made in [#3953, under the expectation that most users are likely to run the latest minor version of their browser](https://github.com/mdn/browser-compat-data/pull/3953#issuecomment-485847399), but not necessarily the latest version overall.
 
 
-## Node.js versioning
+## Node.js releases before 1.0
 
-Unlike other browsers, we include pre-1.0 releases of Node.js because Node did not use major version numbers during its early history. BCD permits including any Node.js release that introduces a feature (typically, these are `major.minor.0` releases).
+Unlike other browsers, use pre-1.0 releases of Node.js because Node did not use major version numbers during its early history. BCD permits including any Node.js release that introduces a feature (typically, these are `major.minor.0` releases).
 
 See [#3160](https://github.com/mdn/browser-compat-data/pull/3160) for a discussion of this approach.
 
 
 ## Safari for iOS versioning
 
-Browser data for Safari for iOS uses the iOS version number, not the Safari version number or the WebKit version number. This versioning scheme came at [Apple's request, in #2006](https://github.com/mdn/browser-compat-data/issues/2006#issuecomment-457277312).
+For Safari for iOS, use the iOS version number, not the Safari version number or WebKit version number.
+
+This versioning scheme came at [Apple's request, in #2006](https://github.com/mdn/browser-compat-data/issues/2006#issuecomment-457277312).

--- a/docs/data-guidelines.md
+++ b/docs/data-guidelines.md
@@ -20,6 +20,30 @@ If it's helpful to understanding the rule, summarize the rationale. Definitely c
 
 -- END TEMPLATE -->
 
+## Worker support
+
+Data for an API's support for Web Workers should be in a subfeature named `worker_support` and have a description with the text `Available in workers`.
+
+For example, if the `ImageData` API has worker support, then it would be recorded like this:
+
+```json
+{
+  "api": {
+    "ImageData": {
+      "__compat": {},
+      "worker_support": {
+        "__compat": {
+          "description": "Available in workers",
+          "support": {}
+        }
+      }
+    }
+  }
+}
+```
+
+Formerly named `available_in_workers`, this policy was set in [#2362](https://github.com/mdn/browser-compat-data/pull/2362).
+
 ## Secure context required
 
 An API that requires HTTPS should contain a subfeature named `secure_context_required` and have a description with the text `Secure context required`, like this:

--- a/docs/data-guidelines.md
+++ b/docs/data-guidelines.md
@@ -1,0 +1,62 @@
+# Data guidelines
+
+This file contains recommendations to help you record data in a consistent and understandable way. It covers the project's preferences for the way features should be represented, rather than hard requirements encoded in the schema definitions or linter logic.
+
+- [Data guidelines](#data-guidelines)
+  * [Naming event features: `eventname_event`](#naming-event-features---eventname-event-)
+  * [Defined names without behaviors imply `partial_implementation`](#defined-names-without-behaviors-imply--partial-implementation-)
+  * [Release lines and backported features](#release-lines-and-backported-features)
+  * [Node.js versioning](#nodejs-versioning)
+  * [Safari for iOS versioning](#safari-for-ios-versioning)
+
+<!-- BEGIN TEMPLATE
+
+## Short title in sentence case
+
+A description of what to do, preferable in the imperative. If applicable, include an example to illustrate the rule.
+
+If it's helpful to understanding the rule, summarize the rationale. Definitely cite the issue or pull request where this was decided (it may be the PR that merges the policy).
+
+-- END TEMPLATE -->
+
+## Naming event features: `eventname_event`
+
+Name DOM event features in the form _eventname_\_event. For example, the feature for a `focus` event would be named `focus_event`.
+
+Note: this rule applies to the event features themselves, not the features for their handlers. For example, `onfocus` and `focus_event` are two separate features.
+
+This practice emerged through several discussions:
+
+* [#935](https://github.com/mdn/browser-compat-data/issues/935#issuecomment-464691417)
+* [#3420](https://github.com/mdn/browser-compat-data/pull/3420)
+* [#3469](https://github.com/mdn/browser-compat-data/pull/3469)
+
+
+## Defined names without behaviors imply `partial_implementation`
+
+If a browser recognizes an API name, but the API doesn’t have any discernable behavior, use `"partial_implementation": true` instead of `"version_added": false`, as if the feature has non-standard support, rather than no support.
+
+For example, suppose there is some specification for a Web API `NewFeature.method()`. Running `typeof NewFeature.method` in some browser returns `function` (not `undefined`), but the method, when called, returns `null` instead of an expected value. For that feature, set `"partial_implementation": true` and write a note describing the feature’s misbehavior.
+
+See [#3904](https://github.com/mdn/browser-compat-data/pull/3904#issuecomment-484433603) for additional background (and nuance).
+
+
+## Release lines and backported features
+
+BCD does not record absolute version numbers; instead, BCD follows release lines (generally, major and minor, but not patch-level releases). Use the earliest applicable release line for recording support for a given feature, even when that support change was backported to a previous release of the browser.
+
+For example, if the current release of browser X is version 10.2, but a new feature was backported to previous versions including a new 9.7.1 release, then the supported version is 9.7 (not 10.2 or 9.7.1).
+
+This decision was made in [#3953, under the expectation that most users are likely to run the latest minor version of their browser](https://github.com/mdn/browser-compat-data/pull/3953#issuecomment-485847399), but not necessarily the latest version overall.
+
+
+## Node.js versioning
+
+Unlike other browsers, we include pre-1.0 releases of Node.js because Node did not use major version numbers during its early history. BCD permits including any Node.js release that introduces a feature (typically, these are `major.minor.0` releases).
+
+See [#3160](https://github.com/mdn/browser-compat-data/pull/3160) for a discussion of this approach.
+
+
+## Safari for iOS versioning
+
+Browser data for Safari for iOS uses the iOS version number, not the Safari version number or the WebKit version number. This versioning scheme came at [Apple's request, in #2006](https://github.com/mdn/browser-compat-data/issues/2006#issuecomment-457277312).

--- a/docs/data-guidelines.md
+++ b/docs/data-guidelines.md
@@ -56,7 +56,6 @@ For example, the feature for a `focus` event would be named `focus_event` with t
   "api": {
     "Element": {
       "__compat": {},
-      ...
       "focus_event": {
         "__compat": {
           "description": "<code>focus</code> event",

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -84,24 +84,6 @@ To add a sub-feature, a new identifier is added below the main feature at the le
 
 The following conventions apply to compatibility data in the `api/` directory.
 
-Worker support for a given feature in `api/` should be in a subfeature titled `worker_support`. It should also have the description `Available in workers`.
-
-```json
-{
-  "api": {
-    "ImageData": {
-      "__compat": {},
-      "worker_support": {
-        "__compat": {
-          "description": "Available in workers",
-          "support": {}
-        }
-      }
-    }
-  }
-}
-```
-
 A constructor for a given feature in `api/` should have the same name as the parent feature (except in special cases where the constructor doesn't share the name of its parent feature). For example, the ImageData constructor, `ImageData()`, would be represented as `api.ImageData.ImageData`. It should also have the description `<code>ImageData()</code> constructor`.
 
 ```json

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -80,6 +80,8 @@ What it represents exactly depends of the evolution of the feature over time, bo
 
 To add a sub-feature, a new identifier is added below the main feature at the level of a `__compat` object (see the sub-features "start" and "end" above). The same could be done for sub-sub-features. There is no depth limit.
 
+See [Data guidelines](/docs/data-guidelines.md) for more information about feature naming conventions and other best practices.
+
 ### The `__compat` object
 The `__compat` object consists of the following:
 

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -80,28 +80,6 @@ What it represents exactly depends of the evolution of the feature over time, bo
 
 To add a sub-feature, a new identifier is added below the main feature at the level of a `__compat` object (see the sub-features "start" and "end" above). The same could be done for sub-sub-features. There is no depth limit.
 
-#### API-specific subfeatures
-
-The following conventions apply to compatibility data in the `api/` directory.
-
-A constructor for a given feature in `api/` should have the same name as the parent feature (except in special cases where the constructor doesn't share the name of its parent feature). For example, the ImageData constructor, `ImageData()`, would be represented as `api.ImageData.ImageData`. It should also have the description `<code>ImageData()</code> constructor`.
-
-```json
-{
-  "api": {
-    "ImageData": {
-      "__compat": {},
-      "ImageData": {
-        "__compat": {
-          "description": "<code>ImageData()</code> constructor",
-          "support": {}
-        }
-      }
-    }
-  }
-}
-```
-
 ### The `__compat` object
 The `__compat` object consists of the following:
 

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -120,54 +120,6 @@ A constructor for a given feature in `api/` should have the same name as the par
 }
 ```
 
-#### Secure context required
-
-A feature that requires HTTPS should contain a subfeature titled `secure_context_required`, which describes how different browsers handle the secure context requirement. This new subfeature should also have the description `Secure context required`.
-
-```json
-{
-  "api": {
-    "ImageData": {
-      "__compat": {},
-      "secure_context_required": {
-        "__compat": {
-          "description": "Secure context required",
-          "support": {}
-        }
-      }
-    }
-  }
-}
-```
-
-For example, if the `ImageData` feature requires a secure context from version 60 in Chrome, version 55 in Firefox, and not at all in Safari, we could represent that as follows:
-
-```json
-{
-  "api": {
-    "ImageData": {
-      "__compat": {},
-      "secure_context_required": {
-        "__compat": {
-          "description": "Secure context required",
-          "support": {
-            "chrome": {
-              "version_added": "60"
-            },
-            "firefox": {
-              "version_added": "55"
-            },
-            "safari": {
-              "version_added": false
-            }
-          }
-        }
-      }
-    }
-  }
-}
-```
-
 ### The `__compat` object
 The `__compat` object consists of the following:
 


### PR DESCRIPTION
This is for #4177; see that issue for details. The summary is that there are a number of conventions we use in recording data that cannot be reliably linted. This new documentation provides a single place for contributors to look for such conventions, a place for reviewers to refer to during reviews, and a process for discussing and accepting a new convention: making a pull request adding to the file.