### PR TITLE
Cover text-transform: capitalize in general

### DIFF
--- a/css/properties/text-transform.json
+++ b/css/properties/text-transform.json
@@ -41,7 +41,7 @@
               "notes": "The <code>text-transform</code> property does not work for <code>::first-line</code> pseudo-elements (also not for the old one-colon syntax). See <a href='https://webkit.org/b/3409'>WebKit bug 3409</a>."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1",
@@ -56,43 +56,44 @@
         },
         "capitalize": {
           "__compat": {
-            "description": "<code>capitalize</code> as defined by CSS level 3",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "14"
+                "version_added": "1",
+                "notes": "Before Firefox 14, some punctuation characters could interfere with correct capitalization. See <a href='https://bugzil.la/731536'>bug 731536</a>."
               },
               "firefox_android": {
-                "version_added": "14"
+                "version_added": "4",
+                "notes": "Before Firefox 14, some punctuation characters could interfere with correct capitalization. See <a href='https://bugzil.la/731536'>bug 731536</a>."
               },
               "ie": {
-                "version_added": "3"
+                "version_added": "4"
               },
               "opera": {
-                "version_added": true
+                "version_added": "7"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "11"
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {


### PR DESCRIPTION
For #4301, I'm fixing the data for `text-transform: capitalize`. I set the data to cover when each browser shipped `capitalize` as a value for `text-transform` (usually the first release, since it's very old), instead of a particular specification.

The existing data explicitly covers the CSS Text Module Level 3 specification of `capitalize`, which is less ambiguous than previous specs for `capitalize`. The former specs called for making the first letter of each word uppercase. Because what constituted the first letter of a word was not specified, browsers inconsistently capitalized words with preceding punctuation.

Tracking down how browsers handled this proved impractical. In any case, it's no longer a live issue in terms of compatibility: all the browsers appear to correctly handle preceding punctuation in recent releases (none of the oldest browsers I could test with demonstrated non-level 3 compliant casing). Where I was able to find definitive data about changes in this behavior—for Firefox alone—I added a note.

Finally, I updated the parent feature for Samsung Internet, for consistency with the `capitalize` feature.