### PR TITLE
test: Move common test utilities into `test/utils.js`

### DIFF
--- a/test/lint.js
+++ b/test/lint.js
@@ -12,10 +12,8 @@ const {
   testSchema,
   testVersions,
 } = require('./linter/index.js');
+const { IS_CI } = require('./utils.js')
 const testCompareFeatures = require('./test-compare-features');
-
-/** Used to check if the process is running in a CI environment. */
-const IS_CI = process.env.CI && String(process.env.CI).toLowerCase() === 'true';
 
 /** @type {Map<string, string>} */
 const filesWithErrors = new Map();

--- a/test/linter/test-browsers.js
+++ b/test/linter/test-browsers.js
@@ -46,7 +46,7 @@ const browsers = {
  * @param {string[]} displayBrowsers
  * @param {string[]} requiredBrowsers
  * @param {string} category
- * @param {{error:function(...unknown):void}} logger
+ * @param {import('../utils').Logger} logger
  * @param {string} [path]
  * @returns {boolean}
  */

--- a/test/linter/test-real-values.js
+++ b/test/linter/test-real-values.js
@@ -43,7 +43,7 @@ const blockList = {
  * @param {SupportBlock} supportData
  * @param {string[]} blockList
  * @param {string} relPath
- * @param {{error:function(...unknown):void}} logger
+ * @param {import('../utils').Logger} logger
  */
 function checkRealValues(supportData, blockList, relPath, logger) {
   let hasErrors = false;

--- a/test/linter/test-style.js
+++ b/test/linter/test-style.js
@@ -1,12 +1,8 @@
 'use strict';
 const fs = require('fs');
-const path = require('path');
 const url = require('url');
 const chalk = require('chalk');
-const { platform } = require('os');
-
-/** Determines if the OS is Windows */
-const IS_WINDOWS = platform() === 'win32';
+const { IS_WINDOWS, indexToPos, jsonDiff } = require('../utils.js');
 
 /**
  * Return a new "support_block" object whose first-level properties
@@ -33,7 +29,7 @@ function orderSupportBlock(key, value) {
 const compareFeatures = (a,b) => {
   if (a == '__compat') return -1;
   if (b == '__compat') return 1;
-  
+
   const wordA = /^[a-zA-Z](\w|-)*$/.test(a);
   const wordB = /^[a-zA-Z](\w|-)*$/.test(b);
 
@@ -62,101 +58,6 @@ function orderFeatures(key, value) {
     }, {});
   }
   return value;
-}
-
-/**
- * @param {string} str
- */
-function escapeInvisibles(str) {
-  /** @type {Array<[string, string]>} */
-  const invisibles = [
-    ['\b', '\\b'],
-    ['\f', '\\f'],
-    ['\n', '\\n'],
-    ['\r', '\\r'],
-    ['\v', '\\v'],
-    ['\t', '\\t'],
-    ['\0', '\\0'],
-  ];
-  let finalString = str;
-
-  invisibles.forEach(([invisible, replacement]) => {
-    finalString = finalString.replace(invisible, replacement);
-  });
-
-  return finalString;
-}
-
-/**
- * Gets the row and column matching the index in a string.
- *
- * @param {string} str
- * @param {number} index
- * @return {[number, number] | [null, null]}
- */
-function indexToPosRaw(str, index) {
-  let line = 1, col = 1;
-  let prevChar = null;
-
-  if (
-    typeof str !== 'string' ||
-    typeof index !== 'number' ||
-    index > str.length
-  ) {
-    return [null, null];
-  }
-
-  for (let i = 0; i < index; i++) {
-    let char = str[i];
-    switch (char) {
-      case '\n':
-        if (prevChar === '\r') break;
-      case '\r':
-        line++;
-        col = 1;
-        break;
-      case '\t':
-        // Use JSON `tab_size` value from `.editorconfig`
-        col += 2;
-        break;
-      default:
-        col++;
-        break;
-    }
-    prevChar = char;
-  }
-
-  return [line, col];
-}
-
-/**
- * Gets the row and column matching the index in a string and formats it.
- *
- * @param {string} str
- * @param {number} index
- * @return {string} The line and column in the form of: `"(Ln <ln>, Col <col>)"`
- */
-function indexToPos(str, index) {
-  const [line, col] = indexToPosRaw(str, index);
-  return `(Ln ${line}, Col ${col})`;
-}
-
-/**
- * @param {string} actual
- * @param {string} expected
- * @return {string}
- */
-function jsonDiff(actual, expected) {
-  var actualLines = actual.split(/\n/);
-  var expectedLines = expected.split(/\n/);
-
-  for (var i = 0; i < actualLines.length; i++) {
-    if (actualLines[i] !== expectedLines[i]) {
-      return `#${i + 1}
-    Actual:   ${escapeInvisibles(actualLines[i])}
-    Expected: ${escapeInvisibles(expectedLines[i])}`;
-    }
-  }
 }
 
 /**

--- a/test/linter/test-style.js
+++ b/test/linter/test-style.js
@@ -62,7 +62,7 @@ function orderFeatures(key, value) {
 
 /**
  * @param {string} filename
- * @param {{error:function(...unknown):void}} logger
+ * @param {import('../utils').Logger} logger
  */
 function processData(filename, logger) {
   let hasErrors = false;

--- a/test/linter/test-versions.js
+++ b/test/linter/test-versions.js
@@ -1,5 +1,4 @@
 'use strict';
-const path = require('path');
 const compareVersions = require('compare-versions');
 const chalk = require('chalk');
 

--- a/test/linter/test-versions.js
+++ b/test/linter/test-versions.js
@@ -40,7 +40,7 @@ function isValidVersion(browserIdentifier, version) {
 /**
  * @param {SupportBlock} supportData
  * @param {string} relPath
- * @param {{error:function(...unknown):void}} logger
+ * @param {import('../utils').Logger} logger
  */
 function checkVersions(supportData, relPath, logger) {
   let hasErrors = false;

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -1,0 +1,77 @@
+'use strict';
+const ora = require('ora');
+const chalk = require('chalk');
+const { IS_CI, escapeInvisibles } = require('./utils.js');
+
+it('`escapeInvisibles()` works correctly', () => {
+  const EXPECTED = [
+    /* ␀ */ ['\0', '\\0'],
+    /* ␁ */ '\x01', /* ␂ */ '\x02', /* ␃ */ '\x03',
+    /* ␄ */ '\x04', /* ␅ */ '\x05', /* ␆ */ '\x06', /* ␇ */ '\x07',
+    /* ␈ */ ['\b', '\\b'],
+    /* ␉ */ ['\t', '\\t'],
+    /* ␊ */ ['\n', '\\n'],
+    /* ␋ */ ['\v', '\\v'],
+    /* ␌ */ ['\f', '\\f'],
+    /* ␍ */ ['\r', '\\r'],
+    /* ␏ */ '\x0F', /* ␎ */ '\x0E',
+    /* ␐ */ '\x10', /* ␑ */ '\x11', /* ␒ */ '\x12', /* ␓ */ '\x13',
+    /* ␔ */ '\x14', /* ␕ */ '\x15', /* ␖ */ '\x16', /* ␗ */ '\x17',
+    /* ␘ */ '\x18', /* ␙ */ '\x19', /* ␚ */ '\x1A', /* ␛ */ '\x1B',
+    /* ␜ */ '\x1C', /* ␝ */ '\x1D', /* ␞ */ '\x1E', /* ␟ */ '\x1F',
+    /* ␠ */ ' ', /* ␡ */ '\x7F',
+  ]
+
+  for (const data of EXPECTED) {
+    let char, expected;
+    if (typeof data === 'string') {
+      char = data;
+      expected = data;
+    } else {
+      [char, expected = char] = data;
+    }
+    console.assert(escapeInvisibles(char) === expected, chalk`{red Character ${escape(char)} does not get correctly escaped.}`);
+  }
+});
+
+/**
+ * TODO: Maybe use a real test suite for this?
+ *
+ * @param {string} message
+ * @param {() => void | Promise<void>} testCase
+ */
+function it(message, testCase) {
+  const spinner = ora({
+    stream: process.stdout,
+    text: message,
+  });
+
+  if (!IS_CI) {
+    // Continuous integration environments don't allow overwriting
+    // previous lines using VT escape sequences, which is how
+    // the spinner animation is implemented.
+    spinner.start();
+  }
+
+  let result;
+  let err;
+
+  try {
+    result = testCase();
+  } catch (e) {
+    err = e;
+  }
+  if (err) {
+    spinner.fail(chalk.red.bold(message));
+    console.error(err);
+    return;
+  }
+  if (result && typeof result.then === 'function') {
+    Promise.resolve(result).then(
+      () => {spinner.succeed()},
+      err => {spinner.fail(chalk.red.bold(message)); console.error(err)},
+    );
+    return;
+  }
+  spinner.succeed();
+}

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,121 @@
+'use strict';
+const { platform } = require('os');
+
+/**
+ * @typedef {object} Logger
+ * @property {(...message: unknown[]) => void} error
+ */
+
+/** @type {{readonly [char: string]: string}} */
+const INVISIBLES_MAP = Object.freeze(
+  Object.assign(Object.create(null), {
+    '\0': '\\0', // ␀ (0x00)
+    '\b': '\\b', // ␈ (0x08)
+    '\t': '\\t', // ␉ (0x09)
+    '\n': '\\n', // ␊ (0x0A)
+    '\v': '\\v', // ␋ (0x0B)
+    '\f': '\\f', // ␌ (0x0C)
+    '\r': '\\r', // ␍ (0x0D)
+  })
+);
+const INVISIBLES_REGEXP = /[\0\x08-\x0D]/g;
+
+/** Used to check if the process is running in a CI environment. */
+const IS_CI = process.env.CI && String(process.env.CI).toLowerCase() === 'true';
+
+/** Determines if the OS is Windows */
+const IS_WINDOWS = platform() === 'win32';
+
+/**
+ * @param {string} str
+ */
+function escapeInvisibles(str) {
+  // This should now be O(n) instead of O(n*m),
+  // where n = string length; m = invisible characters
+  return str.replace(INVISIBLES_REGEXP, char => {
+    return INVISIBLES_MAP[char] || char;
+  });
+}
+
+/**
+ * Gets the row and column matching the index in a string.
+ *
+ * @param {string} str
+ * @param {number} index
+ * @return {[number, number] | [null, null]}
+ */
+function indexToPosRaw(str, index) {
+  let line = 1,
+    col = 1;
+  let prevChar = null;
+
+  if (
+    typeof str !== 'string' ||
+    typeof index !== 'number' ||
+    index > str.length
+  ) {
+    return [null, null];
+  }
+
+  for (let i = 0; i < index; i++) {
+    let char = str[i];
+    switch (char) {
+      case '\n':
+        if (prevChar === '\r') break;
+      case '\r':
+        line++;
+        col = 1;
+        break;
+      case '\t':
+        // Use JSON `tab_size` value from `.editorconfig`
+        col += 2;
+        break;
+      default:
+        col++;
+        break;
+    }
+    prevChar = char;
+  }
+
+  return [line, col];
+}
+
+/**
+ * Gets the row and column matching the index in a string and formats it.
+ *
+ * @param {string} str
+ * @param {number} index
+ * @return {string} The line and column in the form of: `"(Ln <ln>, Col <col>)"`
+ */
+function indexToPos(str, index) {
+  const [line, col] = indexToPosRaw(str, index);
+  return `(Ln ${line}, Col ${col})`;
+}
+
+/**
+ * @param {string} actual
+ * @param {string} expected
+ * @return {string}
+ */
+function jsonDiff(actual, expected) {
+  var actualLines = actual.split(/\n/);
+  var expectedLines = expected.split(/\n/);
+
+  for (var i = 0; i < actualLines.length; i++) {
+    if (actualLines[i] !== expectedLines[i]) {
+      return `#${i + 1}
+    Actual:   ${escapeInvisibles(actualLines[i])}
+    Expected: ${escapeInvisibles(expectedLines[i])}`;
+    }
+  }
+}
+
+module.exports = {
+  INVISIBLES_MAP,
+  IS_CI,
+  IS_WINDOWS,
+  escapeInvisibles,
+  indexToPosRaw,
+  indexToPos,
+  jsonDiff,
+};

--- a/test/utils.js
+++ b/test/utils.js
@@ -18,7 +18,6 @@ const INVISIBLES_MAP = Object.freeze(
     '\r': '\\r', // ␍ (0x0D)
   })
 );
-const INVISIBLES_REGEXP = /[\0\x08-\x0D]/g;
 
 /** Used to check if the process is running in a CI environment. */
 const IS_CI = process.env.CI && String(process.env.CI).toLowerCase() === 'true';
@@ -30,11 +29,18 @@ const IS_WINDOWS = platform() === 'win32';
  * @param {string} str
  */
 function escapeInvisibles(str) {
-  // This should now be O(n) instead of O(n*m),
-  // where n = string length; m = invisible characters
-  return str.replace(INVISIBLES_REGEXP, char => {
-    return INVISIBLES_MAP[char] || char;
+  const invisibles = Array.from(
+    Object.keys(INVISIBLES_MAP),
+    key => /** @type {[string, string]} */ ([key, INVISIBLES_MAP[key]])
+  );
+
+  let finalString = str;
+
+  invisibles.forEach(([invisible, replacement]) => {
+    finalString = finalString.replace(invisible, replacement);
   });
+
+  return finalString;
 }
 
 /**


### PR DESCRIPTION
Part of: #4688

Extracted from: #4686, see @Elchi3’s comment in https://github.com/mdn/browser-compat-data/pull/4686#issuecomment-524806794 for reasoning.