### PR TITLE
Fix Chromium data for border-block-* CSS properties

### DIFF
--- a/css/properties/border-block-color.json
+++ b/css/properties/border-block-color.json
@@ -16,7 +16,14 @@
               ]
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "69",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "edge": {
               "version_added": false
@@ -31,10 +38,24 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari": {
               "version_added": false
@@ -46,7 +67,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": false
             }
           },
           "status": {

--- a/css/properties/border-block-end.json
+++ b/css/properties/border-block-end.json
@@ -50,10 +50,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": "12.1"

--- a/css/properties/border-block-start.json
+++ b/css/properties/border-block-start.json
@@ -50,10 +50,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": "12.1"

--- a/css/properties/border-block-style.json
+++ b/css/properties/border-block-style.json
@@ -24,10 +24,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": false
@@ -39,7 +39,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {

--- a/css/properties/border-block-width.json
+++ b/css/properties/border-block-width.json
@@ -24,10 +24,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": false
@@ -39,7 +39,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {

--- a/css/properties/border-block.json
+++ b/css/properties/border-block.json
@@ -24,10 +24,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": false
@@ -39,7 +39,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {


### PR DESCRIPTION
This PR aims to fix some inconsistencies within the Chromium-based data of the `border-block-*` CSS properties based upon the Chrome data.  Double-checked through some manual testing.