### PR TITLE
add dates to browsers: opera-android and safari-ios 

### DIFF
--- a/browsers/opera_android.json
+++ b/browsers/opera_android.json
@@ -18,13 +18,14 @@
           "engine_version": "2.7"
         },
         "11.1": {
-          "release_date": "2011-06-30",
+          "release_date": "2011-04-11",
           "release_notes": "https://dev.opera.com/blog/opera-mobile-11-1-new-features-and-additions/",
           "status": "retired",
           "engine": "Presto",
           "engine_version": "2.8"
         },
         "11.5": {
+          "release_date": "2011-06-28",
           "status": "retired",
           "engine": "Presto",
           "engine_version": "2.9"
@@ -51,16 +52,19 @@
           "engine_version": "26"
         },
         "15": {
+          "release_date": "2013-07-02",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "28"
         },
         "16": {
+          "release_date": "2013-08-26",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "29"
         },
         "18": {
+          "release_date": "2013-09-13",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "31"

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -6,142 +6,170 @@
         "1": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "522.11"
+          "engine_version": "522.11",
+          "release_date": "2007-06-29"
         },
         "2": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "525.18"
+          "engine_version": "525.18",
+          "release_date": "2008-07-11"
         },
         "3": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "528.18"
+          "engine_version": "528.18",
+          "release_date": "2009-06-17"
         },
         "3.1": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "528.18"
+          "engine_version": "528.18",
+          "release_date": "2009-09-09"
         },
         "3.2": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "531.21"
+          "engine_version": "531.21",
+          "release_date": "2010-04-03"
         },
         "4": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "532.9"
+          "engine_version": "532.9",
+          "release_date": "2010-06-21"
         },
         "4.2": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "533.17"
+          "engine_version": "533.17",
+          "release_date": "2010-10-17"
         },
         "4.3": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "533.17"
+          "engine_version": "533.17",
+          "release_date": "2011-03-09"
         },
         "5": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "534.46"
+          "engine_version": "534.46",
+          "release_date": "2011-10-12"
         },
         "5.1": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "534.46"
+          "engine_version": "534.46",
+          "release_date": "2012-03-07"
         },
         "6": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "536.26"
+          "engine_version": "536.26",
+          "release_date": "2012-09-10"
         },
         "6.1": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "536.26"
+          "engine_version": "536.26",
+          "release_date": "2013-01-28"
         },
         "7": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "537.51"
+          "engine_version": "537.51",
+          "release_date": "2013-09-18"
         },
         "7.1": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "537.51"
+          "engine_version": "537.51",
+          "release_date": "2014-03-10"
         },
         "8": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "600.1"
+          "engine_version": "600.1",
+          "release_date": "2014-09-17"
         },
         "8.1": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "600.1"
+          "engine_version": "600.1",
+          "release_date": "2014-10-20"
         },
         "8.4": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "600.1"
+          "engine_version": "600.1",
+          "release_date": "2015-06-30"
         },
         "9": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "601.1"
+          "engine_version": "601.1",
+          "release_date": "2015-09-16"
         },
         "9.1": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "601.1"
+          "engine_version": "601.1",
+          "release_date": "2015-10-21"
         },
         "9.2": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "601.1"
+          "engine_version": "601.1",
+          "release_date": "2015-12-08"
         },
         "9.3": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "601.1"
+          "engine_version": "601.1",
+          "release_date": "2016-03-21"
         },
         "10": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "602.1.50"
+          "engine_version": "602.1.50",
+          "release_date": "2016-09-13"
         },
         "10.1": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "602.2"
+          "engine_version": "602.2",
+          "release_date": "2016-10-24"
         },
         "10.2": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "602.4"
+          "engine_version": "602.4",
+          "release_date": "2016-12-12"
         },
         "10.3": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "603.2.1"
+          "engine_version": "603.2.1",
+          "release_date": "2017-03-27"
         },
         "11": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "604.2.4"
+          "engine_version": "604.2.4",
+          "release_date": "2017-09-19"
         },
         "11.1": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "604.3.5"
+          "engine_version": "604.3.5",
+          "release_date": "2017-10-31"
         },
         "11.3": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "605.1.33"
+          "engine_version": "605.1.33",
+          "release_date": "2018-03-29"
         },
         "12": {
           "release_date": "2018-09-17",


### PR DESCRIPTION
add dates to browsers: opera-android and safari-ios 


links of resources used are in commit notes

maybe related: #1951
#2006


tested gave empty result, no browsers without date
bcd = require('mdn-browser-compat-data');


Object.keys(bcd.browsers).map( name=>{ console.log ( name, Object.keys(bcd.browsers[name].releases).reduce((state,ver)=>{var obj=bcd.browsers[name].releases[ver]; obj.version=ver; if(obj.release_date)obj.release_date=new Date(); state.push(obj); return state; },[]).filter((a)=>{ return ! (a.release_date||a.status=='beta'||a.status=='nightly'); return d.getTime()>todate.getTime() }) ) })
