### PR TITLE
Fix iOS version for css.properties.hyphens.dutch

### DIFF
--- a/css/properties/hyphens.json
+++ b/css/properties/hyphens.json
@@ -461,7 +461,7 @@
                 "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": "6"
+                "version_added": "5"
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/css/properties/hyphens.json
+++ b/css/properties/hyphens.json
@@ -461,7 +461,7 @@
                 "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "6"
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
This PR fixes the iOS version for the Dutch dictionary of the `hyphens` property.