### PR TITLE
Update Opera release data; no Opera 61

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -7875,11 +7875,11 @@
             },
             "opera": [
               {
-                "version_added": "61"
+                "version_added": "62"
               },
               {
                 "version_added": "60",
-                "version_removed": "61",
+                "version_removed": "62",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/FeaturePolicy.json
+++ b/api/FeaturePolicy.json
@@ -90,11 +90,11 @@
           },
           "opera": [
             {
-              "version_added": "61"
+              "version_added": "62"
             },
             {
               "version_added": "60",
-              "version_removed": "61",
+              "version_removed": "62",
               "flags": [
                 {
                   "type": "preference",
@@ -210,11 +210,11 @@
             },
             "opera": [
               {
-                "version_added": "61"
+                "version_added": "62"
               },
               {
                 "version_added": "56",
-                "version_removed": "61",
+                "version_removed": "62",
                 "flags": [
                   {
                     "type": "preference",
@@ -318,11 +318,11 @@
             },
             "opera": [
               {
-                "version_added": "61"
+                "version_added": "62"
               },
               {
                 "version_added": "56",
-                "version_removed": "61",
+                "version_removed": "62",
                 "flags": [
                   {
                     "type": "preference",
@@ -426,11 +426,11 @@
             },
             "opera": [
               {
-                "version_added": "61"
+                "version_added": "62"
               },
               {
                 "version_added": "56",
-                "version_removed": "61",
+                "version_removed": "62",
                 "flags": [
                   {
                     "type": "preference",
@@ -493,7 +493,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "61"
+              "version_added": "62"
             },
             "opera_android": {
               "version_added": false

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -764,11 +764,11 @@
             },
             "opera": [
               {
-                "version_added": "61"
+                "version_added": "62"
               },
               {
                 "version_added": "60",
-                "version_removed": "61",
+                "version_removed": "62",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -671,7 +671,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "61"
+              "version_added": "62"
             },
             "opera_android": {
               "version_added": "50"

--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -482,17 +482,14 @@
         "60": {
           "release_date": "2019-04-09",
           "release_notes": "https://blogs.opera.com/desktop/2019/04/opera-60-reborn-3-web-3-0-vpn-ad-blocker/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "73"
         },
-        "61": {
-          "status": "beta",
-          "engine": "Blink",
-          "engine_version": "74"
-        },
         "62": {
-          "status": "nightly",
+          "release_date": "2019-06-27",
+          "release_notes": "https://blogs.opera.com/desktop/2019/06/opera-62-comes-with-design-updates-to-reborn-3/",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "75"
         }


### PR DESCRIPTION
Opera Desktop skipped a release number...see https://ftp.opera.com/pub/opera/desktop/

To prevent this from happening again, I've not added future versions for Opera.
Where we've already set Opera 61, I've changed it to 62 instead.