### PR TITLE
Fix Chrome Android/Opera/Samsung Internet values for mix-blend-mode

### DIFF
--- a/css/properties/mix-blend-mode.json
+++ b/css/properties/mix-blend-mode.json
@@ -9,7 +9,7 @@
               "version_added": "41"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "41"
             },
             "edge": {
               "version_added": false
@@ -24,10 +24,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "28"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "28"
             },
             "safari": {
               "version_added": "8"
@@ -36,7 +36,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "41"


### PR DESCRIPTION
This PR is created based upon https://github.com/mdn/browser-compat-data/pull/4738#discussion_r320300549.