### PR TITLE
Fix Safari iOS version of @media CSS rule

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -34,7 +34,7 @@
               "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
For some reason, Safari iOS was set to "3.1" (a traceback revealed this came from the migration of the old browser compatibility table -- potentially a confusion on iOS vs. Safari version) on this rule.  This PR fixes this version and replaces it with "1" to match with Safari Desktop.

_Does not conflict with the upcoming feature sort bulk update._