### PR TITLE
Firefox 69: CSS ::cue limitations enforced

### DIFF
--- a/css/selectors/cue.json
+++ b/css/selectors/cue.json
@@ -17,14 +17,10 @@
             },
             "firefox": {
               "version_added": "55",
-              "notes": [
-                "Firefox currently does not support a parameter on <code>::cue</code>.",
-                "Correct limitations to the CSS properties permitted within <code>::cue</code> were implemented in Firefox 69. See <a href='https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/::cue#Permitted_properties'>Permitted properties</a> for a list of the allowed properties."
-              ]
+              "notes": "Firefox currently does not support a parameter on <code>::cue</code>."
             },
             "firefox_android": {
-              "version_added": "55",
-              "notes": "Firefox currently does not support a parameter on <code>::cue</code>."
+              "version_added": "55"
             },
             "ie": {
               "version_added": false

--- a/css/selectors/cue.json
+++ b/css/selectors/cue.json
@@ -17,10 +17,14 @@
             },
             "firefox": {
               "version_added": "55",
-              "notes": "Firefox currently does not support a parameter on <code>::cue</code>."
+              "notes": [
+                "Firefox currently does not support a parameter on <code>::cue</code>.",
+                "Correct limitations to the CSS properties permitted within <code>::cue</code> were implemented in Firefox 69. See <a href='https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/::cue#Permitted_properties'>Permitted properties</a> for a list of the allowed properties."
+              ]
             },
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "notes": "Firefox currently does not support a parameter on <code>::cue</code>."
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Firefox 69 now enforces the limitations on the CSS properties you can use in a cue.

Source:
* https://bugzilla.mozilla.org/show_bug.cgi?id=1321488