### PR TITLE
Update CSS ratio data

### DIFF
--- a/css/types/ratio.json
+++ b/css/types/ratio.json
@@ -7,10 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/ratio",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "3"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -31,13 +31,13 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "4.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true


### PR DESCRIPTION
This type basically exists for the aspect-ratio media rule, so it is safe to copy the compat data from there
https://developer.mozilla.org/en-US/docs/Web/CSS/@media/aspect-ratio#Browser_compatibility