### PR TITLE
Add Chromium + Safari version for outline-style: auto

### DIFF
--- a/css/properties/outline-style.json
+++ b/css/properties/outline-style.json
@@ -60,10 +60,10 @@
             "description": "<code>auto</code>",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
                 "version_added": false
@@ -78,22 +78,22 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "1.2"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "≤37"
               }
             },
             "status": {


### PR DESCRIPTION
This PR adds the WebKit version for the `auto` value of the `outline-style` CSS property.  Data is as follows:

Implemented in WebKit 125
https://trac.webkit.org/browser/webkit/tags/old/Safari-125/WebCore/khtml/rendering/render_inline.cpp#L299
`auto` was originally called `-apple-aqua` and renamed in the linked file -- however, the outline-style property, let alone `-apple-aqua`, was not present in WebKit 100
Safari 1.2, Chrome 1