### PR TITLE
[Firefox] Bug 1038294: Implement display property multi‑keyword syntax

### DIFF
--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -163,7 +163,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": "70"
               },
               "firefox_android": {
                 "version_added": false


### PR DESCRIPTION
See [bug 1038294](https://bugzilla.mozilla.org/show_bug.cgi?id=1038294), [bug 1105868](https://bugzilla.mozilla.org/show_bug.cgi?id=1105868) and [bug 1557825](https://bugzilla.mozilla.org/show_bug.cgi?id=1557825) for details.