### PR TITLE
Set IE/Edge versions for api.HTMLHyperlinkElementUtils

### DIFF
--- a/api/HTMLHyperlinkElementUtils.json
+++ b/api/HTMLHyperlinkElementUtils.json
@@ -13,7 +13,7 @@
             "notes": "Starting in Chrome 52, the members of this interface were moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
           },
           "edge": {
-            "version_added": true
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "22",
@@ -30,7 +30,7 @@
             ]
           },
           "ie": {
-            "version_added": false
+            "version_added": "5"
           },
           "opera": {
             "version_added": false
@@ -68,7 +68,7 @@
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "22",
@@ -79,7 +79,7 @@
               "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface. Also, from Firefox 29 to Firefox 40, the returned value was incorrectly percent-decoded."
             },
             "ie": {
-              "version_added": true
+              "version_added": "5"
             },
             "opera": {
               "version_added": false
@@ -118,7 +118,7 @@
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "22",
@@ -129,7 +129,7 @@
               "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
             },
             "ie": {
-              "version_added": false,
+              "version_added": "5",
               "notes": "In Internet Explorer 9, the host of an <a href='https://developer.mozilla.org/docs/Web/HTML/Element/a'><code><a></code></a> always include the port (e.g. <code>developer.mozilla.org:443</code>), even if there is no explicit port in the <code>href</code> attribute value."
             },
             "opera": {
@@ -169,7 +169,7 @@
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "22",
@@ -180,7 +180,7 @@
               "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
             },
             "ie": {
-              "version_added": false
+              "version_added": "5"
             },
             "opera": {
               "version_added": false
@@ -269,7 +269,7 @@
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "edge": {
-              "version_added": true
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "26",
@@ -325,7 +325,7 @@
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "26",
@@ -375,7 +375,7 @@
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "edge": {
-              "version_added": false
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "22",
@@ -392,7 +392,7 @@
               ]
             },
             "ie": {
-              "version_added": false
+              "version_added": "5"
             },
             "opera": {
               "version_added": false
@@ -431,7 +431,7 @@
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "edge": {
-              "version_added": false
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "22",
@@ -442,7 +442,7 @@
               "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
             },
             "ie": {
-              "version_added": false
+              "version_added": "5"
             },
             "opera": {
               "version_added": false
@@ -481,7 +481,7 @@
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "edge": {
-              "version_added": false
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "22",
@@ -492,7 +492,7 @@
               "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
             },
             "ie": {
-              "version_added": false
+              "version_added": "5"
             },
             "opera": {
               "version_added": false
@@ -531,7 +531,7 @@
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "22",
@@ -548,7 +548,7 @@
               ]
             },
             "ie": {
-              "version_added": false
+              "version_added": "5"
             },
             "opera": {
               "version_added": false
@@ -634,7 +634,7 @@
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "26",

--- a/api/HTMLHyperlinkElementUtils.json
+++ b/api/HTMLHyperlinkElementUtils.json
@@ -79,7 +79,7 @@
               "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface. Also, from Firefox 29 to Firefox 40, the returned value was incorrectly percent-decoded."
             },
             "ie": {
-              "version_added": false
+              "version_added": true
             },
             "opera": {
               "version_added": false
@@ -219,7 +219,7 @@
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "22",
@@ -230,7 +230,7 @@
               "notes": "From Firefox 22 to Firefox 44, this property was on the <code>URLUtils</code> mixin. It has been moved either on the <code>HTMLHyperlinkElementUtils</code> mixin, or directly on the interface."
             },
             "ie": {
-              "version_added": false
+              "version_added": "5"
             },
             "opera": {
               "version_added": false


### PR DESCRIPTION
Based upon manual testing, I've found that the `hostname` property has been supported since IE 5, amongst various other properties -- one of which was implemented in Edge 17.  This PR fixes #4692.