### PR TITLE
Mirror Chrome to Chromium for html/* (when False)

### DIFF
--- a/html/elements/bdi.json
+++ b/html/elements/bdi.json
@@ -9,7 +9,7 @@
               "version_added": "16"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge": {
               "version_added": false
@@ -24,10 +24,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -36,10 +36,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/html/elements/canvas.json
+++ b/html/elements/canvas.json
@@ -37,7 +37,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "2",
@@ -94,7 +94,7 @@
                 "version_added": "9"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "2",
@@ -199,7 +199,7 @@
                 "version_added": "9"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "2",

--- a/html/elements/dialog.json
+++ b/html/elements/dialog.json
@@ -43,7 +43,7 @@
               "version_added": "24"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "24"
             },
             "safari": {
               "version_added": false
@@ -105,7 +105,7 @@
                 "version_added": "24"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "24"
               },
               "safari": {
                 "version_added": false

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -196,7 +196,7 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": false
+                "version_added": true
               },
               "safari": [
                 {

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -152,7 +152,8 @@
                 "notes": "Chrome does not defer scripts with the <code>defer</code> attribute when the page is served as XHTML (<code>application/xhtml+xml</code>) - <a href='https://crbug.com/611136'>Chromium Issue #611136</a>, <a href='https://crbug.com/874749'>Chromium Issue #874749</a>"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": true,
+                "notes": "Chrome does not defer scripts with the <code>defer</code> attribute when the page is served as XHTML (<code>application/xhtml+xml</code>) - <a href='https://crbug.com/611136'>Chromium Issue #611136</a>, <a href='https://crbug.com/874749'>Chromium Issue #874749</a>"
               },
               "edge": {
                 "version_added": true
@@ -169,10 +170,12 @@
                 "notes": "In versions prior to Internet Explorer 10, it implemented <code>defer</code> by a proprietary specification. Since version 10 it conforms to the W3C specification."
               },
               "opera": {
-                "version_added": false
+                "version_added": true,
+                "notes": "Opera does not defer scripts with the <code>defer</code> attribute when the page is served as XHTML (<code>application/xhtml+xml</code>) - <a href='https://crbug.com/611136'>Chromium Issue #611136</a>, <a href='https://crbug.com/874749'>Chromium Issue #874749</a>"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true,
+                "notes": "Opera does not defer scripts with the <code>defer</code> attribute when the page is served as XHTML (<code>application/xhtml+xml</code>) - <a href='https://crbug.com/611136'>Chromium Issue #611136</a>, <a href='https://crbug.com/874749'>Chromium Issue #874749</a>"
               },
               "safari": {
                 "version_added": true
@@ -181,10 +184,12 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": true,
+                "notes": "Samsung Internet does not defer scripts with the <code>defer</code> attribute when the page is served as XHTML (<code>application/xhtml+xml</code>) - <a href='https://crbug.com/611136'>Chromium Issue #611136</a>, <a href='https://crbug.com/874749'>Chromium Issue #874749</a>"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": true,
+                "notes": "WebView does not defer scripts with the <code>defer</code> attribute when the page is served as XHTML (<code>application/xhtml+xml</code>) - <a href='https://crbug.com/611136'>Chromium Issue #611136</a>, <a href='https://crbug.com/874749'>Chromium Issue #874749</a>"
               }
             },
             "status": {

--- a/html/elements/style.json
+++ b/html/elements/style.json
@@ -110,7 +110,15 @@
                 ]
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "25",
+                "version_removed": "35",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable &lt;style scoped&gt;",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "edge": {
                 "version_added": false
@@ -155,10 +163,26 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "15",
+                "version_removed": "22",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable &lt;style scoped&gt;",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "14",
+                "version_removed": "22",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable &lt;style scoped&gt;",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "safari": {
                 "version_added": false

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -787,10 +787,14 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true,
+              "prefix": "-webkit-",
+              "version_removed": "45"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true,
+              "prefix": "-webkit-",
+              "version_removed": "43"
             },
             "safari": {
               "version_added": false
@@ -997,7 +1001,7 @@
               "version_added": "53"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "47"
             },
             "safari": {
               "version_added": false

--- a/html/manifest/icons.json
+++ b/html/manifest/icons.json
@@ -35,7 +35,7 @@
               "version_added": null
             },
             "opera_android": {
-              "version_added": false
+              "version_added": null
             },
             "safari": {
               "version_added": null

--- a/html/manifest/name.json
+++ b/html/manifest/name.json
@@ -35,7 +35,7 @@
               "version_added": null
             },
             "opera_android": {
-              "version_added": false
+              "version_added": null
             },
             "safari": {
               "version_added": null

--- a/html/manifest/short_name.json
+++ b/html/manifest/short_name.json
@@ -35,7 +35,7 @@
               "version_added": null
             },
             "opera_android": {
-              "version_added": false
+              "version_added": null
             },
             "safari": {
               "version_added": null

--- a/html/manifest/theme_color.json
+++ b/html/manifest/theme_color.json
@@ -35,7 +35,7 @@
               "version_added": null
             },
             "opera_android": {
-              "version_added": false
+              "version_added": null
             },
             "safari": {
               "version_added": null


### PR DESCRIPTION
One thing that had recently concerned me within the BCD data is that when a parent has been updated, its derivatives (like Chrome to WebView Android) don't get updated. This PR intends to help fix such inconsistencies, by copying Chrome data onto its derivatives when they are false, avoiding edge cases (such as OS limitations).