### PR TITLE
Firefox 69: navigator.mediaDevices requires secure context

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1330,12 +1330,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false,
-                "notes": "Release, Beta, and Developer Edition builds of Firefox do not require a secure context by default; however, Nightly builds do."
+                "version_added": "69"
               },
               "firefox_android": {
-                "version_added": false,
-                "notes": "Release, Beta, and Developer Edition builds of Firefox do not require a secure context by default; however, Nightly builds do."
+                "version_added": false
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
In Firefox 68, only Nightly required a secure context; this is now cross all channels.

https://bugzilla.mozilla.org/show_bug.cgi?id=1528031
