### PR TITLE
Update template literal revision compat data

### DIFF
--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -814,7 +814,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "9.0.0"
               },
               "opera": {
                 "version_added": "49"
@@ -823,10 +823,10 @@
                 "version_added": "46"
               },
               "safari": {
-                "version_added": false
+                "version_added": "11"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "11"
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -814,7 +814,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "9.0.0"
+                "version_added": "8.10.0"
               },
               "opera": {
                 "version_added": "49"


### PR DESCRIPTION
### Update template literal revision compatibility data for Node.js and Safari

Node.js 8.10.0 uses [V8 6.2](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V8.md#8.10.0), which [supports template literal revision](https://v8.dev/blog/v8-release-62#template-literal-revision).

Safari (and Safari on iOS) supports it since 11.0. Support was introduced in [this changeset](https://trac.webkit.org/changeset/211319/webkit), but included in Safari in 11.0 (can be verified eg. by looking at https://trac.webkit.org/browser/webkit/releases/Apple/iOS%2011.0/JavaScriptCore/parser/Lexer.cpp#L647)
