### PR TITLE
Samsung Internet browser 9.4

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -131,6 +131,12 @@
         },
         "9.2": {
           "release_date": "2019-04-02",
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "67"
+        },
+        "9.4": {
+          "release_date": "2019-07-25",
           "status": "current",
           "engine": "Blink",
           "engine_version": "67"

--- a/css/properties/custom-property.json
+++ b/css/properties/custom-property.json
@@ -174,7 +174,7 @@
                 "version_added": "9.1"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "9.4"
               },
               "webview_android": {
                 "version_added": "50"

--- a/css/properties/custom-property.json
+++ b/css/properties/custom-property.json
@@ -174,7 +174,7 @@
                 "version_added": "9.1"
               },
               "samsunginternet_android": {
-                "version_added": "9.4"
+                "version_added": null
               },
               "webview_android": {
                 "version_added": "50"


### PR DESCRIPTION
- 9.4 browser added to matrix with documentation from Samsung as to release date.
- MDN's codepen.io tested successfully on Samsung Internet 9.4 with custom color selectors, including making live changes to CSS variable which correctly updated the property in realtime.
- Samsung has not maintained a proper changelog and SI appears to be closed-source.
