### PR TITLE
Clean up <display-outside> data

### DIFF
--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -122,11 +122,11 @@
                 },
                 "opera": {
                   "version_added": "7",
-                  "version_removed": "15"
+                  "version_removed": "19"
                 },
                 "opera_android": {
                   "version_added": "10.1",
-                  "version_removed": "14"
+                  "version_removed": "19"
                 },
                 "safari": {
                   "version_added": "1",

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -970,7 +970,8 @@
                 "version_removed": "15"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "10.1",
+                "version_removed": "14"
               },
               "safari": {
                 "version_added": "1",
@@ -978,12 +979,13 @@
                 "notes": "Before Safari 5, <code>run-in</code> was not supported before inline elements."
               },
               "safari_ios": {
-                "version_added": true,
+                "version_added": "1",
                 "version_removed": "8",
                 "notes": "Before Safari 5, <code>run-in</code> was not supported before inline elements."
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0",
+                "version_removed": "2.0"
               },
               "webview_android": {
                 "version_added": true,

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -50,6 +50,8 @@
         },
         "display-outside": {
           "__compat": {
+            "description": "<code>&lt;display-outside&gt;</code>",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/display-outside",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -73,19 +75,19 @@
                 "version_added": "7"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -96,14 +96,14 @@
           },
           "run-in": {
             "__compat": {
-              "description": "display: run-in support",
               "support": {
                 "chrome": {
-                  "version_added": true,
-                  "version_removed": "32"
+                  "version_added": "1",
+                  "version_removed": "32",
+                  "notes": "Before Chrome 4, <code>run-in</code> was not supported before inline elements."
                 },
                 "chrome_android": {
-                  "version_added": true,
+                  "version_added": "18",
                   "version_removed": "32"
                 },
                 "edge": {
@@ -119,30 +119,34 @@
                   "version_added": "8"
                 },
                 "opera": {
-                  "version_added": true,
-                  "version_removed": "19"
+                  "version_added": "7",
+                  "version_removed": "15"
                 },
                 "opera_android": {
-                  "version_added": true,
-                  "version_removed": "19"
+                  "version_added": "10.1",
+                  "version_removed": "14"
                 },
                 "safari": {
-                  "version_added": true,
-                  "version_removed": "7"
+                  "version_added": "1",
+                  "version_removed": "8",
+                  "notes": "Before Safari 5, <code>run-in</code> was not supported before inline elements."
                 },
                 "safari_ios": {
-                  "version_added": true,
-                  "version_removed": "7"
+                  "version_added": "1",
+                  "version_removed": "8",
+                  "notes": "Before Safari 5, <code>run-in</code> was not supported before inline elements."
                 },
                 "samsunginternet_android": {
-                  "version_added": true
+                  "version_added": "1.0",
+                  "version_removed": "2.0"
                 },
                 "webview_android": {
-                  "version_added": true
+                  "version_added": true,
+                  "version_removed": "4.4.3"
                 }
               },
               "status": {
-                "experimental": false,
+                "experimental": true,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -932,64 +936,6 @@
               },
               "webview_android": {
                 "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "run-in": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "1",
-                "version_removed": "32",
-                "notes": "Before Chrome 4, <code>run-in</code> was not supported before inline elements."
-              },
-              "chrome_android": {
-                "version_added": "18",
-                "version_removed": "32"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": "8"
-              },
-              "opera": {
-                "version_added": "7",
-                "version_removed": "15"
-              },
-              "opera_android": {
-                "version_added": "10.1",
-                "version_removed": "14"
-              },
-              "safari": {
-                "version_added": "1",
-                "version_removed": "8",
-                "notes": "Before Safari 5, <code>run-in</code> was not supported before inline elements."
-              },
-              "safari_ios": {
-                "version_added": "1",
-                "version_removed": "8",
-                "notes": "Before Safari 5, <code>run-in</code> was not supported before inline elements."
-              },
-              "samsunginternet_android": {
-                "version_added": "1.0",
-                "version_removed": "2.0"
-              },
-              "webview_android": {
-                "version_added": true,
-                "version_removed": "4.4.3"
               }
             },
             "status": {


### PR DESCRIPTION
For #4540, this PR cleans up the data for `display: run-in` and its parent feature, `<display-outside>`.

Prior to this PR, `run-in` was duplicated as `css.properties.display.run-in` and `css.properties.display.display-outside.run-in`. This removes the duplication and cleans up some issues with `display-outside`. Here are the details:

* `css.properties.display.run-in` was more complete and I used that data as a starting point. Where there were gaps that could be closed with mirroring, I did so. Nothing particularly exciting about that.
* I moved `css.properties.display.run-in` to replace `css.properties.display.display-outside.run-in`. This made it so there's just one feature for `run-in`.
* I added a description and MDN url to `<display-outside>` itself. It wasn't obviously the representation of a _type_ of value for `display`.
* Finally, I set all of the null values for `css.properties.display.display-outside` to the first release because `display: inline` and `display: block` are as old as dirt.

I don't love the `<display-outside>` structure here, but at least the data is complete and tidy now.