### PR TITLE
Safari 10 supports Destructuring: Computed property names

### DIFF
--- a/javascript/operators/destructuring.json
+++ b/javascript/operators/destructuring.json
@@ -87,10 +87,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": false
+                "version_added": "10"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "10"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"


### PR DESCRIPTION
This PR fixes #4307 by determining a version number via manual testing in SauceLabs.