### PR TITLE
Update Safari compatibility for CSS text-decoration shorthand

### DIFF
--- a/css/properties/text-decoration.json
+++ b/css/properties/text-decoration.json
@@ -141,12 +141,12 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": true,
-                "notes": "Safari doesn't support <a href='https://developer.mozilla.org/docs/Web/CSS/text-decoration-style'><code>text-decoration-style</code></a>."
+                "version_added": false,
+                "notes": "In Safari, <code>text-decoration</code> is only an alias for <a href='https://developer.mozilla.org/docs/Web/CSS/text-decoration-line'><code>text-decoration-line</code></a>."
               },
               "safari_ios": {
-                "version_added": "8",
-                "notes": "Safari doesn't support <a href='https://developer.mozilla.org/docs/Web/CSS/text-decoration-style'><code>text-decoration-style</code></a>."
+                "version_added": false,
+                "notes": "In Safari, <code>text-decoration</code> is only an alias for <a href='https://developer.mozilla.org/docs/Web/CSS/text-decoration-line'><code>text-decoration-line</code></a>."
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/css/properties/text-decoration.json
+++ b/css/properties/text-decoration.json
@@ -141,12 +141,12 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": false,
-                "notes": "In Safari, <code>text-decoration</code> is only an alias for <a href='https://developer.mozilla.org/docs/Web/CSS/text-decoration-line'><code>text-decoration-line</code></a>."
+                "prefix": "-webkit-",
+                "version_added": "8"
               },
               "safari_ios": {
-                "version_added": false,
-                "notes": "In Safari, <code>text-decoration</code> is only an alias for <a href='https://developer.mozilla.org/docs/Web/CSS/text-decoration-line'><code>text-decoration-line</code></a>."
+                "prefix": "-webkit-",
+                "version_added": "8"
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
This PR updates css.properties.text-decoration.shorthand.  Safari and Safari iOS were set to `true` and 8 respectively, but from what I can tell, Safari doesn't support the shorthands of all `text-decoration-*`; it only acts as an alias for `text-decoration-line`.  This PR sets both to `false` and updates the note.