### PR TITLE
Add Chrome and Safari versions for font-stretch support in font shorthand

### DIFF
--- a/css/properties/font.json
+++ b/css/properties/font.json
@@ -101,10 +101,10 @@
             "description": "Support for <code>font-stretch</code> values in shorthand",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "60"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "60"
               },
               "edge": {
                 "version_added": false
@@ -119,10 +119,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "47"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "44"
               },
               "safari": {
                 "version_added": "11"
@@ -131,10 +131,10 @@
                 "version_added": "11"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "8.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "60"
               }
             },
             "status": {

--- a/css/properties/font.json
+++ b/css/properties/font.json
@@ -125,10 +125,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": false
+                "version_added": "11"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "11"
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
For #4301.

Chromium data is for Chrome 60 and derived from Blink engine number for other browsers: https://bugs.chromium.org/p/chromium/issues/detail?id=331119

Safari data is based on the date of this commit: https://trac.webkit.org/changeset/214324/webkit