### PR TITLE
Add Opera 63 release

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -492,6 +492,13 @@
           "status": "current",
           "engine": "Blink",
           "engine_version": "75"
+        },
+        "63": {
+          "release_date": "2019-08-20",
+          "release_notes": "https://blogs.opera.com/desktop/2019/08/opera-63-initial-release/",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "76"
         }
       }
     }

--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -489,7 +489,7 @@
         "62": {
           "release_date": "2019-06-27",
           "release_notes": "https://blogs.opera.com/desktop/2019/06/opera-62-comes-with-design-updates-to-reborn-3/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "75"
         },


### PR DESCRIPTION
https://blogs.opera.com/desktop/2019/08/opera-63-initial-release/