### PR TITLE
Add tip about fix script to browser sort linter

### DIFF
--- a/test/test-style.js
+++ b/test/test-style.js
@@ -152,7 +152,7 @@ function processData(filename, logger) {
 
   if (expected !== expectedBrowserSorting) {
     hasErrors = true;
-    logger.error(chalk`{red Browser sorting error on {bold line ${jsonDiff(expected, expectedBrowserSorting)}}}`);
+    logger.error(chalk`{red Browser sorting error on {bold line ${jsonDiff(expected, expectedBrowserSorting)}}}\n{blue     Tip: Run {bold npm run fix} to fix sorting automatically}`);
   }
 
   const bugzillaMatch = actual.match(String.raw`https?://bugzilla\.mozilla\.org/show_bug\.cgi\?id=(\d+)`);


### PR DESCRIPTION
Since we've now got #4490 and #4665 merged, we should bring back the tip regarding the use of the fix script, which is what this PR does.