### PR TITLE
Fix consistency of Safari iOS in user-select property

### DIFF
--- a/css/properties/user-select.json
+++ b/css/properties/user-select.json
@@ -203,7 +203,7 @@
                 "version_added": "2"
               },
               "safari_ios": {
-                "version_added": "1"
+                "version_added": "3"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -313,7 +313,7 @@
                 "version_added": "2"
               },
               "safari_ios": {
-                "version_added": "1"
+                "version_added": "3"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -362,7 +362,7 @@
                 "notes": "Allows typing in the <code>&lt;html&gt;</code> container."
               },
               "safari_ios": {
-                "version_added": "1",
+                "version_added": "3",
                 "partial_implementation": true,
                 "notes": "Allows typing in the <code>&lt;html&gt;</code> container."
               },


### PR DESCRIPTION
#4061 had set the `user-select` property to Safari iOS 3, which was confirmed by Apple's docs.  However, all of the properties underneath it were not updated.  This PR fixes the version consistency by setting all of the values to "3" or above.