### PR TITLE
Fix WebKit versions in Safari

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -122,42 +122,42 @@
           "release_notes": "https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Articles/Safari_10_0.html",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "602.1"
+          "engine_version": "602.1.50"
         },
         "10.1": {
           "release_date": "2017-03-27",
           "release_notes": "https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Articles/Safari_10_1.html",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "603.1"
+          "engine_version": "603.2.1"
         },
         "11": {
           "release_date": "2017-09-19",
           "release_notes": "https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Safari_11_0/Safari_11_0.html",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "604.1"
+          "engine_version": "604.2.4"
         },
         "11.1": {
           "release_date": "2018-04-12",
           "release_notes": "https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Articles/Safari_11_1.html",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "604.1"
+          "engine_version": "605.1.33"
         },
         "12": {
           "release_date": "2018-09-24",
           "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_12_release_notes",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "605.1"
+          "engine_version": "606.1.36"
         },
         "12.1": {
           "release_date": "2019-03-25",
           "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_12_1_release_notes",
           "status": "current",
           "engine": "WebKit",
-          "engine_version": "605.1"
+          "engine_version": "607.1.40"
         },
         "13": {
           "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_13_beta_release_notes",

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -111,7 +111,7 @@
         "10": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "602.1"
+          "engine_version": "602.1.50"
         },
         "10.1": {
           "status": "retired",
@@ -126,36 +126,36 @@
         "10.3": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "603.3"
+          "engine_version": "603.2.1"
         },
         "11": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "604.1"
+          "engine_version": "604.2.4"
         },
         "11.1": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "604.3"
+          "engine_version": "604.3.5"
         },
         "11.3": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "605.1"
+          "engine_version": "605.1.33"
         },
         "12": {
           "release_date": "2018-09-17",
           "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_12_release_notes",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "605.1"
+          "engine_version": "606.1.36"
         },
         "12.2": {
           "release_date": "2019-03-25",
           "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_12_1_release_notes",
           "status": "current",
           "engine": "WebKit",
-          "engine_version": "605.1"
+          "engine_version": "607.1.40"
         },
         "13": {
           "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_13_beta_release_notes",


### PR DESCRIPTION
Unfortunately, it looks like Safari's user agent string was lying to us regarding the Safari versions -- which I had a hunch about when originally adding browser engines.  After further review, I compared the [release tags](https://trac.webkit.org/browser/webkit/tags) with the [Safari releases](https://trac.webkit.org/browser/webkit/releases/Apple), and found that...well, good thing we caught it sooner than later, right?

By looking in the SVN repository for WebKit and comparing the tags (aka each WebKit release) to the releases (aka each Safari release) by their ChangeLog files, I have determined that the WebKit version outputted by the user agent string outputted by Safari has been incorrect for Safari 10+ (and possibly Safari 9, though I’m unable to confirm this as the repo doesn't have release tags for Safari 9.X):

<img width="960" alt="Screen Shot 2019-07-09 at 22 02 03" src="https://user-images.githubusercontent.com/5179191/60941858-603dcb00-a295-11e9-8d06-caaab1b092a3.png">

In the About panel, I’ve found that the numbers next to the Safari version contain the minor version of macOS (AKA "10.XX"), followed by WebKit version:

<img width="792" alt="Screen Shot 2019-07-09 at 21 58 26" src="https://user-images.githubusercontent.com/5179191/60941731-f6252600-a294-11e9-983b-f61951f8a10e.png">

The screenshot below shows that the ChangeLog file for Safari 12.1 exactly matches that for WebKit 607.2.6.1.1, even though the user agent claims it’s running WebKit 605.1.15:

<img width="1920" alt="Screen Shot 2019-07-09 at 03 52 45" src="https://user-images.githubusercontent.com/5179191/60882780-71d39400-a1fd-11e9-9c5c-a2c93c51d831.png">


Boo to bad UA strings... ☹️