### PR TITLE
Mark IE as not supporting IANA timezones in the timeZone parameter

### DIFF
--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -2568,7 +2568,7 @@
                   "version_added": false
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "nodejs": {
                   "version_added": null


### PR DESCRIPTION
I have tested that IANA time zones are not supported in the timeZone parameter of Internet Explorer.

I tested it with Internet Explorer 11, as can be seen in the following screenshot:
![image](https://user-images.githubusercontent.com/7434508/61538110-b84b9e80-aa06-11e9-9fef-ec4bb7d2d054.png)
