### PR TITLE
Fix Opera Android + Webview versions in letter-spacing CSS property

### DIFF
--- a/css/properties/letter-spacing.json
+++ b/css/properties/letter-spacing.json
@@ -27,7 +27,7 @@
               "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -39,7 +39,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
My version consistency test was complaining about this property.  Opera Android was set to `null`, and Webview was set to just plain old `37` without a range.  This PR fixes both by setting Opera Android to `10.1` (the first version of Opera Android, as the feature was in Opera Desktop before said release), and by adding the range indicator (`≤`) to Webview.

_Does not conflict with the upcoming feature sort bulk update._