### PR TITLE
Element.json - dblclick supported on IE11 and Edge

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "1"

--- a/api/Element.json
+++ b/api/Element.json
@@ -2387,7 +2387,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "opera": {
               "version_added": null


### PR DESCRIPTION
I have tested the dblclick() event on Internet Explorer 11 on behalf of a self-written program. It has been recognised correctly.