### PR TITLE
Set Safari+Chrome versions for several misc. CSS properties

### DIFF
--- a/css/properties/break-after.json
+++ b/css/properties/break-after.json
@@ -297,10 +297,10 @@
                   "version_added": null
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": "10"
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": "10"
                 },
                 "samsunginternet_android": {
                   "version_added": null
@@ -346,10 +346,10 @@
                   "version_added": null
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "samsunginternet_android": {
                   "version_added": null

--- a/css/properties/break-before.json
+++ b/css/properties/break-before.json
@@ -297,10 +297,10 @@
                   "version_added": null
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": "10"
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": "10"
                 },
                 "samsunginternet_android": {
                   "version_added": null
@@ -346,10 +346,10 @@
                   "version_added": null
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "samsunginternet_android": {
                   "version_added": null

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -248,10 +248,10 @@
               "description": "Supported on <code>&lt;legend&gt;</code>",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "71"
                 },
                 "chrome_android": {
-                  "version_added": false
+                  "version_added": "71"
                 },
                 "edge": {
                   "version_added": false
@@ -266,10 +266,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": "58"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "50"
                 },
                 "safari": {
                   "version_added": false
@@ -281,7 +281,7 @@
                   "version_added": false
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "71"
                 }
               },
               "status": {

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -272,10 +272,10 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": true
+                  "version_added": false
                 },
                 "safari_ios": {
-                  "version_added": true
+                  "version_added": false
                 },
                 "samsunginternet_android": {
                   "version_added": false

--- a/css/properties/height.json
+++ b/css/properties/height.json
@@ -89,10 +89,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": true
+                "version_added": "11"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "11"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -149,10 +149,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": true
+                "version_added": "11"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "11"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -200,10 +200,12 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "alternative_name": "-webkit-fill-available",
+                "version_added": "9"
               },
               "safari_ios": {
-                "version_added": null
+                "alternative_name": "-webkit-fill-available",
+                "version_added": "9"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"

--- a/css/properties/hyphens.json
+++ b/css/properties/hyphens.json
@@ -794,10 +794,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": true
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -842,10 +842,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": true
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/css/properties/hyphens.json
+++ b/css/properties/hyphens.json
@@ -794,10 +794,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": null
+                "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": true
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -842,10 +842,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": null
+                "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": true
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -222,10 +222,10 @@
             "description": "Support in SVG",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "19"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "25"
               },
               "edge": {
                 "version_added": "17"
@@ -270,22 +270,22 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "14"
               },
               "safari": {
-                "version_added": null
+                "version_added": "6"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "6"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.5"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {


### PR DESCRIPTION
This PR sets version numbers of when various miscellaneous CSS features were added to Safari (and one for Chrome).  All version numbers were based upon manual testing within SauceLabs and BrowserStack.

css.properties.display.list-item.legend-support
Implemented in Chrome 71

css.properties.break-after.paged_context.always
False in Safari

css.properties.break-after.paged_context.page
Available in Safari 10

css.properties.break-before.paged_context.always
False in Safari

css.properties.break-before.paged_context.page
Available in Safari 10

css.properties.display.list-item.legend-support
False in Safari

css.properties.height.stretch
Implemented in Safari 9 as -webkit-fill-available

css.properties.height.max-content
Implemented in Safari 11

css.properties.height.min-content
Implemented in Safari 11

css.properties.transform-origin.support_in_svg
Implemented in Chrome 19
Implemented in Safari 6

css.properties.hyphens.german_traditional_orthography, css.properties.hyphens.german_swiss_orthography
False in Safari (From what I can tell, the languages that have been marked with compatibility are the only ones bundled within Safari.  All others are handled by the OS, which we've indicated as "False".)