### PR TITLE
Add compatibility data for User Scripts API

### DIFF
--- a/webextensions/api/userScripts.json
+++ b/webextensions/api/userScripts.json
@@ -14,6 +14,9 @@
               },
               "firefox": [
                 {
+                  "version_added": "68"
+                },
+                {
                   "version_added": "66",
                   "version_removed": "68",
                   "flags": [
@@ -23,9 +26,6 @@
                       "value_to_set": "true"
                     }
                   ]
-                },
-                {
-                  "version_added": "68"
                 }
               ],
               "firefox_android": {
@@ -49,6 +49,9 @@
               },
               "firefox": [
                 {
+                  "version_added": "68"
+                },
+                {
                   "version_added": "66",
                   "version_removed": "68",
                   "flags": [
@@ -58,9 +61,6 @@
                       "value_to_set": "true"
                     }
                   ]
-                },
-                {
-                  "version_added": "68"
                 }
               ],
               "firefox_android": {
@@ -85,6 +85,9 @@
             },
             "firefox": [
               {
+                "version_added": "68"
+              },
+              {
                 "version_added": "66",
                 "version_removed": "68",
                 "flags": [
@@ -94,9 +97,6 @@
                     "value_to_set": "true"
                   }
                 ]
-              },
-              {
-                "version_added": "68"
               }
             ],
             "firefox_android": {
@@ -120,6 +120,9 @@
             },
             "firefox": [
               {
+                "version_added": "68"
+              },
+              {
                 "version_added": "66",
                 "version_removed": "68",
                 "flags": [
@@ -129,9 +132,6 @@
                     "value_to_set": "true"
                   }
                 ]
-              },
-              {
-                "version_added": "68"
               }
             ],
             "firefox_android": {

--- a/webextensions/api/userScripts.json
+++ b/webextensions/api/userScripts.json
@@ -18,7 +18,6 @@
                 },
                 {
                   "version_added": "66",
-                  "version_removed": "68",
                   "flags": [
                     {
                       "type": "preference",
@@ -53,7 +52,6 @@
                 },
                 {
                   "version_added": "66",
-                  "version_removed": "68",
                   "flags": [
                     {
                       "type": "preference",
@@ -89,7 +87,6 @@
               },
               {
                 "version_added": "66",
-                "version_removed": "68",
                 "flags": [
                   {
                     "type": "preference",
@@ -124,7 +121,6 @@
               },
               {
                 "version_added": "66",
-                "version_removed": "68",
                 "flags": [
                   {
                     "type": "preference",

--- a/webextensions/api/userScripts.json
+++ b/webextensions/api/userScripts.json
@@ -1,0 +1,148 @@
+{
+  "webextensions": {
+    "api": {
+      "userScripts": {
+        "RegisteredUserScript": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/RegisteredUserScript",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "66",
+                  "version_removed": "68",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "extensions.webextensions.userScripts.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "68"
+                }
+              ],
+              "firefox_android": {
+                "version_added": "68"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "unregister": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/RegisteredUserScript/unregister",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "66",
+                  "version_removed": "68",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "extensions.webextensions.userScripts.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "68"
+                }
+              ],
+              "firefox_android": {
+                "version_added": "68"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      },
+      "register": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/register",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": [
+              {
+                "version_added": "66",
+                "version_removed": "68",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "extensions.webextensions.userScripts.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "68"
+              }
+            ],
+            "firefox_android": {
+              "version_added": "68"
+            },
+            "opera": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "onBeforeScript": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/onBeforeScript",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": [
+              {
+                "version_added": "66",
+                "version_removed": "68",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "extensions.webextensions.userScripts.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "68"
+              }
+            ],
+            "firefox_android": {
+              "version_added": "68"
+            },
+            "opera": {
+              "version_added": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Summary

Add compatibility data for User Scripts API, `browser.userScripts`

# Data
 - I saw a comment that  User Scripts API was available at least since 65, but I don't have links to prove it.
 - Available behind a flag in 66, 67:
   https://blog.mozilla.org/addons/2019/03/26/extensions-in-firefox-67/#userscripts
 - Shipped in Firefox 68:
   https://blog.mozilla.org/addons/2019/08/05/extensions-in-firefox-69/
 - Release notes do not mention it, however:
   https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/68
# Test
API works on Firefox Quantum 69.0 (64-bit).
There is actually a demo extension:
https://github.com/mdn/webextensions-examples/tree/master/user-script
I loaded the extension, followed steps outlined in README.md and it worked as expected. 

Update: manual test.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
