### PR TITLE
Derive chrome_android CSS data from chrome

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -10,7 +10,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -57,7 +57,7 @@
                 "version_added": "6"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -548,7 +548,7 @@
                 "version_added": "4"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"

--- a/css/at-rules/viewport.json
+++ b/css/at-rules/viewport.json
@@ -635,6 +635,9 @@
               "chrome": {
                 "version_added": false
               },
+              "chrome_android": {
+                "version_added": false
+              },
               "edge": {
                 "version_added": false
               },

--- a/css/properties/-webkit-box-reflect.json
+++ b/css/properties/-webkit-box-reflect.json
@@ -9,7 +9,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": false

--- a/css/properties/animation-direction.json
+++ b/css/properties/animation-direction.json
@@ -170,7 +170,7 @@
                 "version_added": "19"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "25"
               },
               "edge": {
                 "version_added": "12"
@@ -215,7 +215,7 @@
                 "version_added": "19"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "25"
               },
               "edge": {
                 "version_added": "12"

--- a/css/properties/animation-duration.json
+++ b/css/properties/animation-duration.json
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "18"
               }
             ],
             "edge": [

--- a/css/properties/background-attachment.json
+++ b/css/properties/background-attachment.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -56,7 +56,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -104,7 +104,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"

--- a/css/properties/background-color.json
+++ b/css/properties/background-color.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -58,7 +58,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -108,7 +108,7 @@
                 "notes": "Some versions support only experimental gradients prefixed with <code>-webkit</code>."
               },
               "chrome_android": {
-                "version_added": true,
+                "version_added": "18",
                 "notes": "Some versions support only experimental gradients prefixed with <code>-webkit</code>."
               },
               "edge": {
@@ -163,7 +163,7 @@
                 "version_added": "8"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -317,7 +317,7 @@
               },
               "chrome_android": {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "25"
               },
               "edge": {
                 "version_added": false

--- a/css/properties/background-origin.json
+++ b/css/properties/background-origin.json
@@ -17,7 +17,7 @@
             ],
             "chrome_android": [
               {
-                "version_added": true
+                "version_added": "18"
               },
               {
                 "version_added": "18",

--- a/css/properties/background-position.json
+++ b/css/properties/background-position.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -56,7 +56,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -104,7 +104,7 @@
                 "version_added": "25"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "25"
               },
               "edge": {
                 "version_added": "12"

--- a/css/properties/background-size.json
+++ b/css/properties/background-size.json
@@ -17,10 +17,10 @@
             ],
             "chrome_android": [
               {
-                "version_added": true
+                "version_added": "18"
               },
               {
-                "version_added": true,
+                "version_added": "18",
                 "prefix": "-webkit-",
                 "notes": "WebKit-based browsers originally implemented an older draft of CSS3 <code>background-size</code> in which an omitted second value is treated as duplicating the first value; this draft does not include the <code>contain</code> or <code>cover</code> keywords."
               }

--- a/css/properties/border-block-end-color.json
+++ b/css/properties/border-block-end-color.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "69"
             },
+            "chrome_android": {
+              "version_added": "69"
+            },
             "edge": {
               "version_added": false
             },

--- a/css/properties/border-block-end-style.json
+++ b/css/properties/border-block-end-style.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "69"
             },
+            "chrome_android": {
+              "version_added": "69"
+            },
             "edge": {
               "version_added": false
             },

--- a/css/properties/border-block-end-width.json
+++ b/css/properties/border-block-end-width.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "69"
             },
+            "chrome_android": {
+              "version_added": "69"
+            },
             "edge": {
               "version_added": false
             },

--- a/css/properties/border-block-end.json
+++ b/css/properties/border-block-end.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "69"
             },
+            "chrome_android": {
+              "version_added": "69"
+            },
             "edge": {
               "version_added": false
             },

--- a/css/properties/border-block-start-color.json
+++ b/css/properties/border-block-start-color.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "69"
             },
+            "chrome_android": {
+              "version_added": "69"
+            },
             "edge": {
               "version_added": false
             },

--- a/css/properties/border-block-start-style.json
+++ b/css/properties/border-block-start-style.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "69"
             },
+            "chrome_android": {
+              "version_added": "69"
+            },
             "edge": {
               "version_added": false
             },

--- a/css/properties/border-block-start-width.json
+++ b/css/properties/border-block-start-width.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "69"
             },
+            "chrome_android": {
+              "version_added": "69"
+            },
             "edge": {
               "version_added": false
             },

--- a/css/properties/border-block-start.json
+++ b/css/properties/border-block-start.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "69"
             },
+            "chrome_android": {
+              "version_added": "69"
+            },
             "edge": {
               "version_added": false
             },

--- a/css/properties/border-block-style.json
+++ b/css/properties/border-block-style.json
@@ -6,14 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-style",
           "support": {
             "chrome": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "69"
             },
             "chrome_android": {
               "version_added": "69"

--- a/css/properties/border-block-width.json
+++ b/css/properties/border-block-width.json
@@ -6,14 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-width",
           "support": {
             "chrome": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "69"
             },
             "chrome_android": {
               "version_added": "69"

--- a/css/properties/border-block.json
+++ b/css/properties/border-block.json
@@ -6,14 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block",
           "support": {
             "chrome": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "69"
             },
             "chrome_android": {
               "version_added": "69"

--- a/css/properties/border-bottom-color.json
+++ b/css/properties/border-bottom-color.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "1"
             },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },

--- a/css/properties/border-bottom-style.json
+++ b/css/properties/border-bottom-style.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "1"
             },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },

--- a/css/properties/border-bottom-width.json
+++ b/css/properties/border-bottom-width.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "1"
             },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },

--- a/css/properties/border-bottom.json
+++ b/css/properties/border-bottom.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "1"
             },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },

--- a/css/properties/border-collapse.json
+++ b/css/properties/border-collapse.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "1"
             },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },

--- a/css/properties/border-color.json
+++ b/css/properties/border-color.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "1"
             },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },

--- a/css/properties/border-image-outset.json
+++ b/css/properties/border-image-outset.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "15"
             },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },

--- a/css/properties/border-image-repeat.json
+++ b/css/properties/border-image-repeat.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "15"
             },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -43,6 +46,9 @@
               "chrome": {
                 "version_added": "30"
               },
+              "chrome_android": {
+                "version_added": "30"
+              },
               "edge": {
                 "version_added": "12"
               },
@@ -74,6 +80,9 @@
             "description": "<code>space</code>",
             "support": {
               "chrome": {
+                "version_added": "56"
+              },
+              "chrome_android": {
                 "version_added": "56"
               },
               "edge": {

--- a/css/properties/border-image-source.json
+++ b/css/properties/border-image-source.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "15"
             },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },

--- a/css/properties/border-image-width.json
+++ b/css/properties/border-image-width.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "15"
             },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },

--- a/css/properties/border-inline-color.json
+++ b/css/properties/border-inline-color.json
@@ -6,14 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-color",
           "support": {
             "chrome": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "69"
             },
             "chrome_android": {
               "version_added": "69"

--- a/css/properties/border-inline-end-color.json
+++ b/css/properties/border-inline-end-color.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "69"
             },
+            "chrome_android": {
+              "version_added": "69"
+            },
             "edge": {
               "version_added": false
             },

--- a/css/properties/border-inline-end-style.json
+++ b/css/properties/border-inline-end-style.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "69"
             },
+            "chrome_android": {
+              "version_added": "69"
+            },
             "edge": {
               "version_added": false
             },

--- a/css/properties/border-inline-end-width.json
+++ b/css/properties/border-inline-end-width.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "69"
             },
+            "chrome_android": {
+              "version_added": "69"
+            },
             "edge": {
               "version_added": false
             },

--- a/css/properties/border-inline-end.json
+++ b/css/properties/border-inline-end.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "69"
             },
+            "chrome_android": {
+              "version_added": "69"
+            },
             "edge": {
               "version_added": false
             },

--- a/css/properties/border-inline-start-color.json
+++ b/css/properties/border-inline-start-color.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "69"
             },
+            "chrome_android": {
+              "version_added": "69"
+            },
             "edge": {
               "version_added": false
             },

--- a/css/properties/border-inline-start-style.json
+++ b/css/properties/border-inline-start-style.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "69"
             },
+            "chrome_android": {
+              "version_added": "69"
+            },
             "edge": {
               "version_added": false
             },

--- a/css/properties/border-inline-start-width.json
+++ b/css/properties/border-inline-start-width.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "69"
             },
+            "chrome_android": {
+              "version_added": "69"
+            },
             "edge": {
               "version_added": false
             },

--- a/css/properties/border-inline-start.json
+++ b/css/properties/border-inline-start.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "69"
             },
+            "chrome_android": {
+              "version_added": "69"
+            },
             "edge": {
               "version_added": false
             },

--- a/css/properties/border-inline-style.json
+++ b/css/properties/border-inline-style.json
@@ -6,14 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-style",
           "support": {
             "chrome": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "69"
             },
             "chrome_android": {
               "version_added": "69"

--- a/css/properties/border-inline-width.json
+++ b/css/properties/border-inline-width.json
@@ -6,14 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-width",
           "support": {
             "chrome": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "69"
             },
             "chrome_android": {
               "version_added": "69"

--- a/css/properties/border-inline.json
+++ b/css/properties/border-inline.json
@@ -6,14 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline",
           "support": {
             "chrome": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "69"
             },
             "chrome_android": {
               "version_added": "69"

--- a/css/properties/border-left-color.json
+++ b/css/properties/border-left-color.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "1"
             },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },

--- a/css/properties/border-left-style.json
+++ b/css/properties/border-left-style.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/border-left-width.json
+++ b/css/properties/border-left-width.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "1"
             },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },

--- a/css/properties/border-left.json
+++ b/css/properties/border-left.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "1"
             },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },

--- a/css/properties/border-radius.json
+++ b/css/properties/border-radius.json
@@ -16,7 +16,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": [
               {

--- a/css/properties/border-right-color.json
+++ b/css/properties/border-right-color.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "1"
             },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },

--- a/css/properties/border-right-style.json
+++ b/css/properties/border-right-style.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "1"
             },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },

--- a/css/properties/border-right-width.json
+++ b/css/properties/border-right-width.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "1"
             },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },

--- a/css/properties/border-right.json
+++ b/css/properties/border-right.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "1"
             },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },

--- a/css/properties/border-spacing.json
+++ b/css/properties/border-spacing.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "1"
             },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },

--- a/css/properties/border-style.json
+++ b/css/properties/border-style.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "1"
             },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },

--- a/css/properties/border-top-color.json
+++ b/css/properties/border-top-color.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "1"
             },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },

--- a/css/properties/border-top-style.json
+++ b/css/properties/border-top-style.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "1"
             },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },

--- a/css/properties/border-top-width.json
+++ b/css/properties/border-top-width.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "1"
             },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },

--- a/css/properties/border-top.json
+++ b/css/properties/border-top.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "1"
             },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },

--- a/css/properties/border-width.json
+++ b/css/properties/border-width.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "1"
             },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },

--- a/css/properties/border.json
+++ b/css/properties/border.json
@@ -8,6 +8,9 @@
             "chrome": {
               "version_added": "1"
             },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },

--- a/css/properties/bottom.json
+++ b/css/properties/bottom.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/break-after.json
+++ b/css/properties/break-after.json
@@ -70,7 +70,7 @@
                   "version_added": "50"
                 },
                 "chrome_android": {
-                  "version_added": true
+                  "version_added": "50"
                 },
                 "edge": {
                   "version_added": "12"

--- a/css/properties/clear.json
+++ b/css/properties/clear.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/color.json
+++ b/css/properties/color.json
@@ -57,7 +57,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -107,7 +107,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -156,7 +156,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -205,7 +205,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -254,7 +254,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"

--- a/css/properties/column-width.json
+++ b/css/properties/column-width.json
@@ -123,6 +123,9 @@
               "chrome": {
                 "version_added": false
               },
+              "chrome_android": {
+                "version_added": false
+              },
               "edge": {
                 "version_added": false
               },

--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/direction.json
+++ b/css/properties/direction.json
@@ -9,7 +9,7 @@
               "version_added": "2"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -55,7 +55,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -204,7 +204,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -299,7 +299,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -353,7 +353,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -401,7 +401,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -950,9 +950,8 @@
                 "notes": "Before Chrome 4, <code>run-in</code> was not supported before inline elements."
               },
               "chrome_android": {
-                "version_added": true,
-                "version_removed": "32",
-                "notes": "Before Chrome 4, <code>run-in</code> was not supported before inline elements."
+                "version_added": "18",
+                "version_removed": "32"
               },
               "edge": {
                 "version_added": false

--- a/css/properties/filter.json
+++ b/css/properties/filter.json
@@ -156,7 +156,7 @@
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": true
               },
               "edge": {
                 "version_added": false

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -159,6 +159,9 @@
               "chrome": {
                 "version_added": "21"
               },
+              "chrome_android": {
+                "version_added": "25"
+              },
               "edge": {
                 "version_added": "12"
               },

--- a/css/properties/flex-grow.json
+++ b/css/properties/flex-grow.json
@@ -134,6 +134,9 @@
               "chrome": {
                 "version_added": "49"
               },
+              "chrome_android": {
+                "version_added": "49"
+              },
               "edge": {
                 "version_added": false
               },

--- a/css/properties/float.json
+++ b/css/properties/float.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/font-smooth.json
+++ b/css/properties/font-smooth.json
@@ -10,7 +10,7 @@
               "alternative_name": "-webkit-font-smoothing"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "alternative_name": "-webkit-font-smoothing"
             },
             "edge": {

--- a/css/properties/font-weight.json
+++ b/css/properties/font-weight.json
@@ -9,7 +9,7 @@
               "version_added": "2"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/font.json
+++ b/css/properties/font.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/hyphens.json
+++ b/css/properties/hyphens.json
@@ -23,7 +23,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "18"
               }
             ],
             "edge": {

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -216,8 +216,7 @@
                   "notes": "This value is recognized, but has no effect."
                 },
                 "chrome_android": {
-                  "version_added": true,
-                  "partial_implementation": true,
+                  "version_added": false,
                   "notes": "This value is recognized, but has no effect."
                 },
                 "edge": {
@@ -270,8 +269,7 @@
                   "notes": "This value is recognized, but has no effect."
                 },
                 "chrome_android": {
-                  "version_added": true,
-                  "partial_implementation": true,
+                  "version_added": false,
                   "notes": "This value is recognized, but has no effect."
                 },
                 "edge": {

--- a/css/properties/left.json
+++ b/css/properties/left.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/line-height.json
+++ b/css/properties/line-height.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/list-style-image.json
+++ b/css/properties/list-style-image.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/list-style-position.json
+++ b/css/properties/list-style-position.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/list-style.json
+++ b/css/properties/list-style.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/margin-block.json
+++ b/css/properties/margin-block.json
@@ -6,14 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-block",
           "support": {
             "chrome": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "69"
             },
             "chrome_android": {
               "version_added": "69"

--- a/css/properties/margin-inline.json
+++ b/css/properties/margin-inline.json
@@ -6,14 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-inline",
           "support": {
             "chrome": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "69"
             },
             "chrome_android": {
               "version_added": "69"

--- a/css/properties/margin.json
+++ b/css/properties/margin.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/opacity.json
+++ b/css/properties/opacity.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/overflow-wrap.json
+++ b/css/properties/overflow-wrap.json
@@ -14,9 +14,15 @@
                 "version_added": "1"
               }
             ],
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": [
+              {
+                "version_added": "25"
+              },
+              {
+                "alternative_name": "word-wrap",
+                "version_added": "18"
+              }
+            ],
             "edge": [
               {
                 "version_added": "18"
@@ -111,7 +117,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"

--- a/css/properties/overflow-x.json
+++ b/css/properties/overflow-x.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/overflow-y.json
+++ b/css/properties/overflow-y.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/padding-block.json
+++ b/css/properties/padding-block.json
@@ -6,14 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-block",
           "support": {
             "chrome": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "69"
             },
             "chrome_android": {
               "version_added": "69"

--- a/css/properties/padding-bottom.json
+++ b/css/properties/padding-bottom.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/padding-inline.json
+++ b/css/properties/padding-inline.json
@@ -6,14 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-inline",
           "support": {
             "chrome": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "69"
             },
             "chrome_android": {
               "version_added": "69"

--- a/css/properties/padding-left.json
+++ b/css/properties/padding-left.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/padding-right.json
+++ b/css/properties/padding-right.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/padding-top.json
+++ b/css/properties/padding-top.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/padding.json
+++ b/css/properties/padding.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/pointer-events.json
+++ b/css/properties/pointer-events.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -56,7 +56,7 @@
                 "version_added": "2"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"

--- a/css/properties/position.json
+++ b/css/properties/position.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -57,7 +57,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"

--- a/css/properties/right.json
+++ b/css/properties/right.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/text-align.json
+++ b/css/properties/text-align.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/text-decoration-line.json
+++ b/css/properties/text-decoration-line.json
@@ -9,7 +9,7 @@
               "version_added": "57"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "57"
             },
             "edge": {
               "version_added": false

--- a/css/properties/text-decoration.json
+++ b/css/properties/text-decoration.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/text-indent.json
+++ b/css/properties/text-indent.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/top.json
+++ b/css/properties/top.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/transform.json
+++ b/css/properties/transform.json
@@ -189,7 +189,7 @@
                 "version_added": "12"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"

--- a/css/properties/transition-delay.json
+++ b/css/properties/transition-delay.json
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "18"
               }
             ],
             "edge": [

--- a/css/properties/transition-duration.json
+++ b/css/properties/transition-duration.json
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "18"
               }
             ],
             "edge": [

--- a/css/properties/transition.json
+++ b/css/properties/transition.json
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "18"
               }
             ],
             "edge": [

--- a/css/properties/unicode-bidi.json
+++ b/css/properties/unicode-bidi.json
@@ -9,7 +9,7 @@
               "version_added": "2"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/properties/visibility.json
+++ b/css/properties/visibility.json
@@ -64,7 +64,7 @@
                 ]
               },
               "chrome_android": {
-                "version_added": true,
+                "version_added": "62",
                 "notes": [
                   "Chrome treats <code>visibility: collapse</code> like <code>hidden</code>, leaving a white gap.",
                   "Chrome supports the <code>collapse</code> value only on <a href='https://developer.mozilla.org/docs/Web/HTML/Element/tr'><code>&lt;tr&gt;</code></a>, <a href='https://developer.mozilla.org/docs/Web/HTML/Element/thead' ><code>&lt;thead&gt;</code></a>, <a href='https://developer.mozilla.org/docs/Web/HTML/Element/tbody'><code>&lt;tbody&gt;</code></a>, and <a href='https://developer.mozilla.org/docs/Web/HTML/Element/tfoot'><code>&lt;tfoot&gt;</code></a>, but not on <a href='https://developer.mozilla.org/docs/Web/HTML/Element/col'><code>&lt;col&gt;</code></a> and <a href='https://developer.mozilla.org/docs/Web/HTML/Element/colgroup'><code>&lt;colgroup&gt;</code></a> elements."

--- a/css/properties/word-break.json
+++ b/css/properties/word-break.json
@@ -64,7 +64,7 @@
                 "version_added": "44"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "44"
               },
               "edge": {
                 "version_added": "12"

--- a/css/properties/writing-mode.json
+++ b/css/properties/writing-mode.json
@@ -189,7 +189,7 @@
                 "version_added": true
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": true
               },
               "edge": {
                 "version_added": false

--- a/css/properties/writing-mode.json
+++ b/css/properties/writing-mode.json
@@ -186,10 +186,10 @@
             "description": "<code>horizontal-tb</code>, <code>vertical-lr</code>, and <code>vertical-rl</code>",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "48"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "48"
               },
               "edge": {
                 "version_added": false
@@ -219,7 +219,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "48"
               }
             },
             "status": {

--- a/css/properties/z-index.json
+++ b/css/properties/z-index.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -56,7 +56,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"

--- a/css/selectors/attribute.json
+++ b/css/selectors/attribute.json
@@ -10,7 +10,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/selectors/before.json
+++ b/css/selectors/before.json
@@ -128,7 +128,7 @@
                 "version_added": "26"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "26"
               },
               "edge": {
                 "version_added": "12"

--- a/css/selectors/first-child.json
+++ b/css/selectors/first-child.json
@@ -10,7 +10,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/selectors/general_sibling.json
+++ b/css/selectors/general_sibling.json
@@ -10,7 +10,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/selectors/last-child.json
+++ b/css/selectors/last-child.json
@@ -10,7 +10,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/selectors/nth-child.json
+++ b/css/selectors/nth-child.json
@@ -10,7 +10,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/selectors/nth-last-child.json
+++ b/css/selectors/nth-last-child.json
@@ -10,7 +10,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/selectors/only-child.json
+++ b/css/selectors/only-child.json
@@ -10,7 +10,7 @@
               "version_added": "2"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/types/dimension.json
+++ b/css/types/dimension.json
@@ -10,7 +10,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/types/global_keywords.json
+++ b/css/types/global_keywords.json
@@ -9,7 +9,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -56,7 +56,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -104,7 +104,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "13"
@@ -218,7 +218,7 @@
                 "version_added": "41"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "41"
               },
               "edge": {
                 "version_added": "13"

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -283,11 +283,11 @@
                 ],
                 "chrome_android": [
                   {
-                    "version_added": true
+                    "version_added": "26"
                   },
                   {
                     "prefix": "-webkit-",
-                    "version_added": true
+                    "version_added": "18"
                   }
                 ],
                 "edge": {
@@ -430,7 +430,7 @@
                     "version_added": "26"
                   },
                   "chrome_android": {
-                    "version_added": true
+                    "version_added": "26"
                   },
                   "edge": {
                     "version_added": "12"
@@ -574,7 +574,7 @@
                     "version_added": "26"
                   },
                   "chrome_android": {
-                    "version_added": true
+                    "version_added": "26"
                   },
                   "edge": {
                     "version_added": "12"
@@ -779,7 +779,7 @@
                     "version_added": "26"
                   },
                   "chrome_android": {
-                    "version_added": true
+                    "version_added": "26"
                   },
                   "edge": {
                     "version_added": "12"
@@ -974,11 +974,11 @@
                 ],
                 "chrome_android": [
                   {
-                    "version_added": true
+                    "version_added": "26"
                   },
                   {
                     "prefix": "-webkit-",
-                    "version_added": true
+                    "version_added": "18"
                   }
                 ],
                 "edge": {
@@ -1122,7 +1122,7 @@
                     "version_added": "26"
                   },
                   "chrome_android": {
-                    "version_added": true
+                    "version_added": "26"
                   },
                   "edge": {
                     "version_added": "12"
@@ -1266,7 +1266,7 @@
                     "version_added": "26"
                   },
                   "chrome_android": {
-                    "version_added": true
+                    "version_added": "26"
                   },
                   "edge": {
                     "version_added": "12"
@@ -1470,7 +1470,7 @@
                     "version_added": "26"
                   },
                   "chrome_android": {
-                    "version_added": true
+                    "version_added": "26"
                   },
                   "edge": {
                     "version_added": "12"
@@ -1813,7 +1813,7 @@
               },
               "chrome_android": {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "25"
               },
               "edge": {
                 "version_added": false
@@ -1877,7 +1877,7 @@
               },
               "chrome_android": {
                 "prefix": "-webkit-",
-                "version_added": true,
+                "version_added": "18",
                 "notes": "Supports the original dual-image with percentage implementation only."
               },
               "edge": {

--- a/css/types/length-percentage.json
+++ b/css/types/length-percentage.json
@@ -10,7 +10,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -105,7 +105,7 @@
                 "version_added": "27"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "27"
               },
               "edge": {
                 "version_added": "12"
@@ -399,7 +399,7 @@
                 "version_added": "4"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -543,7 +543,7 @@
                 "version_added": "20"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "25"
               },
               "edge": {
                 "version_added": "12"
@@ -639,7 +639,7 @@
                 "version_added": "26"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "26"
               },
               "edge": {
                 "version_added": "16"
@@ -751,7 +751,7 @@
                 "version_added": "20"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "25"
               },
               "edge": {
                 "version_added": "12"

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -10,7 +10,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -105,7 +105,7 @@
                 "version_added": "27"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "27"
               },
               "edge": {
                 "version_added": "12"
@@ -399,7 +399,7 @@
                 "version_added": "4"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -543,7 +543,7 @@
                 "version_added": "20"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "25"
               },
               "edge": {
                 "version_added": "12"
@@ -641,7 +641,7 @@
                 "version_added": "26"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "26"
               },
               "edge": {
                 "version_added": "16"
@@ -691,7 +691,7 @@
                 "version_added": "26"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "26"
               },
               "edge": [
                 {
@@ -753,7 +753,7 @@
                 "version_added": "20"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "25"
               },
               "edge": {
                 "version_added": "12"

--- a/css/types/percentage.json
+++ b/css/types/percentage.json
@@ -10,7 +10,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/css/types/position.json
+++ b/css/types/position.json
@@ -10,7 +10,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -57,7 +57,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -105,7 +105,7 @@
                 "version_added": "25"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "25"
               },
               "edge": {
                 "version_added": "12"

--- a/css/types/string.json
+++ b/css/types/string.json
@@ -10,7 +10,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -57,7 +57,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"

--- a/css/types/transform-function.json
+++ b/css/types/transform-function.json
@@ -62,7 +62,7 @@
                 "version_added": "12"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"

--- a/css/types/url.json
+++ b/css/types/url.json
@@ -10,7 +10,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"


### PR DESCRIPTION
For Chrome, we're now over 95% real values, so I've taken the chrome data and copied (or rather derived) the data over to Chrome Android assuming there are no differences as they share the same layout engine.

Please let me know if this is not reviewable as is. The idea would be to compare my updates to the Chrome version numbers that are already in the data (it is always the lines above in the diffs, so it should be relatively easy to compare)

Some notes:

If the Chrome version was below 18, the Chrome Android version is set to 18 as that was the first version the Chrome Android browser saw.

If the Chrome version is 19-24, the Chrome Android version is set to 25 as after Chrome Android version 18 the version number 25 was the next release.

In rare cases, the Chrome versions made no sense (e.g. random things still behind a flag, although all other are marked as supported without a flag). I've updated the Chrome data there, but let me know if I should rather split that out in a separate PR.