### PR TITLE
Add Samsung Internet support for modules in scripts

### DIFF
--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -349,7 +349,7 @@
                 "version_added": "11"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "8.2"
               },
               "webview_android": {
                 "version_added": "61"
@@ -606,7 +606,7 @@
                   "version_added": "10.3"
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "8.2"
                 },
                 "webview_android": {
                   "version_added": "61"

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -349,7 +349,7 @@
                 "version_added": "11"
               },
               "samsunginternet_android": {
-                "version_added": "8.2"
+                "version_added": "8.0"
               },
               "webview_android": {
                 "version_added": "61"
@@ -606,7 +606,7 @@
                   "version_added": "10.3"
                 },
                 "samsunginternet_android": {
-                  "version_added": "8.2"
+                  "version_added": "8.0"
                 },
                 "webview_android": {
                   "version_added": "61"


### PR DESCRIPTION
Samsung v8.2 uses chromium 63, which would seem to support modules. Caniuse also seems to agree.

Possibly this could be 8.0?