### PR TITLE
Add :hover for psuedo-element data for Safari and Chrome

### DIFF
--- a/css/selectors/hover.json
+++ b/css/selectors/hover.json
@@ -189,7 +189,7 @@
                 "version_added": null
               },
               "webview_android": {
-                "version_added": null
+                "version_added": true
               }
             },
             "status": {

--- a/css/selectors/hover.json
+++ b/css/selectors/hover.json
@@ -156,10 +156,10 @@
             "description": "Pseudo-element support",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -180,7 +180,7 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": "2"
               },
               "safari_ios": {
                 "version_added": null


### PR DESCRIPTION
For #4303, this adds data for Safari and Chrome's support of using the `:hover` selector with pseudo-elements (`:after`, `:before`). [WebKit bug 6431](https://bugs.webkit.org/show_bug.cgi?id=6431) suggests this behavior was supported when `:hover` support was added (though there was a brief regression). Since this WebKit behavior long predates Chrome's first release, I've set the Chrome versions to their initial releases.