### PR TITLE
added new blob reading methods

### DIFF
--- a/api/Blob.json
+++ b/api/Blob.json
@@ -98,36 +98,36 @@
           }
         }
       },
-      "size": {
+      "arrayBuffer": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Blob/size",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Blob/arrayBuffer",
           "support": {
             "chrome": {
-              "version_added": "5"
+              "version_added": "76"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "76"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": false
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
-              "version_added": "11"
+              "version_added": false
             },
             "opera_android": {
               "version_added": false
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false
@@ -136,19 +136,19 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": null
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
         }
       },
-      "type": {
+      "size": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Blob/type",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Blob/size",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -258,9 +258,9 @@
           }
         }
       },
-      "arrayBuffer": {
+      "stream": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Blob/arrayBuffer",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Blob/stream",
           "support": {
             "chrome": {
               "version_added": "76"
@@ -354,36 +354,36 @@
           }
         }
       },
-      "stream": {
+      "type": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Blob/stream",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Blob/type",
           "support": {
             "chrome": {
-              "version_added": "76"
+              "version_added": "5"
             },
             "chrome_android": {
-              "version_added": "76"
+              "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": false
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera_android": {
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "5.1"
             },
             "safari_ios": {
               "version_added": false
@@ -392,11 +392,11 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Blob.json
+++ b/api/Blob.json
@@ -257,6 +257,150 @@
             "deprecated": false
           }
         }
+      },
+      "arrayBuffer": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Blob/arrayBuffer",
+          "support": {
+            "chrome": {
+              "version_added": "76"
+            },
+            "chrome_android": {
+              "version_added": "76"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "text": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Blob/text",
+          "support": {
+            "chrome": {
+              "version_added": "76"
+            },
+            "chrome_android": {
+              "version_added": "76"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "stream": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Blob/stream",
+          "support": {
+            "chrome": {
+              "version_added": "76"
+            },
+            "chrome_android": {
+              "version_added": "76"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/Blob.json
+++ b/api/Blob.json
@@ -136,7 +136,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "76"
             }
           },
           "status": {
@@ -296,7 +296,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "76"
             }
           },
           "status": {
@@ -344,7 +344,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "76"
             }
           },
           "status": {


### PR DESCRIPTION
##### Summarize
This adds the 3 new reading methods to the blob, `arrayBuffer`, `text`, and `stream` 

##### link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)

- https://chromestatus.com/features/6206980857266176
- https://bugs.chromium.org/p/chromium/issues/detail?id=945893
- https://github.com/w3c/FileAPI/pull/117
- https://github.com/web-platform-tests/wpt/tree/master/FileAPI/blob