### PR TITLE
Fix versions of text-rendering CSS property

### DIFF
--- a/css/properties/text-rendering.json
+++ b/css/properties/text-rendering.json
@@ -45,10 +45,10 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "4.3"
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "3",
@@ -96,11 +96,11 @@
                 "notes": "Opera treats <code>auto</code> as <code>optimizeSpeed</code>."
               },
               "safari": {
-                "version_added": "4.1",
+                "version_added": "5",
                 "notes": "Safari treats <code>auto</code> as <code>optimizeSpeed</code>. See <a href='https://webkit.org/b/41363'>WebKit bug 41363</a>."
               },
               "safari_ios": {
-                "version_added": "4",
+                "version_added": "4.2",
                 "notes": "Safari treats <code>auto</code> as <code>optimizeSpeed</code>. See <a href='https://webkit.org/b/41363'>WebKit bug 41363</a>."
               },
               "samsunginternet_android": {


### PR DESCRIPTION
This PR fixes some inconsistencies within the `text-rendering` CSS property.  Since Safari 4.1 and 5.0 are the same WebKit version (I've filed an issue regarding possibly removing Safari 4.1, see #4679), I decided to favor Safari 5.0 in the `auto` field.  Furthermore, this fixes Safari iOS versions, and adds a Samsung Internet version.

_Does not conflict with the upcoming feature sort bulk update._