### PR TITLE
Fix Samsung Internet data for clip-path CSS property

### DIFF
--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -73,9 +73,15 @@
                 "version_added": "6.1"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": "6.0"
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "6.0"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1.5"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "55"


### PR DESCRIPTION
Samsung Internet was missing data for the prefixed version of the property, resulting in inconsistency alerts.  This PR fixes that by adding said version data into Samsung Internet.

_Does not conflict with the upcoming feature sort bulk update._