### PR TITLE
Firefox 69: Add deviceId/facingMode/groupId to track settings

### DIFF
--- a/api/MediaTrackConstraints.json
+++ b/api/MediaTrackConstraints.json
@@ -251,7 +251,7 @@
             },
             "firefox": {
               "version_added": "36",
-              "notes": "Firefox supports <code>deviceId</code> in constraints passed into <code>getUserMedia()</code> in Firefox 36, but otherwise not until Firefox 69."
+              "notes": "Prior to Firefox 69, Firefox only supported <code>deviceId</code> in constraints passed into <code>getUserMedia()</code>."
             },
             "firefox_android": {
               "version_added": "36",

--- a/api/MediaTrackConstraints.json
+++ b/api/MediaTrackConstraints.json
@@ -250,10 +250,12 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "50"
+              "version_added": "36",
+              "notes": "Firefox supports <code>deviceId</code> in constraints passed into <code>getUserMedia()</code> in Firefox 36, but otherwise not until Firefox 69."
             },
             "firefox_android": {
-              "version_added": "50"
+              "version_added": "36",
+              "notes": "Firefox for Android only supports <code>deviceId</code> when used in constraints passed into <code>getUserMedia()</code>."
             },
             "ie": {
               "version_added": false

--- a/api/MediaTrackSettings.json
+++ b/api/MediaTrackSettings.json
@@ -252,10 +252,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "36"
+              "version_added": "69"
             },
             "firefox_android": {
-              "version_added": "36"
+              "version_added": false
             },
             "ie": {
               "version_added": null
@@ -387,10 +387,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "36"
+              "version_added": "69"
             },
             "firefox_android": {
-              "version_added": "36"
+              "version_added": false
             },
             "ie": {
               "version_added": null
@@ -477,7 +477,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "69"
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
Starting in Firefox 69, these three members of the MediaTrackSettings
object are set on return from `getSettings()`.

Sources:
* https://bugzilla.mozilla.org/show_bug.cgi?id=1398180
* https://bugzilla.mozilla.org/show_bug.cgi?id=1537986
