### PR TITLE
Fix Opera consistency of length[-percentage] CSS type

### DIFF
--- a/css/types/length-percentage.json
+++ b/css/types/length-percentage.json
@@ -172,10 +172,10 @@
                 "version_added": "4"
               },
               "opera": {
-                "version_added": "2"
+                "version_added": "3.5"
               },
               "opera_android": {
-                "version_added": "11"
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -172,10 +172,10 @@
                 "version_added": "4"
               },
               "opera": {
-                "version_added": "2"
+                "version_added": "3.5"
               },
               "opera_android": {
-                "version_added": "11"
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"


### PR DESCRIPTION
This PR fixes the Opera version consistency of the `ex` value of the `length` CSS type (and consequentially the `length-percentage` type) by bumping it up to the version defined for the type itself.  @Elchi3, you were the last to modify those lines -- as such, I am requesting your review to see if you think this is the right change to make, or if the `length` type needs to be set to a lower version!

_Does not conflict with the upcoming feature sort bulk update._