### PR TITLE
Fix Safari iOS + Samsung Internet versions for outline-style

### DIFF
--- a/css/properties/outline-style.json
+++ b/css/properties/outline-style.json
@@ -40,10 +40,10 @@
               "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "2"


### PR DESCRIPTION
From the original BCD tables in the wiki, it looks like Safari iOS was set by the Safari version rather than the iOS version.  Samsung Internet was also left as `null`.  This PR fixes both by setting Safari iOS to "1", and Samsung Internet to "1.0", based upon their desktop counterparts.

_Does not conflict with the upcoming feature sort bulk update._