### PR TITLE
Mark dir=auto as unsupported in IE/Edge

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -678,7 +678,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": false
             },
             "firefox": {
               "version_added": true
@@ -687,7 +687,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
Fixes #4190.  This has been confirmed in Edge 18 (latest edition).