### PR TITLE
Update data for ParentNode.children

### DIFF
--- a/api/ParentNode.json
+++ b/api/ParentNode.json
@@ -224,7 +224,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -250,7 +250,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "16"
               },
               "firefox": {
                 "version_added": "25"
@@ -268,10 +268,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": false
+                "version_added": "9"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "9"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -298,7 +298,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "16"
               },
               "firefox": {
                 "version_added": true
@@ -316,10 +316,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": false
+                "version_added": "9"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "9"
               },
               "samsunginternet_android": {
                 "version_added": null


### PR DESCRIPTION
iOS Safari 9, Safari 9 and Edge 16 support DocumentFragment.children and SVGElement.children.

I tested these browsers using Browserstack.

Sources:
- https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12481708/
- https://bugs.webkit.org/show_bug.cgi?id=145072
- https://trac.webkit.org/changeset/184420/webkit