### PR TITLE
Firefox 69: TextTrack no longer loads cue files when disabled

### DIFF
--- a/api/TextTrack.json
+++ b/api/TextTrack.json
@@ -62,7 +62,8 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "31"
+              "version_added": "31",
+              "notes": "Starting in Firefox 69, cues are no longer incorrectly loaded when the <code>TextTrack</code>'s <code>mode</code> is <code>disabled</code>; if that's the case, the returned list is empty."
             },
             "firefox_android": {
               "version_added": "31"
@@ -110,7 +111,8 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "31"
+              "version_added": "31",
+              "notes": "Starting in Firefox 69, cues are no longer incorrectly loaded when the <code>TextTrack</code>'s <code>mode</code> is <code>disabled</code>; if that's the case, the returned list is empty."
             },
             "firefox_android": {
               "version_added": "31"


### PR DESCRIPTION
Instead, loading the WebVTT data is now correctly postponed until the mode changes to either `hidden` or `started`.

Source:
* https://bugzilla.mozilla.org/show_bug.cgi?id=1550633