### PR TITLE
Add Safari version for css.properties.text-emphasis-position.left_and_right

### DIFF
--- a/css/properties/text-emphasis-position.json
+++ b/css/properties/text-emphasis-position.json
@@ -151,10 +151,10 @@
                 "version_added": "46"
               },
               "safari": {
-                "version_added": true
+                "version_added": "8"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "8"
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
This PR adds the version number for the left and right values to text-emphasis-position.  Data is as follows:

Implemented in 88ce481c20bae5db90e27d930782024ab485e6a0 (Git commit hash)
Date of commit suggests implementation within Safari 8
Manual testing confirms Safari 8 support
Safari 8