### PR TITLE
Updated HTMLTimeElement API support in Safari

### DIFF
--- a/api/HTMLTimeElement.json
+++ b/api/HTMLTimeElement.json
@@ -41,10 +41,10 @@
             }
           ],
           "safari": {
-            "version_added": false
+            "version_added": "10"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "10"
           },
           "webview_android": {
             "version_added": "62"
@@ -97,10 +97,10 @@
               }
             ],
             "safari": {
-              "version_added": false
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10"
             },
             "webview_android": {
               "version_added": "62"


### PR DESCRIPTION
Safari for Desktop and Mobile has supported HTMLTimeElement API since version 10.

- [https://developer.apple.com/documentation/webkitjs/htmltimeelement](https://developer.apple.com/documentation/webkitjs/htmltimeelement)
- [https://developer.apple.com/documentation/webkitjs/htmltimeelement/1777959-datetime](https://developer.apple.com/documentation/webkitjs/htmltimeelement/1777959-datetime)
