### PR TITLE
Audio capture support in Chrome > 74

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -338,7 +338,8 @@
             "description": "Audio capture support",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "74",
+                "notes": "On Windows the entire system audio can be captured, but on Linux and Mac only the audio of a tab can be captured."
               },
               "chrome_android": {
                 "version_added": false


### PR DESCRIPTION
Audio capture has been added in chrome since v74, see: https://bugs.chromium.org/p/chromium/issues/detail?id=896333

Testable with: `navigator.mediaDevices.getDisplayMedia({ video: true, audio: true })`.