### PR TITLE
Chromium supports api.DOMException constructor

### DIFF
--- a/api/DOMException.json
+++ b/api/DOMException.json
@@ -53,10 +53,10 @@
           "description": "<code>DOMException()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": true
             },
             "edge": {
               "version_added": false
@@ -71,10 +71,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -83,10 +83,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {


### PR DESCRIPTION
Fixes #4478.  This PR does not intend to add version numbers and simply set support to `true` for now.  This way, we can at least state accurate support status before hammering down on a real version number.