### PR TITLE
WebVR deprecation and compatibility data update

### DIFF
--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -473,7 +473,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -100,7 +100,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -1047,7 +1047,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/api/VRDisplay.json
+++ b/api/VRDisplay.json
@@ -56,7 +56,7 @@
         "status": {
           "experimental": true,
           "standard_track": true,
-          "deprecated": false
+          "deprecated": true
         }
       },
       "cancelAnimationFrame": {
@@ -115,7 +115,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -175,7 +175,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -235,7 +235,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -295,7 +295,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -355,7 +355,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -415,7 +415,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -475,7 +475,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -535,7 +535,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -595,7 +595,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -655,7 +655,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -923,7 +923,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -983,7 +983,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -1103,7 +1103,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -1163,7 +1163,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -1223,7 +1223,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/api/VRDisplayCapabilities.json
+++ b/api/VRDisplayCapabilities.json
@@ -56,7 +56,7 @@
         "status": {
           "experimental": true,
           "standard_track": true,
-          "deprecated": false
+          "deprecated": true
         }
       },
       "canPresent": {
@@ -115,7 +115,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -175,7 +175,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -235,7 +235,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -355,7 +355,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/api/VRDisplayEvent.json
+++ b/api/VRDisplayEvent.json
@@ -56,7 +56,7 @@
         "status": {
           "experimental": true,
           "standard_track": true,
-          "deprecated": false
+          "deprecated": true
         }
       },
       "VRDisplayEvent": {
@@ -116,7 +116,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -176,7 +176,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -236,7 +236,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/api/VREyeParameters.json
+++ b/api/VREyeParameters.json
@@ -56,7 +56,7 @@
         "status": {
           "experimental": true,
           "standard_track": true,
-          "deprecated": false
+          "deprecated": true
         }
       },
       "fieldOfView": {
@@ -115,7 +115,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -273,7 +273,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -372,7 +372,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -471,7 +471,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/api/VRFieldOfView.json
+++ b/api/VRFieldOfView.json
@@ -56,7 +56,7 @@
         "status": {
           "experimental": true,
           "standard_track": true,
-          "deprecated": false
+          "deprecated": true
         }
       },
       "VRFieldOfView": {
@@ -155,7 +155,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -215,7 +215,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -275,7 +275,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -335,7 +335,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/api/VRFrameData.json
+++ b/api/VRFrameData.json
@@ -56,7 +56,7 @@
         "status": {
           "experimental": true,
           "standard_track": true,
-          "deprecated": false
+          "deprecated": true
         }
       },
       "VRFrameData": {
@@ -116,7 +116,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -176,7 +176,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -236,7 +236,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -296,7 +296,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -356,7 +356,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -416,7 +416,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -476,7 +476,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/api/VRLayerInit.json
+++ b/api/VRLayerInit.json
@@ -56,7 +56,7 @@
         "status": {
           "experimental": true,
           "standard_track": true,
-          "deprecated": false
+          "deprecated": true
         }
       },
       "leftBounds": {
@@ -115,7 +115,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -175,7 +175,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -235,7 +235,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/api/VRPose.json
+++ b/api/VRPose.json
@@ -56,7 +56,7 @@
         "status": {
           "experimental": true,
           "standard_track": true,
-          "deprecated": false
+          "deprecated": true
         }
       },
       "angularAcceleration": {
@@ -115,7 +115,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -175,7 +175,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -313,7 +313,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -373,7 +373,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -433,7 +433,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -493,7 +493,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/api/VRStageParameters.json
+++ b/api/VRStageParameters.json
@@ -56,7 +56,7 @@
         "status": {
           "experimental": true,
           "standard_track": true,
-          "deprecated": false
+          "deprecated": true
         }
       },
       "sittingToStandingTransform": {
@@ -115,7 +115,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -175,7 +175,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -235,7 +235,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/api/Window.json
+++ b/api/Window.json
@@ -3065,7 +3065,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -3113,7 +3113,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/api/Window.json
+++ b/api/Window.json
@@ -2644,7 +2644,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -2692,7 +2692,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -2766,7 +2766,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -2821,7 +2821,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -2895,7 +2895,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -2943,7 +2943,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -3017,7 +3017,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/api/Window.json
+++ b/api/Window.json
@@ -2753,14 +2753,7 @@
               "notes": "Supported on Samsung Internet for GearVR."
             },
             "webview_android": {
-              "version_added": false,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "WebVR",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": false
             }
           },
           "status": {
@@ -2882,14 +2875,7 @@
               "notes": "Supported on Samsung Internet for GearVR."
             },
             "webview_android": {
-              "version_added": false,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "WebVR",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": false
             }
           },
           "status": {
@@ -3004,14 +2990,7 @@
               "notes": "Supported on Samsung Internet for GearVR."
             },
             "webview_android": {
-              "version_added": "65",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "WebVR",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": false
             }
           },
           "status": {
@@ -9896,14 +9875,7 @@
               "notes": "Supported on Samsung Internet for GearVR."
             },
             "webview_android": {
-              "version_added": false,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "WebVR",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": false
             }
           },
           "status": {
@@ -10027,14 +9999,7 @@
               "notes": "Supported on Samsung Internet for GearVR."
             },
             "webview_android": {
-              "version_added": false,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "WebVR",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": false
             }
           },
           "status": {
@@ -10151,14 +10116,7 @@
               "notes": "Supported on Samsung Internet for GearVR."
             },
             "webview_android": {
-              "version_added": "65",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "WebVR",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
## Summary
WebVR is being replaced with WebXR and will be completely removed soon. This PR deprecates all WebVR interfaces and compatibility data update.

## Details
The first two commits "WebVR deprecation and update (start)" and "WebVR deprecation and update (the rest)" set `deprecated` to `true` for all WebVR interfaces. The third commit removes flags from `webview_android` in `Window` and sets all `version_added` to `false` because Android WebView never supported WebVR.

## Data
 - [Android Webview never supported WebVR](https://chromestatus.com/feature/4532810371039232).
 - [WebVR 1.1 § IDL Index](https://immersive-web.github.io/webvr/spec/1.1/#idl-index)

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any

Edit: Updated this comment.