### PR TITLE
Update WebGL getContext attribute support for Safari

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -478,6 +478,96 @@
               "deprecated": false
             }
           }
+        },
+        "premultipliedAlpha": {
+          "__compat": {
+            "description": "<code>premultipliedAlpha</code> attribute",
+            "support": {
+              "chrome": {
+                "version_added": "33"
+              },
+              "chrome_android": {
+                "version_added": "33"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "24"
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": "11"
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": "14"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "37"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "preserveDrawingBuffer": {
+          "__compat": {
+            "description": "<code>preserveDrawingBuffer</code> attribute",
+            "support": {
+              "chrome": {
+                "version_added": "33"
+              },
+              "chrome_android": {
+                "version_added": "33"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": "24"
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": "11"
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": "14"
+              },
+              "safari": {
+                "version_added": "5.1"
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "37"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "height": {


### PR DESCRIPTION
- [X] Summarize your changes

Safari has long outstanding compatibility issues. These features are not supported in Safari. Bugs are filed. Some ignored over 8 years. Devs need this info to be able to make informed decisions whether or not to use these features

- [X] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)

https://bugs.webkit.org/show_bug.cgi?id=159608

https://bugs.webkit.org/show_bug.cgi?id=55509 
https://bugs.webkit.org/show_bug.cgi?id=200026

- [X] Data: if you tested something, describe how you tested with details like browser and version

Bugs link to tests

