### PR TITLE
Update Safari support for api.Request.prototype.url

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -1522,10 +1522,10 @@
               "notes": "Fragment support added in Opera 46."
             },
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"


### PR DESCRIPTION
This PR supersedes #4555 and applies all requested changes.  Since there was no response from the original author and maintainer updates were disabled, this PR has been created.