### PR TITLE
Update Safari and Chrome data for font-variant with i/I in Turkic languages

### DIFF
--- a/css/properties/font-variant.json
+++ b/css/properties/font-variant.json
@@ -125,10 +125,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "8"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "8"
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/css/properties/font-variant.json
+++ b/css/properties/font-variant.json
@@ -101,10 +101,10 @@
             "description": "<code>i</code> → <code>İ</code> and <code>ı</code> → <code>I</code>",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "31"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "31"
               },
               "edge": {
                 "version_added": "12"


### PR DESCRIPTION
For #4301, this updates the `font-variant` data for dotted and dotless i`/`I` characters.

Safari data was based on this changeset and the corresponding WebKit engine numbers:
https://trac.webkit.org/changeset/156948/webkit

Chrome data was based on this commit (itself a port of the WebKit change) and Chrome release dates: https://bugs.chromium.org/p/chromium/issues/detail?id=304911#c7