### PR TITLE
Mirror Firefox -> Firefox Android for css/* (when Firefox Android=false)

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -896,7 +896,7 @@
                 "version_added": "59"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "59"
               },
               "ie": {
                 "version_added": false

--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -211,7 +211,7 @@
                 "partial_implementation": true
               },
               "firefox_android": {
-                "version_added": false,
+                "version_added": "4",
                 "partial_implementation": true
               },
               "ie": {

--- a/css/properties/column-span.json
+++ b/css/properties/column-span.json
@@ -43,7 +43,14 @@
               ]
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "65",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.column-span.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": "10"

--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -82,7 +82,10 @@
                 "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
               },
               "firefox_android": {
-                "version_added": false
+                "partial_implementation": true,
+                "prefix": "-moz-",
+                "version_added": "4",
+                "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
               },
               "ie": {
                 "version_added": false

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -129,7 +129,9 @@
                 "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
               },
               "firefox_android": {
-                "version_added": false
+                "prefix": "-moz-",
+                "version_added": "4",
+                "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
               },
               "ie": {
                 "version_added": false

--- a/css/properties/overflow-anchor.json
+++ b/css/properties/overflow-anchor.json
@@ -18,7 +18,7 @@
               "version_added": "66"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "66"
             },
             "ie": {
               "version_added": false

--- a/css/properties/overflow-anchor.json
+++ b/css/properties/overflow-anchor.json
@@ -18,7 +18,7 @@
               "version_added": "66"
             },
             "firefox_android": {
-              "version_added": "66"
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/css/properties/resize.json
+++ b/css/properties/resize.json
@@ -115,7 +115,7 @@
                 "version_added": "63"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "63"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
One thing that had recently concerned me within the BCD data is that when a parent has been updated, its derivatives (like Chrome to WebView Android) don't get updated. This PR intends to help fix such inconsistencies, by copying Firefox data onto Firefox Android when false, avoiding edge cases (such as OS limitations).