### PR TITLE
[CORRECTION] Safari supports canvas.clip(path)

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1955,10 +1955,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": false
+                "version_added": "9.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": 9
               },
               "samsunginternet_android": {
                 "version_added": null

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1955,10 +1955,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": "9.1"
+                "version_added": "7"
               },
               "safari_ios": {
-                "version_added": "9"
+                "version_added": "8"
               },
               "samsunginternet_android": {
                 "version_added": null

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1958,7 +1958,7 @@
                 "version_added": "9.1"
               },
               "safari_ios": {
-                "version_added": 9
+                "version_added": "9"
               },
               "samsunginternet_android": {
                 "version_added": null


### PR DESCRIPTION
Support for canvas.clip(path2d) was added here https://trac.webkit.org/changeset/165651/webkit in March 2014.

According to https://caniuse.com/#feat=path2d it's been available in Safari since v9.1 (macos) and v9 (ios)

The sample code from https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/clip works fine -  https://jsfiddle.net/xLc6n4a8/