### PR TITLE
Mirror Chrome -> Opera for css/* (when Opera = false)

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1239,10 +1239,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "62"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "53"
               },
               "safari": {
                 "version_added": "10.1"

--- a/css/properties/background.json
+++ b/css/properties/background.json
@@ -71,10 +71,10 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": "21"
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "5.1"
@@ -119,10 +119,10 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": "21"
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "5.1"

--- a/css/properties/border-image-repeat.json
+++ b/css/properties/border-image-repeat.json
@@ -98,7 +98,7 @@
                 "version_added": "11"
               },
               "opera": {
-                "version_added": false
+                "version_added": "43"
               },
               "safari": {
                 "version_added": "9.1"

--- a/css/properties/color.json
+++ b/css/properties/color.json
@@ -144,18 +144,34 @@
               "ie": {
                 "version_added": false
               },
-              "opera": {
-                "version_added": "39",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera": [
+                {
+                  "version_added": "49"
+                },
+                {
+                  "version_added": "39",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Enable experimental Web Platform features"
+                    }
+                  ]
+                }
+              ],
+              "opera_android": [
+                {
+                  "version_added": "47"
+                },
+                {
+                  "version_added": "41",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "Enable experimental Web Platform features"
+                    }
+                  ]
+                }
+              ],
               "safari": {
                 "version_added": "9.1"
               },

--- a/css/properties/flex-grow.json
+++ b/css/properties/flex-grow.json
@@ -152,10 +152,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "36"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "36"
               },
               "safari": {
                 "version_added": false

--- a/css/properties/margin-block.json
+++ b/css/properties/margin-block.json
@@ -24,10 +24,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": false

--- a/css/properties/margin-inline.json
+++ b/css/properties/margin-inline.json
@@ -24,10 +24,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": false

--- a/css/properties/mask-image.json
+++ b/css/properties/mask-image.json
@@ -82,10 +82,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "4"
@@ -130,10 +130,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "4"

--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -295,10 +295,12 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "alternative_name": "-webkit-fill-available",
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": null
+                "alternative_name": "-webkit-fill-available",
+                "version_added": "15"
               },
               "safari": {
                 "version_added": false

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -301,10 +301,12 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "alternative_name": "-webkit-fill-available",
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": null
+                "alternative_name": "-webkit-fill-available",
+                "version_added": "14"
               },
               "safari": {
                 "version_added": false

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -382,10 +382,12 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "alternative_name": "-webkit-fill-available",
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": null
+                "alternative_name": "-webkit-fill-available",
+                "version_added": "14"
               },
               "safari": {
                 "version_added": false

--- a/css/properties/mix-blend-mode.json
+++ b/css/properties/mix-blend-mode.json
@@ -71,7 +71,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "28"
               },
               "opera_android": {
                 "version_added": false

--- a/css/properties/padding-block.json
+++ b/css/properties/padding-block.json
@@ -24,10 +24,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": false

--- a/css/properties/padding-inline.json
+++ b/css/properties/padding-inline.json
@@ -24,10 +24,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": false

--- a/css/properties/place-self.json
+++ b/css/properties/place-self.json
@@ -29,7 +29,7 @@
                 "version_added": "46"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "43"
               },
               "safari": {
                 "version_added": false
@@ -78,7 +78,7 @@
                 "version_added": "46"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "43"
               },
               "safari": {
                 "version_added": false

--- a/css/properties/scroll-snap-stop.json
+++ b/css/properties/scroll-snap-stop.json
@@ -24,7 +24,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
               "version_added": false

--- a/css/properties/text-underline-position.json
+++ b/css/properties/text-underline-position.json
@@ -24,10 +24,10 @@
               "version_added": "6"
             },
             "opera": {
-              "version_added": false
+              "version_added": "20"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "20"
             },
             "safari": {
               "version_added": false
@@ -167,10 +167,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "58"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "50"
               },
               "safari": {
                 "version_added": false
@@ -215,10 +215,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "20"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "20"
               },
               "safari": {
                 "version_added": false

--- a/css/properties/unicode-bidi.json
+++ b/css/properties/unicode-bidi.json
@@ -96,11 +96,21 @@
               "ie": {
                 "version_added": false
               },
-              "opera": {
-                "version_added": false
-              },
+              "opera": [
+                {
+                  "version_added": "35"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "15",
+                  "notes": [
+                    "Avoiding using <code>-webkit-isolate</code>. It can lock up older versions of Opera (up to version 34).",
+                    "The syntax from a previous version of the specification, where the <code>isolate</code> keyword could be used together with <code>bidi-override</code>, is allowed."
+                  ]
+                }
+              ],
               "opera_android": {
-                "version_added": false
+                "version_added": "35"
               },
               "safari": {
                 "prefix": "-webkit-",
@@ -163,10 +173,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "35"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "35"
               },
               "safari": {
                 "version_added": false
@@ -233,10 +243,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "35"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "35"
               },
               "safari": {
                 "version_added": false

--- a/css/properties/user-modify.json
+++ b/css/properties/user-modify.json
@@ -39,10 +39,12 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "prefix": "-webkit-",
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": null
+              "prefix": "-webkit-",
+              "version_added": "14"
             },
             "safari": [
               {
@@ -95,10 +97,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "3"

--- a/css/properties/white-space.json
+++ b/css/properties/white-space.json
@@ -71,7 +71,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "62"
               },
               "opera_android": {
                 "version_added": false

--- a/css/properties/word-break.json
+++ b/css/properties/word-break.json
@@ -130,7 +130,7 @@
                 "version_added": "31"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "32"
               },
               "safari": {
                 "version_added": "9"

--- a/css/properties/zoom.json
+++ b/css/properties/zoom.json
@@ -76,10 +76,12 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "15",
+                "version_removed": "46"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "14",
+                "version_removed": "43"
               },
               "safari": {
                 "version_added": "3.1"

--- a/css/selectors/after.json
+++ b/css/selectors/after.json
@@ -152,10 +152,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari": {
                 "version_added": false

--- a/css/selectors/backdrop.json
+++ b/css/selectors/backdrop.json
@@ -43,12 +43,24 @@
               "prefix": "-ms-",
               "version_added": "11"
             },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": [
+              {
+                "version_added": "24"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "19"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "24"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "19"
+              }
+            ],
             "safari": {
               "version_added": false
             },
@@ -91,10 +103,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "19"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "19"
               },
               "safari": {
                 "version_added": false

--- a/css/selectors/before.json
+++ b/css/selectors/before.json
@@ -143,10 +143,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari": {
                 "version_added": false

--- a/css/selectors/focus-visible.json
+++ b/css/selectors/focus-visible.json
@@ -41,10 +41,24 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "54",
+              "flags": [
+                {
+                  "name": "#enable-experimental-web-platform-features",
+                  "type": "preference",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48",
+              "flags": [
+                {
+                  "name": "#enable-experimental-web-platform-features",
+                  "type": "preference",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari": {
               "version_added": false

--- a/css/selectors/fullscreen.json
+++ b/css/selectors/fullscreen.json
@@ -73,13 +73,24 @@
               "prefix": "-ms-",
               "version_added": "11"
             },
-            "opera": {
-              "alternative_name": ":-webkit-full-screen",
-              "version_added": "15"
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": [
+              {
+                "version_added": "58"
+              },
+              {
+                "alternative_name": ":-webkit-full-screen",
+                "version_added": "15"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "alternative_name": ":-webkit-full-screen",
+                "version_added": "14"
+              }
+            ],
             "safari": {
               "alternative_name": ":-webkit-full-screen",
               "version_added": "6"

--- a/css/selectors/scope.json
+++ b/css/selectors/scope.json
@@ -55,7 +55,7 @@
               "version_added": "15"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "15"
             },
             "safari": {
               "version_added": "7"
@@ -102,7 +102,7 @@
                 "version_added": "15"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "15"
               },
               "safari": {
                 "version_added": "7"

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -423,10 +423,10 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": false
+                    "version_added": "59"
                   },
                   "opera_android": {
-                    "version_added": false
+                    "version_added": "51"
                   },
                   "safari": {
                     "version_added": "12.1"

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -423,7 +423,7 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": "59"
+                    "version_added": "60"
                   },
                   "opera_android": {
                     "version_added": "51"

--- a/css/types/length-percentage.json
+++ b/css/types/length-percentage.json
@@ -28,7 +28,7 @@
               "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -656,10 +656,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "20"
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "6.1"
@@ -718,10 +718,10 @@
                 }
               ],
               "opera": {
-                "version_added": "20"
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "6.1"

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -28,7 +28,7 @@
               "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -658,10 +658,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "20"
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "6.1"
@@ -720,10 +720,10 @@
                 }
               ],
               "opera": {
-                "version_added": "20"
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "6.1"


### PR DESCRIPTION
While going through the data, I wanted to check against browser derivatives like Opera to see if they differ from their parent (Chrome) when they should not.  I've found several instances where this has been the case.  This PR copies Chrome data to Opera and Opera Android when either were set to "false".  Most properties have already been verified for accuracy.