### PR TITLE
Add documentation for traverse script

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -22,4 +22,7 @@ Paste the generated HTML into the MDN editor (source mode). You can use a new pa
 
 To see how changes will affect the statistics of real, true, and null values, you can run `npm run stats`.  This generates a Markdown-formatted table of the percentages of real, true, and null values for the eight primary browsers that browser-compat-data is focusing on.
 
+## Traverse
+To find all the entries that are non-real, or of a specified value, you can run `npm run traverse <browser> [folder] [value]`.  The browser may be any single browser defined in the [`browsers/` folder](https://github.com/mdn/browser-compat-data/blob/master/browsers/).  The folder may be omitted to search through all data folders, or a comma-separated list of folders to search through.  The value may be omitted to search for all non-real values (or more specifically, `true` and `null` values), or any value accepted by `version_added` and `version_removed`.  For example, to search for all Safari entries that are non-real, run `npm run traverse safari`.  To search for all WebView entries that are marked as `true` in `api` and `javascript`, run `npm run traverse webview_android api,javascript true`.
+
 * _Real_ values are values of which are either `false` or a version number, as defined in [#3555](https://github.com/mdn/browser-compat-data/issues/3555).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -20,9 +20,9 @@ Paste the generated HTML into the MDN editor (source mode). You can use a new pa
 
 ## Statistics
 
-To see how changes will affect the statistics of real, true, and null values, you can run `npm run stats`.  This generates a Markdown-formatted table of the percentages of real, true, and null values for the eight primary browsers that browser-compat-data is focusing on.
+To see how changes will affect the statistics of real*, true, and null values, you can run `npm run stats`.  This generates a Markdown-formatted table of the percentages of real, true, and null values for the eight primary browsers that browser-compat-data is focusing on.
 
 ## Traverse
 To find all the entries that are non-real, or of a specified value, you can run `npm run traverse <browser> [folder] [value]`.  The browser may be any single browser defined in the [`browsers/` folder](https://github.com/mdn/browser-compat-data/blob/master/browsers/).  The folder may be omitted to search through all data folders, or a comma-separated list of folders to search through.  The value may be omitted to search for all non-real values (or more specifically, `true` and `null` values), or any value accepted by `version_added` and `version_removed`.  For example, to search for all Safari entries that are non-real, run `npm run traverse safari`.  To search for all WebView entries that are marked as `true` in `api` and `javascript`, run `npm run traverse webview_android api,javascript true`.
 
-* _Real_ values are values of which are either `false` or a version number, as defined in [#3555](https://github.com/mdn/browser-compat-data/issues/3555).
+\* _Real_ values are values of which are either `false` or a version number, as defined in [#3555](https://github.com/mdn/browser-compat-data/issues/3555).


### PR DESCRIPTION
Follow-up to #4120, and fixes #4147.  The traverse script was recently introduced as a way to help find all non-real values within the data -- however, documentation was minimal, if what's there could even be considered documentation.  (Documentation is one of my weak points, specifically remembering to do so.  😛)  So, that's where this PR comes in, by adding an explanation on what the traverse script is used for, and what its arguments are.

I'm happy to add more details if necessary!