### PR TITLE
Update Safari var() versions; dont mark as experimental

### DIFF
--- a/css/properties/custom-property.json
+++ b/css/properties/custom-property.json
@@ -85,7 +85,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -168,10 +168,10 @@
                 "version_added": "36"
               },
               "safari": {
-                "version_added": true
+                "version_added": "9.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "9.1"
               },
               "samsunginternet_android": {
                 "version_added": null
@@ -181,7 +181,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
https://webkit.org/blog/5989/css-variables-in-webkit/ talks about `var()`, so I assume it was there with the initial support for custom properties. I copied 9.1 from there. I don't think this is experimental anymore, so I also set the flags to false.