### PR TITLE
CORS: Add data for wildcard support to certain headers

### DIFF
--- a/http/headers/access-control-allow-headers.json
+++ b/http/headers/access-control-allow-headers.json
@@ -53,10 +53,10 @@
             "description": "Wildcard (<code>*</code>)",
             "support": {
               "chrome": {
-                "version_added": "65"
+                "version_added": "63"
               },
               "chrome_android": {
-                "version_added": "65"
+                "version_added": "63"
               },
               "edge": {
                 "version_added": false
@@ -71,10 +71,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "52"
+                "version_added": "50"
               },
               "opera_android": {
-                "version_added": "47"
+                "version_added": "46"
               },
               "safari": {
                 "version_added": false
@@ -83,10 +83,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": "9.0"
+                "version_added": "8.2"
               },
               "webview_android": {
-                "version_added": "65"
+                "version_added": "63"
               }
             },
             "status": {

--- a/http/headers/access-control-allow-headers.json
+++ b/http/headers/access-control-allow-headers.json
@@ -53,10 +53,10 @@
             "description": "Wildcard (<code>*</code>)",
             "support": {
               "chrome": {
-                "version_added": "63"
+                "version_added": "65"
               },
               "chrome_android": {
-                "version_added": "63"
+                "version_added": "65"
               },
               "edge": {
                 "version_added": false
@@ -71,10 +71,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "50"
+                "version_added": "52"
               },
               "opera_android": {
-                "version_added": "46"
+                "version_added": "47"
               },
               "safari": {
                 "version_added": false
@@ -83,10 +83,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": "8.2"
+                "version_added": "9.0"
               },
               "webview_android": {
-                "version_added": "63"
+                "version_added": "65"
               }
             },
             "status": {

--- a/http/headers/access-control-allow-headers.json
+++ b/http/headers/access-control-allow-headers.json
@@ -47,6 +47,54 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "wildcard": {
+          "__compat": {
+            "description": "Wildcard (<code>*</code>)",
+            "support": {
+              "chrome": {
+                "version_added": "63"
+              },
+              "chrome_android": {
+                "version_added": "63"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "69"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "50"
+              },
+              "opera_android": {
+                "version_added": "46"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "8.2"
+              },
+              "webview_android": {
+                "version_added": "63"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/http/headers/access-control-allow-methods.json
+++ b/http/headers/access-control-allow-methods.json
@@ -53,10 +53,10 @@
             "description": "Wildcard (<code>*</code>)",
             "support": {
               "chrome": {
-                "version_added": "65"
+                "version_added": "63"
               },
               "chrome_android": {
-                "version_added": "65"
+                "version_added": "63"
               },
               "edge": {
                 "version_added": false
@@ -71,10 +71,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "52"
+                "version_added": "50"
               },
               "opera_android": {
-                "version_added": "47"
+                "version_added": "46"
               },
               "safari": {
                 "version_added": false
@@ -83,10 +83,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": "9.0"
+                "version_added": "8.2"
               },
               "webview_android": {
-                "version_added": "65"
+                "version_added": "63"
               }
             },
             "status": {

--- a/http/headers/access-control-allow-methods.json
+++ b/http/headers/access-control-allow-methods.json
@@ -53,10 +53,10 @@
             "description": "Wildcard (<code>*</code>)",
             "support": {
               "chrome": {
-                "version_added": "63"
+                "version_added": "65"
               },
               "chrome_android": {
-                "version_added": "63"
+                "version_added": "65"
               },
               "edge": {
                 "version_added": false
@@ -71,10 +71,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "50"
+                "version_added": "52"
               },
               "opera_android": {
-                "version_added": "46"
+                "version_added": "47"
               },
               "safari": {
                 "version_added": false
@@ -83,10 +83,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": "8.2"
+                "version_added": "9.0"
               },
               "webview_android": {
-                "version_added": "63"
+                "version_added": "65"
               }
             },
             "status": {

--- a/http/headers/access-control-allow-methods.json
+++ b/http/headers/access-control-allow-methods.json
@@ -47,6 +47,54 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "wildcard": {
+          "__compat": {
+            "description": "Wildcard (<code>*</code>)",
+            "support": {
+              "chrome": {
+                "version_added": "63"
+              },
+              "chrome_android": {
+                "version_added": "63"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "69"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "50"
+              },
+              "opera_android": {
+                "version_added": "46"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "8.2"
+              },
+              "webview_android": {
+                "version_added": "63"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/http/headers/access-control-expose-headers.json
+++ b/http/headers/access-control-expose-headers.json
@@ -53,10 +53,10 @@
             "description": "Wildcard (<code>*</code>)",
             "support": {
               "chrome": {
-                "version_added": "63"
+                "version_added": "65"
               },
               "chrome_android": {
-                "version_added": "63"
+                "version_added": "65"
               },
               "edge": {
                 "version_added": false
@@ -71,10 +71,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "50"
+                "version_added": "52"
               },
               "opera_android": {
-                "version_added": "46"
+                "version_added": "47"
               },
               "safari": {
                 "version_added": false
@@ -83,10 +83,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": "8.2"
+                "version_added": "9.0"
               },
               "webview_android": {
-                "version_added": "63"
+                "version_added": "65"
               }
             },
             "status": {

--- a/http/headers/access-control-expose-headers.json
+++ b/http/headers/access-control-expose-headers.json
@@ -47,6 +47,54 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "wildcard": {
+          "__compat": {
+            "description": "Wildcard (<code>*</code>)",
+            "support": {
+              "chrome": {
+                "version_added": "63"
+              },
+              "chrome_android": {
+                "version_added": "63"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "69"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "50"
+              },
+              "opera_android": {
+                "version_added": "46"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "8.2"
+              },
+              "webview_android": {
+                "version_added": "63"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
For https://bugzilla.mozilla.org/show_bug.cgi?id=1309358#c29

These headers now accept a wildcard (`*`) in certain situations:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers

C.f. https://github.com/Fyrd/caniuse/issues/4987