### PR TITLE
Update :fullscreen selector data for Safari and Chrome

### DIFF
--- a/css/selectors/fullscreen.json
+++ b/css/selectors/fullscreen.json
@@ -96,10 +96,10 @@
             "description": "Select all elements in the fullscreen stack",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
                 "version_added": "12"
@@ -114,13 +114,13 @@
                 "version_added": "11"
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
                 "version_added": false
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
                 "version_added": false
@@ -129,7 +129,7 @@
                 "version_added": null
               },
               "webview_android": {
-                "version_added": null
+                "version_added": false
               }
             },
             "status": {

--- a/css/selectors/fullscreen.json
+++ b/css/selectors/fullscreen.json
@@ -6,14 +6,24 @@
           "description": "<code>:fullscreen</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:fullscreen",
           "support": {
-            "chrome": {
-              "alternative_name": ":-webkit-full-screen",
-              "version_added": "15"
-            },
-            "chrome_android": {
-              "alternative_name": ":-webkit-full-screen",
-              "version_added": "18"
-            },
+            "chrome": [
+              {
+                "version_added": "71"
+              },
+              {
+                "alternative_name": ":-webkit-full-screen",
+                "version_added": "15"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "71"
+              },
+              {
+                "alternative_name": ":-webkit-full-screen",
+                "version_added": "18"
+              }
+            ],
             "edge": {
               "version_added": "12"
             },
@@ -80,10 +90,15 @@
             "samsunginternet_android": {
               "version_added": null
             },
-            "webview_android": {
-              "alternative_name": ":-webkit-full-screen",
-              "version_added": "37"
-            }
+            "webview_android": [
+              {
+                "version_added": "71"
+              },
+              {
+                "alternative_name": ":-webkit-full-screen",
+                "version_added": "37"
+              }
+            ]
           },
           "status": {
             "experimental": true,


### PR DESCRIPTION
For #4303, this PR updates some data for Safari and Chromiums for the `:fullscreen` selector.

* `css.selectors.fullscreen.chrome`: unprefixed in 71, according to https://bugs.chromium.org/p/chromium/issues/detail?id=383813
* `css.selectors.fullscreen.chrome_android`: same as Chrome
* `css.selectors.fullscreen.webview_android`: same as Chrome
* `css.selectors.fullscreen.all_elements.chrome`: tested and failed
* `css.selectors.fullscreen.all_elements.chrome_android`: presumed to be the same as Chrome
* `css.selectors.fullscreen.all_elements.opera`: presumed to be the same as Chrome
* `css.selectors.fullscreen.all_elements.safari`: tested and failed
* `css.selectors.fullscreen.all_elements.webview_android`: presumed to be the same as Chrome
