### PR TITLE
Mirror font-variant data to text-transform for Turkic I characters

### DIFF
--- a/css/properties/text-transform.json
+++ b/css/properties/text-transform.json
@@ -347,10 +347,10 @@
             "description": "<code>i</code> → <code>İ</code> and <code>ı</code> → <code>I</code>",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "31"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "31"
               },
               "edge": {
                 "version_added": "12"
@@ -371,10 +371,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "8"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "8"
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
For #4301, this mirrors the changes from #4543 front `font-variant` to `text-transform`.