### PR TITLE
Remove mask shorthand feature

### DIFF
--- a/css/properties/mask.json
+++ b/css/properties/mask.json
@@ -121,54 +121,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "shorthand_for_mask_properties": {
-          "__compat": {
-            "description": "Shorthand for <code>mask-*</code> properties",
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "53"
-              },
-              "firefox_android": {
-                "version_added": "53"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": null
-              },
-              "webview_android": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
Like #4509, this removes the `shorthand_for_mask_properties` feature from `css.properties.mask`.

I removed this in part because the spec [defines `mask` as a shorthand property](https://drafts.fxtf.org/css-masking-1/#the-mask); I think the root feature should capture this information. Also, I think the feature itself ambiguous (for example, is this truthy if it's a shorthand for all the supported properties for that browser, or only if it implements all the properties in the spec?).

This closes #4305.