### PR TITLE
Update CSS time types compat data

### DIFF
--- a/css/types/time-percentage.json
+++ b/css/types/time-percentage.json
@@ -7,10 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/time-percentage",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -25,22 +25,22 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "2"
             }
           },
           "status": {

--- a/css/types/time.json
+++ b/css/types/time.json
@@ -7,10 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/time",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -25,22 +25,22 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "2"
             }
           },
           "status": {

--- a/css/types/timing-function.json
+++ b/css/types/timing-function.json
@@ -57,7 +57,7 @@
                 "version_added": "16"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -75,7 +75,7 @@
                 "version_added": "12.1"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "6"
@@ -84,10 +84,10 @@
                 "version_added": "6"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "4.4"
               }
             },
             "status": {
@@ -105,7 +105,7 @@
                 "version_added": "8"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -123,7 +123,7 @@
                 "version_added": "12.1"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "5.1"
@@ -132,7 +132,7 @@
                 "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -173,10 +173,10 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "samsunginternet_android": {
                   "version_added": false


### PR DESCRIPTION
- `css.types.time-percentage` and `css.types.time`:
  - Numbers taken from the first implementation (prefixed) of https://developer.mozilla.org/en-US/docs/Web/CSS/transition as that required specifying a time value
- `css.types.timing-function`: 
  - jump is not yet in Safari: https://bugs.webkit.org/show_bug.cgi?id=190406
  - Other values were derived from the Chrome version.