### PR TITLE
documented IE support for `document.createRange()`

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -2065,7 +2065,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
I documented IE support for `document.createRange()`

I was able to find docs placing the introduction of `document.createRange()` at IE9: https://blogs.msdn.microsoft.com/ie/2010/05/11/dom-range-and-html5-selection. https://web.archive.org/web/20120423060025/http://msdn.microsoft.com/en-us/library/ie/ff975303(v=vs.85).aspx confirms `document.createRange()` was at least eventually included in IE.
I also ran
```
if (!document.createRange) { throw new Error('not found'); }
function copy(el) {
  // from alligator.io/js/copying-to-clipboard
  var selection = window.getSelection();
  var range = document.createRange();
  range.selectNodeContents(el);
  selection.removeAllRanges();
  selection.addRange(range);
  try {
    document.execCommand('copy');
    selection.removeAllRanges();
  } catch(e) {
    console.error(e)
  }
}
copy($0);
```
on IE11 on browserstack, and confirmed everything worked as expected.
#4207 also verifies IE11 includes `document.createRange()`.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
