### PR TITLE
Fix Safari iOS version of placeholder-shown CSS selector

### DIFF
--- a/css/selectors/placeholder-shown.json
+++ b/css/selectors/placeholder-shown.json
@@ -50,7 +50,7 @@
               "version_added": "9"
             },
             "safari_ios": {
-              "version_added": "9.2"
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "5.0"


### PR DESCRIPTION
This PR fixes the Safari iOS version of the `placeholder-shown` CSS selector.  Safari iOS was set to 9.2, however the earliest version that matches the WebKit version of Safari Desktop 9 is also Safari iOS 9.

_Does not conflict with the upcoming feature sort bulk update._