### PR TITLE
Remove partial support from member of unsupported API in IE

### DIFF
--- a/api/HTMLHyperlinkElementUtils.json
+++ b/api/HTMLHyperlinkElementUtils.json
@@ -392,9 +392,7 @@
               ]
             },
             "ie": {
-              "version_added": false,
-              "partial_implementation": true,
-              "notes": "Internet Explorer implements this attribute with no leading <code>\"/\"</code>."
+              "version_added": false
             },
             "opera": {
               "version_added": false


### PR DESCRIPTION
I noticed that, while reviewing a question someone had, the `pathname` property of the `HTMLHyperlinkElementUtils` API had partial support in IE.  However, this cannot be possible, as the API is not supported in IE at all.  (This has been confirmed via manual testing in IE 11.)

This PR fixes said inconsistency by removing the note and partial support statement.