### PR TITLE
Fix Chromium data for border-inline-* CSS

### DIFF
--- a/css/properties/border-inline-color.json
+++ b/css/properties/border-inline-color.json
@@ -24,10 +24,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": false

--- a/css/properties/border-inline-end.json
+++ b/css/properties/border-inline-end.json
@@ -48,10 +48,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": "12.1"

--- a/css/properties/border-inline-start.json
+++ b/css/properties/border-inline-start.json
@@ -48,10 +48,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": "12.1"

--- a/css/properties/border-inline-style.json
+++ b/css/properties/border-inline-style.json
@@ -24,10 +24,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": false
@@ -39,7 +39,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {

--- a/css/properties/border-inline-width.json
+++ b/css/properties/border-inline-width.json
@@ -24,10 +24,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": false
@@ -39,7 +39,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {

--- a/css/properties/border-inline.json
+++ b/css/properties/border-inline.json
@@ -24,10 +24,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": false
@@ -39,7 +39,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {


### PR DESCRIPTION
This PR aims to fix some inconsistencies within the Chromium-based data of the `border-inline-*` CSS properties based upon the Chrome data.  Double-checked through some manual testing.