### PR TITLE
Fix Safari iOS version of CSS word-break: break-word

### DIFF
--- a/css/properties/word-break.json
+++ b/css/properties/word-break.json
@@ -88,7 +88,7 @@
                 "version_added": "3"
               },
               "safari_ios": {
-                "version_added": "1"
+                "version_added": "2"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"


### PR DESCRIPTION
This PR updates the `break-word` value of the CSS `word-break` property for Safari iOS.  #4060 had set `word-break` to Safari iOS 2, however it looks like `break-word` was not updated as well.  This was found during a run of the version consistency test's results.