### PR TITLE
Mirror Chrome -> Opera for css/* (when Opera = true/null)

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -538,7 +538,7 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": true

--- a/css/at-rules/import.json
+++ b/css/at-rules/import.json
@@ -25,7 +25,7 @@
               "version_added": "5.5"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": true

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -168,7 +168,7 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": true
@@ -266,7 +266,7 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": true
@@ -413,7 +413,7 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": true
@@ -462,7 +462,7 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": true
@@ -511,7 +511,7 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": true
@@ -611,7 +611,7 @@
                 "version_added": "10"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": true
@@ -660,7 +660,7 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": true
@@ -951,7 +951,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": true
@@ -1000,7 +1000,7 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": true
@@ -1562,7 +1562,7 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": true
@@ -1662,7 +1662,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true,
+                "version_added": "15",
                 "version_removed": "23"
               },
               "opera_android": {
@@ -1775,7 +1775,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": true
@@ -1884,7 +1884,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": true
@@ -1993,7 +1993,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": true
@@ -2044,7 +2044,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true,
+                "version_added": "15",
                 "version_removed": "23"
               },
               "opera_android": {
@@ -2123,7 +2123,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true,
+                "version_added": "15",
                 "version_removed": "23"
               },
               "opera_android": {
@@ -2178,7 +2178,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true,
+                "version_added": "15",
                 "version_removed": "23"
               },
               "opera_android": {

--- a/css/properties/animation-direction.json
+++ b/css/properties/animation-direction.json
@@ -185,7 +185,7 @@
                 "version_added": "10"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "safari": {
                 "version_added": "6"
@@ -227,7 +227,7 @@
                 "version_added": "10"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "safari": {
                 "version_added": "6"

--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -294,7 +294,7 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": true

--- a/css/properties/background-repeat.json
+++ b/css/properties/background-repeat.json
@@ -173,7 +173,7 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": true

--- a/css/properties/background.json
+++ b/css/properties/background.json
@@ -263,7 +263,7 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": true

--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -164,7 +164,7 @@
                 "version_added": "11"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": true
@@ -212,7 +212,7 @@
                 "version_added": "11"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": true

--- a/css/properties/border-radius.json
+++ b/css/properties/border-radius.json
@@ -113,7 +113,7 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": true
@@ -212,7 +212,7 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": true

--- a/css/properties/box-align.json
+++ b/css/properties/box-align.json
@@ -41,7 +41,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "15",
               "prefix": "-webkit-"
             },
             "opera_android": {

--- a/css/properties/box-direction.json
+++ b/css/properties/box-direction.json
@@ -64,7 +64,7 @@
             },
             "opera": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "prefix": "-webkit-",

--- a/css/properties/box-flex-group.json
+++ b/css/properties/box-flex-group.json
@@ -28,7 +28,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "15",
               "version_removed": "54",
               "prefix": "-webkit-"
             },

--- a/css/properties/box-flex.json
+++ b/css/properties/box-flex.json
@@ -64,7 +64,7 @@
             },
             "opera": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "prefix": "-webkit-",

--- a/css/properties/box-lines.json
+++ b/css/properties/box-lines.json
@@ -28,7 +28,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "15",
               "version_removed": "54",
               "prefix": "-webkit-"
             },

--- a/css/properties/box-ordinal-group.json
+++ b/css/properties/box-ordinal-group.json
@@ -63,7 +63,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "15",
               "prefix": "-webkit-"
             },
             "opera_android": {

--- a/css/properties/box-orient.json
+++ b/css/properties/box-orient.json
@@ -64,7 +64,7 @@
             },
             "opera": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "prefix": "-webkit-",

--- a/css/properties/box-pack.json
+++ b/css/properties/box-pack.json
@@ -64,7 +64,7 @@
             },
             "opera": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "prefix": "-webkit-",

--- a/css/properties/break-after.json
+++ b/css/properties/break-after.json
@@ -181,7 +181,7 @@
                   "version_added": "10"
                 },
                 "opera": {
-                  "version_added": true
+                  "version_added": "37"
                 },
                 "opera_android": {
                   "version_added": true

--- a/css/properties/color.json
+++ b/css/properties/color.json
@@ -24,7 +24,7 @@
               "version_added": "3"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": true

--- a/css/properties/font-smooth.json
+++ b/css/properties/font-smooth.json
@@ -28,7 +28,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "15",
               "alternative_name": "-webkit-font-smoothing"
             },
             "opera_android": {

--- a/css/properties/font-variant.json
+++ b/css/properties/font-variant.json
@@ -201,7 +201,7 @@
                 "version_added": "4"
               },
               "opera": {
-                "version_added": true
+                "version_added": "18"
               },
               "opera_android": {
                 "version_added": true

--- a/css/properties/hyphens.json
+++ b/css/properties/hyphens.json
@@ -1367,7 +1367,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
                 "version_added": null

--- a/css/properties/letter-spacing.json
+++ b/css/properties/letter-spacing.json
@@ -71,7 +71,7 @@
                 "version_added": "10"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": true

--- a/css/properties/mask-image.json
+++ b/css/properties/mask-image.json
@@ -29,7 +29,7 @@
             },
             "opera": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": null
@@ -82,7 +82,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": false
@@ -130,7 +130,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": false

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -343,7 +343,7 @@
               },
               "opera": {
                 "alternative_name": "-webkit-fill-available",
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
                 "alternative_name": "-webkit-fill-available",

--- a/css/properties/mix-blend-mode.json
+++ b/css/properties/mix-blend-mode.json
@@ -24,7 +24,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "28"
             },
             "opera_android": {
               "version_added": null

--- a/css/properties/outline-style.json
+++ b/css/properties/outline-style.json
@@ -78,7 +78,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": true

--- a/css/properties/place-content.json
+++ b/css/properties/place-content.json
@@ -28,7 +28,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "46"
               },
               "opera_android": {
                 "version_added": true
@@ -79,7 +79,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "46"
               },
               "opera_android": {
                 "version_added": true

--- a/css/properties/text-align-last.json
+++ b/css/properties/text-align-last.json
@@ -68,9 +68,22 @@
                 "The <code>start</code> and <code>end</code> values are not supported."
               ]
             },
-            "opera": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "34"
+              },
+              {
+                "version_added": "22",
+                "version_removed": "34",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable Experimental Web Platform Features",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
               "version_added": true
             },

--- a/css/properties/text-align.json
+++ b/css/properties/text-align.json
@@ -24,7 +24,7 @@
               "version_added": "3"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": true

--- a/css/properties/text-decoration-line.json
+++ b/css/properties/text-decoration-line.json
@@ -38,7 +38,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "44"
             },
             "opera_android": {
               "version_added": true

--- a/css/properties/text-transform.json
+++ b/css/properties/text-transform.json
@@ -366,7 +366,7 @@
                 "version_added": "4"
               },
               "opera": {
-                "version_added": true
+                "version_added": "18"
               },
               "opera_android": {
                 "version_added": true

--- a/css/properties/transition-property.json
+++ b/css/properties/transition-property.json
@@ -183,7 +183,7 @@
                 "version_added": "10"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": true

--- a/css/properties/writing-mode.json
+++ b/css/properties/writing-mode.json
@@ -155,7 +155,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "35"
               },
               "opera_android": {
                 "version_added": null
@@ -252,7 +252,7 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "35"
               },
               "opera_android": {
                 "version_added": null

--- a/css/selectors/adjacent_sibling.json
+++ b/css/selectors/adjacent_sibling.json
@@ -29,7 +29,7 @@
               ]
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": true

--- a/css/selectors/child.json
+++ b/css/selectors/child.json
@@ -25,7 +25,7 @@
               "version_added": "7"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": true

--- a/css/selectors/class.json
+++ b/css/selectors/class.json
@@ -25,7 +25,7 @@
               "version_added": "3"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": true

--- a/css/selectors/descendant.json
+++ b/css/selectors/descendant.json
@@ -36,9 +36,15 @@
             "ie": {
               "version_added": "3"
             },
-            "opera": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "15"
+              },
+              {
+                "version_added": "48",
+                "notes": "<code>&gt;&gt;&gt;</code> is aliased to this selector <a href='https://developers.google.com/web/updates/2017/06/chrome-60-deprecations#make_shadow-piercing_descendant_combinator_behave_like_descendent_combinator'>since its use as the 'shadow-piercing descendant combinator' was deprecated</a>."
+              }
+            ],
             "opera_android": {
               "version_added": true
             },

--- a/css/selectors/hover.json
+++ b/css/selectors/hover.json
@@ -174,7 +174,7 @@
                 "version_added": "11"
               },
               "opera": {
-                "version_added": null
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": null

--- a/css/selectors/id.json
+++ b/css/selectors/id.json
@@ -25,7 +25,7 @@
               "version_added": "3"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": true

--- a/css/selectors/indeterminate.json
+++ b/css/selectors/indeterminate.json
@@ -25,7 +25,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": true

--- a/css/selectors/read-only.json
+++ b/css/selectors/read-only.json
@@ -29,7 +29,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": true

--- a/css/selectors/read-write.json
+++ b/css/selectors/read-write.json
@@ -29,7 +29,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": true

--- a/css/selectors/type.json
+++ b/css/selectors/type.json
@@ -25,7 +25,7 @@
               "version_added": "3"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": true

--- a/css/selectors/universal.json
+++ b/css/selectors/universal.json
@@ -25,7 +25,7 @@
               "version_added": "7"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": true

--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -242,7 +242,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true,
+                "version_added": "33",
                 "partial_implementation": true,
                 "notes": "Only supported on the <code>offset-path</code> property."
               },

--- a/css/types/counter.json
+++ b/css/types/counter.json
@@ -25,7 +25,7 @@
               "version_added": "8"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": true

--- a/css/types/dimension.json
+++ b/css/types/dimension.json
@@ -25,7 +25,7 @@
               "version_added": "5"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": true

--- a/css/types/global_keywords.json
+++ b/css/types/global_keywords.json
@@ -24,7 +24,7 @@
               "version_added": "3"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": true
@@ -233,7 +233,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "28"
               },
               "opera_android": {
                 "version_added": true

--- a/css/types/integer.json
+++ b/css/types/integer.json
@@ -25,7 +25,7 @@
               "version_added": "3"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": true

--- a/css/types/percentage.json
+++ b/css/types/percentage.json
@@ -25,7 +25,7 @@
               "version_added": "3"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": true

--- a/css/types/resolution.json
+++ b/css/types/resolution.json
@@ -256,7 +256,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "55"
               },
               "opera_android": {
                 "version_added": true

--- a/css/types/string.json
+++ b/css/types/string.json
@@ -25,7 +25,7 @@
               "version_added": "3"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": true
@@ -72,7 +72,7 @@
                 "version_added": "6"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
                 "version_added": true


### PR DESCRIPTION
This PR mirrors the values of Chrome Desktop to Opera is `true` or `null`, to help reduce data inconsistencies and reach towards the 2019 Key Result.  Notes have been adapted to ensure they are not mentioning Chrome versions earlier than 15.

The script that performed the majority of changes can be found here: https://github.com/vinyldarkscratch/bcd-toolkit/blob/master/fix.py