### PR TITLE
Add Safari iOS version to word-spacing CSS property

### DIFF
--- a/css/properties/word-spacing.json
+++ b/css/properties/word-spacing.json
@@ -33,7 +33,7 @@
               "version_added": "1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": null


### PR DESCRIPTION
This PR adds the Safari iOS version to the `word-spacing` CSS property based upon its desktop counterpart.

_Does not conflict with the upcoming feature sort bulk update._