### PR TITLE
feat(css): Add `margin‑trim` property

### DIFF
--- a/css/properties/margin-trim.json
+++ b/css/properties/margin-trim.json
@@ -1,0 +1,56 @@
+{
+  "css": {
+    "properties": {
+      "margin-trim": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-trim",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1506241'>bug 1506241</a>."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1506241'>bug 1506241</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds browser compatibility data for the [`margin‑trim`](https://developer.mozilla.org/docs/Web/CSS/margin-trim) property from [the **CSS Box Model** specification](https://drafts.csswg.org/css-box/#margin-trim).

## See also:
- https://github.com/mdn/data/pull/360
