### PR TITLE
Updated SVGGeometryElement for Firefox 69

### DIFF
--- a/api/SVGGeometryElement.json
+++ b/api/SVGGeometryElement.json
@@ -152,7 +152,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "69"
             },
             "firefox_android": {
               "version_added": false
@@ -197,7 +197,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "69"
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
`SVGGeometryElement.isPointInFill()` and `SVGGeometryElement.isPointInStroke()` are [supported in Firefox since version 69](https://bugzilla.mozilla.org/show_bug.cgi?id=1325319).

Sebastian