### PR TITLE
updating compat data for offset-distance and offset-rotate

### DIFF
--- a/css/properties/offset-distance.json
+++ b/css/properties/offset-distance.json
@@ -27,7 +27,14 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "69",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.motion-path.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false

--- a/css/properties/offset-rotate.json
+++ b/css/properties/offset-rotate.json
@@ -35,7 +35,14 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "69",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.motion-path.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
As per:

* https://bugzilla.mozilla.org/show_bug.cgi?id=1429299
* https://bugzilla.mozilla.org/show_bug.cgi?id=1429301

The useful data is at https://bugzilla.mozilla.org/show_bug.cgi?id=1429299#c15. I've not updated the `offset` shorthand or added data for the `offset-anchor` property, as I've not seen any bugs about those yet.