### PR TITLE
Fix data for image-rendering.

### DIFF
--- a/css/properties/image-rendering.json
+++ b/css/properties/image-rendering.json
@@ -39,7 +39,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "41"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -119,7 +119,7 @@
               },
               "webview_android": {
                 "alternative_name": "-webkit-optimize-contrast",
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -213,7 +213,7 @@
                 "version_added": "1.5"
               },
               "webview_android": {
-                "version_added": "41"
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -260,7 +260,7 @@
                 "version_added": "1.5"
               },
               "webview_android": {
-                "version_added": "41"
+                "version_added": "≤37"
               }
             },
             "status": {


### PR DESCRIPTION
This PR:
* Fixes an error introduced at some unknown point and extended in #4656. The top level of this feature shows it shipping in 41 for WebView. It was the value `pixelated` which [was introduced in 41](https://www.chromestatus.com/features/5118058116939776). The `image-rendering` feature is now marked correctly as `"≤37"`.
* Sets other WebView values to `"≤37"` as appropriate.