### PR TITLE
Update image-rendering: optimize{speed,quality}

### DIFF
--- a/css/properties/image-rendering.json
+++ b/css/properties/image-rendering.json
@@ -180,10 +180,10 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "28"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "28"
               },
               "edge": {
                 "version_added": false
@@ -198,22 +198,22 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "14"
               },
               "safari": {
-                "version_added": true
+                "version_added": "6.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "7"
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "1.5"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "41"
               }
             },
             "status": {
@@ -227,10 +227,10 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "28"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "28"
               },
               "edge": {
                 "version_added": false
@@ -245,22 +245,22 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "14"
               },
               "safari": {
-                "version_added": true
+                "version_added": "6.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "7"
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "1.5"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "41"
               }
             },
             "status": {


### PR DESCRIPTION
I think this got implemented in https://bugs.webkit.org/show_bug.cgi?id=113405 (https://github.com/WebKit/webkit/commit/a6052d989181f0696cfd234efaf169837edf2e40) and so it probably was in Safari 6 / safari ios 7. I've derived the other browser versions from the Safari version then.