### PR TITLE
Compat data for white-space

### DIFF
--- a/css/properties/white-space.json
+++ b/css/properties/white-space.json
@@ -65,16 +65,16 @@
                 "version_added": "69"
               },
               "firefox_android": {
-                "version_added": "69"
+                "version_added": false
               },
               "ie": {
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": null
@@ -83,7 +83,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": "76"

--- a/css/properties/white-space.json
+++ b/css/properties/white-space.json
@@ -48,6 +48,54 @@
             "deprecated": false
           }
         },
+        "break-spaces": {
+          "__compat": {
+            "description": "<code>break-spaces</code>",
+            "support": {
+              "chrome": {
+                "version_added": "76"
+              },
+              "chrome_android": {
+                "version_added": "76"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "69"
+              },
+              "firefox_android": {
+                "version_added": "69"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": "76"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "pre": {
           "__compat": {
             "description": "<code>pre</code>",


### PR DESCRIPTION
Adding the break-spaces value for white-space which is shipping in Firefox 69.

Value is also in Chrome from 76: https://www.chromestatus.com/features/4842781306519552