### PR TITLE
Fix Opera/Samsung Internet versions for api.RTCRtpReceiver.getSynchronizationSources

### DIFF
--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -386,10 +386,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "60"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "52"
             },
             "safari": {
               "version_added": null
@@ -440,10 +440,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "60"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "52"
               },
               "safari": {
                 "version_added": null
@@ -495,10 +495,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": "60"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "52"
               },
               "safari": {
                 "version_added": null
@@ -507,7 +507,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": "73"


### PR DESCRIPTION
During tests for version consistency, I found some issues with this API's version consistency.  This PR fixes them by copying Chrome values to Opera and Samsung Internet.