### PR TITLE
Add Safari support for various CSS properties

### DIFF
--- a/css/properties/custom-property.json
+++ b/css/properties/custom-property.json
@@ -72,10 +72,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": true
+              "version_added": "9.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "9.1"
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/css/properties/font-optical-sizing.json
+++ b/css/properties/font-optical-sizing.json
@@ -56,10 +56,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": null

--- a/css/properties/font-stretch.json
+++ b/css/properties/font-stretch.json
@@ -83,10 +83,10 @@
                 "version_added": "46"
               },
               "safari": {
-                "version_added": true
+                "version_added": "11.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "11.3"
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/css/properties/font-weight.json
+++ b/css/properties/font-weight.json
@@ -77,10 +77,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": "11"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "11"
               },
               "samsunginternet_android": {
                 "version_added": null


### PR DESCRIPTION
This PR adds versions to five CSS properties.  Data is as follows:

<details>
	<summary>css.properties.font-optical-sizing</summary>
	<ol>
		<li>Implemented in a5cbce30addb215041ed51801a675ca372c68d13</li>
		<li>Implemented in Webkit 604.1.15</li>
		<li>Manually confirmed in Safari 11</li>
		<li><strong>Safari 11</strong></li>
	</ol>
</details>

<details>
	<summary>css.properties.font-stretch.percentage</summary>
	<ol>
		<li><strong>Safari 11.1 (manual testing)</strong></li>
	</ol>
</details>

<details>
	<summary>css.properties.font-weight.number</summary>
	<ol>
		<li>Implemented in 851f394ce81889ffc509a3d792c893853ff48ac1</li>
		<li>Implemented in WebKit 604.1.9</li>
		<li>Manually confirmed in Safari 11</li>
		<li><strong>Safari 11</strong></li>
	</ol>
</details>

<details>
	<summary>css.properties.custom-property, css.properties.custom-property.var</summary>
	<ol>
		<li>Manually tested, supported in 9.1</li>
		<li>Confirmed by release notes https://developer.apple.com/library/archive/releasenotes/General/WhatsNewInSafari/Articles/Safari_9_1.html#//apple_ref/doc/uid/TP40014305-CH10-SW13</li>
		<li><strong>Safari 9.1</strong></li>
	</ol>
</details>