### PR TITLE
Update CSS calc Safari support

### DIFF
--- a/css/types/calc.json
+++ b/css/types/calc.json
@@ -124,10 +124,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": null
+                "version_added": "6"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "6"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -175,7 +175,7 @@
                 "version_added": "6"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "6"
               },
               "samsunginternet_android": {
                 "version_added": null
@@ -220,10 +220,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": "11"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "11"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -268,10 +268,10 @@
                 "version_added": "18"
               },
               "safari": {
-                "version_added": null
+                "version_added": "6"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "6"
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
Last PR for https://github.com/mdn/browser-compat-data/issues/4304

- css.types.calc.color_values worked for me in Safari 8 in Saucelabs, I assume it also worked in the initial implementation (Safari 6).
-  css.types.calc.nested works for me in starting with Safari 11 (tested in Saucelabs)
-  css.types.calc.number_values works for me also in Safari 8. Here I also assume it was part of the initial implementation in Safari 6. It can be tested with line-height which accepts number values. It seems like this row was added because Gecko was the outlier here and didn't implemented this from the start (https://bugzilla.mozilla.org/show_bug.cgi?id=594933).
