### PR TITLE
Update font-variant and text-transform with Greek accented characters

### DIFF
--- a/css/properties/font-variant.json
+++ b/css/properties/font-variant.json
@@ -168,10 +168,12 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "15"
+                "version_added": false,
+                "notes": "Some operating systems may correctly omit accents in all-uppercase Greek text."
               },
               "firefox_android": {
-                "version_added": "15"
+                "version_added": false,
+                "notes": "Some operating systems may correctly omit accents in all-uppercase Greek text."
               },
               "ie": {
                 "version_added": false

--- a/css/properties/font-variant.json
+++ b/css/properties/font-variant.json
@@ -165,7 +165,7 @@
                 "notes": "Some operating systems may correctly omit accents in all-uppercase Greek text."
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "15"
@@ -174,7 +174,7 @@
                 "version_added": "15"
               },
               "ie": {
-                "version_added": "4"
+                "version_added": false
               },
               "opera": {
                 "version_added": false,

--- a/css/properties/font-variant.json
+++ b/css/properties/font-variant.json
@@ -157,10 +157,12 @@
             "description": "Greek accented characters",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": false,
+                "notes": "Some operating systems may correctly omit accents in all-uppercase Greek text."
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": false,
+                "notes": "Some operating systems may correctly omit accents in all-uppercase Greek text."
               },
               "edge": {
                 "version_added": "12"
@@ -175,10 +177,12 @@
                 "version_added": "4"
               },
               "opera": {
-                "version_added": true
+                "version_added": false,
+                "notes": "Some operating systems may correctly omit accents in all-uppercase Greek text."
               },
               "opera_android": {
-                "version_added": true
+                "version_added": false,
+                "notes": "Some operating systems may correctly omit accents in all-uppercase Greek text."
               },
               "safari": {
                 "version_added": true
@@ -187,10 +191,12 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": false,
+                "notes": "Some operating systems may correctly omit accents in all-uppercase Greek."
               },
               "webview_android": {
-                "version_added": true
+                "version_added": false,
+                "notes": "Some operating systems may correctly omit accents in all-uppercase Greek."
               }
             },
             "status": {

--- a/css/properties/font-variant.json
+++ b/css/properties/font-variant.json
@@ -185,10 +185,10 @@
                 "notes": "Some operating systems may correctly omit accents in all-uppercase Greek text."
               },
               "safari": {
-                "version_added": true
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false,

--- a/css/properties/text-transform.json
+++ b/css/properties/text-transform.json
@@ -258,7 +258,7 @@
                 "version_added": "34"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "15"
@@ -267,7 +267,7 @@
                 "version_added": "15"
               },
               "ie": {
-                "version_added": "4"
+                "version_added": false
               },
               "opera": {
                 "version_added": "21"

--- a/css/properties/text-transform.json
+++ b/css/properties/text-transform.json
@@ -276,10 +276,10 @@
                 "version_added": "21"
               },
               "safari": {
-                "version_added": true
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "2.0"

--- a/css/properties/text-transform.json
+++ b/css/properties/text-transform.json
@@ -252,10 +252,10 @@
             "description": "Greek accented letters",
             "support": {
               "chrome": {
-                "version_added": "30"
+                "version_added": "34"
               },
               "chrome_android": {
-                "version_added": "30"
+                "version_added": "34"
               },
               "edge": {
                 "version_added": "12"
@@ -270,10 +270,10 @@
                 "version_added": "4"
               },
               "opera": {
-                "version_added": "17"
+                "version_added": "21"
               },
               "opera_android": {
-                "version_added": "18"
+                "version_added": "21"
               },
               "safari": {
                 "version_added": true
@@ -282,7 +282,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
                 "version_added": "4.4"


### PR DESCRIPTION
Greek has some rules around accents and capitalization (all caps has no accents but ordinary capitalization keeps the accents) which are only partially captured by the behavior of `font-variant` and `text-transform`. As a result, the story for this data is similar to the story of the data for ß (see #4548): weird inconsistencies depending on operating system, particularly for `font-variant`.

For Safari, Firefox, Edge, IE, and Chrome, I tested with SauceLabs to find a version number (if supported). I also double checked for consistency with Windows, Linux, and macOS, where applicable. For all other browsers, I mirrored from their corresponding desktop browser.

Yet another part of the continuing saga of #4301.