### PR TITLE
Sort entries starting with uppercase letters first

### DIFF
--- a/scripts/compare-features.js
+++ b/scripts/compare-features.js
@@ -8,8 +8,9 @@
  *
  * Sort a list of features based upon a specific order:
  *  1. __compat is always first
- *  2. Alphanumerical features starting with a letter (without symbols aside from - or _)
- *  3. All other features
+ *  2. Alphanumerical features starting with an uppercase letter (without symbols aside from - or _)
+ *  3. Alphanumerical features starting with a lowercase letter (without symbols aside from - or _)
+ *  4. All other features
  *
  */
 
@@ -17,10 +18,17 @@ const compareFeatures = (a,b) => {
   if (a == '__compat') return -1;
   if (b == '__compat') return 1;
 
+  const capsWordA = /^[A-Z](\w|-)*$/.test(a);
+  const capsWordB = /^[A-Z](\w|-)*$/.test(b);
   const wordA = /^[a-zA-Z](\w|-)*$/.test(a);
   const wordB = /^[a-zA-Z](\w|-)*$/.test(b);
 
   if (wordA || wordB) {
+    if (capsWordA || capsWordB) {
+      if (capsWordA && capsWordB) return a.localeCompare(b, 'en');
+      if (capsWordA) return -1;
+      if (capsWordB) return 1;
+    }
     if (wordA && wordB) return a.localeCompare(b, 'en');
     if (wordA) return -1;
     return 1;

--- a/scripts/migrations/003-sort-features.js
+++ b/scripts/migrations/003-sort-features.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+'use strict';
+
+const { exec } = require('child_process');
+
+exec("node scripts/fix-feature-order.js");

--- a/test/linter/test-style.js
+++ b/test/linter/test-style.js
@@ -5,6 +5,8 @@ const url = require('url');
 const chalk = require('chalk');
 const { platform } = require('os');
 
+const compareFeatures = require('../../scripts/compare-features');
+
 /** Determines if the OS is Windows */
 const IS_WINDOWS = platform() === 'win32';
 
@@ -28,18 +30,6 @@ function orderSupportBlock(key, value) {
     }, {});
   }
   return value;
-}
-
-const compareFeatures = (a,b) => {
-  if (a == '__compat') return -1;
-  if (b == '__compat') return 1;
-  
-  const wordA = /^[a-zA-Z](\w|-)*$/.test(a);
-  const wordB = /^[a-zA-Z](\w|-)*$/.test(b);
-
-  if (wordA && wordB) return a.localeCompare(b, 'en');
-  if (wordA || wordB) return (wordA && -1) || 1;
-  return a.localeCompare(b, 'en');
 }
 
 /**

--- a/test/test-compare-features.js
+++ b/test/test-compare-features.js
@@ -14,9 +14,9 @@ const compareFeatures = require('../scripts/compare-features');
   * @returns {boolean} If the sorter isn't functioning properly
   */
 const testFeatureOrder = () => {
-  let input = ['foobar', 'Foo', '__compat', 'secure_context_required', 'protocol-r30', '$0', '_updated_spec', '43', '--variable', '2-factor-auth'];
+  let input = ['foobar', 'Foo', '__compat', 'toString', 'secure_context_required', 'protocol-r30', '$0', 'Bar', '_updated_spec', '43', '--variable', 'ZOO_Pals', '2-factor-auth'];
   let actual = input.sort(compareFeatures);
-  let expected = ["__compat", "Foo", "foobar", "protocol-r30", "secure_context_required", "_updated_spec", "--variable", "$0", "2-factor-auth", "43"];
+  let expected = ["__compat", "Bar", "Foo", "ZOO_Pals", "foobar", "protocol-r30", "secure_context_required", "toString", "_updated_spec", "--variable", "$0", "2-factor-auth", "43"];
 
   var errors = false;
   for (var i = actual.length; i--;) {


### PR DESCRIPTION
This PR fixes #4726 and updates the feature sorting script to sort features starting with uppercase letters first.  Furthermore, this reapplies a change that was regressed in the recent linter file move, which uses the dedicated `compare-features.js` file.

This will require a new bulk update to perform the re-migration.  **A data PR will be needed to fix the failing test.**