### PR TITLE
Update sticky table positioning data for Chrome and Safari

### DIFF
--- a/css/properties/position.json
+++ b/css/properties/position.json
@@ -302,10 +302,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": false
+                "version_added": "8"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "8"
               },
               "samsunginternet_android": {
                 "version_added": "6.0"

--- a/css/properties/position.json
+++ b/css/properties/position.json
@@ -278,10 +278,10 @@
             "description": "Table elements as <code>sticky</code> positioning containers",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "56"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "56"
               },
               "edge": {
                 "version_added": "16"
@@ -296,10 +296,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "43"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "43"
               },
               "safari": {
                 "version_added": false
@@ -308,10 +308,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "6.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "56"
               }
             },
             "status": {


### PR DESCRIPTION
For #4540, this PR updates the data that covers whether or not tables can be containers for `position: sticky` elements.

I tested this for Chrome (it worked as soon as `sticky` was added to Chrome) and mirrored the data to other browsers.

I also ran across [a bug](https://bugs.webkit.org/show_bug.cgi?id=112024) which added this behavior to Safari. I estimated the version based on the date of the changeset.

