### PR TITLE
Update <blend-mode> compat data

### DIFF
--- a/css/types/blend-mode.json
+++ b/css/types/blend-mode.json
@@ -28,13 +28,13 @@
               "version_added": "22"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "22"
             },
             "safari": {
-              "version_added": null
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": "7.0"


### PR DESCRIPTION
Updates this table https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode#Browser_Compatibility to use the Safari values from this table: https://developer.mozilla.org/en-US/docs/Web/CSS/background-blend-mode#Browser_compatibility

Also added Opera Android version while I was there.