### PR TITLE
Remove javascript.builtins.RegExp.toString.generic_function

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -1741,57 +1741,6 @@
                 "deprecated": false
               }
             }
-          },
-          "generic_function": {
-            "__compat": {
-              "description": "Generic function",
-              "support": {
-                "chrome": {
-                  "version_added": null
-                },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": null
-                },
-                "firefox": {
-                  "version_added": "39"
-                },
-                "firefox_android": {
-                  "version_added": "39"
-                },
-                "ie": {
-                  "version_added": null
-                },
-                "nodejs": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": {
-                  "version_added": null
-                },
-                "samsunginternet_android": {
-                  "version_added": null
-                },
-                "webview_android": {
-                  "version_added": null
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
           }
         },
         "unicode": {


### PR DESCRIPTION
This PR fixes #4759 by removing `javascript.builtins.RegExp.toString.generic_function` from the data.