### PR TITLE
Update CSS number type data

### DIFF
--- a/css/types/number.json
+++ b/css/types/number.json
@@ -10,7 +10,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -25,22 +25,22 @@
               "version_added": "5"
             },
             "opera": {
-              "version_added": true
+              "version_added": "2"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -57,7 +57,7 @@
                 "version_added": "43"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "43"
               },
               "edge": {
                 "version_added": "12"
@@ -75,19 +75,19 @@
                 "version_added": "30"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "30"
               },
               "safari": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "43"
               }
             },
             "status": {


### PR DESCRIPTION
For scientific_notation, I've found that it appeared in TP 20. We don't have a Safari version that maps here, but we know that TP21 was Safari 11. So, I'm assuming this was in the version before Safari 11 which is 10.1. https://webkit.org/blog/7120/release-notes-for-safari-technology-preview-20/

For the basic number type support, I assume that this very basic functionality was in every browser's first version.