### PR TITLE
Update text-justify CSS property data

### DIFF
--- a/css/properties/text-justify.json
+++ b/css/properties/text-justify.json
@@ -88,10 +88,12 @@
               "notes": "<code>inter-word</code> and <code>distribute</code> (deprecated) values are supported, but <code>distribute</code> behavior is buggy."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://webkit.org/b/99945'>bug 9945</a>."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://webkit.org/b/99945'>bug 9945</a>."
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/text-justify.json
+++ b/css/properties/text-justify.json
@@ -28,7 +28,7 @@
               "notes": "<code>inter-word</code> and <code>distribute</code> (deprecated) values are supported, but <code>distribute</code> behavior is buggy."
             },
             "edge": {
-              "version_added": "14",
+              "version_added": "12",
               "notes": "Standard values <code>inter-character</code> and <code>none</code> are supported. The deprecated <code>distribute</code> value is also supported."
             },
             "firefox": {

--- a/css/properties/text-justify.json
+++ b/css/properties/text-justify.json
@@ -31,12 +31,36 @@
               "version_added": "12",
               "notes": "Standard values <code>inter-character</code> and <code>none</code> are supported. The deprecated <code>distribute</code> value is also supported."
             },
-            "firefox": {
-              "version_added": "55"
-            },
-            "firefox_android": {
-              "version_added": "55"
-            },
+            "firefox": [
+              {
+                "version_added": "55"
+              },
+              {
+                "version_added": "54",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.text-justify.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "55"
+              },
+              {
+                "version_added": "54",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.text-justify.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": "11",
               "notes": "Standard values <code>inter-character</code> and <code>none</code> are supported. The deprecated <code>distribute</code> value is also supported."

--- a/css/properties/text-justify.json
+++ b/css/properties/text-justify.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-justify",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "32",
               "flags": [
                 {
                   "type": "preference",
@@ -17,7 +17,7 @@
               "notes": "<code>inter-word</code> and <code>distribute</code> (deprecated) values are supported, but <code>distribute</code> behavior is buggy."
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "32",
               "flags": [
                 {
                   "type": "preference",
@@ -42,7 +42,7 @@
               "notes": "Standard values <code>inter-character</code> and <code>none</code> are supported. The deprecated <code>distribute</code> value is also supported."
             },
             "opera": {
-              "version_added": true,
+              "version_added": "19",
               "flags": [
                 {
                   "type": "preference",
@@ -53,7 +53,7 @@
               "notes": "<code>inter-word</code> and <code>distribute</code> (deprecated) values are supported, but <code>distribute</code> behavior is buggy."
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "19",
               "flags": [
                 {
                   "type": "preference",
@@ -70,7 +70,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
For #4301, this PR updates the data for `text-justify`.

* Chrome and derivatives: estimated by dates of changes in 
https://bugs.chromium.org/p/chromium/issues/detail?id=248894
* Edge: tested
* Firefox: added in prior pref data (I stumbled across the bug for this feature and it showed fixed in 54—I thought this would clear up any future confusion)
* Safari: added a link to the bug, to help if this ever needs updating in the future