### PR TITLE
fix: Apply MDN URL fixes from #3913

### DIFF
--- a/api/CharacterData.json
+++ b/api/CharacterData.json
@@ -46,7 +46,7 @@
       },
       "ChildNode": {
         "__compat": {
-          "description": "Implements <a href='https://developer.mozilla.org/docs/Web/API/ChildNode'><code>ChildNode</code></a> Interface",
+          "description": "Implements the <a href='https://developer.mozilla.org/docs/Web/API/ChildNode'><code>ChildNode</code></a> interface",
           "support": {
             "chrome": {
               "version_added": true

--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -15,7 +15,7 @@
           },
           "firefox": {
             "version_added": "2",
-            "notes": "You should watch for <a href='https://developer.mozilla.org/docs/Web/Events/change'>change</a> events on <a href='https://developer.mozilla.org/docs/Web/HTML/Element/select'><code>&lt;select&gt;</code></a> instead of watching <code>&lt;option&gt;</code> elements for events. See <a href='https://bugzil.la/1090602'>bug 1090602</a> and <a href='https://developer.mozilla.org/Firefox/Multiprocess_Firefox/Web_content_compatibility'>Multiprocess Firefox Web content compatibility</a> for details."
+            "notes": "You should watch for <a href='https://developer.mozilla.org/docs/Web/Events/change'>change</a> events on <a href='https://developer.mozilla.org/docs/Web/HTML/Element/select'><code>&lt;select&gt;</code></a> instead of watching <code>&lt;option&gt;</code> elements for events. See <a href='https://bugzil.la/1090602'>bug 1090602</a> and <a href='https://developer.mozilla.org/docs/Mozilla/Firefox/Multiprocess_Firefox/Web_content_compatibility'>Multiprocess Firefox Web content compatibility</a> for details."
           },
           "firefox_android": {
             "version_added": "4"

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -98,7 +98,7 @@
             ],
             "ie": {
               "version_added": "11",
-              "notes": "When a non-<code>auto</code> <code>flex-basis</code> is specified, Internet Explorer 10 and 11 always uses a <code>content-box</code> box model to calculate the size of a flex item, even if <a href='http://developer.mozilla.org/docs/Web/CSS/box-sizing'><code>box-sizing: border-box</code></a> is applied to the element. See <a href='https://github.com/philipwalton/flexbugs#7-flex-basis-doesnt-account-for-box-sizingborder-box'>Flexbug #7</a> for more info."
+              "notes": "When a non-<code>auto</code> <code>flex-basis</code> is specified, Internet Explorer 10 and 11 always uses a <code>content-box</code> box model to calculate the size of a flex item, even if <a href='https://developer.mozilla.org/docs/Web/CSS/box-sizing'><code>box-sizing: border-box</code></a> is applied to the element. See <a href='https://github.com/philipwalton/flexbugs#7-flex-basis-doesnt-account-for-box-sizingborder-box'>Flexbug #7</a> for more info."
             },
             "opera": [
               {

--- a/css/selectors/cue.json
+++ b/css/selectors/cue.json
@@ -19,7 +19,7 @@
               "version_added": "55",
               "notes": [
                 "Firefox currently does not support a parameter on <code>::cue</code>.",
-                "Correct limitations to the CSS properties permitted within <code>::cue</code> were implemented in Firefox 69. See <a href='https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/::cue#Permitted_properties'>Permitted properties</a> for a list of the allowed properties."
+                "Correct limitations to the CSS properties permitted within <code>::cue</code> were implemented in Firefox 69. See <a href='https://developer.mozilla.org/docs/Web/CSS/::cue#Permitted_properties'>Permitted properties</a> for a list of the allowed properties."
               ]
             },
             "firefox_android": {

--- a/webextensions/api/browsingData.json
+++ b/webextensions/api/browsingData.json
@@ -494,7 +494,7 @@
                 "version_added": "53"
               },
               "firefox_android": {
-                "notes": "See <a href='https://bugzil.la/1363010'>bug 1363010</a>. <a href='https://developer.mozilla.org/Add-ons/WebExtensions/API/browsingData/remove'><code>browser.history.remove(options, {history:true})</code></a> can be used instead.",
+                "notes": "See <a href='https://bugzil.la/1363010'>bug 1363010</a>. <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/remove'><code>browser.history.remove(options, {history:true})</code></a> can be used instead.",
                 "version_added": false
               },
               "opera": {


### PR DESCRIPTION
Some MDN URLs were incorrect, especially the one from #4571, which links to the `wiki` subdomain, and as such wasn’t caught by the current lint script’s heuristics.

See #3913 for the updated lint heuristics, which will catch these errors in the future.