### PR TITLE
Chrome doesn't support css filters on svg elements

### DIFF
--- a/css/properties/filter.json
+++ b/css/properties/filter.json
@@ -153,10 +153,10 @@
             "description": "On SVG elements",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": false
               },
               "edge": {
                 "version_added": false


### PR DESCRIPTION
We've got this wrong in https://github.com/mdn/browser-compat-data/pull/1870

See https://stackoverflow.com/questions/32567156/why-dont-css-filters-work-on-svg-elements-in-chrome
Chromium bug: https://bugs.chromium.org/p/chromium/issues/detail?id=109224
Test case: https://jsfiddle.net/LtffLagn/2/