### PR TITLE
Firefox 69: GroupData.value now supports scheduled changes

### DIFF
--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -625,7 +625,7 @@
             },
             "firefox": {
               "version_added": "25",
-              "notes": "Prior to Firefox 69, <code>value</code> did not take into accoutn scheduled or gradiated changes to the parameter's value; instead, only explicitly set values were returned."
+              "notes": "Prior to Firefox 69, <code>value</code> did not take into account scheduled or gradiated changes to the parameter's value; instead, only explicitly set values were returned."
             },
             "firefox_android": {
               "version_added": "26",

--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -624,10 +624,12 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "25",
+              "notes": "Prior to Firefox 69, <code>value</code> did not take into account scheduled changes to the parameter's value; instead, the returned value never took into account scheduled or gradiated changes to the value. Instead, only explicitly-set values were returned."
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "26",
+              "notes": "Firefox for Android does not currently take into account scheduled or gradiated changes to the parameter's value; instead, only the initial value or the most recent explicitly-set value is returned."
             },
             "ie": {
               "version_added": false

--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -625,11 +625,11 @@
             },
             "firefox": {
               "version_added": "25",
-              "notes": "Prior to Firefox 69, <code>value</code> did not take into account scheduled changes to the parameter's value; instead, the returned value never took into account scheduled or gradiated changes to the value. Instead, only explicitly-set values were returned."
+              "notes": "Prior to Firefox 69, <code>value</code> did not take into accoutn scheduled or gradiated changes to the parameter's value; instead, only explicitly set values were returned."
             },
             "firefox_android": {
               "version_added": "26",
-              "notes": "Firefox for Android does not currently take into account scheduled or gradiated changes to the parameter's value; instead, only the initial value or the most recent explicitly-set value is returned."
+              "notes": "Firefox for Android does not currently take into account scheduled or gradiated changes to the parameter's value; only the initial value or the most recent explicitly set value is returned."
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Previously, `value` would only return the parameter's most recently
*explicitly-set* value. Now the returned value includes alterations
made by any scheduled or gradiated changes.

Source:
* https://bugzilla.mozilla.org/show_bug.cgi?id=893020