### PR TITLE
Safari (incl. Mobile) supported Event.isTrusted from 10

### DIFF
--- a/api/Event.json
+++ b/api/Event.json
@@ -734,10 +734,10 @@
               "notes": "Starting with Chrome 53 and Opera 40, untrusted events do not invoke the default action."
             },
             "safari": {
-              "version_added": false
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10"
             },
             "webview_android": {
               "version_added": "46",


### PR DESCRIPTION
Amended Event.isTrusted

- Safari supported since v10
- Mobile Safari supported since v10

Documentation
---
https://developer.apple.com/documentation/webkitjs/event/1777991-istrusted

Testing
---
I was testing on iOS 12 Safari and the call responded with *true* to a genuine gesture event and *false* to a Javascript created event. 

Apologies if I am misunderstanding something here! 
