### PR TITLE
Set Safari iOS version for track HTML element

### DIFF
--- a/html/elements/track.json
+++ b/html/elements/track.json
@@ -60,7 +60,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds the Safari iOS version for the `<track>` element based upon the Safari Desktop value.
