### PR TITLE
Add data for numeric separators

### DIFF
--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -428,6 +428,57 @@
           }
         }
       },
+      "numeric_separators": {
+        "__compat": {
+          "description": "Numeric separators (<code>1_000_000_000_000</code>)",
+          "support": {
+            "chrome": {
+              "version_added": "75"
+            },
+            "chrome_android": {
+              "version_added": "75"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "70"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": true
+            },
+            "opera": {
+              "version_added": "62"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "75"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "octal_numeric_literals": {
         "__compat": {
           "description": "Octal numeric literals (<code>0o</code>)",


### PR DESCRIPTION
Fixes #4538.  Data comes from the following:

https://bugzilla.mozilla.org/show_bug.cgi?id=1435818
https://www.chromestatus.com/feature/5829906369871872
Feature is too new for IE