### PR TITLE
Safari has always supported Request.prototype.url

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -1522,10 +1522,10 @@
               "notes": "Fragment support added in Opera 46."
             },
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": "4.0"


### PR DESCRIPTION
According the the [trac](https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/Modules/fetch/FetchRequest.idl?rev=195954) the property has been defined in Safari since the Fetch API was first implemented.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
