### PR TITLE
Optional chaining operator addition -stage 3

### DIFF
--- a/javascript/operators/optional_chaining.json
+++ b/javascript/operators/optional_chaining.json
@@ -1,0 +1,60 @@
+{
+  "javascript": {
+    "operators": {
+      "optional_chaining": {
+        "__compat": {
+          "description": "Optional chaining operator (<code>?.</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Optional_chaining",
+          "spec_url": "https://tc39.es/proposal-optional-chaining/#top",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}
+  


### PR DESCRIPTION
- Addition of the new (stage 3) operator `?.`
- Data: tested on Firefox Release / Nightly, Chrome Release / Canary, node 12.4, IE 11 (up to date), Edge (up to date). I was not able to test on macOS/iOS so I put `null` instead of false.
  - That being written, I'm not aware of any implementation note from Apple.
- Linting: no lint issue got when `npm test`ed