### PR TITLE
Mirror Chrome -> WebView for css/*

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -40,7 +40,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -294,7 +294,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -403,7 +403,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -504,7 +504,7 @@
                 "version_removed": "3.0"
               },
               "webview_android": {
-                "version_added": true,
+                "version_added": "≤37",
                 "version_removed": "38"
               }
             },
@@ -553,7 +553,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/at-rules/import.json
+++ b/css/at-rules/import.json
@@ -40,7 +40,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -148,7 +148,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -183,7 +183,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -281,7 +281,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -379,7 +379,7 @@
                 "version_added": "2.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -428,7 +428,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -477,7 +477,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -526,7 +526,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -626,7 +626,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -675,7 +675,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -966,7 +966,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -1015,7 +1015,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -1328,7 +1328,7 @@
                 "version_added": "1.5"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -1577,7 +1577,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -1680,8 +1680,8 @@
                 "version_removed": "3.0"
               },
               "webview_android": {
-                "version_added": true,
-                "version_removed": "37"
+                "version_added": "≤37",
+                "version_removed": "≤37"
               }
             },
             "status": {
@@ -1790,7 +1790,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -1899,7 +1899,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -2008,7 +2008,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -2062,8 +2062,8 @@
                 "version_removed": "3.0"
               },
               "webview_android": {
-                "version_added": true,
-                "version_removed": "37"
+                "version_added": "≤37",
+                "version_removed": "≤37"
               }
             },
             "status": {
@@ -2141,8 +2141,8 @@
                 "version_removed": "3.0"
               },
               "webview_android": {
-                "version_added": true,
-                "version_removed": "37"
+                "version_added": "≤37",
+                "version_removed": "≤37"
               }
             },
             "status": {
@@ -2196,8 +2196,8 @@
                 "version_removed": "3.0"
               },
               "webview_android": {
-                "version_added": true,
-                "version_removed": "37"
+                "version_added": "≤37",
+                "version_removed": "≤37"
               }
             },
             "status": {

--- a/css/at-rules/supports.json
+++ b/css/at-rules/supports.json
@@ -66,7 +66,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/at-rules/viewport.json
+++ b/css/at-rules/viewport.json
@@ -658,6 +658,9 @@
               },
               "safari_ios": {
                 "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
               }
             },
             "status": {

--- a/css/properties/-webkit-line-clamp.json
+++ b/css/properties/-webkit-line-clamp.json
@@ -39,7 +39,7 @@
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/-webkit-mask-attachment.json
+++ b/css/properties/-webkit-mask-attachment.json
@@ -42,8 +42,8 @@
               "version_removed": true
             },
             "webview_android": {
-              "version_added": true,
-              "version_removed": "37"
+              "version_added": "≤37",
+              "version_removed": "≤37"
             }
           },
           "status": {

--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -110,7 +110,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": true
+                  "version_added": "≤37"
                 }
               ]
             },

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -161,7 +161,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": true
+                  "version_added": "≤37"
                 }
               ]
             },

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -154,7 +154,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": true
+                  "version_added": "≤37"
                 }
               ]
             },

--- a/css/properties/animation-delay.json
+++ b/css/properties/animation-delay.json
@@ -141,7 +141,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },

--- a/css/properties/animation-direction.json
+++ b/css/properties/animation-direction.json
@@ -152,7 +152,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },
@@ -195,6 +195,9 @@
               },
               "samsunginternet_android": {
                 "version_added": true
+              },
+              "webview_android": {
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/properties/animation-duration.json
+++ b/css/properties/animation-duration.json
@@ -148,7 +148,7 @@
             ],
             "webview_android": [
               {
-                "version_added": true
+                "version_added": "43"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/animation-fill-mode.json
+++ b/css/properties/animation-fill-mode.json
@@ -152,7 +152,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },

--- a/css/properties/animation-iteration-count.json
+++ b/css/properties/animation-iteration-count.json
@@ -152,7 +152,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },

--- a/css/properties/animation-name.json
+++ b/css/properties/animation-name.json
@@ -152,7 +152,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },

--- a/css/properties/animation-play-state.json
+++ b/css/properties/animation-play-state.json
@@ -152,7 +152,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },

--- a/css/properties/animation-timing-function.json
+++ b/css/properties/animation-timing-function.json
@@ -148,11 +148,11 @@
             ],
             "webview_android": [
               {
-                "version_added": true
+                "version_added": "43"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },

--- a/css/properties/animation.json
+++ b/css/properties/animation.json
@@ -148,7 +148,7 @@
             ],
             "webview_android": [
               {
-                "version_added": true
+                "version_added": "43"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/background-attachment.json
+++ b/css/properties/background-attachment.json
@@ -39,7 +39,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -134,7 +134,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/properties/background-blend-mode.json
+++ b/css/properties/background-blend-mode.json
@@ -40,7 +40,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -97,7 +97,7 @@
                 "version_added": "4.1"
               },
               {
-                "version_added": true,
+                "version_added": "≤37",
                 "prefix": "-webkit-",
                 "notes": "WebView also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }

--- a/css/properties/background-color.json
+++ b/css/properties/background-color.json
@@ -40,7 +40,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -41,7 +41,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -147,7 +147,8 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37",
+                "notes": "Some versions support only experimental gradients prefixed with <code>-webkit</code>."
               }
             },
             "status": {
@@ -309,7 +310,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/properties/background-position-x.json
+++ b/css/properties/background-position-x.json
@@ -39,7 +39,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/background-position-y.json
+++ b/css/properties/background-position-y.json
@@ -39,7 +39,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/background-position.json
+++ b/css/properties/background-position.json
@@ -39,7 +39,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -86,7 +86,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -134,7 +134,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/properties/background-repeat.json
+++ b/css/properties/background-repeat.json
@@ -140,7 +140,7 @@
                 "version_added": "2.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -188,7 +188,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/properties/background-size.json
+++ b/css/properties/background-size.json
@@ -107,7 +107,7 @@
                 "version_added": "2.3"
               },
               {
-                "version_added": true,
+                "version_added": "≤37",
                 "prefix": "-webkit-",
                 "notes": "WebKit-based browsers originally implemented an older draft of CSS3 <code>background-size</code> in which an omitted second value is treated as duplicating the first value; this draft does not include the <code>contain</code> or <code>cover</code> keywords."
               }

--- a/css/properties/background.json
+++ b/css/properties/background.json
@@ -278,7 +278,7 @@
                 "version_added": null
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/properties/border-bottom-left-radius.json
+++ b/css/properties/border-bottom-left-radius.json
@@ -103,7 +103,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -150,7 +150,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -204,7 +204,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/properties/border-bottom-right-radius.json
+++ b/css/properties/border-bottom-right-radius.json
@@ -103,7 +103,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -150,7 +150,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -204,7 +204,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/properties/border-bottom-style.json
+++ b/css/properties/border-bottom-style.json
@@ -38,7 +38,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/border-image-outset.json
+++ b/css/properties/border-image-outset.json
@@ -28,6 +28,9 @@
             },
             "safari": {
               "version_added": "6"
+            },
+            "webview_android": {
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/border-image-repeat.json
+++ b/css/properties/border-image-repeat.json
@@ -31,6 +31,9 @@
             },
             "safari_ios": {
               "version_added": "9.3"
+            },
+            "webview_android": {
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -66,6 +69,9 @@
               },
               "safari": {
                 "version_added": "9.1"
+              },
+              "webview_android": {
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -102,6 +108,9 @@
               },
               "safari": {
                 "version_added": "9.1"
+              },
+              "webview_android": {
+                "version_added": "56"
               }
             },
             "status": {

--- a/css/properties/border-image-source.json
+++ b/css/properties/border-image-source.json
@@ -28,6 +28,9 @@
             },
             "safari": {
               "version_added": "6"
+            },
+            "webview_android": {
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/border-image-width.json
+++ b/css/properties/border-image-width.json
@@ -28,6 +28,9 @@
             },
             "safari": {
               "version_added": "6"
+            },
+            "webview_android": {
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -179,7 +179,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -227,7 +227,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -275,7 +275,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/properties/border-radius.json
+++ b/css/properties/border-radius.json
@@ -129,7 +129,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -179,7 +179,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -227,7 +227,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/properties/border-right-style.json
+++ b/css/properties/border-right-style.json
@@ -38,7 +38,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/border-right.json
+++ b/css/properties/border-right.json
@@ -36,7 +36,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/border-spacing.json
+++ b/css/properties/border-spacing.json
@@ -28,6 +28,9 @@
             },
             "safari": {
               "version_added": "1"
+            },
+            "webview_android": {
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/border-top-left-radius.json
+++ b/css/properties/border-top-left-radius.json
@@ -103,7 +103,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -150,7 +150,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -204,7 +204,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/properties/border-top-right-radius.json
+++ b/css/properties/border-top-right-radius.json
@@ -103,7 +103,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -150,7 +150,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -204,7 +204,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/properties/border-top-style.json
+++ b/css/properties/border-top-style.json
@@ -30,6 +30,9 @@
             },
             "safari": {
               "version_added": "1"
+            },
+            "webview_android": {
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/border.json
+++ b/css/properties/border.json
@@ -31,6 +31,9 @@
             },
             "safari_ios": {
               "version_added": "1"
+            },
+            "webview_android": {
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/bottom.json
+++ b/css/properties/bottom.json
@@ -40,7 +40,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/box-align.json
+++ b/css/properties/box-align.json
@@ -68,7 +68,7 @@
               "prefix": "-webkit-"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "≤37",
               "prefix": "-webkit-"
             }
           },

--- a/css/properties/box-decoration-break.json
+++ b/css/properties/box-decoration-break.json
@@ -73,7 +73,8 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true,
+              "prefix": "-webkit-",
+              "version_added": "≤37",
               "notes": "This property is only supported for inline elements."
             }
           },

--- a/css/properties/box-direction.json
+++ b/css/properties/box-direction.json
@@ -91,7 +91,7 @@
             },
             "webview_android": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/box-flex-group.json
+++ b/css/properties/box-flex-group.json
@@ -58,7 +58,7 @@
               "prefix": "-webkit-"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "≤37",
               "version_removed": "67",
               "prefix": "-webkit-"
             }

--- a/css/properties/box-flex.json
+++ b/css/properties/box-flex.json
@@ -91,7 +91,7 @@
             },
             "webview_android": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/box-lines.json
+++ b/css/properties/box-lines.json
@@ -58,7 +58,7 @@
               "prefix": "-webkit-"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "≤37",
               "version_removed": "67",
               "prefix": "-webkit-"
             }

--- a/css/properties/box-ordinal-group.json
+++ b/css/properties/box-ordinal-group.json
@@ -90,7 +90,7 @@
               "prefix": "-webkit-"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "≤37",
               "prefix": "-webkit-"
             }
           },

--- a/css/properties/box-orient.json
+++ b/css/properties/box-orient.json
@@ -91,7 +91,7 @@
             },
             "webview_android": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/box-pack.json
+++ b/css/properties/box-pack.json
@@ -91,7 +91,7 @@
             },
             "webview_android": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/box-shadow.json
+++ b/css/properties/box-shadow.json
@@ -118,11 +118,16 @@
             "samsunginternet_android": {
               "version_added": null
             },
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": true,
-              "notes": "Shadows affect layout in this browser. For example, if you cast an outer shadow to a box with a <code>width</code> of <code>100%</code>, then you'll see a scrollbar."
-            }
+            "webview_android": [
+              {
+                "version_added": "≤37",
+                "notes": "Shadows affect layout in this browser. For example, if you cast an outer shadow to a box with a <code>width</code> of <code>100%</code>, then you'll see a scrollbar."
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "≤37"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -210,10 +215,15 @@
               "samsunginternet_android": {
                 "version_added": null
               },
-              "webview_android": {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
+              "webview_android": [
+                {
+                  "version_added": "≤37"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "≤37"
+                }
+              ]
             },
             "status": {
               "experimental": false,
@@ -298,10 +308,15 @@
               "samsunginternet_android": {
                 "version_added": null
               },
-              "webview_android": {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
+              "webview_android": [
+                {
+                  "version_added": "≤37"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "≤37"
+                }
+              ]
             },
             "status": {
               "experimental": false,
@@ -386,10 +401,15 @@
               "samsunginternet_android": {
                 "version_added": null
               },
-              "webview_android": {
-                "prefix": "-webkit-",
-                "version_added": true
-              }
+              "webview_android": [
+                {
+                  "version_added": "≤37"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "≤37"
+                }
+              ]
             },
             "status": {
               "experimental": false,

--- a/css/properties/break-after.json
+++ b/css/properties/break-after.json
@@ -196,7 +196,7 @@
                   "version_added": null
                 },
                 "webview_android": {
-                  "version_added": true
+                  "version_added": "50"
                 }
               },
               "status": {

--- a/css/properties/caption-side.json
+++ b/css/properties/caption-side.json
@@ -39,7 +39,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -88,7 +88,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },

--- a/css/properties/color.json
+++ b/css/properties/color.json
@@ -87,7 +87,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -320,7 +320,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -370,7 +370,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -467,7 +467,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -516,7 +516,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/properties/column-count.json
+++ b/css/properties/column-count.json
@@ -106,7 +106,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },

--- a/css/properties/column-gap.json
+++ b/css/properties/column-gap.json
@@ -367,7 +367,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": true
+                  "version_added": "≤37"
                 }
               ]
             },

--- a/css/properties/column-rule-color.json
+++ b/css/properties/column-rule-color.json
@@ -104,7 +104,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },

--- a/css/properties/column-rule-style.json
+++ b/css/properties/column-rule-style.json
@@ -104,7 +104,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },

--- a/css/properties/column-rule-width.json
+++ b/css/properties/column-rule-width.json
@@ -104,7 +104,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },

--- a/css/properties/column-rule.json
+++ b/css/properties/column-rule.json
@@ -105,7 +105,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },

--- a/css/properties/column-span.json
+++ b/css/properties/column-span.json
@@ -99,7 +99,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },

--- a/css/properties/column-width.json
+++ b/css/properties/column-width.json
@@ -106,7 +106,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },

--- a/css/properties/columns.json
+++ b/css/properties/columns.json
@@ -90,7 +90,7 @@
             },
             "webview_android": [
               {
-                "version_added": true
+                "version_added": "50"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/counter-increment.json
+++ b/css/properties/counter-increment.json
@@ -39,7 +39,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/counter-reset.json
+++ b/css/properties/counter-reset.json
@@ -39,7 +39,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/custom-property.json
+++ b/css/properties/custom-property.json
@@ -146,7 +146,10 @@
                   "version_removed": "11.1",
                   "alternative_name": "constant"
                 }
-              ]
+              ],
+              "webview_android": {
+                "version_added": "69"
+              }
             },
             "status": {
               "experimental": true,

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -435,7 +435,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": true
+                  "version_added": "≤37"
                 }
               ]
             },
@@ -715,7 +715,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": true
+                  "version_added": "≤37"
                 }
               ]
             },

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -39,7 +39,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -299,8 +299,8 @@
                   "version_removed": "2.0"
                 },
                 "webview_android": {
-                  "version_added": true,
-                  "version_removed": "4.4.3"
+                  "version_added": "≤37",
+                  "version_removed": "≤37"
                 }
               },
               "status": {
@@ -593,7 +593,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -819,7 +819,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -866,7 +866,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -1013,7 +1013,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true,
+                "version_added": "≤37",
                 "notes": "WebView 65 stopped creating layout objects for elements inside an <code>&lt;iframe&gt;</code> with <code>display:none</code> applied."
               }
             },
@@ -1192,7 +1192,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -142,7 +142,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },
@@ -183,6 +183,9 @@
               "safari": {
                 "prefix": "-webkit-",
                 "version_added": "7"
+              },
+              "webview_android": {
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -227,6 +230,9 @@
                 "version_added": false
               },
               "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
                 "version_added": false
               }
             },

--- a/css/properties/flex-direction.json
+++ b/css/properties/flex-direction.json
@@ -147,7 +147,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },

--- a/css/properties/flex-flow.json
+++ b/css/properties/flex-flow.json
@@ -111,7 +111,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },

--- a/css/properties/flex-grow.json
+++ b/css/properties/flex-grow.json
@@ -117,7 +117,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },
@@ -162,6 +162,9 @@
               },
               "safari_ios": {
                 "version_added": false
+              },
+              "webview_android": {
+                "version_added": "49"
               }
             },
             "status": {

--- a/css/properties/flex-shrink.json
+++ b/css/properties/flex-shrink.json
@@ -148,7 +148,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },

--- a/css/properties/flex-wrap.json
+++ b/css/properties/flex-wrap.json
@@ -67,7 +67,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },

--- a/css/properties/flex.json
+++ b/css/properties/flex.json
@@ -154,7 +154,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },

--- a/css/properties/font-smooth.json
+++ b/css/properties/font-smooth.json
@@ -43,7 +43,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "≤37",
               "alternative_name": "-webkit-font-smoothing"
             }
           },

--- a/css/properties/font-variant.json
+++ b/css/properties/font-variant.json
@@ -216,7 +216,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/properties/font.json
+++ b/css/properties/font.json
@@ -39,7 +39,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -149,7 +149,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": true
+                  "version_added": "≤37"
                 }
               ]
             },

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -305,8 +305,7 @@
                   "version_added": null
                 },
                 "webview_android": {
-                  "version_added": true,
-                  "partial_implementation": true,
+                  "version_added": false,
                   "notes": "This value is recognized, but has no effect."
                 }
               },
@@ -454,8 +453,7 @@
                   "version_added": null
                 },
                 "webview_android": {
-                  "version_added": true,
-                  "partial_implementation": true,
+                  "version_added": false,
                   "notes": "This value is recognized, but has no effect."
                 }
               },

--- a/css/properties/line-break.json
+++ b/css/properties/line-break.json
@@ -89,7 +89,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },

--- a/css/properties/list-style-position.json
+++ b/css/properties/list-style-position.json
@@ -39,7 +39,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/mask-image.json
+++ b/css/properties/mask-image.json
@@ -97,7 +97,7 @@
                 "version_added": null
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -145,7 +145,7 @@
                 "version_added": null
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -115,7 +115,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": true
+                  "version_added": "≤37"
                 }
               ]
             },

--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -41,7 +41,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -113,7 +113,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": true
+                  "version_added": "≤37"
                 }
               ]
             },
@@ -192,7 +192,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": true
+                  "version_added": "≤37"
                 }
               ]
             },

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -162,7 +162,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": true
+                  "version_added": "≤37"
                 }
               ]
             },

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -185,7 +185,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": true
+                  "version_added": "≤37"
                 }
               ]
             },
@@ -264,7 +264,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": true
+                  "version_added": "≤37"
                 }
               ]
             },
@@ -346,7 +346,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": true
+                  "version_added": "≤37"
                 }
               ]
             },

--- a/css/properties/order.json
+++ b/css/properties/order.json
@@ -138,7 +138,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },

--- a/css/properties/orphans.json
+++ b/css/properties/orphans.json
@@ -39,7 +39,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/overflow-wrap.json
+++ b/css/properties/overflow-wrap.json
@@ -195,7 +195,7 @@
                 "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/properties/padding-bottom.json
+++ b/css/properties/padding-bottom.json
@@ -39,7 +39,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/padding-left.json
+++ b/css/properties/padding-left.json
@@ -39,7 +39,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/padding-right.json
+++ b/css/properties/padding-right.json
@@ -39,7 +39,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/padding-top.json
+++ b/css/properties/padding-top.json
@@ -39,7 +39,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/padding.json
+++ b/css/properties/padding.json
@@ -39,7 +39,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/position.json
+++ b/css/properties/position.json
@@ -47,7 +47,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -145,7 +145,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/properties/text-align.json
+++ b/css/properties/text-align.json
@@ -39,7 +39,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/text-combine-upright.json
+++ b/css/properties/text-combine-upright.json
@@ -165,7 +165,7 @@
               {
                 "partial_implementation": true,
                 "alternative_name": "-webkit-text-combine",
-                "version_added": true,
+                "version_added": "≤37",
                 "notes": "This property was initially named <code>-webkit-text-combine</code> according to a <a href='http://www.w3.org/TR/2011/WD-css3-writing-modes-20110531/#text-combine'>2011 version of the CSS3 Writing Modes specification</a>, supporting the values <code>none</code> and <code>horizontal</code> without <code>digits</code>."
               }
             ]

--- a/css/properties/text-decoration-line.json
+++ b/css/properties/text-decoration-line.json
@@ -65,7 +65,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "57"
             }
           },
           "status": {

--- a/css/properties/text-decoration.json
+++ b/css/properties/text-decoration.json
@@ -39,7 +39,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/text-indent.json
+++ b/css/properties/text-indent.json
@@ -39,7 +39,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/text-orientation.json
+++ b/css/properties/text-orientation.json
@@ -92,7 +92,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },

--- a/css/properties/text-overflow.json
+++ b/css/properties/text-overflow.json
@@ -59,7 +59,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/text-rendering.json
+++ b/css/properties/text-rendering.json
@@ -108,8 +108,8 @@
                 "notes": "Samsung Internet treats <code>auto</code> as <code>optimizeSpeed</code>."
               },
               "webview_android": {
-                "version_added": true,
-                "notes": "Chrome treats <code>auto</code> as <code>optimizeSpeed</code>."
+                "version_added": "≤37",
+                "notes": "WebView treats <code>auto</code> as <code>optimizeSpeed</code>."
               }
             },
             "status": {

--- a/css/properties/text-transform.json
+++ b/css/properties/text-transform.json
@@ -381,7 +381,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/properties/top.json
+++ b/css/properties/top.json
@@ -40,7 +40,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -156,7 +156,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },

--- a/css/properties/transition-delay.json
+++ b/css/properties/transition-delay.json
@@ -146,7 +146,7 @@
             ],
             "webview_android": [
               {
-                "version_added": true
+                "version_added": "≤37"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/transition-duration.json
+++ b/css/properties/transition-duration.json
@@ -146,7 +146,7 @@
             ],
             "webview_android": [
               {
-                "version_added": true
+                "version_added": "≤37"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/transition-property.json
+++ b/css/properties/transition-property.json
@@ -146,11 +146,11 @@
             ],
             "webview_android": [
               {
-                "version_added": true
+                "version_added": "≤37"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },

--- a/css/properties/transition-property.json
+++ b/css/properties/transition-property.json
@@ -198,7 +198,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/properties/transition-timing-function.json
+++ b/css/properties/transition-timing-function.json
@@ -146,11 +146,11 @@
             ],
             "webview_android": [
               {
-                "version_added": true
+                "version_added": "≤37"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },

--- a/css/properties/transition.json
+++ b/css/properties/transition.json
@@ -156,7 +156,7 @@
             ],
             "webview_android": [
               {
-                "version_added": true
+                "version_added": "≤37"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/word-break.json
+++ b/css/properties/word-break.json
@@ -47,7 +47,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -142,7 +142,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "44"
               }
             },
             "status": {

--- a/css/properties/word-wrap.json
+++ b/css/properties/word-wrap.json
@@ -95,7 +95,7 @@
             "webview_android": [
               {
                 "alternative_name": "overflow-wrap",
-                "version_added": true
+                "version_added": "≤37"
               },
               {
                 "version_added": "1"

--- a/css/properties/z-index.json
+++ b/css/properties/z-index.json
@@ -39,7 +39,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -86,7 +86,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/properties/zoom.json
+++ b/css/properties/zoom.json
@@ -41,7 +41,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -91,7 +91,7 @@
                 "version_added": null
               },
               "webview_android": {
-                "version_added": true,
+                "version_added": "≤37",
                 "version_removed": "59"
               }
             },

--- a/css/selectors/-webkit-meter-bar.json
+++ b/css/selectors/-webkit-meter-bar.json
@@ -37,7 +37,7 @@
               "version_added": "5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/-webkit-meter-even-less-good-value.json
+++ b/css/selectors/-webkit-meter-even-less-good-value.json
@@ -37,7 +37,7 @@
               "version_added": "5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/-webkit-meter-inner-element.json
+++ b/css/selectors/-webkit-meter-inner-element.json
@@ -37,7 +37,7 @@
               "version_added": "7"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/-webkit-meter-optimum-value.json
+++ b/css/selectors/-webkit-meter-optimum-value.json
@@ -37,7 +37,7 @@
               "version_added": "5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/-webkit-meter-suboptimum-value.json
+++ b/css/selectors/-webkit-meter-suboptimum-value.json
@@ -37,7 +37,7 @@
               "version_added": "5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/-webkit-progress-bar.json
+++ b/css/selectors/-webkit-progress-bar.json
@@ -37,7 +37,7 @@
               "version_added": "7"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/-webkit-progress-inner-element.json
+++ b/css/selectors/-webkit-progress-inner-element.json
@@ -37,7 +37,7 @@
               "version_added": "7"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/-webkit-progress-value.json
+++ b/css/selectors/-webkit-progress-value.json
@@ -37,7 +37,7 @@
               "version_added": "7"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/-webkit-resizer.json
+++ b/css/selectors/-webkit-resizer.json
@@ -52,7 +52,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/-webkit-scrollbar-button.json
+++ b/css/selectors/-webkit-scrollbar-button.json
@@ -52,7 +52,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/-webkit-scrollbar-corner.json
+++ b/css/selectors/-webkit-scrollbar-corner.json
@@ -52,7 +52,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/-webkit-scrollbar-thumb.json
+++ b/css/selectors/-webkit-scrollbar-thumb.json
@@ -52,7 +52,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/-webkit-scrollbar-track-piece.json
+++ b/css/selectors/-webkit-scrollbar-track-piece.json
@@ -52,7 +52,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/-webkit-scrollbar-track.json
+++ b/css/selectors/-webkit-scrollbar-track.json
@@ -52,7 +52,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/-webkit-scrollbar.json
+++ b/css/selectors/-webkit-scrollbar.json
@@ -52,7 +52,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/-webkit-search-cancel-button.json
+++ b/css/selectors/-webkit-search-cancel-button.json
@@ -37,7 +37,7 @@
               "version_added": "1"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/-webkit-search-results-button.json
+++ b/css/selectors/-webkit-search-results-button.json
@@ -37,7 +37,7 @@
               "version_added": "1"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/adjacent_sibling.json
+++ b/css/selectors/adjacent_sibling.json
@@ -44,7 +44,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/after.json
+++ b/css/selectors/after.json
@@ -167,7 +167,7 @@
                 "version_added": null
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/selectors/after.json
+++ b/css/selectors/after.json
@@ -115,11 +115,11 @@
             ],
             "webview_android": [
               {
-                "version_added": true
+                "version_added": "≤37"
               },
               {
                 "alternative_name": ":after",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },

--- a/css/selectors/any-link.json
+++ b/css/selectors/any-link.json
@@ -106,7 +106,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },

--- a/css/selectors/attribute.json
+++ b/css/selectors/attribute.json
@@ -40,7 +40,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/before.json
+++ b/css/selectors/before.json
@@ -158,7 +158,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/selectors/before.json
+++ b/css/selectors/before.json
@@ -106,11 +106,11 @@
             ],
             "webview_android": [
               {
-                "version_added": true
+                "version_added": "≤37"
               },
               {
                 "alternative_name": ":before",
-                "version_added": true
+                "version_added": "≤37"
               }
             ]
           },

--- a/css/selectors/child.json
+++ b/css/selectors/child.json
@@ -40,7 +40,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/class.json
+++ b/css/selectors/class.json
@@ -40,7 +40,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/cue.json
+++ b/css/selectors/cue.json
@@ -45,7 +45,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/descendant.json
+++ b/css/selectors/descendant.json
@@ -51,9 +51,15 @@
             "samsunginternet_android": {
               "version_added": "1.0"
             },
-            "webview_android": {
-              "version_added": true
-            }
+            "webview_android": [
+              {
+                "version_added": "≤37"
+              },
+              {
+                "version_added": "61",
+                "notes": "<code>&gt;&gt;&gt;</code> is aliased to this selector <a href='https://developers.google.com/web/updates/2017/06/chrome-60-deprecations#make_shadow-piercing_descendant_combinator_behave_like_descendent_combinator'>since its use as the 'shadow-piercing descendant combinator' was deprecated</a>."
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/selectors/first-child.json
+++ b/css/selectors/first-child.json
@@ -44,7 +44,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/first-line.json
+++ b/css/selectors/first-line.json
@@ -103,9 +103,17 @@
             "samsunginternet_android": {
               "version_added": null
             },
-            "webview_android": {
-              "version_added": true
-            }
+            "webview_android": [
+              {
+                "version_added": "≤37",
+                "notes": "Before WebView 62, the <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work on <code>::first-line</code> pseudo-elements. See <a href='https://crbug.com/129669'>Chromium bug 129669</a>."
+              },
+              {
+                "alternative_name": ":first-line",
+                "version_added": "≤37",
+                "notes": "Before WebView 62, the <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work on <code>::first-line</code> pseudo-elements. See <a href='https://crbug.com/129669'>Chromium bug 129669</a>."
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/selectors/general_sibling.json
+++ b/css/selectors/general_sibling.json
@@ -40,7 +40,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/hover.json
+++ b/css/selectors/hover.json
@@ -189,7 +189,7 @@
                 "version_added": null
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/selectors/id.json
+++ b/css/selectors/id.json
@@ -40,7 +40,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/indeterminate.json
+++ b/css/selectors/indeterminate.json
@@ -40,7 +40,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -87,7 +87,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/selectors/is.json
+++ b/css/selectors/is.json
@@ -129,11 +129,25 @@
             "samsunginternet_android": {
               "version_added": false
             },
-            "webview_android": {
-              "version_added": true,
-              "alternative_name": ":-webkit-any()",
-              "notes": "Doesn't support combinators."
-            }
+            "webview_android": [
+              {
+                "version_added": "66",
+                "alternative_name": ":matches()",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features",
+                    "value_to_set": "enabled"
+                  }
+                ],
+                "notes": "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+              },
+              {
+                "version_added": "≤37",
+                "alternative_name": ":-webkit-any()",
+                "notes": "Doesn't support combinators."
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/selectors/last-child.json
+++ b/css/selectors/last-child.json
@@ -40,7 +40,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/left.json
+++ b/css/selectors/left.json
@@ -40,7 +40,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/nth-child.json
+++ b/css/selectors/nth-child.json
@@ -42,7 +42,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/nth-last-child.json
+++ b/css/selectors/nth-last-child.json
@@ -40,7 +40,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/only-child.json
+++ b/css/selectors/only-child.json
@@ -40,7 +40,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/read-only.json
+++ b/css/selectors/read-only.json
@@ -44,7 +44,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/read-write.json
+++ b/css/selectors/read-write.json
@@ -44,7 +44,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/right.json
+++ b/css/selectors/right.json
@@ -42,7 +42,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/selectors/scope.json
+++ b/css/selectors/scope.json
@@ -67,7 +67,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -114,7 +114,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/selectors/type.json
+++ b/css/selectors/type.json
@@ -40,7 +40,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -87,7 +87,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/selectors/universal.json
+++ b/css/selectors/universal.json
@@ -40,7 +40,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -87,7 +87,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/types/attr.json
+++ b/css/types/attr.json
@@ -40,7 +40,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/types/counter.json
+++ b/css/types/counter.json
@@ -40,7 +40,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/types/dimension.json
+++ b/css/types/dimension.json
@@ -40,7 +40,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/types/global_keywords.json
+++ b/css/types/global_keywords.json
@@ -248,7 +248,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "41"
               }
             },
             "status": {

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -596,11 +596,11 @@
                 },
                 "webview_android": [
                   {
-                    "version_added": true
+                    "version_added": "≤37"
                   },
                   {
                     "prefix": "-webkit-",
-                    "version_added": true
+                    "version_added": "≤37"
                   }
                 ]
               },
@@ -945,11 +945,11 @@
                 },
                 "webview_android": [
                   {
-                    "version_added": true
+                    "version_added": "≤37"
                   },
                   {
                     "prefix": "-webkit-",
-                    "version_added": true
+                    "version_added": "≤37"
                   }
                 ]
               },
@@ -1391,11 +1391,11 @@
                 },
                 "webview_android": [
                   {
-                    "version_added": true
+                    "version_added": "≤37"
                   },
                   {
                     "prefix": "-webkit-",
-                    "version_added": true
+                    "version_added": "≤37"
                   }
                 ]
               },
@@ -1744,7 +1744,7 @@
                   },
                   {
                     "prefix": "-webkit-",
-                    "version_added": true
+                    "version_added": "≤37"
                   }
                 ]
               },

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -115,7 +115,7 @@
               },
               "webview_android": {
                 "prefix": "-webkit-",
-                "version_added": true,
+                "version_added": "≤37",
                 "notes": "Supports the original dual-image with percentage implementation only."
               }
             },
@@ -287,9 +287,15 @@
               "samsunginternet_android": {
                 "version_added": true
               },
-              "webview_android": {
-                "version_added": true
-              }
+              "webview_android": [
+                {
+                  "version_added": "≤37"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "≤37"
+                }
+              ]
             },
             "status": {
               "experimental": false,
@@ -738,7 +744,7 @@
                     "version_added": true
                   },
                   "webview_android": {
-                    "version_added": true
+                    "version_added": "≤37"
                   }
                 },
                 "status": {
@@ -800,7 +806,7 @@
                     "version_added": true
                   },
                   "webview_android": {
-                    "version_added": true
+                    "version_added": "≤37"
                   }
                 },
                 "status": {
@@ -1034,7 +1040,7 @@
                     "version_added": true
                   },
                   "webview_android": {
-                    "version_added": true
+                    "version_added": "≤37"
                   }
                 },
                 "status": {
@@ -1534,7 +1540,7 @@
                     "version_added": true
                   },
                   "webview_android": {
-                    "version_added": true
+                    "version_added": "≤37"
                   }
                 },
                 "status": {
@@ -1596,7 +1602,7 @@
                     "version_added": true
                   },
                   "webview_android": {
-                    "version_added": true
+                    "version_added": "≤37"
                   }
                 },
                 "status": {
@@ -1846,7 +1852,7 @@
                     "version_added": true
                   },
                   "webview_android": {
-                    "version_added": true
+                    "version_added": "≤37"
                   }
                 },
                 "status": {

--- a/css/types/integer.json
+++ b/css/types/integer.json
@@ -40,7 +40,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/types/length-percentage.json
+++ b/css/types/length-percentage.json
@@ -40,7 +40,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -139,7 +139,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -573,7 +573,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -733,7 +733,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -783,7 +783,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -40,7 +40,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -139,7 +139,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -575,7 +575,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -735,7 +735,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -785,7 +785,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/types/percentage.json
+++ b/css/types/percentage.json
@@ -40,7 +40,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/types/position.json
+++ b/css/types/position.json
@@ -40,7 +40,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -87,7 +87,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -135,7 +135,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/types/ratio.json
+++ b/css/types/ratio.json
@@ -40,7 +40,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/types/resolution.json
+++ b/css/types/resolution.json
@@ -56,7 +56,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -115,7 +115,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -175,7 +175,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -223,7 +223,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -271,7 +271,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "68"
               }
             },
             "status": {

--- a/css/types/string.json
+++ b/css/types/string.json
@@ -40,7 +40,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -87,7 +87,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {


### PR DESCRIPTION
This PR mirrors the values of Chrome Desktop to WebView Android is `true` or `null`, to help reduce data inconsistencies and reach towards the 2019 Key Result.  Notes have been adapted to ensure they are not mentioning Chrome versions earlier than 37.

The script that performed the majority of changes can be found here: https://github.com/vinyldarkscratch/bcd-toolkit/blob/master/fix.py