### PR TITLE
Update letter-spacing data

### DIFF
--- a/css/properties/letter-spacing.json
+++ b/css/properties/letter-spacing.json
@@ -33,10 +33,10 @@
               "version_added": "1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -53,10 +53,10 @@
             "description": "SVG support",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -74,19 +74,19 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {


### PR DESCRIPTION
For #4301, I've updated the data for the `letter-spacing` property.

I wasn't able to find anything definitive, but some evidence (like questions on StackOverflow) points toward `letter-spacing` support with SVG being well-supported from each browsers' initial release with `letter-spacing`, some bugs with fractional values notwithstanding. The oldest browsers I could test handled SVG letter-spacing as expected, with the exception of Firefox (which does not support it). Based on that, I've made the guess that such support existed in those browser from their first release with `letter-spacing` and mirrored the parent `letter-spacing` data where applicable.