### PR TITLE
Set Chromium + Safari version for text-rendering auto value

### DIFF
--- a/css/properties/text-rendering.json
+++ b/css/properties/text-rendering.json
@@ -66,11 +66,11 @@
             "description": "<code>auto</code>",
             "support": {
               "chrome": {
-                "version_added": true,
+                "version_added": "4",
                 "notes": "Chrome treats <code>auto</code> as <code>optimizeSpeed</code>."
               },
               "chrome_android": {
-                "version_added": true,
+                "version_added": "18",
                 "notes": "Chrome treats <code>auto</code> as <code>optimizeSpeed</code>."
               },
               "edge": {
@@ -88,21 +88,24 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true,
+                "version_added": "15",
                 "notes": "Opera treats <code>auto</code> as <code>optimizeSpeed</code>."
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "14",
+                "notes": "Opera treats <code>auto</code> as <code>optimizeSpeed</code>."
               },
               "safari": {
-                "version_added": true,
+                "version_added": "4.1",
                 "notes": "Safari treats <code>auto</code> as <code>optimizeSpeed</code>. See <a href='https://webkit.org/b/41363'>WebKit bug 41363</a>."
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "4",
+                "notes": "Safari treats <code>auto</code> as <code>optimizeSpeed</code>. See <a href='https://webkit.org/b/41363'>WebKit bug 41363</a>."
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0",
+                "notes": "Samsung Internet treats <code>auto</code> as <code>optimizeSpeed</code>."
               },
               "webview_android": {
                 "version_added": true,


### PR DESCRIPTION
This PR sets the Chrome and Safari versions for the CSS text-rendering `auto` value.  Data is as follows:

Date of the tracking bug in Safari note suggests Chrome + Safari 5 or below
Implemented in WebKit 532.2
Chrome 4, Safari 4.1