### PR TITLE
Update data for fit-content for Safari

### DIFF
--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -304,17 +304,22 @@
               },
               "safari": [
                 {
-                  "version_added": true
+                  "version_added": "11"
                 },
                 {
                   "prefix": "-webkit-",
                   "version_added": "6.1"
                 }
               ],
-              "safari_ios": {
-                "prefix": "-webkit-",
-                "version_added": "7"
-              },
+              "safari_ios": [
+                {
+                  "version_added": "11"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "7"
+                }
+              ],
               "samsunginternet_android": {
                 "alternative_name": "-webkit-fill-available",
                 "version_added": "5.0"

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -307,12 +307,13 @@
                   "version_added": true
                 },
                 {
-                  "alternative_name": "-webkit-fill-available",
+                  "prefix": "-webkit-",
                   "version_added": "6.1"
                 }
               ],
               "safari_ios": {
-                "version_added": null
+                "prefix": "-webkit-",
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "alternative_name": "-webkit-fill-available",

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -337,8 +337,8 @@
                   "version_added": "11"
                 },
                 {
-                  "version_added": "9",
-                  "prefix": "-webkit-"
+                  "prefix": "-webkit-",
+                  "version_added": "6.1"
                 }
               ],
               "safari_ios": [
@@ -346,8 +346,8 @@
                   "version_added": "11"
                 },
                 {
-                  "version_added": "9",
-                  "prefix": "-webkit-"
+                  "prefix": "-webkit-",
+                  "version_added": "7"
                 }
               ],
               "samsunginternet_android": {


### PR DESCRIPTION
For #4540, this PR updates the data for `-webkit-fit-content` and `fit-content` with the `width` and `min-width` properties.

Originally appeared as `-webkit-fit-content`:

- https://trac.webkit.org/changeset/120849/webkit
- https://bugs.webkit.org/show_bug.cgi?id=38919

Then unprefixed:

- https://trac.webkit.org/changeset/213831/webkit
- https://bugs.webkit.org/show_bug.cgi?id=169195

I estimated the versions based on the dates of the commits, which were basically consistent with the data we already had.