### PR TITLE
Drop '1in is always 96px'

### DIFF
--- a/css/types/length-percentage.json
+++ b/css/types/length-percentage.json
@@ -792,54 +792,6 @@
               "deprecated": false
             }
           }
-        },
-        "1in_is_96px": {
-          "__compat": {
-            "description": "<code>1in</code> is always equal to <code>96px</code>",
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "4"
-              },
-              "firefox_android": {
-                "version_added": "4"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       }
     }

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -794,54 +794,6 @@
               "deprecated": false
             }
           }
-        },
-        "1in_is_96px": {
-          "__compat": {
-            "description": "<code>1in</code> is always equal to <code>96px</code>",
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "4"
-              },
-              "firefox_android": {
-                "version_added": "4"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
In our length docs, the compat table says "1in is always equal to 96px" https://developer.mozilla.org/en-US/docs/Web/CSS/length

This stackoverflow answer convinces me that this statement is not _always_ true https://stackoverflow.com/a/40544791. It depends on type of device and I think it is impossible for us to figure out reliable compat data (which, likely, without resolution type, makes no sense).

I'm proposing to drop this from our data.