### PR TITLE
Update align_items.start_end for Chrome & Safari

### DIFF
--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -224,10 +224,10 @@
               "description": "<code>start</code> and <code>end</code>",
               "support": {
                 "chrome": {
-                  "version_added": "57"
+                  "version_added": false
                 },
                 "chrome_android": {
-                  "version_added": "57"
+                  "version_added": false
                 },
                 "edge": {
                   "version_added": false
@@ -248,16 +248,16 @@
                   "version_added": "43"
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "samsunginternet_android": {
                   "version_added": true
                 },
                 "webview_android": {
-                  "version_added": "57"
+                  "version_added": false
                 }
               },
               "status": {


### PR DESCRIPTION
Changes:
Updated `css.properties.align-items.flex_context.start_end` for Chrome & Safari

Test case: https://codepen.io/anon/pen/voxqrd

Tested in Chrome 75
![image](https://user-images.githubusercontent.com/21784/62142303-12c4e480-b2bc-11e9-8f4f-f50ec738f096.png)
Tested in Chrome Android 75
Tested in Safari 12.1.2
Tested in Safari iOS 12.1

Related issue: https://github.com/mdn/browser-compat-data/issues/4298