### PR TITLE
Added stable sub-feature for Array.prototype.sort.

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -1758,6 +1758,42 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "stable": {
+            "__compat": {
+              "description": "Stable",
+              "support": {
+                "chrome": {
+                  "version_added": "70"
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "3"
+                },
+                "firefox_android": {
+                  "version_added": "4"
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "nodejs": {
+                  "version_added": "12.0.0"
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         },
         "splice": {

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -1766,6 +1766,9 @@
                 "chrome": {
                   "version_added": "70"
                 },
+                "chrome_android": {
+                  "version_added": "70"
+                },
                 "edge": {
                   "version_added": true
                 },
@@ -1786,6 +1789,9 @@
                 },
                 "safari": {
                   "version_added": null
+                },
+                "webview_android": {
+                  "version_added": "70"
                 }
               },
               "status": {

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -1770,7 +1770,7 @@
                   "version_added": "70"
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "3"
@@ -1779,7 +1779,7 @@
                   "version_added": "4"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "nodejs": {
                   "version_added": "12.0.0"

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -1761,7 +1761,7 @@
           },
           "stable": {
             "__compat": {
-              "description": "Stable",
+              "description": "Stable sorting",
               "support": {
                 "chrome": {
                   "version_added": "70"


### PR DESCRIPTION
According to [the current ECMAScript spec][ecmascript-sort] (and since [version 10][ecmascript-10-sort]), `Array.prototype.sort` must be stable.

It seems sorting has been stable in Firefox since version 3 ([bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=224128)). I assume this means it has been in Firefox for Android since its birth.

Sorting is currently stable in V8, and [according to v8.dev](https://v8.dev/features/stable-sort) it has landed in Chrome 70 and Node.js 12. However, it seems Node.js 11 includes V8 7.0 ([changelog of Node.js](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V11.md#11.0.0)). So it might have landed as early as Node.js 11.

Sorting is currently stable in Chakra Core ([PR #5724 in ChakraCore](https://github.com/microsoft/ChakraCore/pull/5724)), but I can't find in which version of Edge this landed.

According to [a post on StackOverflow](https://stackoverflow.com/a/3027715), sorting has been stable in Opera since 10, Safari since 4, and IE since 6, but I have no other sources to back up these claims.


[ecmascript-sort]: https://tc39.es/ecma262/#sec-array.prototype.sort
[ecmascript-10-sort]: https://www.ecma-international.org/ecma-262/10.0/#sec-array.prototype.sort