### PR TITLE
Set false for unsupported features in Safari

### DIFF
--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -258,10 +258,10 @@
                   "notes": "This value is recognized, but has no effect."
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "samsunginternet_android": {
                   "version_added": true

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -229,10 +229,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": null
@@ -288,10 +288,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": null

--- a/css/properties/font-style.json
+++ b/css/properties/font-style.json
@@ -79,10 +79,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": null

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -349,10 +349,10 @@
                   "version_added": null
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "samsunginternet_android": {
                   "version_added": null
@@ -401,10 +401,10 @@
                   "version_added": null
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "samsunginternet_android": {
                   "version_added": false


### PR DESCRIPTION
From manual testing, I've found that the following features are not supported in Safari:

css.properties.align-content.flex_context.left_right
css.properties.flex-basis.max-content
css.properties.flex-basis.min-content
css.properties.justify-content.flex_context.baseline
css.properties.justify-content.flex_context.first_last_baseline
css.properties.font-style.oblique-angle