### PR TITLE
Set Chromium versions for repeat() in grid-template-columns/rows

### DIFF
--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -247,7 +247,7 @@
                   "version_added": "57"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "38",
                   "flags": [
                     {
                       "type": "preference",
@@ -261,7 +261,7 @@
                   "version_added": "57"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "38",
                   "flags": [
                     {
                       "type": "preference",
@@ -327,7 +327,7 @@
                   "version_added": "44"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "25",
                   "flags": [
                     {
                       "type": "preference",
@@ -341,7 +341,7 @@
                   "version_added": "43"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "25",
                   "flags": [
                     {
                       "type": "preference",
@@ -364,7 +364,7 @@
                   "version_added": "57"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "38",
                   "flags": [
                     {
                       "type": "preference",

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -247,7 +247,7 @@
                   "version_added": "57"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "38",
                   "flags": [
                     {
                       "type": "preference",
@@ -261,7 +261,7 @@
                   "version_added": "57"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "38",
                   "flags": [
                     {
                       "type": "preference",
@@ -327,7 +327,7 @@
                   "version_added": "44"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "25",
                   "flags": [
                     {
                       "type": "preference",
@@ -341,7 +341,7 @@
                   "version_added": "43"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "25",
                   "flags": [
                     {
                       "type": "preference",
@@ -364,7 +364,7 @@
                   "version_added": "57"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "38",
                   "flags": [
                     {
                       "type": "preference",


### PR DESCRIPTION
This PR adds Chromium versions for the repeat() function for `grid-template-columns` and `grid-template-rows`.  Chrome 38 was identified based upon manual testing in SauceLabs.