### PR TITLE
Update webkit-scrollbar-corner compat data

### DIFF
--- a/css/selectors/-webkit-scrollbar-corner.json
+++ b/css/selectors/-webkit-scrollbar-corner.json
@@ -7,10 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-webkit-scrollbar-corner",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "2"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": false,
@@ -37,10 +37,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
Was forgotten in https://github.com/mdn/browser-compat-data/pull/4402
(listed in the description even but apparently the file wasn't updated then)