### PR TITLE
Update data for -webkit-background-clip and -webkit-background-origin

### DIFF
--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -13,7 +13,7 @@
                 "version_added": "1",
                 "version_removed": "64",
                 "prefix": "-webkit-",
-                "notes": "Chrome also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+                "notes": "Chrome accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
             "chrome_android": [
@@ -24,7 +24,7 @@
                 "version_added": "18",
                 "version_removed": "64",
                 "prefix": "-webkit-",
-                "notes": "Chrome also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+                "notes": "Chrome accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
             "edge": {
@@ -67,7 +67,7 @@
                 "version_added": "15",
                 "version_removed": "51",
                 "prefix": "-webkit-",
-                "notes": "Opera also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+                "notes": "Opera accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
             "opera_android": [
@@ -78,18 +78,18 @@
                 "version_added": "14",
                 "version_removed": "47",
                 "prefix": "-webkit-",
-                "notes": "Opera also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+                "notes": "Opera accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
             "safari": {
               "version_added": "3",
               "prefix": "-webkit-",
-              "notes": "Safari also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+              "notes": "Safari accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
             },
             "safari_ios": {
               "version_added": "1",
               "prefix": "-webkit-",
-              "notes": "Safari also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+              "notes": "Safari accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -102,7 +102,7 @@
                 "version_added": "≤37",
                 "version_removed": "64",
                 "prefix": "-webkit-",
-                "notes": "WebView also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+                "notes": "WebView accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ]
           },

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -11,6 +11,7 @@
               },
               {
                 "version_added": "1",
+                "version_removed": "64",
                 "prefix": "-webkit-",
                 "notes": "Chrome also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
@@ -21,6 +22,7 @@
               },
               {
                 "version_added": "18",
+                "version_removed": "64",
                 "prefix": "-webkit-",
                 "notes": "Chrome also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
@@ -34,8 +36,7 @@
               },
               {
                 "version_added": "49",
-                "prefix": "-webkit-",
-                "notes": "Firefox also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+                "prefix": "-webkit-"
               },
               {
                 "version_added": "1",
@@ -51,8 +52,7 @@
               },
               {
                 "version_added": "49",
-                "prefix": "-webkit-",
-                "notes": "Firefox also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+                "prefix": "-webkit-"
               }
             ],
             "ie": {
@@ -65,6 +65,7 @@
               },
               {
                 "version_added": "15",
+                "version_removed": "51",
                 "prefix": "-webkit-",
                 "notes": "Opera also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
@@ -75,6 +76,7 @@
               },
               {
                 "version_added": "14",
+                "version_removed": "47",
                 "prefix": "-webkit-",
                 "notes": "Opera also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
@@ -98,6 +100,7 @@
               },
               {
                 "version_added": "≤37",
+                "version_removed": "64",
                 "prefix": "-webkit-",
                 "notes": "WebView also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -265,7 +265,7 @@
                 ]
               },
               "webview_android": {
-                "version_added": "1",
+                "version_added": "≤37",
                 "partial_implementation": true,
                 "notes": [
                   "This value is supported with the prefixed version of the property only.",

--- a/css/properties/background-origin.json
+++ b/css/properties/background-origin.json
@@ -11,8 +11,9 @@
               },
               {
                 "version_added": "1",
+                "version_removed": "64",
                 "prefix": "-webkit-",
-                "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+                "notes": "Chrome also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
             "chrome_android": [
@@ -21,8 +22,9 @@
               },
               {
                 "version_added": "18",
+                "version_removed": "64",
                 "prefix": "-webkit-",
-                "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+                "notes": "Chrome also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
             "edge": {
@@ -34,8 +36,7 @@
               },
               {
                 "version_added": "49",
-                "prefix": "-webkit-",
-                "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+                "prefix": "-webkit-"
               },
               {
                 "version_added": "1",
@@ -51,8 +52,7 @@
               },
               {
                 "version_added": "49",
-                "prefix": "-webkit-",
-                "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+                "prefix": "-webkit-"
               }
             ],
             "ie": {
@@ -65,8 +65,9 @@
               },
               {
                 "version_added": "15",
+                "version_removed": "51",
                 "prefix": "-webkit-",
-                "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+                "notes": "Opera also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
             "opera_android": [
@@ -75,8 +76,9 @@
               },
               {
                 "version_added": "14",
+                "version_removed": "47",
                 "prefix": "-webkit-",
-                "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+                "notes": "Opera also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
             "safari": [
@@ -108,8 +110,9 @@
               },
               {
                 "version_added": "4.1",
+                "version_removed": "64",
                 "prefix": "-webkit-",
-                "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+                "notes": "WebView also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ]
           },

--- a/css/properties/background-origin.json
+++ b/css/properties/background-origin.json
@@ -13,7 +13,7 @@
                 "version_added": "1",
                 "version_removed": "64",
                 "prefix": "-webkit-",
-                "notes": "Chrome also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+                "notes": "Chrome accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
             "chrome_android": [
@@ -24,7 +24,7 @@
                 "version_added": "18",
                 "version_removed": "64",
                 "prefix": "-webkit-",
-                "notes": "Chrome also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+                "notes": "Chrome accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
             "edge": {
@@ -67,7 +67,7 @@
                 "version_added": "15",
                 "version_removed": "51",
                 "prefix": "-webkit-",
-                "notes": "Opera also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+                "notes": "Opera accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
             "opera_android": [
@@ -78,7 +78,7 @@
                 "version_added": "14",
                 "version_removed": "47",
                 "prefix": "-webkit-",
-                "notes": "Opera also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+                "notes": "Opera accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
             "safari": [
@@ -88,7 +88,7 @@
               {
                 "version_added": "3",
                 "prefix": "-webkit-",
-                "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+                "notes": "Webkit accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
             "safari_ios": [
@@ -98,7 +98,7 @@
               {
                 "version_added": "1",
                 "prefix": "-webkit-",
-                "notes": "Webkit also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+                "notes": "Webkit accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
             "samsunginternet_android": {
@@ -112,7 +112,7 @@
                 "version_added": "4.1",
                 "version_removed": "64",
                 "prefix": "-webkit-",
-                "notes": "WebView also supports the prefixed version of this property, and in that case, in addition to the current keywords, the alternative synonyms are: <code>padding</code>, <code>border</code>, and <code>content</code>."
+                "notes": "WebView accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ]
           },


### PR DESCRIPTION
This PR updates the data for the WebKit-prefixed versions of `background-clip` and `background-origin` based upon some playing around throughout browsers, I've found some new data, which is as follows:

1. Firefox supports the WebKit-prefixed version of these properties without any flags changed from their defaults.  However, the alternative synonyms have not been supported.  These notes have been removed.
2. The WebKit-prefixed versions of the properties were removed in Chrome 64.  This has been determined via manual testing.
3. Some of the notes for Chrome/Opera said "WebKit".  This has been fixed to use their actual names.
4. There's a little consistency issue to fix within the data.  This sets the `text` property for WebView back to "≤37".

Fixes #4072.