### PR TITLE
Statistics script: add optional folder argument

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -20,6 +20,6 @@ Paste the generated HTML into the MDN editor (source mode). You can use a new pa
 
 ## Statistics
 
-To see how changes will affect the statistics of real, true, and null values, you can run `npm run stats`.  This generates a Markdown-formatted table of the percentages of real, true, and null values for the eight primary browsers that browser-compat-data is focusing on.
+To see how changes will affect the statistics of real, true, and null values, you can run `npm run stats`.  This generates a Markdown-formatted table of the percentages of real, true, and null values for the eight primary browsers that browser-compat-data is focusing on.  The script also takes an optional argument regarding a specific folder (such as `api` or `javascript`), which will print statistics result for only that folder.
 
 * _Real_ values are values of which are either `false` or a version number, as defined in [#3555](https://github.com/mdn/browser-compat-data/issues/3555).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -20,6 +20,6 @@ Paste the generated HTML into the MDN editor (source mode). You can use a new pa
 
 ## Statistics
 
-To see how changes will affect the statistics of real, true, and null values, you can run `npm run stats`.  This generates a Markdown-formatted table of the percentages of real, true, and null values for the eight primary browsers that browser-compat-data is focusing on.  The script also takes an optional argument regarding a specific folder (such as `api` or `javascript`), which will print statistics result for only that folder.
+To see how changes will affect the statistics of real, true, and null values, you can run `npm run stats [folder]`.  This generates a Markdown-formatted table of the percentages of real, true, and null values for the eight primary browsers that browser-compat-data is focusing on.  The script also takes an optional argument regarding a specific folder (such as `api` or `javascript`), which will print statistics result for only that folder.
 
 * _Real_ values are values of which are either `false` or a version number, as defined in [#3555](https://github.com/mdn/browser-compat-data/issues/3555).

--- a/scripts/statistics.js
+++ b/scripts/statistics.js
@@ -78,9 +78,13 @@ const iterateData = (data) => {
   }
 };
 
-for (let data in bcd) {
-  if (!(data === 'browsers' || data === 'webextensions')) {
-    iterateData(bcd[data]);
+if (process.argv[2]) {
+  iterateData(bcd[process.argv[2]]);
+} else {
+  for (let data in bcd) {
+    if (!(data === 'browsers' || data === 'webextensions')) {
+      iterateData(bcd[data]);
+    }
   }
 }
 
@@ -101,5 +105,5 @@ const printTable = () => {
   console.log(table);
 }
 
-console.log('Status as of version 0.0.xx (released on 2019-MM-DD) for web platform features: \n')
+console.log(`Status as of version 0.0.xx (released on 2019-MM-DD) for ${process.argv[2] ? `${process.argv[2]}/ directory` : `web platform features`}: \n`);
 printTable();


### PR DESCRIPTION
Something I've been finding myself commonly doing is modifying the statistics script a little bit to restrict the results to only CSS alone.  But after how many times I've performed this action, I thought: "why not make it a command line argument?"  This PR adds the ability to specify a particular folder such as `api`, `css`, `javascript`, or `xpath` and obtain statistics for only that folder.  The "Status as of..." line will update accordingly to indicate the selected folder if applicable.

This PR also updates the matching documentation to mention this optional argument.