### PR TITLE
Element: Indicate partial IE support for classList

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -1186,7 +1186,9 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "10"
+              "version_added": "10",
+              "notes": "Not supported for SVG elements.",
+              "partial_implementation": true
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
IE 10-11 supports `classList` but not on SVG nodes. There's already a note for this limitation for early versions of Edge, there was one missing for IE.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests) https://output.jsbin.com/zuyapal/1
- [x] Data: if you tested something, describe how you tested with details like browser and version - the test case above displays `svg: FAIL` . `div: PASS` in IE 11 & 10
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
