### PR TITLE
Set Chrome+Safari values for css.properties.content.element_replacement

### DIFF
--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -53,10 +53,10 @@
             "description": "Element replacement",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "28"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "28"
               },
               "edge": {
                 "version_added": false
@@ -71,22 +71,22 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "14"
               },
               "safari": {
-                "version_added": true
+                "version_added": "9"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "9"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.5"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {


### PR DESCRIPTION
This sets the Chromium and Safari values for the element replacement subfeature of the `content` property.  Values were identified via manual testing.