### PR TITLE
Adding Firefox 69 support for line-break

### DIFF
--- a/css/properties/line-break.json
+++ b/css/properties/line-break.json
@@ -27,7 +27,7 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "69"
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
The `line-break` property has been implemented in Firefox 69, this adds support to BCD https://bugzilla.mozilla.org/show_bug.cgi?id=1011369
