### PR TITLE
Fix Chrome version of @font-face CSS rule

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-face",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"


### PR DESCRIPTION
Chrome was set to "4" for the CSS @font-face rule.  However, this doesn't make sense as Safari was set to 3.1.  By WebKit version, Chrome 1 was right in between Safari 3.2 and Safari 4, so anything that's supported in Safari 3.2 or below is in Chrome 1.

_Does not conflict with the upcoming feature sort bulk update._