### PR TITLE
Separate all modifier keys KeyboardEvent.getModifierState() can take

### DIFF
--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -665,8 +665,8 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
-              "deprecated": true
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
@@ -713,8 +713,8 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
-              "deprecated": true
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
@@ -761,8 +761,8 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
-              "deprecated": true
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
@@ -809,8 +809,8 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
-              "deprecated": true
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
@@ -857,7 +857,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": true
             }
           }
@@ -905,8 +905,8 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
-              "deprecated": true
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
@@ -953,8 +953,8 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
-              "deprecated": true
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
@@ -1003,8 +1003,8 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
-              "deprecated": true
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
@@ -1053,8 +1053,8 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
-              "deprecated": true
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
@@ -1101,8 +1101,8 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
-              "deprecated": true
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
@@ -1149,7 +1149,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": true
             }
           }
@@ -1197,8 +1197,8 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
-              "deprecated": true
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },
@@ -1245,8 +1245,8 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
-              "deprecated": true
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -457,7 +457,7 @@
               "version_added": "17"
             },
             "opera_android": {
-              "version_added": "17"
+              "version_added": "18"
             },
             "safari": {
               "version_added": "10.1"

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -457,7 +457,7 @@
               "version_added": "17"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "17"
             },
             "safari": {
               "version_added": "10.1"
@@ -480,7 +480,7 @@
         },
         "accel_support": {
           "__compat": {
-            "description": "<code>\"Accel\"</code> is a valid parameter",
+            "description": "<code>\"Accel\"</code> as a parameter",
             "support": {
               "chrome": {
                 "version_added": "48"
@@ -501,10 +501,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "35"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "35"
               },
               "safari": {
                 "version_added": false
@@ -513,10 +513,734 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "48"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "alt_support": {
+          "__compat": {
+            "description": "<code>\"Alt\"</code> as a parameter",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "10.1"
+              },
+              "safari_ios": {
+                "version_added": "10.3"
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "altgraph_support": {
+          "__compat": {
+            "description": "<code>\"AltGraph\"</code> as a parameter",
+            "support": {
+              "chrome": {
+                "version_added": "48"
+              },
+              "chrome_android": {
+                "version_added": "48"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "35"
+              },
+              "opera_android": {
+                "version_added": "35"
+              },
+              "safari": {
+                "version_added": "10.1"
+              },
+              "safari_ios": {
+                "version_added": "10.3"
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "48"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "capslock_support": {
+          "__compat": {
+            "description": "<code>\"CapsLock\"</code> as a parameter",
+            "support": {
+              "chrome": {
+                "version_added": "48"
+              },
+              "chrome_android": {
+                "version_added": "48"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "35"
+              },
+              "opera_android": {
+                "version_added": "35"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "48"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "control_support": {
+          "__compat": {
+            "description": "<code>\"Control\"</code> as a parameter",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "10.1"
+              },
+              "safari_ios": {
+                "version_added": "10.3"
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "fn_support": {
+          "__compat": {
+            "description": "<code>\"Fn\"</code> as a parameter",
+            "support": {
+              "chrome": {
+                "version_added": "48"
+              },
+              "chrome_android": {
+                "version_added": "48"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "35"
+              },
+              "opera_android": {
+                "version_added": "35"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "48"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "fnlock_support": {
+          "__compat": {
+            "description": "<code>\"FnLock\"</code> as a parameter",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "hyper_support": {
+          "__compat": {
+            "description": "<code>\"Hyper\"</code> as a parameter",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "meta_support": {
+          "__compat": {
+            "description": "<code>\"Meta\"</code> as a parameter",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "10.1"
+              },
+              "safari_ios": {
+                "version_added": "10.3"
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "numlock_support": {
+          "__compat": {
+            "description": "<code>\"NumLock\"</code> as a parameter",
+            "support": {
+              "chrome": {
+                "version_added": "48"
+              },
+              "chrome_android": {
+                "version_added": "48"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "35"
+              },
+              "opera_android": {
+                "version_added": "35"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "48"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "os_support": {
+          "__compat": {
+            "description": "<code>\"OS\"</code> as a parameter",
+            "support": {
+              "chrome": {
+                "version_added": "48"
+              },
+              "chrome_android": {
+                "version_added": "48"
+              },
+              "edge": {
+                "version_added": "12",
+                "alternative_name": "Win"
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true,
+                "alternative_name": "Win"
+              },
+              "opera": {
+                "version_added": "35"
+              },
+              "opera_android": {
+                "version_added": "35"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "48"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "scrolllock_support": {
+          "__compat": {
+            "description": "<code>\"ScrollLock\"</code> as a parameter",
+            "support": {
+              "chrome": {
+                "version_added": "48"
+              },
+              "chrome_android": {
+                "version_added": "48"
+              },
+              "edge": {
+                "version_added": "12",
+                "alternative_name": "Scroll"
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true,
+                "alternative_name": "Scroll"
+              },
+              "opera": {
+                "version_added": "35"
+              },
+              "opera_android": {
+                "version_added": "35"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "48"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "shift_support": {
+          "__compat": {
+            "description": "<code>\"Shift\"</code> as a parameter",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "10.1"
+              },
+              "safari_ios": {
+                "version_added": "10.3"
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "super_support": {
+          "__compat": {
+            "description": "<code>\"Super\"</code> as a parameter",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "symbol_support": {
+          "__compat": {
+            "description": "<code>\"Symbol\"</code> as a parameter",
+            "support": {
+              "chrome": {
+                "version_added": "48"
+              },
+              "chrome_android": {
+                "version_added": "48"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "35"
+              },
+              "opera_android": {
+                "version_added": "35"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "48"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "symbollock_support": {
+          "__compat": {
+            "description": "<code>\"SymbolLock\"</code> as a parameter",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
               }
             },
             "status": {

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -478,7 +478,7 @@
             "deprecated": false
           }
         },
-        "accel_support": {
+        "accel_parameter": {
           "__compat": {
             "description": "<code>\"Accel\"</code> as a parameter",
             "support": {
@@ -526,7 +526,7 @@
             }
           }
         },
-        "alt_support": {
+        "alt_parameter": {
           "__compat": {
             "description": "<code>\"Alt\"</code> as a parameter",
             "support": {
@@ -574,7 +574,7 @@
             }
           }
         },
-        "altgraph_support": {
+        "altgraph_parameter": {
           "__compat": {
             "description": "<code>\"AltGraph\"</code> as a parameter",
             "support": {
@@ -622,7 +622,7 @@
             }
           }
         },
-        "capslock_support": {
+        "capslock_parameter": {
           "__compat": {
             "description": "<code>\"CapsLock\"</code> as a parameter",
             "support": {
@@ -670,7 +670,7 @@
             }
           }
         },
-        "control_support": {
+        "control_parameter": {
           "__compat": {
             "description": "<code>\"Control\"</code> as a parameter",
             "support": {
@@ -718,7 +718,7 @@
             }
           }
         },
-        "fn_support": {
+        "fn_parameter": {
           "__compat": {
             "description": "<code>\"Fn\"</code> as a parameter",
             "support": {
@@ -766,7 +766,7 @@
             }
           }
         },
-        "fnlock_support": {
+        "fnlock_parameter": {
           "__compat": {
             "description": "<code>\"FnLock\"</code> as a parameter",
             "support": {
@@ -814,7 +814,7 @@
             }
           }
         },
-        "hyper_support": {
+        "hyper_parameter": {
           "__compat": {
             "description": "<code>\"Hyper\"</code> as a parameter",
             "support": {
@@ -862,7 +862,7 @@
             }
           }
         },
-        "meta_support": {
+        "meta_parameter": {
           "__compat": {
             "description": "<code>\"Meta\"</code> as a parameter",
             "support": {
@@ -910,7 +910,7 @@
             }
           }
         },
-        "numlock_support": {
+        "numlock_parameter": {
           "__compat": {
             "description": "<code>\"NumLock\"</code> as a parameter",
             "support": {
@@ -958,7 +958,7 @@
             }
           }
         },
-        "os_support": {
+        "os_parameter": {
           "__compat": {
             "description": "<code>\"OS\"</code> as a parameter",
             "support": {
@@ -1008,7 +1008,7 @@
             }
           }
         },
-        "scrolllock_support": {
+        "scrolllock_parameter": {
           "__compat": {
             "description": "<code>\"ScrollLock\"</code> as a parameter",
             "support": {
@@ -1058,7 +1058,7 @@
             }
           }
         },
-        "shift_support": {
+        "shift_parameter": {
           "__compat": {
             "description": "<code>\"Shift\"</code> as a parameter",
             "support": {
@@ -1106,7 +1106,7 @@
             }
           }
         },
-        "super_support": {
+        "super_parameter": {
           "__compat": {
             "description": "<code>\"Super\"</code> as a parameter",
             "support": {
@@ -1154,7 +1154,7 @@
             }
           }
         },
-        "symbol_support": {
+        "symbol_parameter": {
           "__compat": {
             "description": "<code>\"Symbol\"</code> as a parameter",
             "support": {
@@ -1202,7 +1202,7 @@
             }
           }
         },
-        "symbollock_support": {
+        "symbollock_parameter": {
           "__compat": {
             "description": "<code>\"SymbolLock\"</code> as a parameter",
             "support": {


### PR DESCRIPTION
This PR fixes #3514 by separating all the possible options of `getModifierState()` into their own compatibility lines.  Versions were determined via the following sources:

- https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/getModifierState (Firefox, IE/Edge)
- https://bugs.chromium.org/p/chromium/issues/detail?id=265458 (Chromium)
- https://chromium.googlesource.com/chromium/src.git/+/299efe15d10d2dfbfb5bcc7c2f753ddc4f318832 (Chromium)
- https://storage.googleapis.com/chromium-find-releases-static/299.html#299efe15d10d2dfbfb5bcc7c2f753ddc4f318832 (Chromium)
- https://bugs.webkit.org/show_bug.cgi?id=162855 (Safari)
- https://trac.webkit.org/changeset/206725/webkit (Safari)
- https://bugs.webkit.org/show_bug.cgi?id=162861 (Safari)
- https://trac.webkit.org/changeset/206828/webkit (Safari)
- https://webkit.org/blog/6987/release-notes-for-safari-technology-preview-15/ (Safari)
- https://webkit.org/blog/7030/release-notes-for-safari-technology-preview-16/ (Safari)
- https://webkit.org/blog/7477/new-web-features-in-safari-10-1/ (Safari)

I'll admit that my data is not complete -- there are a lot of "null" values.  If anyone has sources for the missing data, I'd be more than happy to add it in!