### PR TITLE
Migration 002: Remove WebView entries with flags

### DIFF
--- a/scripts/migrations/002-remove-webview-flags.js
+++ b/scripts/migrations/002-remove-webview-flags.js
@@ -95,4 +95,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = fixWebViewFlags;
+module.exports = {removeWebViewFlags, fixWebViewFlags};

--- a/scripts/migrations/002-remove-webview-flags.js
+++ b/scripts/migrations/002-remove-webview-flags.js
@@ -14,7 +14,7 @@ const removeWebViewFlags = (key, value) => {
   if (key === "__compat") {
     if (value.support.webview_android !== undefined) {
       if (Array.isArray(value.support.webview_android)) {
-        var result = [];
+        const result = [];
         for (let i = 0; i < value.support.webview_android.length; i++) {
           if (value.support.webview_android[i].flags === undefined) {
             result.push(value.support.webview_android[i]);

--- a/scripts/migrations/002-remove-webview-flags.js
+++ b/scripts/migrations/002-remove-webview-flags.js
@@ -21,7 +21,13 @@ const removeWebViewFlags = (key, value) => {
           }
         }
 
-        value.support.webview_android = result.length > 1 ? result : result[0];
+        if (result.length == 0) {
+          value.support.webview_android = {"version_added": false};
+        } else if (result.length == 1) {
+          value.support.webview_android = result[0];
+        } else {
+          value.support.webview_android = result;
+        }
       } else if (value.support.webview_android.flags !== undefined) {
         value.support.webview_android = {"version_added": false};
       }

--- a/scripts/migrations/002-remove-webview-flags.js
+++ b/scripts/migrations/002-remove-webview-flags.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const { platform } = require('os');
+
+/** Determines if the OS is Windows */
+const IS_WINDOWS = platform() === 'win32';
+
+const removeWebViewFlags = (key, value) => {
+  if (key === "__compat") {
+    if (value.support.webview_android !== undefined) {
+      if (Array.isArray(value.support.webview_android)) {
+        var result = [];
+        for (var i = 0; i < value.support.webview_android.length; i++) {
+          if (value.support.webview_android[i].flags === undefined) {
+            result.push(value.support.webview_android[i]);
+          }
+        }
+
+        value.support.webview_android = result.length > 1 ? result : result[0];
+      } else if (value.support.webview_android.flags !== undefined) {
+        value.support.webview_android = {"version_added": false};
+      }
+    }
+  }
+  return value;
+};
+
+ /**
+  * @param {Promise<void>} filename
+  */
+const fixWebViewFlags = (filename) => {
+  let actual   = fs.readFileSync(filename, 'utf-8').trim();
+  let expected = JSON.stringify(JSON.parse(actual, removeWebViewFlags), null, 2);
+
+  if (IS_WINDOWS) { // prevent false positives from git.core.autocrlf on Windows
+    actual   = actual.replace(/\r/g, '');
+    expected = expected.replace(/\r/g, '');
+  }
+
+  if (actual !== expected) {
+    fs.writeFileSync(filename, expected + '\n', 'utf-8');
+  }
+}
+
+if (require.main === module) {
+  /**
+   * @param {string[]} files
+   */
+  function load(...files) {
+    for (let file of files) {
+      if (file.indexOf(__dirname) !== 0) {
+        file = path.resolve(__dirname, '..', '..', file);
+      }
+
+      if (!fs.existsSync(file)) {
+        continue; // Ignore non-existent files
+      }
+
+      if (fs.statSync(file).isFile()) {
+        if (path.extname(file) === '.json') {
+          fixWebViewFlags(file);
+        }
+
+        continue;
+      }
+
+      const subFiles = fs.readdirSync(file).map((subfile) => {
+        return path.join(file, subfile);
+      });
+
+      load(...subFiles);
+    }
+  }
+
+  if (process.argv[2]) {
+    load(process.argv[2]);
+  } else {
+    load(
+      'api',
+      'css',
+      'html',
+      'http',
+      'svg',
+      'javascript',
+      'mathml',
+      'test',
+      'webdriver',
+      'webextensions'
+    );
+  }
+}
+
+module.exports = fixWebViewFlags;

--- a/scripts/migrations/002-remove-webview-flags.js
+++ b/scripts/migrations/002-remove-webview-flags.js
@@ -15,7 +15,7 @@ const removeWebViewFlags = (key, value) => {
     if (value.support.webview_android !== undefined) {
       if (Array.isArray(value.support.webview_android)) {
         var result = [];
-        for (var i = 0; i < value.support.webview_android.length; i++) {
+        for (let i = 0; i < value.support.webview_android.length; i++) {
           if (value.support.webview_android[i].flags === undefined) {
             result.push(value.support.webview_android[i]);
           }

--- a/scripts/migrations/002-remove-webview-flags.js
+++ b/scripts/migrations/002-remove-webview-flags.js
@@ -34,8 +34,8 @@ const removeWebViewFlags = (key, value) => {
   * @param {Promise<void>} filename
   */
 const fixWebViewFlags = (filename) => {
-  let actual   = fs.readFileSync(filename, 'utf-8').trim();
-  let expected = JSON.stringify(JSON.parse(actual, removeWebViewFlags), null, 2);
+  const actual   = fs.readFileSync(filename, 'utf-8').trim();
+  const expected = JSON.stringify(JSON.parse(actual, removeWebViewFlags), null, 2);
 
   if (IS_WINDOWS) { // prevent false positives from git.core.autocrlf on Windows
     actual   = actual.replace(/\r/g, '');

--- a/scripts/migrations/002-remove-webview-flags.test.js
+++ b/scripts/migrations/002-remove-webview-flags.test.js
@@ -53,7 +53,7 @@ const expected = JSON.stringify({
 /** Determines if the OS is Windows */
 const IS_WINDOWS = platform() === 'win32';
 
-const testFixWebViewFlags = () => {
+const testFixWebViewFlags = (logger = console) => {
   let output = JSON.stringify(JSON.parse(input, removeWebViewFlags), null, 2);
 
   if (IS_WINDOWS) { // prevent false positives from git.core.autocrlf on Windows
@@ -61,8 +61,8 @@ const testFixWebViewFlags = () => {
   }
 
   if (output !== expected) {
-    console.error("Output does not match expected result!");
-    console.error(output);
+    logger.error("Output does not match expected result!");
+    logger.error(output);
     return true;
   }
   return false;

--- a/scripts/migrations/002-remove-webview-flags.test.js
+++ b/scripts/migrations/002-remove-webview-flags.test.js
@@ -53,7 +53,7 @@ const expected = JSON.stringify({
 /** Determines if the OS is Windows */
 const IS_WINDOWS = platform() === 'win32';
 
-if (require.main === module) {
+const testFixWebViewFlags = () => {
   let output = JSON.stringify(JSON.parse(input, removeWebViewFlags), null, 2);
 
   if (IS_WINDOWS) { // prevent false positives from git.core.autocrlf on Windows
@@ -63,5 +63,13 @@ if (require.main === module) {
   if (output !== expected) {
     console.error("Output does not match expected result!");
     console.error(output);
+    return true;
   }
+  return false;
 }
+
+if (require.main === module) {
+  testFixWebViewFlags();
+}
+
+module.exports = testFixWebViewFlags;

--- a/scripts/migrations/002-remove-webview-flags.test.js
+++ b/scripts/migrations/002-remove-webview-flags.test.js
@@ -7,6 +7,8 @@ const fs = require('fs');
 const path = require('path');
 const { platform } = require('os');
 
+const { removeWebViewFlags } = require('002-remove-webview-flags.js');
+
 const input = JSON.stringify({
   "test": {
     "__compat": {
@@ -50,26 +52,6 @@ const expected = JSON.stringify({
 
 /** Determines if the OS is Windows */
 const IS_WINDOWS = platform() === 'win32';
-
-const removeWebViewFlags = (key, value) => {
-  if (key === "__compat") {
-    if (value.support.webview_android !== undefined) {
-      if (Array.isArray(value.support.webview_android)) {
-        var result = [];
-        for (var i = 0; i < value.support.webview_android.length; i++) {
-          if (value.support.webview_android[i].flags === undefined) {
-            result.push(value.support.webview_android[i]);
-          }
-        }
-
-        value.support.webview_android = result.length > 1 ? result : result[0];
-      } else if (value.support.webview_android.flags !== undefined) {
-        value.support.webview_android = {"version_added": false};
-      }
-    }
-  }
-  return value;
-};
 
 if (require.main === module) {
   let output = JSON.stringify(JSON.parse(input, removeWebViewFlags), null, 2);

--- a/scripts/migrations/002-remove-webview-flags.test.js
+++ b/scripts/migrations/002-remove-webview-flags.test.js
@@ -135,7 +135,7 @@ const tests = [
 ];
 
 const testFixWebViewFlags = (logger = console) => {
-  var hasErrors = false;
+  let hasErrors = false;
   for (let i = 0; i < tests.length; i++) {
     let expected = JSON.stringify(tests[i][1], null, 2);
     let output = JSON.stringify(JSON.parse(JSON.stringify(tests[i][0]), removeWebViewFlags), null, 2);

--- a/scripts/migrations/002-remove-webview-flags.test.js
+++ b/scripts/migrations/002-remove-webview-flags.test.js
@@ -5,6 +5,7 @@
 'use strict';
 const fs = require('fs');
 const path = require('path');
+const chalk = require('chalk');
 const { platform } = require('os');
 
 const { removeWebViewFlags } = require('./002-remove-webview-flags.js');
@@ -61,8 +62,7 @@ const testFixWebViewFlags = (logger = console) => {
   }
 
   if (output !== expected) {
-    logger.error("Output does not match expected result!");
-    logger.error(output);
+    logger.error(chalk`WebView flags aren't removed properly!\n      Actual: {yellow ${output}}\n      Expected: {green ${expected}}`);
     return true;
   }
   return false;

--- a/scripts/migrations/002-remove-webview-flags.test.js
+++ b/scripts/migrations/002-remove-webview-flags.test.js
@@ -11,8 +11,8 @@ const { platform } = require('os');
 const { removeWebViewFlags } = require('./002-remove-webview-flags.js');
 
 const tests = [
-  [
-    {
+  {
+    "input": {
       "test1": {
         "__compat": {
           "support": {
@@ -35,7 +35,7 @@ const tests = [
         }
       }
     },
-    {
+    "output": {
       "test1": {
         "__compat": {
           "support": {
@@ -51,9 +51,9 @@ const tests = [
         }
       }
     }
-  ],
-  [
-    {
+  },
+  {
+    "input": {
       "test2": {
         "__compat": {
           "support": {
@@ -69,7 +69,7 @@ const tests = [
         }
       }
     },
-    {
+    "output": {
       "test2": {
         "__compat": {
           "support": {
@@ -85,9 +85,9 @@ const tests = [
         }
       }
     }
-  ],
-  [
-    {
+  },
+  {
+    "input": {
       "test3": {
         "__compat": {
           "support": {
@@ -115,7 +115,7 @@ const tests = [
         }
       }
     },
-    {
+    "output": {
       "test3": {
         "__compat": {
           "support": {
@@ -131,14 +131,14 @@ const tests = [
         }
       }
     }
-  ]
+  }
 ];
 
 const testFixWebViewFlags = (logger = console) => {
   let hasErrors = false;
   for (let i = 0; i < tests.length; i++) {
-    let expected = JSON.stringify(tests[i][1], null, 2);
-    let output = JSON.stringify(JSON.parse(JSON.stringify(tests[i][0]), removeWebViewFlags), null, 2);
+    let expected = JSON.stringify(tests[i]["output"], null, 2);
+    let output = JSON.stringify(JSON.parse(JSON.stringify(tests[i]["input"]), removeWebViewFlags), null, 2);
 
     if (output !== expected) {
       logger.error(chalk`WebView flags aren't removed properly!\n      Actual: {yellow ${output}}\n      Expected: {green ${expected}}`);

--- a/scripts/migrations/002-remove-webview-flags.test.js
+++ b/scripts/migrations/002-remove-webview-flags.test.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 const path = require('path');
 const { platform } = require('os');
 
-const { removeWebViewFlags } = require('002-remove-webview-flags.js');
+const { removeWebViewFlags } = require('./002-remove-webview-flags.js');
 
 const input = JSON.stringify({
   "test": {

--- a/scripts/migrations/002-remove-webview-flags.test.js
+++ b/scripts/migrations/002-remove-webview-flags.test.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const { platform } = require('os');
+
+const input = JSON.stringify({
+  "test": {
+    "__compat": {
+      "support": {
+        "webview_android": {
+          "version_added": "61",
+          "flags": [
+            {
+              "type": "preference",
+              "name": "#service-worker-payment-apps",
+              "value_to_set": "Enabled"
+            }
+          ]
+        }
+      },
+      "status": {
+        "experimental": true,
+        "standard_track": false,
+        "deprecated": false
+      }
+    }
+  }
+}, null, 2);
+
+const expected = JSON.stringify({
+  "test": {
+    "__compat": {
+      "support": {
+        "webview_android": {
+          "version_added": false
+        }
+      },
+      "status": {
+        "experimental": true,
+        "standard_track": false,
+        "deprecated": false
+      }
+    }
+  }
+}, null, 2);
+
+/** Determines if the OS is Windows */
+const IS_WINDOWS = platform() === 'win32';
+
+const removeWebViewFlags = (key, value) => {
+  if (key === "__compat") {
+    if (value.support.webview_android !== undefined) {
+      if (Array.isArray(value.support.webview_android)) {
+        var result = [];
+        for (var i = 0; i < value.support.webview_android.length; i++) {
+          if (value.support.webview_android[i].flags === undefined) {
+            result.push(value.support.webview_android[i]);
+          }
+        }
+
+        value.support.webview_android = result.length > 1 ? result : result[0];
+      } else if (value.support.webview_android.flags !== undefined) {
+        value.support.webview_android = {"version_added": false};
+      }
+    }
+  }
+  return value;
+};
+
+if (require.main === module) {
+  let output = JSON.stringify(JSON.parse(input, removeWebViewFlags), null, 2);
+
+  if (IS_WINDOWS) { // prevent false positives from git.core.autocrlf on Windows
+    output = output.replace(/\r/g, '');
+  }
+
+  if (output !== expected) {
+    console.error("Output does not match expected result!");
+    console.error(output);
+  }
+}

--- a/scripts/migrations/002-remove-webview-flags.test.js
+++ b/scripts/migrations/002-remove-webview-flags.test.js
@@ -141,7 +141,9 @@ const testFixWebViewFlags = (logger = console) => {
     let output = JSON.stringify(JSON.parse(JSON.stringify(tests[i]["input"]), removeWebViewFlags), null, 2);
 
     if (output !== expected) {
-      logger.error(chalk`WebView flags aren't removed properly!\n      Actual: {yellow ${output}}\n      Expected: {green ${expected}}`);
+      logger.error(chalk`{red WebView flags aren't removed properly!}
+      {yellow Actual: {bold ${output}}}
+      {green Expected: {bold ${expected}}}`);
       hasErrors = true;
     }
   }

--- a/scripts/migrations/002-remove-webview-flags.test.js
+++ b/scripts/migrations/002-remove-webview-flags.test.js
@@ -13,7 +13,7 @@ const { removeWebViewFlags } = require('./002-remove-webview-flags.js');
 const tests = [
   [
     {
-      "test": {
+      "test1": {
         "__compat": {
           "support": {
             "webview_android": {
@@ -36,7 +36,7 @@ const tests = [
       }
     },
     {
-      "test": {
+      "test1": {
         "__compat": {
           "support": {
             "webview_android": {
@@ -75,6 +75,52 @@ const tests = [
           "support": {
             "webview_android": {
               "version_added": true
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  ],
+  [
+    {
+      "test3": {
+        "__compat": {
+          "support": {
+            "webview_android": [
+              {
+                "version_added": "40",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#service-worker-payment-apps",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "56"
+              }
+            ]
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    },
+    {
+      "test3": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": "56"
             }
           },
           "status": {

--- a/scripts/migrations/002-remove-webview-flags.test.js
+++ b/scripts/migrations/002-remove-webview-flags.test.js
@@ -10,62 +10,97 @@ const { platform } = require('os');
 
 const { removeWebViewFlags } = require('./002-remove-webview-flags.js');
 
-const input = JSON.stringify({
-  "test": {
-    "__compat": {
-      "support": {
-        "webview_android": {
-          "version_added": "61",
-          "flags": [
-            {
-              "type": "preference",
-              "name": "#service-worker-payment-apps",
-              "value_to_set": "Enabled"
+const tests = [
+  [
+    {
+      "test": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": "61",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#service-worker-payment-apps",
+                  "value_to_set": "Enabled"
+                }
+              ]
             }
-          ]
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
         }
-      },
-      "status": {
-        "experimental": true,
-        "standard_track": false,
-        "deprecated": false
+      }
+    },
+    {
+      "test": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
       }
     }
-  }
-}, null, 2);
-
-const expected = JSON.stringify({
-  "test": {
-    "__compat": {
-      "support": {
-        "webview_android": {
-          "version_added": false
+  ],
+  [
+    {
+      "test2": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
         }
-      },
-      "status": {
-        "experimental": true,
-        "standard_track": false,
-        "deprecated": false
+      }
+    },
+    {
+      "test2": {
+        "__compat": {
+          "support": {
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
       }
     }
-  }
-}, null, 2);
-
-/** Determines if the OS is Windows */
-const IS_WINDOWS = platform() === 'win32';
+  ]
+];
 
 const testFixWebViewFlags = (logger = console) => {
-  let output = JSON.stringify(JSON.parse(input, removeWebViewFlags), null, 2);
+  var hasErrors = false;
+  for (let i = 0; i < tests.length; i++) {
+    let expected = JSON.stringify(tests[i][1], null, 2);
+    let output = JSON.stringify(JSON.parse(JSON.stringify(tests[i][0]), removeWebViewFlags), null, 2);
 
-  if (IS_WINDOWS) { // prevent false positives from git.core.autocrlf on Windows
-    output = output.replace(/\r/g, '');
+    if (output !== expected) {
+      logger.error(chalk`WebView flags aren't removed properly!\n      Actual: {yellow ${output}}\n      Expected: {green ${expected}}`);
+      hasErrors = true;
+    }
   }
 
-  if (output !== expected) {
-    logger.error(chalk`WebView flags aren't removed properly!\n      Actual: {yellow ${output}}\n      Expected: {green ${expected}}`);
-    return true;
-  }
-  return false;
+  return hasErrors;
 }
 
 if (require.main === module) {

--- a/test/lint.js
+++ b/test/lint.js
@@ -16,6 +16,7 @@ const {
 } = require('./linter/index.js');
 const { IS_CI } = require('./utils.js')
 const testCompareFeatures = require('./test-compare-features');
+const testMigrations = require('./test-migrations');
 
 /** @type {Map<string, string>} */
 const filesWithErrors = new Map();
@@ -130,7 +131,7 @@ function load(...files) {
 }
 
 /** @type {boolean} */
-const hasErrors = argv.files
+var hasErrors = argv.files
   ? load.apply(undefined, argv.files)
   : load(
     'api',
@@ -145,7 +146,9 @@ const hasErrors = argv.files
     'webextensions',
     'xpath',
     'xslt',
-  ) || testCompareFeatures();
+  );
+hasErrors = testCompareFeatures() || hasErrors;
+hasErrors = testMigrations() || hasErrors;
 
 if (hasErrors) {
   console.warn('');

--- a/test/test-migrations.js
+++ b/test/test-migrations.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const chalk = require('chalk');
+
+const m002 = require('../scripts/migrations/002-remove-webview-flags.test.js');
+
+ /**
+  * @returns {boolean} If the migrations aren't functioning properly
+  */
+const testMigrations = () => {
+  /** @type {string[]} */
+  const errors = [];
+  const logger = {
+    /** @param {...unknown} message */
+    error: (...message) => {
+      errors.push(message.join(' '));
+    },
+  };
+
+  m002(logger);
+
+  if (errors.length) {
+    console.error(chalk`{red Migrations – {bold ${errors.length}} ${errors.length === 1 ? 'error' : 'errors'}:}`);
+    for (let i in errors) {
+      console.error(chalk`{red   ${errors[i]}}`);
+    }
+    return true;
+  }
+  return false;
+}
+
+module.exports = testMigrations;


### PR DESCRIPTION
As per the bulk update proposed by #4609, this PR introduces the next migration script that looks through the data for any WebView entries that contain flags, and if it finds them, removes them from the compatibility data.  This is due to the fact that WebView does not have flags (as mentioned by @jpmedley).

The logic is as follows:
- Any single-object statements with a flag will simply be set to `"version_added": false`
- Any arrays with a statement containing a flag will have that statement removed
- Any arrays affected that have a single item will be turned into a single statement object