### PR TITLE
DocumentFragment constructor at safari

### DIFF
--- a/api/DocumentFragment.json
+++ b/api/DocumentFragment.json
@@ -80,7 +80,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/DocumentFragment.json
+++ b/api/DocumentFragment.json
@@ -77,7 +77,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": null

--- a/api/DocumentFragment.json
+++ b/api/DocumentFragment.json
@@ -77,7 +77,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": true
             },
             "safari_ios": {
               "version_added": null


### PR DESCRIPTION
Empirically tested `new DocumentFragment()` this works on quite an old safari.

