### PR TITLE
Add note regarding api.SpeechSynthesis.pause functionality on Android

### DIFF
--- a/api/SpeechSynthesis.json
+++ b/api/SpeechSynthesis.json
@@ -240,7 +240,7 @@
             },
             "chrome_android": {
               "version_added": "33",
-              "notes": "In Android, <code>pause()</code> ends the current utterance.  As such, <code>pause()</code> behaves just like <code>cancel()</code>."
+              "notes": "In Android, <code>pause()</code> ends the current utterance. <code>pause()</code> behaves the same as <code>cancel()</code>."
             },
             "edge": {
               "version_added": "14"
@@ -251,7 +251,7 @@
             "firefox_android": [
               {
                 "version_added": "62",
-                "notes": "In Android, <code>pause()</code> ends the current utterance.  As such, <code>pause()</code> behaves just like <code>cancel()</code>."
+                "notes": "In Android, <code>pause()</code> ends the current utterance. <code>pause()</code> behaves the same as <code>cancel()</code>."
               },
               {
                 "version_added": "61",
@@ -263,7 +263,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "In Android, <code>pause()</code> ends the current utterance.  As such, <code>pause()</code> behaves just like <code>cancel()</code>."
+                "notes": "In Android, <code>pause()</code> ends the current utterance. <code>pause()</code> behaves the same as <code>cancel()</code>."
               }
             ],
             "ie": {
@@ -283,7 +283,7 @@
             },
             "webview_android": {
               "version_added": "4.4.3",
-              "notes": "In Android, <code>pause()</code> ends the current utterance.  As such, <code>pause()</code> behaves just like <code>cancel()</code>."
+              "notes": "In Android, <code>pause()</code> ends the current utterance. <code>pause()</code> behaves the same as <code>cancel()</code>."
             }
           },
           "status": {

--- a/api/SpeechSynthesis.json
+++ b/api/SpeechSynthesis.json
@@ -239,7 +239,8 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": "33"
+              "version_added": "33",
+              "notes": "In Android, <code>pause()</code> ends the current utterance.  As such, <code>pause()</code> behaves just like <code>cancel()</code>."
             },
             "edge": {
               "version_added": "14"
@@ -249,7 +250,8 @@
             },
             "firefox_android": [
               {
-                "version_added": "62"
+                "version_added": "62",
+                "notes": "In Android, <code>pause()</code> ends the current utterance.  As such, <code>pause()</code> behaves just like <code>cancel()</code>."
               },
               {
                 "version_added": "61",
@@ -260,7 +262,8 @@
                     "name": "media.webspeech.synth.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "notes": "In Android, <code>pause()</code> ends the current utterance.  As such, <code>pause()</code> behaves just like <code>cancel()</code>."
               }
             ],
             "ie": {
@@ -279,7 +282,8 @@
               "version_added": "7.1"
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "4.4.3",
+              "notes": "In Android, <code>pause()</code> ends the current utterance.  As such, <code>pause()</code> behaves just like <code>cancel()</code>."
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds a note regarding the issues with `SpeechSynthesis.pause()` on Android, as described in #4500.