### PR TITLE
Update version consistency linter to allow ranged values

### DIFF
--- a/test/test-versions.js
+++ b/test/test-versions.js
@@ -79,8 +79,11 @@ function checkVersions(supportData, relPath, logger) {
             if (
               (
                 statement.version_added.startsWith("≤") && statement.version_removed.startsWith("≤") &&
-                compareVersions(statement.version_added.replace("≤", ""), statement.version_removed.replace("≤", "")) != -1
-              ) || compareVersions(statement.version_added.replace("≤", ""), statement.version_removed.replace("≤", "")) >= 0
+                compareVersions(statement.version_added.replace("≤", ""), statement.version_removed.replace("≤", "")) == -1
+              ) || (
+                (!statement.version_added.startsWith("≤") || !statement.version_removed.startsWith("≤")) &&
+                compareVersions(statement.version_added.replace("≤", ""), statement.version_removed.replace("≤", "")) >= 0
+              )
             ) {
               logger.error(chalk`{red {bold ${relPath}} - {bold version_removed: "${statement.version_removed}"} must be greater than {bold version_added: "${statement.version_added}"}}`);
               hasErrors = true;

--- a/test/test-versions.js
+++ b/test/test-versions.js
@@ -76,10 +76,10 @@ function checkVersions(supportData, relPath, logger) {
             logger.error(chalk`{red {bold ${relPath}} - {bold version_added: "${statement.version_added}"} is {bold NOT} a valid version number for {bold ${browser}} when {bold version_removed} is present\n    Valid {bold ${browser}} versions are: ${validBrowserVersionsTruthy}}`);
             hasErrors = true;
           } else if (
-            typeof statement.version_added === 'string' &&
-            typeof statement.version_removed === 'string' &&
-            compareVersions(statement.version_added, statement.version_removed) >= 0
-          ) {
+            typeof statement.version_added === 'string' && typeof statement.version_removed === 'string' &&
+            !statement.version_added.startsWith("≤") && !statement.version_removed.startsWith("≤") &&
+            compareVersions(statement.version_added, statement.version_removed) >= 0)
+          {
             logger.error(chalk`{red {bold ${relPath}} - {bold version_removed: "${statement.version_removed}"} must be greater than {bold version_added: "${statement.version_added}"}}`);
             hasErrors = true;
           }

--- a/test/test-versions.js
+++ b/test/test-versions.js
@@ -79,10 +79,10 @@ function checkVersions(supportData, relPath, logger) {
             if (
               (
                 statement.version_added.startsWith("≤") && statement.version_removed.startsWith("≤") &&
-                compareVersions(statement.version_added.replace("≤", ""), statement.version_removed.replace("≤", "")) == -1
+                compareVersions.compare(statement.version_added.replace("≤", ""), statement.version_removed.replace("≤", ""), "<")
               ) || (
                 (!statement.version_added.startsWith("≤") || !statement.version_removed.startsWith("≤")) &&
-                compareVersions(statement.version_added.replace("≤", ""), statement.version_removed.replace("≤", "")) >= 0
+                compareVersions.compare(statement.version_added.replace("≤", ""), statement.version_removed.replace("≤", ""), ">=")
               )
             ) {
               logger.error(chalk`{red {bold ${relPath}} - {bold version_removed: "${statement.version_removed}"} must be greater than {bold version_added: "${statement.version_added}"}}`);

--- a/test/test-versions.js
+++ b/test/test-versions.js
@@ -75,13 +75,16 @@ function checkVersions(supportData, relPath, logger) {
           ) {
             logger.error(chalk`{red {bold ${relPath}} - {bold version_added: "${statement.version_added}"} is {bold NOT} a valid version number for {bold ${browser}} when {bold version_removed} is present\n    Valid {bold ${browser}} versions are: ${validBrowserVersionsTruthy}}`);
             hasErrors = true;
-          } else if (
-            typeof statement.version_added === 'string' && typeof statement.version_removed === 'string' &&
-            !statement.version_added.startsWith("≤") && !statement.version_removed.startsWith("≤") &&
-            compareVersions(statement.version_added, statement.version_removed) >= 0)
-          {
-            logger.error(chalk`{red {bold ${relPath}} - {bold version_removed: "${statement.version_removed}"} must be greater than {bold version_added: "${statement.version_added}"}}`);
-            hasErrors = true;
+          } else if (typeof statement.version_added === 'string' && typeof statement.version_removed === 'string') {
+            if (
+              (
+                statement.version_added.startsWith("≤") && statement.version_removed.startsWith("≤") &&
+                compareVersions(statement.version_added.replace("≤", ""), statement.version_removed.replace("≤", "")) != -1
+              ) || compareVersions(statement.version_added.replace("≤", ""), statement.version_removed.replace("≤", "")) >= 0
+            ) {
+              logger.error(chalk`{red {bold ${relPath}} - {bold version_removed: "${statement.version_removed}"} must be greater than {bold version_added: "${statement.version_added}"}}`);
+              hasErrors = true;
+            }
           }
         }
       }


### PR DESCRIPTION
During mirroring of Chrome to WebView, I realized that the version comparison library doesn't like our little range indicators.  One of the features of the version comparison is to check if the version added and version removed are the same, and if so, disallow it.  Version ranges are an exception to this rule.

This PR removes the `≤` that precedes ranged values before comparing them to non-ranged real values.  If both values are ranged values, the linter will now only validate against if version_removed is a lower value, thus allowing two ranged values to be the same.