### PR TITLE
Correct Chrome support for Screen interface.

### DIFF
--- a/api/Screen.json
+++ b/api/Screen.json
@@ -345,7 +345,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Screen/left",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": false
             },
             "chrome_android": {
               "version_added": true
@@ -730,7 +730,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Screen/top",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": false
             },
             "chrome_android": {
               "version_added": true


### PR DESCRIPTION
Chrome does not appear to support `window.screen.top` and `window.screen.left`. 

Testing on Canary (v78.0) yields `undefined`.

The [Chromium IDL file](https://cs.chromium.org/chromium/src/third_party/blink/renderer/core/frame/screen.idl?q=screen.idl&sq=package:chromium&g=0&l=1) does not expose `top` and `left`, and a quick hop through its version history suggests that it never did.