### PR TITLE
fix(npmignore): Remove the `.github` directory from the npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+.github
 .vscode
 docs
 test


### PR DESCRIPTION
The `.github` directory is unnecessarily included in the published npm package.