### PR TITLE
Remove old paragraph from partial impl. section

### DIFF
--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -308,14 +308,8 @@ Example for two flags required:
 
 #### `partial_implementation`
 A `boolean` value indicating whether or not the implementation of the sub-feature
-follows the current specification closely enough to not create major interoperability problems.
-It defaults to `false` (no interoperability problem expected).
-If set to `true`, it is recommended to add a note indicating how it diverges from
-the standard (implements an old version of the standard, for example).
-
-A `boolean` value indicating whether or not the implementation of the sub-feature
-deviates from the specification in a way that may cause compatibility problems. It
-defaults to `false` (no interoperability problems expected). If set to `true`, it is
+deviates from the specification in a way that may cause significant compatibility problems.
+It defaults to `false` (no interoperability problems expected). If set to `true`, it is
 recommended that you add a note explaining how it diverges from the standard (such as
 that it implements an old version of the standard, for example).
 


### PR DESCRIPTION
Under `partial_implementation`, the first and second paragraphs are nearly
identical. This is because the second one was added to replace the first,
in order to improve the description of the value (the old text made it easy
to reverse the presumed meaning of the value). Somehow, the original
paragraph did not get removed when the rewrite was added. This PR deletes
the older version of the paragraph and tidies the new paragraph just a
little bit more.