### PR TITLE
Update Safari support for DOMTokenList API

### DIFF
--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -29,10 +29,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": true
+            "version_added": "5.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "5.1"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -79,7 +79,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.0"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -123,10 +123,10 @@
                 "version_added": "48"
               },
               "safari": {
-                "version_added": "10.1"
+                "version_added": "12"
               },
               "safari_ios": {
-                "version_added": "10.1"
+                "version_added": "12"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -172,10 +172,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -222,10 +222,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -273,7 +273,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "5.1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -374,7 +374,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "5.1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -422,7 +422,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "5.1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -470,7 +470,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "5.1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -515,10 +515,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "5.1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -566,7 +566,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "5.1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -610,10 +610,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": "5.1"
+                "version_added": "6.2"
               },
               "safari_ios": {
-                "version_added": "5"
+                "version_added": "6.2"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -659,10 +659,10 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -707,10 +707,10 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -755,10 +755,10 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -803,10 +803,10 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -79,7 +79,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -178,7 +178,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "5"
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -76,10 +76,10 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -123,10 +123,10 @@
                 "version_added": "48"
               },
               "safari": {
-                "version_added": false
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "10.1"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -270,10 +270,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -322,10 +322,10 @@
               "notes": "Before Opera 37, this property was part of the deprecated child <code>DOMSettableTokenList</code> interface."
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -371,10 +371,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -419,10 +419,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -467,10 +467,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -515,10 +515,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -563,10 +563,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -610,10 +610,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -659,10 +659,10 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -707,10 +707,10 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -755,10 +755,10 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -803,10 +803,10 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -178,7 +178,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "5"
             },
             "webview_android": {
               "version_added": "49"
@@ -273,7 +273,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5.0"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -322,10 +322,10 @@
               "notes": "Before Opera 37, this property was part of the deprecated child <code>DOMSettableTokenList</code> interface."
             },
             "safari": {
-              "version_added": "10.0"
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": "10.0"
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -374,7 +374,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5.0"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -422,7 +422,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5.0"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -470,7 +470,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5.0"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -515,10 +515,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "10.0"
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": "10.0"
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -566,7 +566,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5.0"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -613,7 +613,7 @@
                 "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": "5.0"
+                "version_added": "5"
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -79,7 +79,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.0"
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -175,7 +175,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -79,7 +79,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -610,10 +610,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": "6.2"
+                "version_added": "6.1"
               },
               "safari_ios": {
-                "version_added": "6.2"
+                "version_added": "6.1"
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
Updated support for DOMTokenList methods and properties in Safari Desktop and Mobile.

- https://developer.apple.com/documentation/webkitjs/domtokenlist
  - https://developer.apple.com/documentation/webkitjs/domtokenlist/1631733-length
  - https://developer.apple.com/documentation/webkitjs/domtokenlist/1777741-value
  - https://developer.apple.com/documentation/webkitjs/domtokenlist/1634479-add
  - https://developer.apple.com/documentation/webkitjs/domtokenlist/1634493-contains
  - https://developer.apple.com/documentation/webkitjs/domtokenlist/1629151-item
  - https://developer.apple.com/documentation/webkitjs/domtokenlist/1631666-remove
  - https://developer.apple.com/documentation/webkitjs/domtokenlist/2871437-replace
  - https://developer.apple.com/documentation/webkitjs/domtokenlist/1630503-toggle