### PR TITLE
CORP is still behind a pref in Firefox

### DIFF
--- a/http/headers/cross-origin-resource-policy.json
+++ b/http/headers/cross-origin-resource-policy.json
@@ -17,7 +17,14 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "69"
+              "version_added": "69",
+              "flags": [
+                {
+                  "name": "browser.tabs.remote.useCORP",
+                  "type": "preference",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
This wasn't followed up in https://github.com/mdn/browser-compat-data/pull/4352

Still behind a pref, see https://bugzilla.mozilla.org/show_bug.cgi?id=1459573#c8