### PR TITLE
Fix a typo from #4457 in Chrome version

### DIFF
--- a/css/properties/image-rendering.json
+++ b/css/properties/image-rendering.json
@@ -53,7 +53,7 @@
             "support": {
               "chrome": {
                 "alternative_name": "-webkit-optimize-contrast",
-                "version_added": "1"
+                "version_added": "13"
               },
               "chrome_android": {
                 "alternative_name": "-webkit-optimize-contrast",


### PR DESCRIPTION
I unfortunately made a little typo in PR #4457 regarding the `crisp-edges` value to `image-rendering`, typing in "1" rather than "13".  I caught this while validating version consistency of the latest master branch.

_Does not conflict with the upcoming feature sort bulk update._