### PR TITLE
Correct border-*-radius properties for Chromium browsers

### DIFF
--- a/css/properties/border-bottom-left-radius.json
+++ b/css/properties/border-bottom-left-radius.json
@@ -14,9 +14,15 @@
                 "version_added": "1"
               }
             ],
-            "chrome_android": {
-              "version_added": "18"
-            },
+            "chrome_android": [
+              {
+                "version_added": "18"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "18"
+              }
+            ],
             "edge": [
               {
                 "version_added": "12"
@@ -81,12 +87,24 @@
             "ie": {
               "version_added": "9"
             },
-            "opera": {
-              "version_added": "10.5"
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "10.5"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "11"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "14"
+              }
+            ],
             "safari": [
               {
                 "version_added": "5"
@@ -105,12 +123,24 @@
                 "version_added": "1"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": true
-            },
-            "webview_android": {
-              "version_added": true
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "1.0"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1.0"
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "≤37"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "≤37"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/border-bottom-right-radius.json
+++ b/css/properties/border-bottom-right-radius.json
@@ -14,9 +14,15 @@
                 "version_added": "1"
               }
             ],
-            "chrome_android": {
-              "version_added": "18"
-            },
+            "chrome_android": [
+              {
+                "version_added": "18"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "18"
+              }
+            ],
             "edge": [
               {
                 "version_added": "12"
@@ -81,12 +87,24 @@
             "ie": {
               "version_added": "9"
             },
-            "opera": {
-              "version_added": "10.5"
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "10.5"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "11"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "14"
+              }
+            ],
             "safari": [
               {
                 "version_added": "5"
@@ -105,12 +123,24 @@
                 "version_added": "1"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": true
-            },
-            "webview_android": {
-              "version_added": true
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "1.0"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1.0"
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "≤37"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "≤37"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/border-top-left-radius.json
+++ b/css/properties/border-top-left-radius.json
@@ -14,9 +14,15 @@
                 "version_added": "1"
               }
             ],
-            "chrome_android": {
-              "version_added": "18"
-            },
+            "chrome_android": [
+              {
+                "version_added": "18"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "18"
+              }
+            ],
             "edge": [
               {
                 "version_added": "12"
@@ -81,12 +87,24 @@
             "ie": {
               "version_added": "9"
             },
-            "opera": {
-              "version_added": "10.5"
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "10.5"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "11"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "14"
+              }
+            ],
             "safari": [
               {
                 "version_added": "5"
@@ -105,12 +123,24 @@
                 "version_added": "1"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": true
-            },
-            "webview_android": {
-              "version_added": true
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "1.0"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1.0"
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "≤37"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "≤37"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/border-top-right-radius.json
+++ b/css/properties/border-top-right-radius.json
@@ -14,9 +14,15 @@
                 "version_added": "1"
               }
             ],
-            "chrome_android": {
-              "version_added": "18"
-            },
+            "chrome_android": [
+              {
+                "version_added": "18"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "18"
+              }
+            ],
             "edge": [
               {
                 "version_added": "12"
@@ -81,12 +87,24 @@
             "ie": {
               "version_added": "9"
             },
-            "opera": {
-              "version_added": "10.5"
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "10.5"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "11"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "14"
+              }
+            ],
             "safari": [
               {
                 "version_added": "5"
@@ -105,12 +123,24 @@
                 "version_added": "1"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": true
-            },
-            "webview_android": {
-              "version_added": true
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "1.0"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1.0"
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "≤37"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "≤37"
+              }
+            ]
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
Forked off of #4637.  While copying from Chrome Android to WebView, there were some issues with the Chrome Android data found.  After further review, I determined issues within Opera and Samsung Internet as well.  This copies all data from Chrome to its derivatives to eliminate said inconsistencies.