### PR TITLE
Correct transition event data for Chromium browsers

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2989,10 +2989,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "53"
             },
             "safari": {
               "version_added": null
@@ -3001,7 +3001,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"
@@ -3038,10 +3038,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "53"
             },
             "safari": {
               "version_added": true
@@ -3050,7 +3050,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"
@@ -3068,12 +3068,24 @@
           "description": "<code>transitionrun</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/transitionrun_event",
           "support": {
-            "chrome": {
-              "version_added": "74"
-            },
-            "chrome_android": {
-              "version_added": "74"
-            },
+            "chrome": [
+              {
+                "version_added": "26"
+              },
+              {
+                "alternative_name": "webkitTransitionEnd",
+                "version_added": true
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "26"
+              },
+              {
+                "alternative_name": "webkitTransitionEnd",
+                "version_added": true
+              }
+            ],
             "edge": {
               "version_added": null
             },
@@ -3086,24 +3098,48 @@
             "ie": {
               "version_added": null
             },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "15"
+              },
+              {
+                "alternative_name": "webkitTransitionEnd",
+                "version_added": true
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "14"
+              },
+              {
+                "alternative_name": "webkitTransitionEnd",
+                "version_added": true
+              }
+            ],
             "safari": {
               "version_added": null
             },
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
-            "webview_android": {
-              "version_added": "74"
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "alternative_name": "webkitTransitionEnd",
+                "version_added": true
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "≤37"
+              },
+              {
+                "alternative_name": "webkitTransitionEnd",
+                "version_added": true
+              }
+            ],
           },
           "status": {
             "experimental": false,
@@ -3136,10 +3172,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "53"
             },
             "safari": {
               "version_added": null
@@ -3148,7 +3184,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -3139,7 +3139,7 @@
                 "alternative_name": "webkitTransitionEnd",
                 "version_added": true
               }
-            ],
+            ]
           },
           "status": {
             "experimental": false,

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -3019,55 +3019,6 @@
           "description": "<code>transitionend</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/transitionend_event",
           "support": {
-            "chrome": {
-              "version_added": "74"
-            },
-            "chrome_android": {
-              "version_added": "74"
-            },
-            "edge": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": "51"
-            },
-            "firefox_android": {
-              "version_added": "51"
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": "62"
-            },
-            "opera_android": {
-              "version_added": "53"
-            },
-            "safari": {
-              "version_added": true
-            },
-            "safari_ios": {
-              "version_added": true
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": "74"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "transitionrun_event": {
-        "__compat": {
-          "description": "<code>transitionrun</code> event",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/transitionrun_event",
-          "support": {
             "chrome": [
               {
                 "version_added": "26"
@@ -3090,10 +3041,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "51"
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "51"
             },
             "ie": {
               "version_added": null
@@ -3117,10 +3068,10 @@
               }
             ],
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": [
               {
@@ -3140,6 +3091,55 @@
                 "version_added": true
               }
             ]
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitionrun_event": {
+        "__compat": {
+          "description": "<code>transitionrun</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/transitionrun_event",
+          "support": {
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "53"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "62"
+            },
+            "opera_android": {
+              "version_added": "53"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "74"
+            }
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
Based upon the report from #4618, I've gone through and determined a more accurate listing of support for the transition events.  Three of the four were indeed implemented in Chrome 74, so I have copied the data over to Opera and Samsung Internet.  The last, `transitionend`, was implemented in Chrome 26, and in an even older version with a prefix (though I cannot determine what version since it's before Chrome 15).

This PR fixes #4618.