### PR TITLE
Set Safari versions for feature-policy HTTP header and iframe allow property

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -130,7 +130,7 @@
                 "version_added": "11.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "11.3"
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -44,10 +44,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": false
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": false

--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -44,10 +44,14 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1",
+              "partial_implementation": true,
+              "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3",
+              "partial_implementation": true,
+              "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
#4647 sets the camera and microphone feature-policy header values to Safari 11.1.  However, this fails the version consistency linter.  As such, this PR intends to fix it by setting the `feature-policy` HTTP header to "true", as well as set the version number of Safari iOS for the `<iframe allow="">` property.