### PR TITLE
Set feImage SVG element to True for Safari

### DIFF
--- a/svg/elements/feImage.json
+++ b/svg/elements/feImage.json
@@ -30,10 +30,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true


### PR DESCRIPTION
In #4644, I set the `href` attribute to various SVG elements based upon its changeset, however the `feImage` SVG element was set to `null`, violating the version consistency.  Because we can confirm there was definitely such an element, this sets it to `true` for now.