### PR TITLE
Note Chrome bug with spurious Expect-CT reports

### DIFF
--- a/http/headers/expect-ct.json
+++ b/http/headers/expect-ct.json
@@ -6,7 +6,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Expect-CT",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "61",
+              "notes": "In version 64 invalid Expect-CT reports would be sent (even after 10 weeks had elapsed after the build date).  See <a href='https://crbug.com/786563'>bug 786563</a>."
             },
             "chrome_android": {
               "version_added": "61"

--- a/http/headers/expect-ct.json
+++ b/http/headers/expect-ct.json
@@ -7,7 +7,7 @@
           "support": {
             "chrome": {
               "version_added": "61",
-              "notes": "In version 64 invalid Expect-CT reports would be sent (even after 10 weeks had elapsed after the build date).  See <a href='https://crbug.com/786563'>bug 786563</a>."
+              "notes": "Before later builds of Chrome 64, invalid Expect-CT reports would be sent. Newer versions do not send reports after 10 weeks from the build date.  See <a href='https://crbug.com/786563'>bug 786563</a>."
             },
             "chrome_android": {
               "version_added": "61"


### PR DESCRIPTION

Bug 786563

https://groups.google.com/forum/#!topic/certificate-transparency/vvdzBzC5guw
