### PR TITLE
Mark CSS frequency as unsupported

### DIFF
--- a/css/types/frequency-percentage.json
+++ b/css/types/frequency-percentage.json
@@ -7,10 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/frequency-percentage",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": false
@@ -40,7 +40,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": true
+              "version_added": false
             }
           },
           "status": {

--- a/css/types/frequency.json
+++ b/css/types/frequency.json
@@ -7,10 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/frequency",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": false
@@ -40,7 +40,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": true
+              "version_added": false
             }
           },
           "status": {
@@ -54,10 +54,10 @@
             "description": "<code>Hz</code> unit",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": false
               },
               "edge": {
                 "version_added": false
@@ -87,7 +87,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": true
+                "version_added": false
               }
             },
             "status": {
@@ -102,10 +102,10 @@
             "description": "<code>kHz</code> unit",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": false
               },
               "edge": {
                 "version_added": false
@@ -135,7 +135,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": true
+                "version_added": false
               }
             },
             "status": {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/CSS/frequency
https://developer.mozilla.org/en-US/docs/Web/CSS/frequency-percentage

"the \<frequency> data type has been reintroduced in CSS3, though no CSS property is using it at the moment."

I think it makes no sense to have true values here. Every browser should have this set to false.