### PR TITLE
Remove "applies to HTML" mask features

### DIFF
--- a/css/properties/mask-type.json
+++ b/css/properties/mask-type.json
@@ -73,54 +73,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "applies_to_html": {
-          "__compat": {
-            "description": "Applies to HTML elements",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "20"
-              },
-              "firefox_android": {
-                "version_added": "20"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       }
     }

--- a/css/properties/mask.json
+++ b/css/properties/mask.json
@@ -122,54 +122,6 @@
             "deprecated": false
           }
         },
-        "applies_to_html_elements": {
-          "__compat": {
-            "description": "Applies to HTML elements",
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "3.5"
-              },
-              "firefox_android": {
-                "version_added": "4"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": null
-              },
-              "webview_android": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "shorthand_for_mask_properties": {
           "__compat": {
             "description": "Shorthand for <code>mask-*</code> properties",


### PR DESCRIPTION
I propose to drop the "applies to HTML" features from `css.properties.mask` and `css.properties.mask-type`. Here's my thinking:

* The spec for these properties suggests that the properties act on visual elements and doesn't seem to distinguish between HTML and SVG.
* [A bug filed against WebKit](https://bugs.webkit.org/show_bug.cgi?id=137291) suggests that the situation might be reversed: that HTML elements are ordinarily supported and SVG is the outlier.
* The feature isn't very specific and it's not clear to me how to judge whether or not the data is substantively accurate (e.g., should a value be truthy if the property works with any HTML element, more than one element, or all HTML elements?).
* The features both originated in the data migrated from the old-style tables on MDN. That data is probably not up to our current standards.

My guess is that whomever wrote the original tables on MDN was combining (or confusing) information about the CSS mask properties with [the SVG mask element](https://beta.developer.mozilla.org/en-US/docs/Web/SVG/Element/mask).

This is related to #4305.