### PR TITLE
Correct Opera support for mask-image CSS property

### DIFF
--- a/css/properties/mask-image.json
+++ b/css/properties/mask-image.json
@@ -29,10 +29,11 @@
             },
             "opera": {
               "prefix": "-webkit-",
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": null
+              "prefix": "-webkit-",
+              "version_added": "14"
             },
             "safari": {
               "prefix": "-webkit-",


### PR DESCRIPTION
This PR corrects the Opera and Opera Android support for the `mask-image` CSS property by adding versions based upon Chrome versions.  (This lets the version consistency linter pass.)