### PR TITLE
Add text-decoration-thickness and text-underline-offset

### DIFF
--- a/css/properties/text-decoration-thickness.json
+++ b/css/properties/text-decoration-thickness.json
@@ -14,9 +14,29 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "70",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.text-decoration-thickness.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "69",
+                "alternative_name": "text-decoration-width",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.text-decoration-width.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },

--- a/css/properties/text-decoration-thickness.json
+++ b/css/properties/text-decoration-thickness.json
@@ -1,0 +1,54 @@
+{
+  "css": {
+    "properties": {
+      "text-decoration-thickness": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-decoration-thickness",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "12.1"
+            },
+            "safari_ios": {
+              "version_added": "12.2"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/text-underline-offset.json
+++ b/css/properties/text-underline-offset.json
@@ -1,0 +1,54 @@
+{
+  "css": {
+    "properties": {
+      "text-underline-offset": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-underline-offset",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "12.1"
+            },
+            "safari_ios": {
+              "version_added": "12.2"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/text-underline-offset.json
+++ b/css/properties/text-underline-offset.json
@@ -15,7 +15,14 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "69",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.text-underline-offset.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
Fixes #3786, which contains a bunch of information about the addition of `text-decoration-thickness` and `text-underline-offset` to Safari. [This post](https://webkit.org/blog/8718/new-webkit-features-in-safari-12-1/) covers it in the _Better Text Decorations_ section. As best I can tell, Safari is the only browser to support it so far.