### PR TITLE
Add Safari versions for Gamepad API

### DIFF
--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -70,10 +70,10 @@
             }
           ],
           "safari": {
-            "version_added": false
+            "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "10.3"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -131,10 +131,10 @@
               "version_added": "22"
             },
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -220,10 +220,10 @@
               }
             ],
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -309,10 +309,10 @@
               }
             ],
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -398,10 +398,10 @@
               }
             ],
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -748,10 +748,10 @@
               }
             ],
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -837,10 +837,10 @@
               }
             ],
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -982,10 +982,10 @@
               }
             ],
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/GamepadButton.json
+++ b/api/GamepadButton.json
@@ -63,10 +63,10 @@
             }
           ],
           "safari": {
-            "version_added": false
+            "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "10.3"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -144,10 +144,10 @@
               }
             ],
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -226,10 +226,10 @@
               }
             ],
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -274,10 +274,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/GamepadEvent.json
+++ b/api/GamepadEvent.json
@@ -63,10 +63,10 @@
             }
           ],
           "safari": {
-            "version_added": false
+            "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "10.3"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -144,10 +144,10 @@
               }
             ],
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR fixes #4589 by adding Safari versions for the Gamepad API.