### PR TITLE
Update touch-action for Safari for iOS

### DIFF
--- a/css/properties/touch-action.json
+++ b/css/properties/touch-action.json
@@ -65,7 +65,7 @@
               "version_added": "13"
             },
             "safari_ios": {
-              "version_added": "9.1"
+              "version_added": "9.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -143,7 +143,7 @@
                 "version_added": "13"
               },
               "safari_ios": {
-                "version_added": "9.1"
+                "version_added": "9.3"
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
This fixes #4366. Several sources point toward the touch-action landing in Safari for iOS later than we have recorded. The main point is that [it was announced] after versions 9.1 and 9.2; other sources (like caniuse) support the idea that it first appeared in iOS 9.3.