### PR TITLE
Add data for Digest and Want-Digest

### DIFF
--- a/http/headers/digest.json
+++ b/http/headers/digest.json
@@ -1,0 +1,54 @@
+{
+  "http": {
+    "headers": {
+      "Date": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Date",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/http/headers/digest.json
+++ b/http/headers/digest.json
@@ -1,9 +1,9 @@
 {
   "http": {
     "headers": {
-      "Date": {
+      "Digest": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Date",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Digest",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/want-digest.json
+++ b/http/headers/want-digest.json
@@ -1,0 +1,54 @@
+{
+  "http": {
+    "headers": {
+      "Date": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Date",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": {
+              "version_added": true
+            },
+            "ie": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/http/headers/want-digest.json
+++ b/http/headers/want-digest.json
@@ -1,9 +1,9 @@
 {
   "http": {
     "headers": {
-      "Date": {
+      "Want-Digest": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Date",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Want-Digest",
           "support": {
             "chrome": {
               "version_added": true


### PR DESCRIPTION
This is for https://github.com/mdn/sprints/issues/1478.

I wasn't sure what to put for this, as browsers don't really have anything to do to support `Digest` or `Want-Digest`, as far as I can tell.

That is, the spec doesn't say when browsers should include `Want-Digest`, or what they should do when they receive `Digest`. It seems to be a thing for the application.

There's some discussion about this issue in https://discourse.mozilla.org/t/bcd-and-want-digest-digest-http-headers/43340.

So I have just used `true` here, since all browsers have to do to support it is include any request headers they are asked to include, and expose any response headers the server sends them.

