### PR TITLE
Fix version of Safari iOS user-modify subfeature

### DIFF
--- a/css/properties/user-modify.json
+++ b/css/properties/user-modify.json
@@ -104,7 +104,7 @@
                 "version_added": "3"
               },
               "safari_ios": {
-                "version_added": "1"
+                "version_added": "5"
               },
               "samsunginternet_android": {
                 "version_added": null


### PR DESCRIPTION
This PR fixes a version inconsistency in the `user-modify` CSS property for Safari iOS.  The property is implemented in Safari iOS 5.0, but the subfeature said "1".