### PR TITLE
Update OffscreenCanvas.json for `convertToBlob` quirks in Firefox

### DIFF
--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -549,6 +549,7 @@
             },
             "firefox": {
               "version_added": "46",
+              "notes": "In Firefox, <code>convertToBlob</code> is named <code>toBlob</code>.",
               "flags": [
                 {
                   "type": "preference",

--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -534,7 +534,7 @@
           }
         }
       },
-      "toBlob": {
+      "convertToBlob": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OffscreenCanvas/toBlob",
           "support": {
@@ -549,7 +549,7 @@
             },
             "firefox": {
               "version_added": "46",
-              "notes": "In Firefox, <code>convertToBlob</code> is named <code>toBlob</code>.",
+              "alternative_name": "toBlob",
               "flags": [
                 {
                   "type": "preference",
@@ -559,6 +559,7 @@
             },
             "firefox_android": {
               "version_added": "46",
+              "alternative_name": "toBlob",
               "flags": [
                 {
                   "type": "preference",


### PR DESCRIPTION
Firefox (up to) 68.0.1 does not support `OffscreenCanvas.convertToBlob` even `gfx.offscreencanvas.enabled` is set to true. But `OffscreenCanvas.toBlob` looks good.

![image](https://user-images.githubusercontent.com/1622400/61567391-2fe3f280-aa34-11e9-9802-459e274c5ce4.png)

HTML Living Standard reference to `OffscreenCanvas.convertToBlob` can be found here, https://html.spec.whatwg.org/multipage/canvas.html#the-offscreencanvas-interface.

It seems Firefox is confused with `Canvas.toBlob` and `OffscreenCanvas.convertToBlob`. And made the `OffscreenCanvas.toBlob`.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] ~Link to related issues or pull requests, if any~
