### PR TITLE
Fix Safari iOS consistency within repeating-radial-gradient type

### DIFF
--- a/css/types/image.json
+++ b/css/types/image.json
@@ -1768,9 +1768,16 @@
                     "notes": "Safari 4 was supporting an experimental <code><a href='http://developer.apple.com/safari/library/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(radial,…)</a></code> function. This old outdated syntax is still supported for compatibility purposes."
                   }
                 ],
-                "safari_ios": {
-                  "version_added": "7.1"
-                },
+                "safari_ios": [
+                  {
+                    "version_added": "7"
+                  },
+                  {
+                    "prefix": "-webkit-",
+                    "version_added": "6",
+                    "notes": "Safari 4 was supporting an experimental <code><a href='http://developer.apple.com/safari/library/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(radial,…)</a></code> function. This old outdated syntax is still supported for compatibility purposes."
+                  }
+                ],
                 "samsunginternet_android": {
                   "version_added": true
                 },
@@ -1978,7 +1985,7 @@
                     "version_added": "6.1"
                   },
                   "safari_ios": {
-                    "version_added": "6.1"
+                    "version_added": "7"
                   },
                   "samsunginternet_android": {
                     "version_added": true


### PR DESCRIPTION
I noticed a couple of version inconsistencies within Safari iOS regarding the `repeating-radial-gradient` image type.  This PR intends to fix said inconsistencies.