### PR TITLE
Add IE version for api.Document.createElementNS

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -1557,7 +1557,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR fixes #4543 and adds the IE version for the `Document` API's `createElementNS()` function.  It was mentioned that IE 8 [supported it with "some flakiness"](https://code.google.com/archive/p/svgweb/issues/625), however I was not successful with IE 8 whatsoever, only IE 9 and above.  (I believe the person performing the tests had a polyfill, based upon the mentioned delay.)