### PR TITLE
Add Safari versions for several align/justify-content/items values

### DIFF
--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -307,10 +307,10 @@
                   "version_added": "43"
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": "9"
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": "9"
                 },
                 "samsunginternet_android": {
                   "version_added": "7.0"
@@ -355,10 +355,10 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": "11"
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": "11"
                 },
                 "samsunginternet_android": {
                   "version_added": false
@@ -451,10 +451,10 @@
                   "version_added": null
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "samsunginternet_android": {
                   "version_added": false

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -200,10 +200,10 @@
                   "version_added": "43"
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": "11"
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": "11"
                 },
                 "samsunginternet_android": {
                   "version_added": true
@@ -296,10 +296,10 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": "9"
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": "9"
                 },
                 "samsunginternet_android": {
                   "version_added": false
@@ -344,10 +344,10 @@
                   "version_added": null
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": "9"
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": "9"
                 },
                 "samsunginternet_android": {
                   "version_added": false
@@ -441,10 +441,10 @@
                   "version_added": "43"
                 },
                 "safari": {
-                  "version_added": true
+                  "version_added": "11"
                 },
                 "safari_ios": {
-                  "version_added": true
+                  "version_added": "11"
                 },
                 "samsunginternet_android": {
                   "version_added": true

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -240,10 +240,10 @@
                   "version_added": null
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": "9"
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": "9"
                 },
                 "samsunginternet_android": {
                   "version_added": null
@@ -295,10 +295,10 @@
                   "version_added": null
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": "9"
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": "9"
                 },
                 "samsunginternet_android": {
                   "version_added": null
@@ -449,10 +449,10 @@
                   "version_added": null
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": "9"
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": "9"
                 },
                 "samsunginternet_android": {
                   "version_added": null
@@ -497,10 +497,10 @@
                   "version_added": null
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": "9"
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": "9"
                 },
                 "samsunginternet_android": {
                   "version_added": false


### PR DESCRIPTION
This PR adds Safari and Safari iOS versions for various values to `align-content`, `align-items`, and `justify-content`, based upon manual testing in SauceLabs throughout Safari 8-12.  Affected properties are:

- css.properties.align-content.flex_context.baseline
- css.properties.align-content.flex_context.first_last_baseline
- css.properties.align-content.flex_context.safe_unsafe
- css.properties.align-items.grid_context.start_end
- css.properties.align-items.flex_context.first_last_baseline
- css.properties.align-items.flex_context.left_right
- css.properties.align-items.flex_context.safe_unsafe
- css.properties.justify-content.flex_context.start_end
- css.properties.justify-content.flex_context.left_right
- css.properties.justify-content.flex_context.stretch
- css.properties.justify-content.flex_context.safe_unsafe