### PR TITLE
Fold subfeature into Firefox note

### DIFF
--- a/css/properties/position.json
+++ b/css/properties/position.json
@@ -22,7 +22,11 @@
               ]
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "4",
+              "notes": [
+                "Before Firefox 57, absolute positioning did not work correctly when applied to elements inside tables that have <a href='https://developer.mozilla.org/docs/Web/CSS/border-collapse'><code>border-collapse</code></a> applied to them (<a href='https://bugzil.la/1379306'>bug 1379306</a>).",
+                "Before Firefox 30, absolute positioning of table rows and row groups was not supported (<a href='https://bugzil.la/63895'>bug 63895</a>)."
+              ]
             },
             "ie": {
               "version_added": "4"

--- a/css/properties/position.json
+++ b/css/properties/position.json
@@ -16,7 +16,10 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": "Before Firefox 57, absolute positioning did not work correctly when applied to elements inside tables that have <a href='https://developer.mozilla.org/docs/Web/CSS/border-collapse'><code>border-collapse</code></a> applied to them (<a href='https://bugzil.la/1379306'>bug 1379306</a>)."
+              "notes": [
+                "Before Firefox 57, absolute positioning did not work correctly when applied to elements inside tables that have <a href='https://developer.mozilla.org/docs/Web/CSS/border-collapse'><code>border-collapse</code></a> applied to them (<a href='https://bugzil.la/1379306'>bug 1379306</a>).",
+                "Before Firefox 30, absolute positioning of table rows and row groups was not supported (<a href='https://bugzil.la/63895'>bug 63895</a>)."
+              ]
             },
             "firefox_android": {
               "version_added": "4"
@@ -214,56 +217,6 @@
               },
               "webview_android": {
                 "version_added": "56"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "position_absolute_table_elements": {
-          "__compat": {
-            "description": "Table elements as <code>absolute</code> positioning containers",
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "30",
-                "notes": "Firefox helps developers transition to the new behavior and detect any rendering issues it may cause on their sites by printing the following warning to the JavaScript console: &quot;Absolute positioning of table rows and row groups is now supported. This site may need to be updated because it may depend on this feature having no effect.&quot;"
-              },
-              "firefox_android": {
-                "version_added": "30",
-                "notes": "Firefox helps developers transition to the new behavior and detect any rendering issues it may cause on their sites by printing the following warning to the JavaScript console: &quot;Absolute positioning of table rows and row groups is now supported. This site may need to be updated because it may depend on this feature having no effect.&quot;"
-              },
-              "ie": {
-                "version_added": "4"
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": true
-              },
-              "safari_ios": {
-                "version_added": true
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": true
               }
             },
             "status": {


### PR DESCRIPTION
See https://github.com/mdn/browser-compat-data/issues/4540#issuecomment-523923353 for some resources to read.

I've read through that and some bugs now but I think it is not worth having this as a sub feature. Lets instead document it as a Firefox note. Firefox 30 is quite old at this point, so I think a note is fine.