### PR TITLE
Fix Safari version for @media color-gamut

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -321,10 +321,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": "10.1"
+                "version_added": "10"
               },
               "safari_ios": {
-                "version_added": "10.3"
+                "version_added": "10"
               },
               "samsunginternet_android": {
                 "version_added": "7.0"


### PR DESCRIPTION
After further review of Safari <-> WebKit mappings as presented in #4470, it turns out the `color-gamut` feature of the CSS `@media` rule was supported in a slightly earlier version in Safari.  This PR fixes said data.

Since Safari 10 is WebKit 602.1.50, and the feature was implemented in WebKit 602.1.30 (see #4369 for more details), `color-gamut` is in Safari 10.