### PR TITLE
Add Firefox to supported browsers of backdrop-filter

### DIFF
--- a/css/properties/backdrop-filter.json
+++ b/css/properties/backdrop-filter.json
@@ -37,8 +37,14 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1178765'>bug 1178765</a>."
+              "version_added": 70,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.backdrop-filter.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false,

--- a/css/properties/backdrop-filter.json
+++ b/css/properties/backdrop-filter.json
@@ -37,7 +37,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": 70,
+              "version_added": "70",
               "flags": [
                 {
                   "type": "preference",


### PR DESCRIPTION
- Firefox will add experimental support of backdrop-filter in 70, now it's behind a flag, so update data then
