### PR TITLE
Add Safari versions for place-content and place-items CSS properties

### DIFF
--- a/css/properties/place-content.json
+++ b/css/properties/place-content.json
@@ -32,10 +32,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "9"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "9"
               },
               "samsunginternet_android": {
                 "version_added": "7.0"
@@ -81,10 +81,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "11"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "11"
               },
               "samsunginternet_android": {
                 "version_added": "7.0"

--- a/css/properties/place-items.json
+++ b/css/properties/place-items.json
@@ -32,10 +32,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": "11"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "11"
               },
               "samsunginternet_android": {
                 "version_added": "7.0"
@@ -81,10 +81,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": "11"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "11"
               },
               "samsunginternet_android": {
                 "version_added": "7.0"


### PR DESCRIPTION
The version numbers were determined from manual testing within SauceLabs.