### PR TITLE
Add migrations process documentation

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -49,6 +49,8 @@ The process is:
    * For new pages, you must add the [`{{Compat}}`](https://github.com/mdn/kumascript/blob/master/macros/Compat.ejs) macro to the page.
      For instructions, see [Inserting the data into MDN pages](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Structures/Compatibility_tables#Inserting_the_data_into_MDN_pages).
 
+Large-scale changes follow a different process. See [Migrations](migrations.md) for details.
+
 ## Opening issues and pull requests
 
 Before submitting your pull request, [validate your new data against the schema](testing.md).

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -1,0 +1,33 @@
+# Migrations
+
+From time to time, we make changes that must modify many files in [mdn/browser-compat-data](https://github.com/mdn/browser-compat-data/). We approach such changes like database migrations: automate the change, test that it works, and apply the change at a time that minimizes disruption to others. Using this process saves time (compared to manually creating and reviewing changes) and improves data quality.
+
+Follow this process for changes that are amenable to automation, affects many files, and modifies existing data. If you want to make smaller-scale changes or changes that aren’t compatible with automation, open a pull request or issue instead.
+
+## Step 1: Announce your intent
+
+In a new or existing issue, announce your intent to complete a migration. This issue is where the overall migration process will be discussed and tracked.
+
+A good migration starts with a clear description of the changes to be made, with a focus on one kind of change at a time. Using a checklist to plan and track progress can be helpful. Finally, consider awaiting feedback before proceeding to the next step.
+
+## Step 2: Create and test the migration scripts
+
+Next, create a migration script and tests for that script.
+
+Put migration scripts in the [`/scripts/migrations/`](https://github.com/mdn/browser-compat-data/tree/master/scripts/migrations) directory. Name the scripts in the pattern `###-<description>.js` where `###` is the sequential number of the migration and `<description>` is a short name for the migration. For example, the first migration was `001-sort-features.js`.
+
+The script must be accompanied by one or more tests that demonstrate that the migration makes the changes described and doesn’t introduce other, unrelated changes. Typically, tests in the `/scripts/migrations/` directory are named in the form `###-<description>.test.js`.
+
+When the script and tests are ready, open a pull request. To be accepted, the PR must be reviewed and approved by at least one [project owner](https://github.com/mdn/browser-compat-data/blob/master/GOVERNANCE.md#owners).
+
+## Step 3: Migrate
+
+After the migration script is merged, schedule a time with a project owner to complete the migration. At the scheduled time, one project participant will run the migration script and open a PR; the owner will merge it.
+
+To find a good time to run the migration, review open pull requests for potential conflicts. If there are large manual PRs still in review, consider allowing time for those to be merged before completing the migration.
+
+## Step 4: Wrap up
+
+If applicable, follow the migration with a pull request to apply new linter checks or other quality enforcement tools related to the migration.
+
+Finally, celebrate by announcing the completion of the project in the original issue!


### PR DESCRIPTION
This PR adds documentation of our new exercised migrations process. I've tried to write a guide that's not too bogged down with details, but provides enough information so we can actually tell whether we've completed the process and reflects what we learned going through the process for the first time.

This fixes #4469.