### PR TITLE
Add Feature-Policy directive webauthn

### DIFF
--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -1681,6 +1681,54 @@
               "deprecated": false
             }
           }
+        },
+        "webauthn": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/webauthn",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
Web Authentication API Level 2 draft added Feature Policy integration with feature name `webauthn`.

## Data
No browser implemented this yet.

## Links
Web Authentication API Level 2 draft Feature Policy:
https://w3c.github.io/webauthn/#sctn-feature-policy
MDN page:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy/webauthn

Firefox issue:
https://bugzilla.mozilla.org/show_bug.cgi?id=1294514

## Related 
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
