### PR TITLE
Correct Firefox PointerEvent.getCoalescedEvents data

### DIFF
--- a/api/PointerEvent.json
+++ b/api/PointerEvent.json
@@ -88,11 +88,18 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "59",
-              "version_removed": true
+              "version_added": "59"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "59",
+              "partial_implementation": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.w3c_pointer_events.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Forked from https://github.com/mdn/browser-compat-data/pull/4671

### getCoalescedEvents() ###

From my testing on a Samsung S10e, `getCoalescedEvents()` appears to be supported behind a flag in the latest stable version of Firefox for Android. However, no action I performed (swipe, tap, pinch zoom) returned any coalesced events on my device when listening to `pointermove` with `touch-action: none`, the returned array was always empty. Therefore, I marked it as a partial implementation. Similarly, I see no evidence this method was ever removed from desktop Firefox, where >0 coalesced events are still returned.