### PR TITLE
Update data for transform-origin's 3-value syntax

### DIFF
--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -174,10 +174,10 @@
             },
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "12"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -192,10 +192,10 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": false
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari": {
                 "version_added": true
@@ -204,10 +204,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -198,10 +198,10 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": true
+                "version_added": "4.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "3.2"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"


### PR DESCRIPTION
For #4540, this PR updates the data for `transform-origin`'s three-value syntax (i.e., the form that adds a z-offset).

For Safari, I estimated versions based on the date of [this WebKit blog post which explicitly mentions `transform-origin`](https://webkit.org/blog/386/3d-transforms/). It's possible it landed earlier (`4` versus `4.1` — there's some discrepancy here with the 3D feature for `transform`, but the Safari 4 release notes make no mention of _3D_ transforms), but we're dealing with some pretty old versions. If it's not quite right, then it's only off by one version.

For Chrome and its derivatives, I did some digging and it looks like it picked this up along with the other 3D transform features in the pre-Blink era (there's some additional circumstantial evidence for this being correct in [the bug for unprefixing transforms](
https://bugs.chromium.org/p/chromium/issues/detail?id=154772)).