### PR TITLE
Move prevent-duplicate-values to a Firefox note

### DIFF
--- a/css/properties/place-content.json
+++ b/css/properties/place-content.json
@@ -17,10 +17,12 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "45"
+                "version_added": "45",
+                "notes": "Starting with version 60, you can only specify a single value if it is valid for both <code>align-content</code> and <code>justify-content</code>."
               },
               "firefox_android": {
-                "version_added": "45"
+                "version_added": "45",
+                "notes": "Starting with version 60, you can only specify a single value if it is valid for both <code>align-content</code> and <code>justify-content</code>."
               },
               "ie": {
                 "version_added": false
@@ -66,10 +68,12 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "53"
+                "version_added": "53",
+                "notes": "Starting with version 60, you can only specify a single value if it is valid for both <code>align-content</code> and <code>justify-content</code>."
               },
               "firefox_android": {
-                "version_added": "53"
+                "version_added": "53",
+                "notes": "Starting with version 60, you can only specify a single value if it is valid for both <code>align-content</code> and <code>justify-content</code>."
               },
               "ie": {
                 "version_added": false
@@ -91,54 +95,6 @@
               },
               "webview_android": {
                 "version_added": "59"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "prevent-duplicated-values": {
-          "__compat": {
-            "description": "You can only specify a single value if it is valid for both <code>align-content</code> and <code>justify-content</code>",
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "60"
-              },
-              "firefox_android": {
-                "version_added": "60"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": true
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": true
               }
             },
             "status": {


### PR DESCRIPTION
I don't think this one deserves a sub feature. Made it a Firefox note instead.

(originally added in https://github.com/mdn/browser-compat-data/pull/1173 for some history)