### PR TITLE
Update absolutely positioned flex children data

### DIFF
--- a/css/properties/order.json
+++ b/css/properties/order.json
@@ -153,10 +153,10 @@
             "description": "Absolutely-positioned flex children",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "52"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "52"
               },
               "edge": {
                 "version_added": "12"
@@ -171,10 +171,10 @@
                 "version_added": "10"
               },
               "opera": {
-                "version_added": "12.1"
+                "version_added": "39"
               },
               "opera_android": {
-                "version_added": "12.1"
+                "version_added": "41"
               },
               "safari": {
                 "version_added": true
@@ -183,10 +183,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "6.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "52"
               }
             },
             "status": {

--- a/css/properties/order.json
+++ b/css/properties/order.json
@@ -147,54 +147,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "absolutely_positioned_flex_children": {
-          "__compat": {
-            "description": "Absolutely-positioned flex children",
-            "support": {
-              "chrome": {
-                "version_added": "52"
-              },
-              "chrome_android": {
-                "version_added": "52"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "52"
-              },
-              "firefox_android": {
-                "version_added": "52"
-              },
-              "ie": {
-                "version_added": "10"
-              },
-              "opera": {
-                "version_added": "39"
-              },
-              "opera_android": {
-                "version_added": "41"
-              },
-              "safari": {
-                "version_added": "11"
-              },
-              "safari_ios": {
-                "version_added": "11"
-              },
-              "samsunginternet_android": {
-                "version_added": "6.0"
-              },
-              "webview_android": {
-                "version_added": "52"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       }
     }

--- a/css/properties/order.json
+++ b/css/properties/order.json
@@ -162,10 +162,10 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": false
+                "version_added": "52"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "52"
               },
               "ie": {
                 "version_added": "10"

--- a/css/properties/order.json
+++ b/css/properties/order.json
@@ -177,10 +177,10 @@
                 "version_added": "41"
               },
               "safari": {
-                "version_added": true
+                "version_added": "11"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "11"
               },
               "samsunginternet_android": {
                 "version_added": "6.0"

--- a/css/properties/position.json
+++ b/css/properties/position.json
@@ -49,6 +49,54 @@
             "deprecated": false
           }
         },
+        "absolutely_positioned_flex_children": {
+          "__compat": {
+            "description": "Absolutely-positioned flex children",
+            "support": {
+              "chrome": {
+                "version_added": "52"
+              },
+              "chrome_android": {
+                "version_added": "52"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": "52"
+              },
+              "ie": {
+                "version_added": "10"
+              },
+              "opera": {
+                "version_added": "39"
+              },
+              "opera_android": {
+                "version_added": "41"
+              },
+              "safari": {
+                "version_added": "11"
+              },
+              "safari_ios": {
+                "version_added": "11"
+              },
+              "samsunginternet_android": {
+                "version_added": "6.0"
+              },
+              "webview_android": {
+                "version_added": "52"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "fixed": {
           "__compat": {
             "description": "<code>fixed</code>",


### PR DESCRIPTION
For #4298, this updates the data for `css.properties.order.absolutely_positioned_flex_children` and moves the whole feature to a more sensible place.

I kinda get why the data was in `order` (absolute positioning seems to take the item _out_ of the order), but I moved it to `css.properties.position` because I think it has more to do with what developers expect to happen with `position: absolute`.

## Sources

Chrome:
* https://developers.google.com/web/updates/2016/06/absolute-positioned-children
* https://www.chromestatus.com/feature/6600926009753600
* Mirrored for the other Chromiums

Safari: tested on SauceLabs, then mirrored to iOS.

Firefox: [bug 874718](https://bugzilla.mozilla.org/show_bug.cgi?id=874718#c29)