### PR TITLE
Edge removed support for X-XSS-Protection header

### DIFF
--- a/http/headers/x-xss-protection.json
+++ b/http/headers/x-xss-protection.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true,
+              "version_added": "12",
               "version_removed": "17"
             },
             "firefox": {

--- a/http/headers/x-xss-protection.json
+++ b/http/headers/x-xss-protection.json
@@ -12,7 +12,8 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "17"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
https://scotthelme.co.uk/security-headers-updates/
https://textslashplain.com/2018/11/06/an-update-on-the-edge-xss-filter/

Also planned for removal from Chrome (https://groups.google.com/a/chromium.org/forum/#!msg/blink-dev/TuYw-EZhO9g/blGViehIAwAJ)