### PR TITLE
Add Chromium + Safari versions for -webkit-text-orientation

### DIFF
--- a/css/properties/text-orientation.json
+++ b/css/properties/text-orientation.json
@@ -11,7 +11,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "11"
               }
             ],
             "chrome_android": [
@@ -20,7 +20,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "18"
               }
             ],
             "edge": {
@@ -63,16 +63,19 @@
             },
             "opera": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": false
+              "prefix": "-webkit-",
+              "version_added": "14"
             },
             "safari": {
-              "version_added": false
+              "prefix": "-webkit-",
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": false
+              "prefix": "-webkit-",
+              "version_added": "5"
             },
             "samsunginternet_android": [
               {
@@ -80,7 +83,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "1.0"
               }
             ],
             "webview_android": [


### PR DESCRIPTION
This PR adds the Chrome and Safari versions for the `text-orientation` CSS property with a WebKit prefix.  Initially marked as unsupported in Safari, I found that the property has been implemented since WebKit 534.24, equalling Safari 5.1, Chrome 11.