### PR TITLE
Mark storage event as supported in Chrome

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -9176,10 +9176,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/storage_event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -9194,10 +9194,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "14"
             },
             "safari": {
               "version_added": null
@@ -9206,7 +9206,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -9176,7 +9176,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/storage_event",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true
             },
             "chrome_android": {
               "version_added": false

--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -600,7 +600,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WindowEventHandlers/onstorage",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": true
             },
             "chrome_android": {
               "version_added": false

--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -600,10 +600,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WindowEventHandlers/onstorage",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge": {
               "version_added": true
@@ -618,10 +618,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "14"
             },
             "safari": {
               "version_added": null
@@ -630,7 +630,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
`storage` event is supported in Chrome, tested it on Chrome 62 and 76.

https://chromium.googlesource.com/external/Webkit/+/master/Source/WebCore/page/DOMWindow.idl#272 lists `onstorage`
https://bugs.chromium.org/p/chromium/issues/detail?id=128482 talks about `storage` event propogation improvements, thus confirming it was implemented