### PR TITLE
Move table-caption bug into a note

### DIFF
--- a/css/properties/column-count.json
+++ b/css/properties/column-count.json
@@ -38,7 +38,8 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "1.5"
+                "version_added": "1.5",
+                "notes": "Prior to version 37, multiple columns didn't work with <code>display: table-caption</code> elements."
               }
             ],
             "firefox_android": [
@@ -47,7 +48,8 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "4"
+                "version_added": "4",
+                "notes": "Prior to version 37, multiple columns didn't work with <code>display: table-caption</code> elements."
               }
             ],
             "ie": {
@@ -112,48 +114,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "on_display_table_caption": {
-          "__compat": {
-            "description": "On <code>display: table-caption</code>",
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "37"
-              },
-              "firefox_android": {
-                "version_added": "37"
-              },
-              "ie": {
-                "version_added": "10"
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": true
-              },
-              "safari_ios": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       }

--- a/css/properties/column-width.json
+++ b/css/properties/column-width.json
@@ -38,7 +38,8 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "1.5"
+                "version_added": "1.5",
+                "notes": "Prior to version 37, multiple columns didn't work with <code>display: table-caption</code> elements."
               }
             ],
             "firefox_android": [
@@ -47,7 +48,8 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "4"
+                "version_added": "4",
+                "notes": "Prior to version 37, multiple columns didn't work with <code>display: table-caption</code> elements."
               }
             ],
             "ie": {
@@ -151,54 +153,6 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "on_display_table_caption": {
-          "__compat": {
-            "description": "On <code>display: table-caption</code>",
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": {
-                "version_added": "50"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "37"
-              },
-              "firefox_android": {
-                "version_added": "37"
-              },
-              "ie": {
-                "version_added": "10"
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": true
-              },
-              "safari_ios": {
-                "version_added": true
-              },
-              "samsunginternet_android": {
-                "version_added": "5.0"
-              },
-              "webview_android": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/columns.json
+++ b/css/properties/columns.json
@@ -32,7 +32,8 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "9"
+                "version_added": "9",
+                "notes": "Prior to version 37, multiple columns didn't work with <code>display: table-caption</code> elements."
               }
             ],
             "firefox_android": [
@@ -41,7 +42,8 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "22"
+                "version_added": "22",
+                "notes": "Prior to version 37, multiple columns didn't work with <code>display: table-caption</code> elements."
               }
             ],
             "ie": {
@@ -100,48 +102,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "on_display_table_caption": {
-          "__compat": {
-            "description": "On <code>display: table-caption</code>",
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "37"
-              },
-              "firefox_android": {
-                "version_added": "37"
-              },
-              "ie": {
-                "version_added": "10"
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": true
-              },
-              "safari_ios": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       }


### PR DESCRIPTION
This moves a few the sub feature into a Firefox note, because this isn't really a spec addition or a new sub feature, but just a bug in Firefox. See https://bugzilla.mozilla.org/show_bug.cgi?id=1109571 "All the other browsers, latest versions, display the columns correctly." 

Fixes #4297 

MDN pages
- https://developer.mozilla.org/en-US/docs/Web/CSS/column-count
- https://developer.mozilla.org/en-US/docs/Web/CSS/column-width
- https://developer.mozilla.org/en-US/docs/Web/CSS/columns