### PR TITLE
`dateTime` property is camel-cased

### DIFF
--- a/api/HTMLModElement.json
+++ b/api/HTMLModElement.json
@@ -95,9 +95,9 @@
           }
         }
       },
-      "datetime": {
+      "dateTime": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLModElement/datetime",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLModElement/dateTime",
           "support": {
             "chrome": {
               "version_added": true


### PR DESCRIPTION
Fix typo (<code>date<del>t</del><ins>T</ins>ime</code>).

`HTMLModElement`'s `dateTime` property reflects the `datetime` content attribute, but with a camel-cased name (like `HTMLTimeElement`). [[1]](https://html.spec.whatwg.org/multipage/edits.html#dom-mod-datetime)