### PR TITLE
Add RegExp named capture groups data

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -950,6 +950,57 @@
             }
           }
         },
+        "named_capture_groups": {
+          "__compat": {
+            "description": "Named capture groups",
+            "support": {
+              "chrome": {
+                "version_added": "64"
+              },
+              "chrome_android": {
+                "version_added": "64"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": null
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "51"
+              },
+              "opera_android": {
+                "version_added": "47"
+              },
+              "safari": {
+                "version_added": "11.1"
+              },
+              "safari_ios": {
+                "version_added": "11.3"
+              },
+              "samsunginternet_android": {
+                "version_added": "9.0"
+              },
+              "webview_android": {
+                "version_added": "64"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
         "property_escapes": {
           "__compat": {
             "description": "Unicode property escapes (<code>\\p{...}</code>)",

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -972,9 +972,20 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": true
-              },
+              "nodejs": [
+                {
+                  "version_added": "10.0.0"
+                },
+                {
+                  "version_added": "8.3.0",
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--harmony"
+                    }
+                  ]
+                }
+              ],
               "opera": {
                 "version_added": "51"
               },

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -961,7 +961,7 @@
                 "version_added": "64"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -970,7 +970,7 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "nodejs": {
                 "version_added": true


### PR DESCRIPTION
This PR fixes #3937.  Browser versions were determined from the following sources:

https://www.chromestatus.com/features/5653365786673152
https://bugs.webkit.org/show_bug.cgi?id=176435 / https://trac.webkit.org/changeset/221769/webkit / https://webkit.org/blog/7922/release-notes-for-safari-technology-preview-40/
https://bugzilla.mozilla.org/show_bug.cgi?id=1362154
https://node.green/#ES2018-features--RegExp-named-capture-groups