### PR TITLE
Mark RTCRtpTransceiver.stopped as deprecated

### DIFF
--- a/api/RTCRtpTransceiver.json
+++ b/api/RTCRtpTransceiver.json
@@ -331,7 +331,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
This has just been deprecated in the specification. Initial content
changes have been made to note this is incoming and to prepare
developers to switch to the new way to detect stopped transceivers.
Further updates will come when the change is implemented in browsers.

Reference:
* https://github.com/w3c/webrtc-pc/pull/2220

Content changes:
* https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpTransceiver/stopped
* https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpTransceiver/stop
