### PR TITLE
test(utils): Improve `escapeInvisibles()` performance

### DIFF
--- a/test/utils.js
+++ b/test/utils.js
@@ -18,6 +18,7 @@ const INVISIBLES_MAP = Object.freeze(
     '\r': '\\r', // ␍ (0x0D)
   })
 );
+const INVISIBLES_REGEXP = /[\0\x08-\x0D]/g;
 
 /** Used to check if the process is running in a CI environment. */
 const IS_CI = process.env.CI && String(process.env.CI).toLowerCase() === 'true';
@@ -26,21 +27,16 @@ const IS_CI = process.env.CI && String(process.env.CI).toLowerCase() === 'true';
 const IS_WINDOWS = platform() === 'win32';
 
 /**
+ * Escapes common invisible characters.
+ *
  * @param {string} str
  */
 function escapeInvisibles(str) {
-  const invisibles = Array.from(
-    Object.keys(INVISIBLES_MAP),
-    key => /** @type {[string, string]} */ ([key, INVISIBLES_MAP[key]])
-  );
-
-  let finalString = str;
-
-  invisibles.forEach(([invisible, replacement]) => {
-    finalString = finalString.replace(invisible, replacement);
+  // This should now be O(n) instead of O(n*m),
+  // where n = string length; m = invisible characters
+  return INVISIBLES_REGEXP[Symbol.replace](str, char => {
+    return INVISIBLES_MAP[char] || char;
   });
-
-  return finalString;
 }
 
 /**


### PR DESCRIPTION
This should now be `O(n)` instead of `O(n*m)`,
where `n` = string length; `m` = invisible characters.

This reverts commit 5787ce9825f1c7d6398af84692fe69800a58b734.