### PR TITLE
Set Safari version for api.HTMLCanvasElement.captureStream

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -78,10 +78,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "5.0"


### PR DESCRIPTION
This PR supersedes #4440.  The primary source of data origins from https://github.com/mdn/browser-compat-data/pull/4440#issuecomment-508718858.