### PR TITLE
Fix Safari iOS version of :visited selector

### DIFF
--- a/css/selectors/visited.json
+++ b/css/selectors/visited.json
@@ -34,7 +34,7 @@
               "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "9.3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": null


### PR DESCRIPTION
In the `:visited` CSS selector, Safari iOS was set to 9.3, yet Safari Desktop was set to 1.  I highly doubt that Apple waited THAT long to implement the selector into Safari iOS -- further review showed the data came from the MDN docs migration.  Therefore, this sets Safari iOS to 1.