### PR TITLE
Fix bad string literal in test-style.js

### DIFF
--- a/test/test-style.js
+++ b/test/test-style.js
@@ -214,7 +214,7 @@ function processData(filename, logger) {
   if (webkitMatch) {
     // use https://webkit.org/b/100000 instead
     hasErrors = true;
-    logger.error(chalk`{red ${indexToPos(actual, webkitMatch.index)} – Use shortenable URL ({yellow ${webkitMatch[0]}} → }{green {bold https://webkit.org/b/}${webkitMatch[1]}}).}`);
+    logger.error(chalk`{red ${indexToPos(actual, webkitMatch.index)} – Use shortenable URL ({yellow ${webkitMatch[0]}} → {green {bold https://webkit.org/b/}${webkitMatch[1]}}).}`);
   }
 
   const mdnUrlMatch = actual.match(String.raw`https?://developer.mozilla.org/(\w\w-\w\w)/(.*?)(?=["'\s])`);


### PR DESCRIPTION
This issue was found during review of #4529.  There was a stray closing bracket ( } ) found in the string literal.  This PR fixes said literal and removes the stray bracket.