### PR TITLE
Update http/headers/content-security-policy.json

### DIFF
--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -318,6 +318,7 @@
           },
           "disown-opener": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/disown-opener",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -358,7 +359,7 @@
               },
               "status": {
                 "experimental": true,
-                "standard_track": true,
+                "standard_track": false,
                 "deprecated": false
               }
             }
@@ -751,6 +752,7 @@
           },
           "navigate-to": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/navigate-to",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -888,6 +890,61 @@
               },
               "status": {
                 "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "prefetch-src": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/prefetch-src",
+              "support": {
+                "chrome": {
+                  "version_added": false,
+                  "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=801561'>bug 801561</a>."
+                },
+                "chrome_android": {
+                  "version_added": false,
+                  "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=801561'>bug 801561</a>."
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false,
+                  "notes": "See <a href='https://bugzil.la/1457204'>bug 1457204</a>."
+                },
+                "firefox_android": {
+                  "version_added": false,
+                  "notes": "See <a href='https://bugzil.la/1457204'>bug 1457204</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false,
+                  "notes": "See <a href='https://bugs.webkit.org/show_bug.cgi?id=185070'>bug 185070</a>."
+                },
+                "safari_ios": {
+                  "version_added": false,
+                  "notes": "See <a href='https://bugs.webkit.org/show_bug.cgi?id=185070'>bug 185070</a>."
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false,
+                  "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=801561'>bug 801561</a>."
+                }
+              },
+              "status": {
+                "experimental": true,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -1299,6 +1356,106 @@
               }
             }
           },
+          "script-src-attr": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/script-src-attr",
+              "support": {
+                "chrome": {
+                  "version_added": "75"
+                },
+                "chrome_android": {
+                  "version_added": "75"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false,
+                  "notes": "See <a href='https://bugzil.la/1529337'>bug 1529337</a>."
+                },
+                "firefox_android": {
+                  "version_added": false,
+                  "notes": "See <a href='https://bugzil.la/1529337'>bug 1529337</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "62"
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": "75"
+                }
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "script-src-elem": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/script-src-elem",
+              "support": {
+                "chrome": {
+                  "version_added": "75"
+                },
+                "chrome_android": {
+                  "version_added": "75"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false,
+                  "notes": "See <a href='https://bugzil.la/1529337'>bug 1529337</a>."
+                },
+                "firefox_android": {
+                  "version_added": false,
+                  "notes": "See <a href='https://bugzil.la/1529337'>bug 1529337</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "62"
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": "75"
+                }
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "strict-dynamic": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#strict-dynamic",
@@ -1390,6 +1547,180 @@
               },
               "status": {
                 "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "style-src-attr": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/style-src-attr",
+              "support": {
+                "chrome": {
+                  "version_added": "75"
+                },
+                "chrome_android": {
+                  "version_added": "75"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false,
+                  "notes": "See <a href='https://bugzil.la/1529338'>bug 1529338</a>."
+                },
+                "firefox_android": {
+                  "version_added": false,
+                  "notes": "See <a href='https://bugzil.la/1529338'>bug 1529338</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "62"
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": "75"
+                }
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "style-src-elem": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/style-src-elem",
+              "support": {
+                "chrome": {
+                  "version_added": "75"
+                },
+                "chrome_android": {
+                  "version_added": "75"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false,
+                  "notes": "See <a href='https://bugzil.la/1529338'>bug 1529338</a>."
+                },
+                "firefox_android": {
+                  "version_added": false,
+                  "notes": "See <a href='https://bugzil.la/1529338'>bug 1529338</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "62"
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": "75"
+                }
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "trusted-types": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types",
+              "support": {
+                "chrome": [
+                  {
+                    "version_added": null
+                  },
+                  {
+                    "version_added": "73",
+                    "version_removed": "76",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#enable-experimental-productivity-features",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
+                "chrome_android": [
+                  {
+                    "version_added": null
+                  },
+                  {
+                    "version_added": "73",
+                    "version_removed": "76",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#enable-experimental-productivity-features",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
+              },
+              "status": {
+                "experimental": true,
                 "standard_track": true,
                 "deprecated": false
               }

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -316,54 +316,6 @@
               }
             }
           },
-          "disown-opener": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/disown-opener",
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "samsunginternet_android": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": false,
-                "deprecated": false
-              }
-            }
-          },
           "font-src": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/font-src",

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -929,11 +929,11 @@
                 },
                 "safari": {
                   "version_added": false,
-                  "notes": "See <a href='https://bugs.webkit.org/show_bug.cgi?id=185070'>bug 185070</a>."
+                  "notes": "See <a href='https://webkit.org/b/185070'>bug 185070</a>."
                 },
                 "safari_ios": {
                   "version_added": false,
-                  "notes": "See <a href='https://bugs.webkit.org/show_bug.cgi?id=185070'>bug 185070</a>."
+                  "notes": "See <a href='https://webkit.org/b/185070'>bug 185070</a>."
                 },
                 "samsunginternet_android": {
                   "version_added": false

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -901,11 +901,11 @@
               "support": {
                 "chrome": {
                   "version_added": false,
-                  "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=801561'>bug 801561</a>."
+                  "notes": "See <a href='https://crbug.com/801561'>bug 801561</a>."
                 },
                 "chrome_android": {
                   "version_added": false,
-                  "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=801561'>bug 801561</a>."
+                  "notes": "See <a href='https://crbug.com/801561'>bug 801561</a>."
                 },
                 "edge": {
                   "version_added": false
@@ -940,7 +940,7 @@
                 },
                 "webview_android": {
                   "version_added": false,
-                  "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=801561'>bug 801561</a>."
+                  "notes": "See <a href='https://crbug.com/801561'>bug 801561</a>."
                 }
               },
               "status": {


### PR DESCRIPTION
# Summary
Update CSP compatibility data: add a few headers that were added to the spec, 

# Details
## `disown-opener`
Mark `disown-opener` as `trandards_track: false` because it was [removed from CSP 3 draft](https://github.com/w3c/webappsec-csp/pull/327).

## `script-src-attr`, `script-src-elem`, `style-src-attr`, `style-src-elem`
[Chrome status](https://chromestatus.com/feature/5141352765456384)
For other browsers see notes in the PR.

## `trusted-types`
 - Chrome 73-76: [origin trials with a flag](https://developers.google.com/web/updates/2019/02/trusted-types), [Chrome status](https://chromestatus.com/feature/5650088592408576)
 - Chrome 77: I do not know result of origin trials and I can't find launch date, leaving `null` for now

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
