### PR TITLE
Chrome supports :is() selector since M68

### DIFF
--- a/css/selectors/is.json
+++ b/css/selectors/is.json
@@ -1,4 +1,4 @@
- {
+{
   "css": {
     "selectors": {
       "is": {

--- a/css/selectors/is.json
+++ b/css/selectors/is.json
@@ -8,7 +8,19 @@
           "support": {
             "chrome": [
               {
+                "version_added": "68",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features",
+                    "value_to_set": "enabled"
+                  }
+                ],
+                "notes": "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+              },
+              {
                 "version_added": "66",
+                "version_removed": "71",
                 "alternative_name": ":matches()",
                 "flags": [
                   {
@@ -28,6 +40,7 @@
             "chrome_android": [
               {
                 "version_added": "66",
+                "version_removed": "71",
                 "alternative_name": ":matches()",
                 "flags": [
                   {
@@ -68,7 +81,19 @@
             },
             "opera": [
               {
+                "version_added": "55",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features",
+                    "value_to_set": "enabled"
+                  }
+                ],
+                "notes": "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+              },
+              {
                 "version_added": "53",
+                "version_removed": "58",
                 "alternative_name": ":matches()",
                 "flags": [
                   {
@@ -87,7 +112,19 @@
             ],
             "opera_android": [
               {
+                "version_added": "48",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features",
+                    "value_to_set": "enabled"
+                  }
+                ],
+                "notes": "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+              },
+              {
                 "version_added": "47",
+                "version_removed": "50",
                 "alternative_name": ":matches()",
                 "flags": [
                   {

--- a/css/selectors/is.json
+++ b/css/selectors/is.json
@@ -16,7 +16,7 @@
                     "value_to_set": "enabled"
                   }
                 ],
-                "notes": "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+                "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
               },
               {
                 "version_added": "66",

--- a/css/selectors/is.json
+++ b/css/selectors/is.json
@@ -1,4 +1,4 @@
-{
+ {
   "css": {
     "selectors": {
       "is": {
@@ -29,7 +29,7 @@
                     "value_to_set": "enabled"
                   }
                 ],
-                "notes": "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+                "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
               },
               {
                 "version_added": "12",
@@ -49,7 +49,7 @@
                     "value_to_set": "enabled"
                   }
                 ],
-                "notes": "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+                "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
               },
               {
                 "version_added": "18",
@@ -89,7 +89,7 @@
                     "value_to_set": "enabled"
                   }
                 ],
-                "notes": "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+                "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
               },
               {
                 "version_added": "53",
@@ -102,7 +102,7 @@
                     "value_to_set": "enabled"
                   }
                 ],
-                "notes": "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+                "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
               },
               {
                 "version_added": true,
@@ -120,7 +120,7 @@
                     "value_to_set": "enabled"
                   }
                 ],
-                "notes": "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+                "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
               },
               {
                 "version_added": "47",
@@ -133,7 +133,7 @@
                     "value_to_set": "enabled"
                   }
                 ],
-                "notes": "Has issues with combinators (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+                "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
               },
               {
                 "version_added": true,


### PR DESCRIPTION
After some manual testing and playing around in various versions of Chrome upon the report from #4670, I found that Chrome implemented support for the `:is()` selector, and removed its older name a few versions later.  This PR fixes #4670.