### PR TITLE
Fix Safari consistency of mask-clip property

### DIFF
--- a/css/properties/mask-clip.json
+++ b/css/properties/mask-clip.json
@@ -111,7 +111,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "3.2"
+                "version_added": "4"
               },
               "safari_ios": {
                 "version_added": "3.2"
@@ -159,7 +159,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "3.2"
+                "version_added": "4"
               },
               "safari_ios": {
                 "version_added": "3.2"
@@ -207,7 +207,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "3.2"
+                "version_added": "4"
               },
               "safari_ios": {
                 "version_added": "3.2"
@@ -255,7 +255,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "3.2"
+                "version_added": "4"
               },
               "safari_ios": {
                 "version_added": "3.2"


### PR DESCRIPTION
In #4059, I went through the Apple documentation to obtain real version numbers for various properties.  It turns out that I forgot to go through the values to the `mask-clip` property and bump them up to match.  This PR performs said action, setting all values to the property for Safari Desktop to 4, just like its parent.

_Does not conflict with the upcoming feature sort bulk update._