### PR TITLE
SVG textPath : Improve Chrome and Safari compat data

### DIFF
--- a/svg/elements/textpath.json
+++ b/svg/elements/textpath.json
@@ -52,11 +52,11 @@
             "support": {
               "chrome": {
                 "version_added": true,
-                "notes": "Chrome only accepts references to path elements. Basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
+                "notes": "Only accepts references to path elements. Basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
               },
               "chrome_android": {
                 "version_added": true,
-                "notes": "Chrome only accepts references to path elements. Basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
+                "notes": "Only accepts references to path elements. Basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
               },
               "edge": {
                 "version_added": "12"
@@ -78,15 +78,15 @@
               },
               "safari": {
                 "version_added": true,
-                "notes": "Safari only accepts references to path elements. Basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
+                "notes": "Only accepts references to path elements. Basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
               },
               "safari_ios": {
                 "version_added": true,
-                "notes": "Safari only accepts references to path elements. Basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
+                "notes": "Only accepts references to path elements. Basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
               },
               "webview_android": {
                 "version_added": true,
-                "notes": "The Androit webview only accepts references to path elements. Basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
+                "notes": "Only accepts references to path elements. Basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
               }
             },
             "status": {

--- a/svg/elements/textpath.json
+++ b/svg/elements/textpath.json
@@ -52,11 +52,11 @@
             "support": {
               "chrome": {
                 "version_added": true,
-                "notes": "Chrome only accept path element as a valid reference, basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
+                "notes": "Chrome only accepts references to path elements. Basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
               },
               "chrome_android": {
                 "version_added": true,
-                "notes": "Chrome only accept path element as a valid reference, basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
+                "notes": "Chrome only accepts references to path elements. Basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
               },
               "edge": {
                 "version_added": "12"
@@ -78,15 +78,15 @@
               },
               "safari": {
                 "version_added": true,
-                "notes": "Safari only accept path element as a valid reference, basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
+                "notes": "Safari only accepts references to path elements. Basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
               },
               "safari_ios": {
                 "version_added": true,
-                "notes": "Safari only accept path element as a valid reference, basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
+                "notes": "Safari only accepts references to path elements. Basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
               },
               "webview_android": {
                 "version_added": true,
-                "notes": "The Androit webview only accept path element as a valid reference, basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
+                "notes": "The Androit webview only accepts references to path elements. Basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
               }
             },
             "status": {

--- a/svg/elements/textpath.json
+++ b/svg/elements/textpath.json
@@ -51,10 +51,12 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": true,
+                "notes": "Chrome only accept path element as a valid reference, basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": true,
+                "notes": "Chrome only accept path element as a valid reference, basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
               },
               "edge": {
                 "version_added": "12"
@@ -75,13 +77,16 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": true,
+                "notes": "Safari only accept path element as a valid reference, basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": true,
+                "notes": "Safari only accept path element as a valid reference, basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
               },
               "webview_android": {
-                "version_added": true
+                "version_added": true,
+                "notes": "The Androit webview only accept path element as a valid reference, basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
               }
             },
             "status": {
@@ -139,10 +144,10 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
                 "version_added": null
@@ -163,13 +168,13 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
-                "version_added": null
+                "version_added": false
               }
             },
             "status": {


### PR DESCRIPTION
This pull request add some info on how Chrome and Safari actually support the SVG `textPath` element

Tests have been performed with this test case: https://codepen.io/JeremiePat/pen/OKLzKj on MacOS, iOS and Android (I haven't been able to test IE and Edge due to a lack of proper devices)

In summary: Both Chrome and Safari ignore the `path` attribute and both ignore references to basic shapes (this is new in SVG2) (it's hard to find related bugs but I've found this: https://bugs.chromium.org/p/chromium/issues/detail?id=366559 mansionning the lack of support for basic shapes)
