### PR TITLE
Set Safari versions for several misc. CSS properties (part 2)

### DIFF
--- a/css/properties/height.json
+++ b/css/properties/height.json
@@ -248,12 +248,24 @@
               "opera_android": {
                 "version_added": null
               },
-              "safari": {
-                "version_added": true
-              },
-              "safari_ios": {
-                "version_added": true
-              },
+              "safari": [
+                {
+                  "version_added": "11"
+                },
+                {
+                  "version_added": "9",
+                  "prefix": "-webkit-"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "11"
+                },
+                {
+                  "version_added": "9",
+                  "prefix": "-webkit-"
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": "5.0"
               },

--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -166,12 +166,24 @@
               "opera_android": {
                 "version_added": "43"
               },
-              "safari": {
-                "version_added": true
-              },
-              "safari_ios": {
-                "version_added": true
-              },
+              "safari": [
+                {
+                  "version_added": "11"
+                },
+                {
+                  "version_added": "9",
+                  "prefix": "-webkit-"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "11"
+                },
+                {
+                  "version_added": "9",
+                  "prefix": "-webkit-"
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": "5.0"
               },
@@ -226,12 +238,24 @@
               "opera_android": {
                 "version_added": "43"
               },
-              "safari": {
-                "version_added": true
-              },
-              "safari_ios": {
-                "version_added": true
-              },
+              "safari": [
+                {
+                  "version_added": "11"
+                },
+                {
+                  "version_added": "9",
+                  "prefix": "-webkit-"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "11"
+                },
+                {
+                  "version_added": "9",
+                  "prefix": "-webkit-"
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": "5.0"
               },

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -92,12 +92,24 @@
               "opera_android": {
                 "version_added": "43"
               },
-              "safari": {
-                "version_added": true
-              },
-              "safari_ios": {
-                "version_added": true
-              },
+              "safari": [
+                {
+                  "version_added": "11"
+                },
+                {
+                  "version_added": "9",
+                  "prefix": "-webkit-"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "11"
+                },
+                {
+                  "version_added": "9",
+                  "prefix": "-webkit-"
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": "5.0"
               },
@@ -152,12 +164,24 @@
               "opera_android": {
                 "version_added": "43"
               },
-              "safari": {
-                "version_added": true
-              },
-              "safari_ios": {
-                "version_added": true
-              },
+              "safari": [
+                {
+                  "version_added": "11"
+                },
+                {
+                  "version_added": "9",
+                  "prefix": "-webkit-"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "11"
+                },
+                {
+                  "version_added": "9",
+                  "prefix": "-webkit-"
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": "5.0"
               },

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -304,11 +304,12 @@
               },
               "safari": [
                 {
-                  "version_added": true
+                  "prefix": "-webkit-",
+                  "version_added": "6.1"
                 },
                 {
-                  "alternative_name": "-webkit-fill-available",
-                  "version_added": "6.1"
+                  "alternative_name": "intrinsic",
+                  "version_added": "2"
                 }
               ],
               "safari_ios": {

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -304,12 +304,11 @@
               },
               "safari": [
                 {
-                  "prefix": "-webkit-",
-                  "version_added": "6.1"
+                  "version_added": true
                 },
                 {
-                  "alternative_name": "intrinsic",
-                  "version_added": "2"
+                  "alternative_name": "-webkit-fill-available",
+                  "version_added": "6.1"
                 }
               ],
               "safari_ios": {

--- a/css/properties/overflow-wrap.json
+++ b/css/properties/overflow-wrap.json
@@ -186,10 +186,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": null

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -334,16 +334,22 @@
               },
               "safari": [
                 {
-                  "version_added": true
+                  "version_added": "11"
                 },
                 {
-                  "alternative_name": "-webkit-fill-available",
-                  "version_added": "6.1"
+                  "version_added": "9",
+                  "prefix": "-webkit-"
                 }
               ],
-              "safari_ios": {
-                "version_added": null
-              },
+              "safari_ios": [
+                {
+                  "version_added": "11"
+                },
+                {
+                  "version_added": "9",
+                  "prefix": "-webkit-"
+                }
+              ],
               "samsunginternet_android": {
                 "alternative_name": "-webkit-fill-available",
                 "version_added": "5.0"
@@ -484,10 +490,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": "12"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "12"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"

--- a/css/properties/writing-mode.json
+++ b/css/properties/writing-mode.json
@@ -162,10 +162,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -210,10 +210,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": "9"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "9"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -258,10 +258,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
This PR sets Safari versions for several CSS properties, based upon manual testing in SauceLabs.  Changes are as follows:

css.properties.height.fit-content, css.properties.width.fit-content
Safari 11
Safari 9 with -webkit- prefix
(I don't think it's "-webkit-fill-available" because that's "stretch")

css.properties.max-height.max-content, css.properties.max-height.min-content, css.properties.min-height.max-content, css.properties.min-height.min-content
Safari 11
Safari 9 with -webkit- prefix

css.properties.overflow-wrap.anywhere
False for Safari

css.properties.width.fill
Safari 12

css.properties.writing-mode.svg_values
Safari 10.1

css.properties.writing-mode.horizontal_vertical_values
Safari 9

css.properties.writing-mode.sideways_values
False for Safari