### PR TITLE
Add repeating conic gradients; update conic gradients

### DIFF
--- a/css/types/image.json
+++ b/css/types/image.json
@@ -146,15 +146,20 @@
                 "ie": {
                   "version_added": false
                 },
-                "opera": {
-                  "version_added": "46",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable Experimental Web Platform Features"
-                    }
-                  ]
-                },
+                "opera": [
+                  {
+                    "version_added": "56"
+                  },
+                  {
+                    "version_added": "46",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "Enable Experimental Web Platform Features"
+                      }
+                    ]
+                  }
+                ],
                 "opera_android": {
                   "version_added": "48"
                 },
@@ -974,15 +979,20 @@
                 "ie": {
                   "version_added": false
                 },
-                "opera": {
-                  "version_added": "46",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable Experimental Web Platform Features"
-                    }
-                  ]
-                },
+                "opera": [
+                  {
+                    "version_added": "56"
+                  },
+                  {
+                    "version_added": "46",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "Enable Experimental Web Platform Features"
+                      }
+                    ]
+                  }
+                ],
                 "opera_android": {
                   "version_added": "48"
                 },

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -147,7 +147,13 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": "56"
+                  "version_added": "46",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Enable Experimental Web Platform Features"
+                    }
+                  ]
                 },
                 "opera_android": {
                   "version_added": "48"
@@ -920,6 +926,94 @@
                   "standard_track": true,
                   "deprecated": false
                 }
+              }
+            }
+          },
+          "repeating-conic-gradient": {
+            "__compat": {
+              "description": "<code>repeating-conic-gradient()</code>",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/repeating-conic-gradient",
+              "support": {
+                "chrome": [
+                  {
+                    "version_added": "69"
+                  },
+                  {
+                    "version_added": "59",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "Enable Experimental Web Platform Features"
+                      }
+                    ]
+                  }
+                ],
+                "chrome_android": [
+                  {
+                    "version_added": "69"
+                  },
+                  {
+                    "version_added": "59",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "Enable Experimental Web Platform Features"
+                      }
+                    ]
+                  }
+                ],
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "46",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Enable Experimental Web Platform Features"
+                    }
+                  ]
+                },
+                "opera_android": {
+                  "version_added": "48"
+                },
+                "safari": {
+                  "version_added": "12.1"
+                },
+                "safari_ios": {
+                  "version_added": "12.2"
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": [
+                  {
+                    "version_added": "69"
+                  },
+                  {
+                    "version_added": "59",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "Enable Experimental Web Platform Features"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           },

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -160,9 +160,20 @@
                     ]
                   }
                 ],
-                "opera_android": {
-                  "version_added": "48"
-                },
+                "opera_android": [
+                  {
+                    "version_added": "48"
+                  },
+                  {
+                    "version_added": "43",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "Enable Experimental Web Platform Features"
+                      }
+                    ]
+                  }
+                ],
                 "safari": {
                   "version_added": "12.1"
                 },
@@ -993,9 +1004,20 @@
                     ]
                   }
                 ],
-                "opera_android": {
-                  "version_added": "48"
-                },
+                "opera_android": [
+                  {
+                    "version_added": "48"
+                  },
+                  {
+                    "version_added": "43",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "Enable Experimental Web Platform Features"
+                      }
+                    ]
+                  }
+                ],
                 "safari": {
                   "version_added": "12.1"
                 },


### PR DESCRIPTION

Added repeating-conic-gradients() for https://developer.mozilla.org/docs/Web/CSS/repeating-conic-gradient
Updated the behind a flag version for opera
Compared to CanIUse.
Looked at browser releases (Chrome, Opera, Safari)
Tested on Various browsers (still not supported in FF and Samsung. Supported Chrome, Opera). Need to update my OS to update Safari, so not tested, but it's in CanIUse and their release notes that it's supported

