### PR TITLE
Clean up Firefox release statuses

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -490,35 +490,35 @@
         "66": {
           "release_date": "2019-03-19",
           "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/66",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "66"
         },
         "67": {
           "release_date": "2019-05-21",
           "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/67",
-          "status": "beta",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "67"
         },
         "68": {
           "release_date": "2019-07-09",
           "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/68",
-          "status": "nightly",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "68"
         },
         "69": {
           "release_date": "2019-09-03",
           "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/69",
-          "status": "planned",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "69"
         },
         "70": {
           "release_date": "2019-10-22",
           "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/70",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "70"
         },

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -420,21 +420,21 @@
         "66": {
           "release_date": "2019-03-19",
           "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/66",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "66"
         },
         "67": {
           "release_date": "2019-05-21",
           "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/67",
-          "status": "beta",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "67"
         },
         "68": {
           "release_date": "2019-07-09",
           "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/68",
-          "status": "nightly",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "68"
         }


### PR DESCRIPTION
The statuses for Firefox releases had fallen out of sync with reality. This fixes Firefox 66 through 70 and Firefox for Android 66 through 68.