### PR TITLE
add queueMicrotask compat data

### DIFF
--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -1036,13 +1036,13 @@
               "version_added": "58"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "50"
             },
             "safari": {
               "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12.2"
             },
             "webview_android": {
               "version_added": "71"

--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -1010,6 +1010,51 @@
           }
         }
       },
+      "queueMicrotask": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/queueMicrotask",
+          "support": {
+            "chrome": {
+              "version_added": "71"
+            },
+            "chrome_android": {
+              "version_added": "71"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "69"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "58"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "12.1"
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "71"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "setInterval": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/setInterval",


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1480236

I got the other support details from the Chrome engineer who originally wrote the MDN ref page. See https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/queueMicrotask$revision/1563106 for those details.

I got the Opera version by working it from the Chrome version. I hope I got it right. 