### PR TITLE
Firefox does not support linearRampToValueAtTime or exponentialRampToValueAtTime

### DIFF
--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -288,7 +288,9 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "25",
+              "partial_implementation": true,
+              "notes": "Does not work (see <a href='https://bugzil.la/1171438'>bug 1171438</a>)."
             },
             "firefox_android": {
               "version_added": "26"
@@ -336,7 +338,9 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "25",
+              "partial_implementation": true,
+              "notes": "Does not work (see <a href='https://bugzil.la/1171438'>bug 1171438</a>)."
             },
             "firefox_android": {
               "version_added": "26"

--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -288,7 +288,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": false
             },
             "firefox_android": {
               "version_added": "26"
@@ -336,7 +336,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": false
             },
             "firefox_android": {
               "version_added": "26"

--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -290,10 +290,12 @@
             "firefox": {
               "version_added": "25",
               "partial_implementation": true,
-              "notes": "Does not work (see <a href='https://bugzil.la/1171438'>bug 1171438</a>)."
+              "notes": "Does not work (see <a href='https://bugzil.la/1171438'>bug 1171438</a> and <a href='https://bugzil.la/1567777'>bug 1567777</a>)."
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "26",
+              "partial_implementation": true,
+              "notes": "Does not work (see <a href='https://bugzil.la/1171438'>bug 1171438</a> and <a href='https://bugzil.la/1567777'>bug 1567777</a>)."
             },
             "ie": {
               "version_added": false
@@ -340,10 +342,12 @@
             "firefox": {
               "version_added": "25",
               "partial_implementation": true,
-              "notes": "Does not work (see <a href='https://bugzil.la/1171438'>bug 1171438</a>)."
+              "notes": "Does not work (see <a href='https://bugzil.la/1171438'>bug 1171438</a> and <a href='https://bugzil.la/1567777'>bug 1567777</a>)."
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "26",
+              "partial_implementation": true,
+              "notes": "Does not work (see <a href='https://bugzil.la/1171438'>bug 1171438</a> and <a href='https://bugzil.la/1567777'>bug 1567777</a>)."
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
linearRampToValueAtTime and exponentialRampToValueAtTime compatibility in Firefox set to false. 

Firefox does not support linearRampToValueAtTime or exponentialRampToValueAtTime and has not supported them for at least three years. The methods are there but they do not work / are not implemented. 
Source:
https://bugzilla.mozilla.org/show_bug.cgi?id=1567777
https://bugzilla.mozilla.org/show_bug.cgi?id=1171438

