### PR TITLE
Add Safari support for href attribute on select SVG elements

### DIFF
--- a/css/properties/text-decoration.json
+++ b/css/properties/text-decoration.json
@@ -141,12 +141,12 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": true,
-                "notes": "Safari doesn't support <a href='https://developer.mozilla.org/docs/Web/CSS/text-decoration-style'><code>text-decoration-style</code></a>."
+                "version_added": false,
+                "notes": "In Safari, <code>text-decoration</code> is only an alias for <a href='https://developer.mozilla.org/docs/Web/CSS/text-decoration-line'><code>text-decoration-line</code></a>."
               },
               "safari_ios": {
-                "version_added": "8",
-                "notes": "Safari doesn't support <a href='https://developer.mozilla.org/docs/Web/CSS/text-decoration-style'><code>text-decoration-style</code></a>."
+                "version_added": false,
+                "notes": "In Safari, <code>text-decoration</code> is only an alias for <a href='https://developer.mozilla.org/docs/Web/CSS/text-decoration-line'><code>text-decoration-line</code></a>."
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/css/properties/text-decoration.json
+++ b/css/properties/text-decoration.json
@@ -141,12 +141,12 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": false,
-                "notes": "In Safari, <code>text-decoration</code> is only an alias for <a href='https://developer.mozilla.org/docs/Web/CSS/text-decoration-line'><code>text-decoration-line</code></a>."
+                "version_added": true,
+                "notes": "Safari doesn't support <a href='https://developer.mozilla.org/docs/Web/CSS/text-decoration-style'><code>text-decoration-style</code></a>."
               },
               "safari_ios": {
-                "version_added": false,
-                "notes": "In Safari, <code>text-decoration</code> is only an alias for <a href='https://developer.mozilla.org/docs/Web/CSS/text-decoration-line'><code>text-decoration-line</code></a>."
+                "version_added": "8",
+                "notes": "Safari doesn't support <a href='https://developer.mozilla.org/docs/Web/CSS/text-decoration-style'><code>text-decoration-style</code></a>."
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/svg/attributes/href.json
+++ b/svg/attributes/href.json
@@ -30,10 +30,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "9"
             },
             "webview_android": {
               "version_added": true

--- a/svg/elements/a.json
+++ b/svg/elements/a.json
@@ -123,10 +123,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": false
+                "version_added": "9"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "9"
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/svg/elements/cursor.json
+++ b/svg/elements/cursor.json
@@ -73,10 +73,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": null
+                "version_added": "9"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "9"
               },
               "webview_android": {
                 "version_added": null

--- a/svg/elements/feImage.json
+++ b/svg/elements/feImage.json
@@ -73,10 +73,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": "9"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "9"
               },
               "webview_android": {
                 "version_added": true

--- a/svg/elements/pattern.json
+++ b/svg/elements/pattern.json
@@ -117,10 +117,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": "9"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "9"
               },
               "webview_android": {
                 "version_added": null

--- a/svg/elements/use.json
+++ b/svg/elements/use.json
@@ -209,10 +209,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": false
+                "version_added": "9"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "9"
               },
               "webview_android": {
                 "version_added": true


### PR DESCRIPTION
Fixes #4551.  This PR sets the `href` attribute to `"9"` for Safari on elements affected by [the relevant changeset](https://trac.webkit.org/changeset/234683/webkit).  The version number comes from the [tracking bug](https://bugs.webkit.org/show_bug.cgi?id=153854).