### PR TITLE
Update Safari / Safari iOS engine versions

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -108,14 +108,14 @@
           "release_notes": "https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Articles/Safari_9_0.html",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "601.1"
+          "engine_version": "601.1.56"
         },
         "9.1": {
           "release_date": "2016-03-21",
           "release_notes": "https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Articles/Safari_9_1.html",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "601.5"
+          "engine_version": "601.5.17"
         },
         "10": {
           "release_date": "2016-09-20",

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -90,43 +90,43 @@
         "8": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "600.1",
+          "engine_version": "600.1.4",
           "release_date": "2014-09-17"
         },
         "8.1": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "600.1",
+          "engine_version": "600.1.4",
           "release_date": "2014-10-20"
         },
         "8.4": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "600.1",
+          "engine_version": "600.1.4",
           "release_date": "2015-06-30"
         },
         "9": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "601.1",
+          "engine_version": "601.1.56",
           "release_date": "2015-09-16"
         },
         "9.1": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "601.1",
+          "engine_version": "601.1.56",
           "release_date": "2015-10-21"
         },
         "9.2": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "601.1",
+          "engine_version": "601.1.56",
           "release_date": "2015-12-08"
         },
         "9.3": {
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "601.1",
+          "engine_version": "601.5.17",
           "release_date": "2016-03-21"
         },
         "10": {


### PR DESCRIPTION
This PR updates the engine versions of Safari and Safari iOS 8.x and 9.x based upon some further research and manual testing.  WebKit versions were found from a combination of [Wikipedia](https://en.wikipedia.org/wiki/Safari_version_history#Safari_9) and testing in BrowserStack.