### PR TITLE
Mark image-rendering: pixelated as supported in Safari 10

### DIFF
--- a/css/properties/image-rendering.json
+++ b/css/properties/image-rendering.json
@@ -157,10 +157,10 @@
                 "version_added": "26"
               },
               "safari": {
-                "version_added": null
+                "version_added": "10"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10"
               },
               "samsunginternet_android": {
                 "version_added": "4.0"


### PR DESCRIPTION
Bug: https://bugs.webkit.org/show_bug.cgi?id=146771
Changeset: https://trac.webkit.org/changeset/195848/webkit
caniuse: https://caniuse.com/#feat=css-crisp-edges
test case: http://jsfiddle.net/greggman/mn9ebgkL/
Also tested in saucelabs and it works with version 10.