### PR TITLE
Update image/gradient data

### DIFF
--- a/css/types/image.json
+++ b/css/types/image.json
@@ -7,10 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -25,22 +25,22 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "2"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -53,13 +53,24 @@
           "__compat": {
             "description": "<code>&lt;gradient&gt;</code>",
             "support": {
-              "chrome": {
-                "prefix": "-webkit-",
-                "version_added": true
-              },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome": [
+                {
+                  "version_added": "26"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "10"
+                }
+              ],
+              "chrome_android": [
+                {
+                  "version_added": "26"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "18"
+                }
+              ],
               "edge": {
                 "prefix": "-ms-",
                 "version_added": "12"
@@ -76,18 +87,43 @@
                 "prefix": "-ms-",
                 "version_added": "10"
               },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": true
-              },
-              "safari_ios": {
-                "version_added": true
-              },
+              "opera": [
+                {
+                  "version_added": "12.1"
+                },
+                {
+                  "prefix": "-o-",
+                  "version_added": "11",
+                  "version_removed": "15"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "15"
+                }
+              ],
+              "opera_android": [
+                {
+                  "version_added": "12.1"
+                },
+                {
+                  "prefix": "-o-",
+                  "version_added": "11",
+                  "version_removed": "14"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "14"
+                }
+              ],
+              "safari": [
+                {
+                  "version_added": "6.1"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "5.1"
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": true
               },

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -1783,10 +1783,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
Updated for https://developer.mozilla.org/en-US/docs/Web/CSS/image#Browser_compatibility

I've considered `css.types.image` as a basic feature that every browser supports in the first version.

For `css.types.image.gradient`, I've derived the support from linear-gradient as that seems to be the first gradient supported and so that's when the gradient type was introduced first, too.

The `css.types.image.image` feature seems to be supported nowhere yet.

Completes three more items on #4304