### PR TITLE
test(real‑values): Fix broken chalk tagged template literal call

### DIFF
--- a/test/test-real-values.js
+++ b/test/test-real-values.js
@@ -51,7 +51,7 @@ function checkRealValues(supportData, blockList, relPath, logger) {
 
     for (const statement of supportStatements) {
       if (statement === undefined) {
-        logger.error(chalk`{red {bold ${browser}} must be defined for {bold ${relPath}}`);
+        logger.error(chalk`{red {bold ${browser}} must be defined for {bold ${relPath}}}`);
           hasErrors = true;
       } else {
         if ([true, null].includes(statement.version_added)) {


### PR DESCRIPTION
Bug introduced by: #4265

Previously, the top level `red` chalk tag was unclosed, this fixes it.