### PR TITLE
Update performance.now() version for opera_android

### DIFF
--- a/api/Performance.json
+++ b/api/Performance.json
@@ -670,7 +670,7 @@
               "version_added": "15"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "16"
             },
             "safari": {
               "version_added": "8"

--- a/api/Performance.json
+++ b/api/Performance.json
@@ -670,7 +670,7 @@
               "version_added": "15"
             },
             "opera_android": {
-              "version_added": "16"
+              "version_added": "14"
             },
             "safari": {
               "version_added": "8"


### PR DESCRIPTION
Opera for Android has supported performance.now() since at least version 16.