### PR TITLE
Update CSS ex unit support

### DIFF
--- a/css/types/length-percentage.json
+++ b/css/types/length-percentage.json
@@ -154,10 +154,10 @@
             "description": "<code>ex</code> unit",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -172,22 +172,22 @@
                 "version_added": "4"
               },
               "opera": {
-                "version_added": true
+                "version_added": "2"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "11"
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -154,10 +154,10 @@
             "description": "<code>ex</code> unit",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -172,22 +172,22 @@
                 "version_added": "4"
               },
               "opera": {
-                "version_added": true
+                "version_added": "2"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "11"
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {


### PR DESCRIPTION
This part of CSS 2.1 and I've seen it quite ancient docs. My assumption is that is was supported from very early on hence I've set this to the first browser versions.

Completes two more items on https://github.com/mdn/browser-compat-data/issues/4304