### PR TITLE
Add version numbers grid-template-(rows|columns) repeat

### DIFF
--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -247,7 +247,7 @@
                   "version_added": "57"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "29",
                   "flags": [
                     {
                       "type": "preference",
@@ -261,7 +261,7 @@
                   "version_added": "57"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "29",
                   "flags": [
                     {
                       "type": "preference",
@@ -364,7 +364,7 @@
                   "version_added": "57"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "28",
                   "flags": [
                     {
                       "type": "preference",

--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -359,20 +359,9 @@
               "samsunginternet_android": {
                 "version_added": null
               },
-              "webview_android": [
-                {
-                  "version_added": "57"
-                },
-                {
-                  "version_added": "28",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
-                }
-              ]
+              "webview_android": {
+                "version_added": "57"
+              }
             },
             "status": {
               "experimental": false,

--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -247,7 +247,7 @@
                   "version_added": "57"
                 },
                 {
-                  "version_added": "29",
+                  "version_added": "38",
                   "flags": [
                     {
                       "type": "preference",
@@ -261,7 +261,7 @@
                   "version_added": "57"
                 },
                 {
-                  "version_added": "29",
+                  "version_added": "38",
                   "flags": [
                     {
                       "type": "preference",

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -247,7 +247,7 @@
                   "version_added": "57"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "29",
                   "flags": [
                     {
                       "type": "preference",
@@ -261,7 +261,7 @@
                   "version_added": "57"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "29",
                   "flags": [
                     {
                       "type": "preference",
@@ -364,7 +364,7 @@
                   "version_added": "57"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "28",
                   "flags": [
                     {
                       "type": "preference",

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -359,20 +359,9 @@
               "samsunginternet_android": {
                 "version_added": null
               },
-              "webview_android": [
-                {
-                  "version_added": "57"
-                },
-                {
-                  "version_added": "28",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Web Platform features"
-                    }
-                  ]
-                }
-              ]
+              "webview_android": {
+                "version_added": "57"
+              }
             },
             "status": {
               "experimental": false,

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -247,7 +247,7 @@
                   "version_added": "57"
                 },
                 {
-                  "version_added": "29",
+                  "version_added": "38",
                   "flags": [
                     {
                       "type": "preference",
@@ -261,7 +261,7 @@
                   "version_added": "57"
                 },
                 {
-                  "version_added": "29",
+                  "version_added": "38",
                   "flags": [
                     {
                       "type": "preference",


### PR DESCRIPTION
Was unable to find an exact proof for this but these version numbers would be consistent with the rest of the chrome grid data.