### PR TITLE
Fix broken links in data guidelines table of contents

### DIFF
--- a/docs/data-guidelines.md
+++ b/docs/data-guidelines.md
@@ -4,10 +4,10 @@ This file contains recommendations to help you record data in a consistent and u
 
 - [Data guidelines](#data-guidelines)
   * [Constructors](#constructors)
-  * [DOM events (`eventname_event`)](#dom-events---eventname-event--)
-  * [Secure context required (`secure_context_required`)](#secure-context-required---secure-context-required--)
-  * [Web Workers (`worker_support`)](#web-workers---worker-support--)
-  * [Non-functional defined names imply `partial_implementation`](#non-functional-defined-names-imply--partial-implementation-)
+  * [DOM events (`eventname_event`)](#dom-events-eventname_event)
+  * [Secure context required (`secure_context_required`)](#secure-context-required-secure_context_required)
+  * [Web Workers (`worker_support`)](#web-workers-worker_support)
+  * [Non-functional defined names imply `partial_implementation`](#non-functional-defined-names-imply-partial_implementation)
   * [Release lines and backported features](#release-lines-and-backported-features)
   * [Safari for iOS versioning](#safari-for-ios-versioning)
 


### PR DESCRIPTION
This fixes some broken links in the ToC for the data guidelines doc. The script I used to generate the ToC didn't use GitHub Flavored Markdown's section IDs