### PR TITLE
Updated version information for text-decoration-skip-ink for Firefox

### DIFF
--- a/css/properties/text-decoration-skip-ink.json
+++ b/css/properties/text-decoration-skip-ink.json
@@ -15,7 +15,14 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "70",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.text-decoration-skip-ink.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
The CSS property [`text-decoration-skip-ink`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-skip-ink) just got implemented (currently behind a flag). See https://bugzil.la/1411922.

I've tested it in today's Nightly (2019-08-08) and it works just fine.

Sebastian