### PR TITLE
Updated Firefox support of the 'contain' CSS property

### DIFF
--- a/css/properties/contain.json
+++ b/css/properties/contain.json
@@ -15,26 +15,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "41",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.contain.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/1150081'>bug 1150081</a> for the overall implementation status."
+              "version_added": "69"
             },
             "firefox_android": {
-              "version_added": "41",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.contain.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/1150081'>bug 1150081</a> for the overall implementation status."
+              "version_added": "69"
             },
             "ie": {
               "version_added": false

--- a/css/properties/contain.json
+++ b/css/properties/contain.json
@@ -14,11 +14,32 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "69"
-            },
+            "firefox": [
+              {
+                "version_added": "69"
+              },
+              {
+                "version_added": "41",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.contain.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See <a href='https://bugzil.la/1150081'>bug 1150081</a> for the overall implementation status."
+              }
+            ],
             "firefox_android": {
-              "version_added": "69"
+              "version_added": "41",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.contain.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "See <a href='https://bugzil.la/1150081'>bug 1150081</a> for the overall implementation status."
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Firefox will ship support for the CSS property `contain` in version 69. See [bug 1487493](https://bugzil.la/1487493).

Confirmed that it's enabled by default in Firefox Developer Edition 69.0b16.

I've also added this to the [developer release notes for Firefox 69](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/69#CSS).

The patch removes the info that it was availble since 41 behind a flag. Is that ok or should that info be restored?

Sebastian