### PR TITLE
Update font-variant and text-transform ß (eszett, sharp s) daa

### DIFF
--- a/css/properties/font-variant.json
+++ b/css/properties/font-variant.json
@@ -53,28 +53,34 @@
             "description": "<code>ß</code> → <code>SS</code>",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": false,
+                "notes": "Some operating systems may capitalize <code>ß</code> as <code>SS</code>."
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": false,
+                "notes": "Some operating systems may capitalize <code>ß</code> as <code>SS</code>."
               },
               "edge": {
                 "version_added": false
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": false,
+                "notes": "Some operating systems may capitalize <code>ß</code> as <code>SS</code>."
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": false,
+                "notes": "Some operating systems may capitalize <code>ß</code> as <code>SS</code>."
               },
               "ie": {
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": false,
+                "notes": "Some operating systems may capitalize <code>ß</code> as <code>SS</code>."
               },
               "opera_android": {
-                "version_added": true
+                "version_added": false,
+                "notes": "Some operating systems may capitalize <code>ß</code> as <code>SS</code>."
               },
               "safari": {
                 "version_added": false
@@ -83,10 +89,12 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": false,
+                "notes": "Some operating systems may capitalize <code>ß</code> as <code>SS</code>."
               },
               "webview_android": {
-                "version_added": true
+                "version_added": false,
+                "notes": "Some operating systems may capitalize <code>ß</code> as <code>SS</code>."
               }
             },
             "status": {

--- a/css/properties/text-transform.json
+++ b/css/properties/text-transform.json
@@ -395,10 +395,10 @@
             "description": "<code>ß</code> → <code>SS</code>",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "18"
@@ -413,22 +413,22 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "7"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "11"
               },
               "safari": {
-                "version_added": false
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {


### PR DESCRIPTION
For #4301, I've updated the data for capitalizing ß (eszett, sharp s) characters.

This is a werid one and I tried my best to capture what I could. I did several tests with Chrome, Firefox, and Safari on my Mac, and several more tests on SauceLabs. All the changes here come from direct testing, except for inference on the non-Google Chromium-derived browsers and Safari for iOS. Ultimately, I had to make some compromises and guesses.

## `font-variant`

`font-variant` seems to handle uppercase eszetts wrongly more often than not. Most of the time, my testing seemed to show that the feature works in some environments (e.g., Firefox on Mac, Chrome on a Google Pixel phone), but not on others (e.g., Firefox on Windows, Chrome in the Android emulator); of course, a few didn't work at all (Safari).

Since it seemed to vary from platform to platform, I put a note to indicate that it might work, but I still marked support as `false`. I chose `false` for two reasons: a guess that the behavior is probably dependent on some system APIs that has nothing to do with the browser version and the impracticality of finding which versions supported this feature, since it seems to be a long-standing issue.

## `text-transform`

`text-transform` is much more reliable. In most cases, I was able to test that a browser consistently capitalized the character without regard for the operating system (for a given browser).

That said, I wasn't actually sure what version first introduced this feature. I tested with the oldest browser I could and they behaved as expected (except Edge). In these cases, I have decided to assume that this feature appeared at the same time as `text-transform` itself.