### PR TITLE
Update CSS <angle> compat data

### DIFF
--- a/css/types/angle-percentage.json
+++ b/css/types/angle-percentage.json
@@ -10,7 +10,7 @@
               "version_added": "2"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -25,22 +25,22 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "2"
             }
           },
           "status": {
@@ -57,7 +57,7 @@
                 "version_added": "2"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -72,22 +72,22 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "4"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "3.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "2"
               }
             },
             "status": {
@@ -105,7 +105,7 @@
                 "version_added": "2"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -120,22 +120,22 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "4"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "3.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "2"
               }
             },
             "status": {
@@ -153,7 +153,7 @@
                 "version_added": "2"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -168,22 +168,22 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "4"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "3.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "2"
               }
             },
             "status": {
@@ -198,40 +198,40 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/angle#turn",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "2"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "13"
+                "version_added": "3.6"
               },
               "firefox_android": {
-                "version_added": "14"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "14"
               },
               "safari": {
-                "version_added": "10"
+                "version_added": "4"
               },
               "safari_ios": {
-                "version_added": "10"
+                "version_added": "3.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "2"
               }
             },
             "status": {

--- a/css/types/angle.json
+++ b/css/types/angle.json
@@ -10,7 +10,7 @@
               "version_added": "2"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -25,22 +25,22 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "2"
             }
           },
           "status": {
@@ -57,7 +57,7 @@
                 "version_added": "2"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -72,22 +72,22 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "4"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "3.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "2"
               }
             },
             "status": {
@@ -105,7 +105,7 @@
                 "version_added": "2"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -120,22 +120,22 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "4"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "3.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "2"
               }
             },
             "status": {
@@ -153,7 +153,7 @@
                 "version_added": "2"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -168,22 +168,22 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "4"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "3.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "2"
               }
             },
             "status": {
@@ -198,10 +198,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/angle#turn",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "2"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -216,22 +216,22 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "14"
               },
               "safari": {
-                "version_added": "10"
+                "version_added": "4"
               },
               "safari_ios": {
-                "version_added": "10"
+                "version_added": "3.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "2"
               }
             },
             "status": {


### PR DESCRIPTION
For `turn` I found https://trac.webkit.org/changeset/38959/webkit for Safari, so instead of Safari 10, it was already there in Safari 4.

The other updates are just to complete the remaining data in the file and it is derived from the Chrome or Safari version that was already in the data.