### PR TITLE
Note that Chome does not accept svg icons.

### DIFF
--- a/webextensions/manifest/icons.json
+++ b/webextensions/manifest/icons.json
@@ -6,7 +6,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/icons",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Chrome does not support SVG format for icons. It is recommended to use PNG images."
             },
             "edge": {
               "version_added": "14"


### PR DESCRIPTION
Tests of my extension showed that Chrome does not accept svg icons. This is already noted in the `default_icon` section of `browser_compat_data`, but not in the `icons` section.

[Chrome documentation](https://developer.chrome.com/apps/manifest/icons) does not list SVG as one of the supported types.
