### PR TITLE
Markdown syntax consistency and readability

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,12 +1,17 @@
 # Community Participation Guidelines
 
-This repository is governed by Mozilla's code of conduct and etiquette guidelines.
-For more details, please read the
+This repository is governed by Mozilla's code of conduct and etiquette
+guidelines. For more details, please read the
 [Mozilla Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/).
 
 ## How to Report
-For more information on how to report violations of the Community Participation Guidelines, please read our [How to Report](https://www.mozilla.org/about/governance/policies/participation/reporting/) page.
+
+For more information on how to report violations of the Community Participation
+Guidelines, please read our
+[How to Report](https://www.mozilla.org/about/governance/policies/participation/reporting/)
+page.
 
 ## Project Specific Etiquette
 
-For more specific information about how and by whom this project is governed, please see the BCD [governance](GOVERNANCE.md) doc.
+For more specific information about how and by whom this project is governed,
+please see the BCD [governance](GOVERNANCE.md) doc.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,52 +1,113 @@
 # Governance
 
-[mdn-browser-compat-data](https://github.com/mdn/browser-compat-data) (also often referred to as "BCD") is an open source project that depends on contributions from the community. As long as they abide by the project’s Contribution Guidelines, anyone may contribute to the project at any time by submitting code, participating in discussions, making suggestions, or any other contribution they see fit. This document describes how various types of contributors work within the mdn-browser-compat-data project and how decisions are made.
+[mdn-browser-compat-data](https://github.com/mdn/browser-compat-data) (also
+often referred to as "BCD") is an open source project that depends on
+contributions from the community. As long as they abide by the project’s
+Contribution Guidelines, anyone may contribute to the project at any time by
+submitting code, participating in discussions, making suggestions, or any other
+contribution they see fit. This document describes how various types of
+contributors work within the mdn-browser-compat-data project and how decisions
+are made.
 
 ## Roles and Responsibilities
 
 ### Community members
-_Everyone_ who is involved in any form with the project must abide by the project’s [Contribution Guidelines](https://github.com/mdn/browser-compat-data/blob/master/CODE_OF_CONDUCT.md) and Commit Access Guidelines. Everyone is expected to be respectful of fellow community members and to work collaboratively respective of the Code of Conduct (CPG). Consequences for not adhering to these Guidelines are listed in their respective documents.
+
+_Everyone_ who is involved in any form with the project must abide by the
+project’s
+[Contribution Guidelines](https://github.com/mdn/browser-compat-data/blob/master/CODE_OF_CONDUCT.md)
+and Commit Access Guidelines. Everyone is expected to be respectful of fellow
+community members and to work collaboratively respective of the Code of Conduct
+(CPG). Consequences for not adhering to these Guidelines are listed in their
+respective documents.
 
 ### Users
-Users are community members who have a need for the project. They are typically consumers of the compat data (see [data consumers](https://github.com/mdn/browser-compat-data#projects-using-the-data)). Anyone can be a User; there are no special requirements and the data is licensed under [CC0](https://github.com/mdn/browser-compat-data/blob/master/LICENSE). Common User contributions include evangelizing the project (e.g., display a link on a website and raise awareness through word-of-mouth), informing developers of strengths and weaknesses from a new user perspective, or providing moral support (a “thank you” goes a long way).
 
-Users who continue to engage with the project and its community will often become more and more involved. Such Users may find themselves becoming [Contributors](#Contributors), as described in the next section.
+Users are community members who have a need for the project. They are typically
+consumers of the compat data (see
+[data consumers](https://github.com/mdn/browser-compat-data#projects-using-the-data)).
+Anyone can be a User; there are no special requirements and the data is licensed
+under [CC0](https://github.com/mdn/browser-compat-data/blob/master/LICENSE).
+Common User contributions include evangelizing the project (e.g., display a link
+on a website and raise awareness through word-of-mouth), informing developers of
+strengths and weaknesses from a new user perspective, or providing moral support
+(a “thank you” goes a long way).
+
+Users who continue to engage with the project and its community will often
+become more and more involved. Such Users may find themselves becoming
+[Contributors](#Contributors), as described in the next section.
 
 ### Contributors
-Contributors are community members who contribute in concrete ways to the project, most often in the form of data updates, code and/or documentation. Anyone can become a Contributor, and contributions can take many forms. There is no expectation of commitment to the project, no specific skill requirements, and no selection process. We do expect contributors to follow Mozilla’s Contribution Guidelines.
+
+Contributors are community members who contribute in concrete ways to the
+project, most often in the form of data updates, code and/or documentation.
+Anyone can become a Contributor, and contributions can take many forms. There is
+no expectation of commitment to the project, no specific skill requirements, and
+no selection process. We do expect contributors to follow Mozilla’s Contribution
+Guidelines.
 
 Contributors:
-- Have read-only access to source code and therefore can submit changes via pull requests.
-- Have their contribution reviewed and merged by a [Peer](#Peers) or [Owner](#Owners). Owners and Peers work with Contributors to review their code and prepare it for merging.
-- May also review pull requests. This can be helpful, but their approval or disapproval is not decisive for merging or not merging PRs.
 
-As Contributors gain experience and familiarity with the project, their profile within, and commitment to, the community will increase. At some stage, they may find themselves being nominated for becoming a Peer by an existing Peer or Owner.
+- Have read-only access to source code and therefore can submit changes via pull
+  requests.
+- Have their contribution reviewed and merged by a [Peer](#Peers) or
+  [Owner](#Owners). Owners and Peers work with Contributors to review their code
+  and prepare it for merging.
+- May also review pull requests. This can be helpful, but their approval or
+  disapproval is not decisive for merging or not merging PRs.
+
+As Contributors gain experience and familiarity with the project, their profile
+within, and commitment to, the community will increase. At some stage, they may
+find themselves being nominated for becoming a Peer by an existing Peer or
+Owner.
 
 ### Peers
-Peers are community members who have shown that they are committed to the continued development of the project through ongoing engagement with the community. Peers are given push/write access to the project’s GitHub repos.
+
+Peers are community members who have shown that they are committed to the
+continued development of the project through ongoing engagement with the
+community. Peers are given push/write access to the project’s GitHub repos.
 
 Peers:
 
-- Are expected to work on public branches of their forks and submit pull requests to the master branch.
+- Are expected to work on public branches of their forks and submit pull
+  requests to the master branch.
 - Must submit pull requests for all their changes.
 - May label and close issues.
-- May only merge other people's pull requests that relate to compat data updates.
-- Have their non-data update work reviewed and merged by [Owners](#Owners). Non-data pull requests are PRs that change the schema, update project meta-docs, the linter, or other infrastructure changes.
-- Should ask for additional review from other Peers or Owners on other people's PRs that are disruptive or controversial.
+- May only merge other people's pull requests that relate to compat data
+  updates.
+- Have their non-data update work reviewed and merged by [Owners](#Owners).
+  Non-data pull requests are PRs that change the schema, update project
+  meta-docs, the linter, or other infrastructure changes.
+- Should ask for additional review from other Peers or Owners on other people's
+  PRs that are disruptive or controversial.
 
 To become a Peer one must:
 
-- Have shown a willingness and ability to participate in the project in a helpful and collaborative way with the MDN community.
-- Typically, a potential Peer will need to show that they have an understanding of and alignment with the project, its objectives, and its strategy.
-- Have contributed a significant amount of work to the project (e.g. in the form of PRs or PR reviews), thereby demonstrating their trustworthiness and commitment to the project.
-- Read and agree to abide by the [Mozilla Commit Access Requirements](https://www.mozilla.org/en-US/about/governance/policies/commit/requirements/).
-- File an issue in the [mdn/mdn](https://github.com/mdn/mdn) repository and record “I have read, and agree to abide by, the Mozilla Commit Access Requirements.”
+- Have shown a willingness and ability to participate in the project in a
+  helpful and collaborative way with the MDN community.
+- Typically, a potential Peer will need to show that they have an understanding
+  of and alignment with the project, its objectives, and its strategy.
+- Have contributed a significant amount of work to the project (e.g. in the form
+  of PRs or PR reviews), thereby demonstrating their trustworthiness and
+  commitment to the project.
+- Read and agree to abide by the
+  [Mozilla Commit Access Requirements](https://www.mozilla.org/en-US/about/governance/policies/commit/requirements/).
+- File an issue in the [mdn/mdn](https://github.com/mdn/mdn) repository and
+  record “I have read, and agree to abide by, the Mozilla Commit Access
+  Requirements.”
 
-New Peers can be nominated by any existing Peers. Once they have been nominated, there will be a vote by the Owners.
+New Peers can be nominated by any existing Peers. Once they have been nominated,
+there will be a vote by the Owners.
 
-It is important to recognize that being a Peer is a privilege, not a right. That privilege must be earned and once earned it can be removed by the Owners. However, under normal circumstances the Peer status exists for as long as the Peer wishes to continue engaging with the project. Inactive Peers (no activity on the project for longer for a few months or more) might be marked as inactive or removed by the Owners and may re-enter when they choose to contribute again.
+It is important to recognize that being a Peer is a privilege, not a right. That
+privilege must be earned and once earned it can be removed by the Owners.
+However, under normal circumstances the Peer status exists for as long as the
+Peer wishes to continue engaging with the project. Inactive Peers (no activity
+on the project for longer for a few months or more) might be marked as inactive
+or removed by the Owners and may re-enter when they choose to contribute again.
 
 #### List of current peers
+
 - Rachel Andrew (@rachelandrew)
 - Vinyl Darkscratch (@vinyldarkscratch)
 - Ryan Johnson (@escattone), Mozilla
@@ -56,42 +117,66 @@ It is important to recognize that being a Peer is a privilege, not a right. That
 - Irene Smith (@irenesmith), Mozilla
 - Estelle Weyl (@estelle), Mozilla
 
-A Peer who shows an above-average level of contribution to the project, particularly with respect to its strategic direction and long-term health, may be nominated to become an Owner, described below.
+A Peer who shows an above-average level of contribution to the project,
+particularly with respect to its strategic direction and long-term health, may
+be nominated to become an Owner, described below.
 
 ### Owners
-The mdn-browser-compat-data project is jointly governed by the [Mozilla MDN staff team](https://wiki.mozilla.org/Engagement/MDN_Durable_Team#Team_Members), the [MDN Product Advisory Board Members](https://developer.mozilla.org/en-US/docs/MDN/MDN_Product_Advisory_Board/Members), and the [Owner group](#list-of-current-owners). They are collectively responsible for high-level guidance of the project.
 
-The [Owner group](#list-of-current-owners) has final authority over this project including:
+The mdn-browser-compat-data project is jointly governed by the
+[Mozilla MDN staff team](https://wiki.mozilla.org/Engagement/MDN_Durable_Team#Team_Members),
+the
+[MDN Product Advisory Board Members](https://developer.mozilla.org/en-US/docs/MDN/MDN_Product_Advisory_Board/Members),
+and the [Owner group](#list-of-current-owners). They are collectively
+responsible for high-level guidance of the project.
 
-- Technical direction of the project, especially infrastructure PRs and linting and/or schema decisions.
+The [Owner group](#list-of-current-owners) has final authority over this project
+including:
+
+- Technical direction of the project, especially infrastructure PRs and linting
+  and/or schema decisions.
 - Project governance and process (including this policy and any updates).
 - Contribution policy.
 - GitHub repository hosting.
 - Confirming Peers.
 
-Being an Owner is not time-limited. There is no fixed size of the Owner group. The Owner group should be of such a size as to ensure adequate coverage of important areas of expertise balanced with the ability to make decisions efficiently.
-An Owner may be removed from the Owner group by voluntary resignation, or by a standard Owner group motion, including for violations of Contribution and/or Commit Access Guidelines.
+Being an Owner is not time-limited. There is no fixed size of the Owner group.
+The Owner group should be of such a size as to ensure adequate coverage of
+important areas of expertise balanced with the ability to make decisions
+efficiently. An Owner may be removed from the Owner group by voluntary
+resignation, or by a standard Owner group motion, including for violations of
+Contribution and/or Commit Access Guidelines.
 
-Changes to the Owner group should be posted in the agenda, and may be suggested as any other agenda item (see [Project Meetings](#project-meetings) below).
+Changes to the Owner group should be posted in the agenda, and may be suggested
+as any other agenda item (see [Project Meetings](#project-meetings) below).
 
 Owners fulfill all requirements of Peers, and also:
 
 - Ensure the smooth running of the project.
-- Review code contributions, approve changes to this document, manage the copyrights within the project outputs.
+- Review code contributions, approve changes to this document, manage the
+  copyrights within the project outputs.
 - Participate in the project discussions and meetings.
-- Manage and merge non-data pull requests such as schema, linter, or infrastructure changes.
-- May merge their own pull requests once they have collected the feedback they deem necessary. (No pull request should be merged without at least one peer or owner comment stating they’ve looked at the PR.)
+- Manage and merge non-data pull requests such as schema, linter, or
+  infrastructure changes.
+- May merge their own pull requests once they have collected the feedback they
+  deem necessary. (No pull request should be merged without at least one peer or
+  owner comment stating they’ve looked at the PR.)
 - Release a new npm version of the project on a regular (weekly) basis.
 
-To become an Owner one must fulfill at least the following conditions and commit to being a part of the community for the long-term.
+To become an Owner one must fulfill at least the following conditions and commit
+to being a part of the community for the long-term.
 
 - Have worked in a helpful and collaborative way with the MDN community.
-- Have given good feedback on others’ submissions and displayed an overall understanding of the code quality standards for the project.
-- Have the ability to drive the project forward, manage requirements from users, and taking on responsibility for the overall health of the project.
+- Have given good feedback on others’ submissions and displayed an overall
+  understanding of the code quality standards for the project.
+- Have the ability to drive the project forward, manage requirements from users,
+  and taking on responsibility for the overall health of the project.
 
-An individual is invited to become an Owner by existing Owners. A nomination will result in discussion and then a decision by the Owner group.
+An individual is invited to become an Owner by existing Owners. A nomination
+will result in discussion and then a decision by the Owner group.
 
 #### List of current Owners
+
 - Florian Scholz (@Elchi3), Mozilla, BCD project lead
 - Daniel Beck (@ddbeck)
 - Will Bamberg (@wbamberg), Mozilla
@@ -100,54 +185,98 @@ An individual is invited to become an Owner by existing Owners. A nomination wil
 
 ## Additional paths to becoming a Peer or Owner
 
-Some Owners or Peers are also [MDN Content Curators](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Documentation_topics_and_curators) and have thus earned the privilege to be a mdn-browser-compat-data Peer, so that their expertise in a given content area (CSS, HTML, etc.) can help improve the compat data for that same content area. Such Peers are marked in the relevant folders using GitHub’s Code Owner mechanism.
+Some Owners or Peers are also
+[MDN Content Curators](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Documentation_topics_and_curators)
+and have thus earned the privilege to be a mdn-browser-compat-data Peer, so that
+their expertise in a given content area (CSS, HTML, etc.) can help improve the
+compat data for that same content area. Such Peers are marked in the relevant
+folders using GitHub’s Code Owner mechanism.
 
-Peers might also be representatives of browser vendors and have expertise and/or access to browser-specific information within their company. Their company name is listed in the Peer list.
+Peers might also be representatives of browser vendors and have expertise and/or
+access to browser-specific information within their company. Their company name
+is listed in the Peer list.
 
 ## Owner-delegate rule
-Owners may, at their discretion, nominate an owner-delegate to carry out a task or make a decision ordinarily carried out by an Owner. Delegation should be limited in duration or scope, or both; delegation may be withdrawn by any Owner at any time. For example, an Owner may nominate an owner-delegate to approve an infrastructure PR or to publish npm packages for a set time or number of releases.
+
+Owners may, at their discretion, nominate an owner-delegate to carry out a task
+or make a decision ordinarily carried out by an Owner. Delegation should be
+limited in duration or scope, or both; delegation may be withdrawn by any Owner
+at any time. For example, an Owner may nominate an owner-delegate to approve an
+infrastructure PR or to publish npm packages for a set time or number of
+releases.
 
 ## Decision Making
-Decision making generally follows a [Consensus-seeking decision-making](https://en.wikipedia.org/wiki/Consensus-seeking_decision-making) model.
 
-When an agenda item has appeared to reach a consensus, the moderator will ask “Does anyone object?” as a final call for dissent from the consensus.
+Decision making generally follows a
+[Consensus-seeking decision-making](https://en.wikipedia.org/wiki/Consensus-seeking_decision-making)
+model.
 
-If an agenda item cannot reach a consensus, an owner can call for either a closing vote or a vote to table the issue to the next meeting. The call for a vote must be approved by a majority of the owners or else the discussion will continue. Simple majority wins.
+When an agenda item has appeared to reach a consensus, the moderator will ask
+“Does anyone object?” as a final call for dissent from the consensus.
+
+If an agenda item cannot reach a consensus, an owner can call for either a
+closing vote or a vote to table the issue to the next meeting. The call for a
+vote must be approved by a majority of the owners or else the discussion will
+continue. Simple majority wins.
 
 ## Licensing
 
 Please note that this project is made available using the
 [CC0 license](https://github.com/mdn/browser-compat-data/blob/master/LICENSE),
-so anyone contributing should only submit data if they know they have the right to submit it under CC0. If you're not sure about that, just ask.
+so anyone contributing should only submit data if they know they have the right
+to submit it under CC0. If you're not sure about that, just ask.
 
 ## Project Meetings
-There are no recurrent project meetings; they are scheduled when required at a time that works for the owners, and using tools that enable participation by the community. The meeting is run by a designated moderator approved by the owners group.
-Meetings will typically be held when there are particularly important items to review, such as  modifications of governance, contribution policy, owner membership, or release process.
 
-Any community member or Peer can ask that something be added to the next meeting’s agenda by logging a GitHub Issue. Peers can add the item to the agenda by adding the [meeting-agenda](https://github.com/mdn/browser-compat-data/labels/meeting-agenda) label to the issue and Contributors can ask Peers to add the label for them.
+There are no recurrent project meetings; they are scheduled when required at a
+time that works for the owners, and using tools that enable participation by the
+community. The meeting is run by a designated moderator approved by the owners
+group. Meetings will typically be held when there are particularly important
+items to review, such as  modifications of governance, contribution policy,
+owner membership, or release process.
 
-The intention of the agenda is not to approve or review all patches. That should happen continuously on GitHub and be handled by the larger group of Peers. The exception to this is when defining how the schema should look (or when proposing an update), or when a PR discussion has stalled due to disagreement or inaction, and progress needs to be unblocked.
+Any community member or Peer can ask that something be added to the next
+meeting’s agenda by logging a GitHub Issue. Peers can add the item to the agenda
+by adding the
+[meeting-agenda](https://github.com/mdn/browser-compat-data/labels/meeting-agenda)
+label to the issue and Contributors can ask Peers to add the label for them.
 
-Prior to each project meeting, the moderator will share the agenda with the owners. Owners can add any items they like to the agenda at the beginning of each meeting. The moderator and the owners cannot veto or remove items.
+The intention of the agenda is not to approve or review all patches. That should
+happen continuously on GitHub and be handled by the larger group of Peers. The
+exception to this is when defining how the schema should look (or when proposing
+an update), or when a PR discussion has stalled due to disagreement or inaction,
+and progress needs to be unblocked.
 
-The Owners may invite persons or representatives from certain projects to participate in a non-voting capacity.
+Prior to each project meeting, the moderator will share the agenda with the
+owners. Owners can add any items they like to the agenda at the beginning of
+each meeting. The moderator and the owners cannot veto or remove items.
 
-The moderator is responsible for summarizing the discussion of each agenda item and adding it to the [repository's wiki](https://github.com/mdn/browser-compat-data/wiki/Project-meetings) after the meeting.
+The Owners may invite persons or representatives from certain projects to
+participate in a non-voting capacity.
+
+The moderator is responsible for summarizing the discussion of each agenda item
+and adding it to the
+[repository's wiki](https://github.com/mdn/browser-compat-data/wiki/Project-meetings)
+after the meeting.
 
 ## Privileges and responsibilities matrix
 
 | Privilege / responsibility | Everyone / Users | Contributors | Peers | Owners |
-| --- | --- | --- | --- | --- |
-| Abide to Code of Conduct | • | • | • | • |
-| Evangelize the project | • | • | • | • |
-| Make use of the data, fork it, repackage it, etc. | • | • | • | • |
-| Open pull requests or issues |  | • | • | • |
-| Review pull requests or comment on issues |  | • | • | • |
-| Label issues and PRs |  |  | • | • |
-| Merge compat data PRs |  |  | • | • |
-| Merge schema, linter, infrastructure or policy changes |  |  |  | • |
-| Release new npm package versions |  |  |  | • |
-| Merge to branches directly (without pull requests)  |  |  |  | • |
+| -------------------------- | ---------------- | ------------ | ----- | ------ |
+| Abide to Code of Conduct   |         •        |       •      |   •   |    •   |
+| Evangelize the project     |         •        |       •      |   •   |    •   |
+| Make use of the data, fork it, repackage it, etc. | • |   •  |   •   |    •   |
+| Open pull requests or issues |                |       •      |   •   |    •   |
+| Review pull requests or comment on issues |   |       •      |   •   |    •   |
+| Label issues and PRs       |                  |              |   •   |    •   |
+| Merge compat data PRs      |                  |              |   •   |    •   |
+| Merge schema, linter, infrastructure or policy changes | |   |       |    •   |
+| Release new npm package versions |            |              |       |    •   |
+| Merge to branches directly (without pull requests) | |       |       |    •   |
 
 ## Credits
-This work is a derivative of [ESLint Governance](https://github.com/eslint/eslint.github.io/blob/master/docs/maintainer-guide/governance.md), [YUI Contributor Model](https://github.com/yui/yui3/wiki/Contributor-Model), and the [JS Foundation TAC Charter](https://github.com/JSFoundation/TAC).
+
+This work is a derivative of
+[ESLint Governance](https://github.com/eslint/eslint.github.io/blob/master/docs/maintainer-guide/governance.md),
+[YUI Contributor Model](https://github.com/yui/yui3/wiki/Contributor-Model), and
+the [JS Foundation TAC Charter](https://github.com/JSFoundation/TAC).

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [https://github.com/mdn/browser-compat-data](https://github.com/mdn/browser-compat-data)
 
-This repository contains compatibility data for Web technologies.
-Browser compatibility data describes which platforms (where "platforms" are
-usually, but not always, web browsers) support particular Web APIs.
+This repository contains compatibility data for Web technologies. Browser
+compatibility data describes which platforms (where "platforms" are usually, but
+not always, web browsers) support particular Web APIs.
 
 This data can be used in documentation, to build compatibility tables listing
 browser support for APIs. For example:
@@ -14,15 +14,19 @@ browser support for APIs. For example:
 [![Build Status](https://travis-ci.org/mdn/browser-compat-data.svg?branch=master)](https://travis-ci.org/mdn/browser-compat-data)
 [![Twitter Follow](https://img.shields.io/twitter/follow/mozdevnet.svg?style=social&label=Follow&style=plastic)](https://twitter.com/MozDevNet)
 
-Read how this project is [governed](https://github.com/mdn/browser-compat-data/blob/master/GOVERNANCE.md).
+Read how this project is
+[governed](https://github.com/mdn/browser-compat-data/blob/master/GOVERNANCE.md).
 
 ## Installation
+
 You can install mdn-browser-compat-data as a node package.
+
 ```
 npm install mdn-browser-compat-data
 ```
 
 ## Usage
+
 ```js
 const bcd = require('mdn-browser-compat-data');
 bcd.css.properties.background;
@@ -35,53 +39,101 @@ There's a top-level directory for each broad area covered: for example, "http",
 "javascript", "webextensions". Inside each of these directories is one or more
 JSON file containing the compatibility data.
 
-*Please note that we have not (yet) migrated all compatibility data from the MDN wiki pages into this repository.*
+*Please note that we have not (yet) migrated all compatibility data from the MDN
+wiki pages into this repository.*
 
-- [api/](https://github.com/mdn/browser-compat-data/tree/master/api) contains data for each [Web API](https://developer.mozilla.org/en-US/docs/Web/API) interface.
+- [api/](https://github.com/mdn/browser-compat-data/tree/master/api) contains
+  data for each [Web API](https://developer.mozilla.org/en-US/docs/Web/API)
+  interface.
 
-- [css/](https://github.com/mdn/browser-compat-data/tree/master/css) contains data for [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS) properties, selectors, and at-rules.
+- [css/](https://github.com/mdn/browser-compat-data/tree/master/css) contains
+  data for [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS) properties,
+  selectors, and at-rules.
 
-- [html/](https://github.com/mdn/browser-compat-data/tree/master/html) contains data for
-[HTML](https://developer.mozilla.org/en-US/docs/Web/HTML) elements, attributes, and global attributes.
+- [html/](https://github.com/mdn/browser-compat-data/tree/master/html) contains
+  data for [HTML](https://developer.mozilla.org/en-US/docs/Web/HTML) elements,
+  attributes, and global attributes.
 
-- [http/](https://github.com/mdn/browser-compat-data/tree/master/http) contains data for [HTTP](https://developer.mozilla.org/en-US/docs/Web/HTTP) headers, statuses, and methods.
+- [http/](https://github.com/mdn/browser-compat-data/tree/master/http) contains
+  data for [HTTP](https://developer.mozilla.org/en-US/docs/Web/HTTP) headers,
+  statuses, and methods.
 
-- [javascript/](https://github.com/mdn/browser-compat-data/tree/master/javascript) contains data for [JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript) built-in Objects, statement, operators, and other ECMAScript language features.
+- [javascript/](https://github.com/mdn/browser-compat-data/tree/master/javascript)
+  contains data for
+  [JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript) built-in
+  Objects, statement, operators, and other ECMAScript language features.
 
-- [mathml/](https://github.com/mdn/browser-compat-data/tree/master/mathml) contains data for [MathML](https://developer.mozilla.org/docs/Web/MathML) elements, attributes, and global attributes.
+- [mathml/](https://github.com/mdn/browser-compat-data/tree/master/mathml)
+  contains data for [MathML](https://developer.mozilla.org/docs/Web/MathML)
+  elements, attributes, and global attributes.
 
-- [svg/](https://github.com/mdn/browser-compat-data/tree/master/svg) contains data for [SVG](https://developer.mozilla.org/en-US/docs/Web/SVG) elements, attributes, and global attributes.
+- [svg/](https://github.com/mdn/browser-compat-data/tree/master/svg) contains
+  data for [SVG](https://developer.mozilla.org/en-US/docs/Web/SVG) elements,
+  attributes, and global attributes.
 
-- [webdriver/](https://github.com/mdn/browser-compat-data/tree/master/webdriver) contains data for [WebDriver](https://developer.mozilla.org/en-US/docs/Web/WebDriver) commands.
+- [webdriver/](https://github.com/mdn/browser-compat-data/tree/master/webdriver)
+  contains data for
+  [WebDriver](https://developer.mozilla.org/en-US/docs/Web/WebDriver) commands.
 
-- [webextensions/](https://github.com/mdn/browser-compat-data/tree/master/webextensions) contains data for [WebExtensions](https://developer.mozilla.org/en-US/Add-ons/WebExtensions) JavaScript APIs and manifest keys.
+- [webextensions/](https://github.com/mdn/browser-compat-data/tree/master/webextensions)
+  contains data for
+  [WebExtensions](https://developer.mozilla.org/en-US/Add-ons/WebExtensions)
+  JavaScript APIs and manifest keys.
 
-- [xpath/](https://github.com/mdn/browser-compat-data/tree/master/xpath) contains data for [XPath](https://developer.mozilla.org/docs/Web/XPath) axes, and functions.
+- [xpath/](https://github.com/mdn/browser-compat-data/tree/master/xpath)
+  contains data for [XPath](https://developer.mozilla.org/docs/Web/XPath) axes,
+  and functions.
 
-- [xslt/](https://github.com/mdn/browser-compat-data/tree/master/xslt) contains data for [XSLT](https://developer.mozilla.org/docs/Web/XSLT) elements, attributes, and global attributes.
+- [xslt/](https://github.com/mdn/browser-compat-data/tree/master/xslt) contains
+  data for [XSLT](https://developer.mozilla.org/docs/Web/XSLT) elements,
+  attributes, and global attributes.
 
 ## Format of the browser compat json files
-The definitive description of the format used to represent compatibility data is the [schema file](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data.schema.json).
-You can also have a look at the [schema documentation](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md).
+
+The definitive description of the format used to represent compatibility data is
+the
+[schema file](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data.schema.json).
+You can also have a look at the
+[schema documentation](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md).
 
 *Please note that we do not (yet) guarantee the stability of the data format.
-You're welcome to use the data, but its structure is subject to change without notice.*
+You're welcome to use the data, but its structure is subject to change without
+notice.*
 
 ## Issues?
 
-If you find a problem, please [file a bug](https://github.com/mdn/browser-compat-data/issues/new).
+If you find a problem, please
+[file a bug](https://github.com/mdn/browser-compat-data/issues/new).
 
 ## Contributing
 
-We're very happy to accept contributions to this data. See [Contributing to browser-compat-data](/docs/contributing.md) for more information.
+We're very happy to accept contributions to this data. See
+[Contributing to browser-compat-data](/docs/contributing.md) for more
+information.
 
 ## Projects using the data
-Here are some projects using the data, as an [npm module](https://www.npmjs.com/browse/depended/mdn-browser-compat-data) or directly:
 
-* [Add-ons Linter](https://github.com/mozilla/addons-linter) - the Add-ons Linter is used on [addons.mozilla.org](https://addons.mozilla.org/) and the [web-ext](https://github.com/mozilla/web-ext/) tool. It uses browser-compat-data to check that the Firefox version that the add-on lists support for does in fact support the APIs used by the add-on.
-* [Browser Compatibility Data Explorer](https://github.com/connorshea/mdn-compat-data-explorer) - View, search, and visualize data from the compatibility dataset.
-* [Compat Report](https://addons.mozilla.org/en-US/firefox/addon/compat-report/) - Firefox Add-on that shows compatibility data for the current site in the developer tools.
-* [compat-tester](https://github.com/SphinxKnight/compat-tester) - Scan local documents for compatibility issues.
-* [Visual Studio Code](https://code.visualstudio.com) - Shows the compatibility information in [the code completion popup](https://code.visualstudio.com/updates/v1_25#_improved-accuracy-of-browser-compatibility-data).
-* [webhint.io](https://webhint.io/docs/user-guide/hints/hint-compat-api/) - Hints to check if your CSS HTML and JavaScript have deprecated or not broadly supported features.
-* [WebStorm](https://www.jetbrains.com/webstorm/whatsnew/#v2019-1-html-and-css) - JavaScript IDE allowing you to check whether all CSS properties you use are supported in the target browser version.
+Here are some projects using the data, as an
+[npm module](https://www.npmjs.com/browse/depended/mdn-browser-compat-data) or
+directly:
+
+- [Add-ons Linter](https://github.com/mozilla/addons-linter) - the Add-ons
+  Linter is used on [addons.mozilla.org](https://addons.mozilla.org/) and the
+  [web-ext](https://github.com/mozilla/web-ext/) tool. It uses
+  browser-compat-data to check that the Firefox version that the add-on lists
+  support for does in fact support the APIs used by the add-on.
+- [Browser Compatibility Data Explorer](https://github.com/connorshea/mdn-compat-data-explorer) -
+  View, search, and visualize data from the compatibility dataset.
+- [Compat Report](https://addons.mozilla.org/en-US/firefox/addon/compat-report/) -
+  Firefox Add-on that shows compatibility data for the current site in the developer tools.
+- [compat-tester](https://github.com/SphinxKnight/compat-tester) - Scan local
+  documents for compatibility issues.
+- [Visual Studio Code](https://code.visualstudio.com) - Shows the compatibility
+  information in
+  [the code completion popup](https://code.visualstudio.com/updates/v1_25#_improved-accuracy-of-browser-compatibility-data).
+- [webhint.io](https://webhint.io/docs/user-guide/hints/hint-compat-api/) -
+  Hints to check if your CSS HTML and JavaScript have deprecated or not broadly
+  supported features.
+- [WebStorm](https://www.jetbrains.com/webstorm/whatsnew/#v2019-1-html-and-css) -
+  JavaScript IDE allowing you to check whether all CSS properties you use are
+  supported in the target browser version.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,7 @@
 # Contributing to browser-compat-data
 
-We're really happy to accept contributions to the mdn-browser-compat-data repository!
+We're really happy to accept contributions to the mdn-browser-compat-data
+repository!
 
 ## Table of contents
 
@@ -13,59 +14,92 @@ We're really happy to accept contributions to the mdn-browser-compat-data reposi
 
 ## Before you begin
 
-The browser-compat-data project (BCD) welcomes contributors of all kinds, but we ask that you keep these guidelines in mind when you're contributing.
+The browser-compat-data project (BCD) welcomes contributors of all kinds, but we
+ask that you keep these guidelines in mind when you're contributing.
 
-The project requires that all contributors follow [Mozilla's code of conduct and etiquette guidelines](/CODE_OF_CONDUCT.md).
+The project requires that all contributors follow
+[Mozilla's code of conduct and etiquette guidelines](/CODE_OF_CONDUCT.md).
 
-This project has [a formal governance document](/GOVERNANCE.md), which describes how various types of contributors work within the project and how decisions are made.
+This project has [a formal governance document](/GOVERNANCE.md), which describes
+how various types of contributors work within the project and how decisions are
+made.
 
-The repository is made available under the terms the [Creative Commons CC0 Public Domain Dedication](/LICENSE). Any contributions must be compatible with its terms. If you're not sure about that, [please ask](#getting-help).
+The repository is made available under the terms the
+[Creative Commons CC0 Public Domain Dedication](/LICENSE). Any contributions
+must be compatible with its terms. If you're not sure about that,
+[please ask](#getting-help).
 
 ## Ways to contribute
 
 There are many ways you can help improve this repository! For example:
 
-* **Add new compat data**: familiarize yourself with the [schema](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data.schema.json) and read the [schema docs](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md) and [data guidelines](data-guidelines.md) to add new files.
-* **Fix existing compat data**: maybe a browser now supports a certain feature. Yay! If you open a PR to fix a browser's data, it would be most helpful if you include a link to a bug report or similar so that we can double-check the good news.
-* **Fix a bug:** we have a list of [issues](https://github.com/mdn/browser-compat-data/issues),
-or maybe you found your own.
-* **Review a pull request:** there is a list of [PRs](https://github.com/mdn/browser-compat-data/pulls).
-Let us know if these look good to you.
+- **Add new compat data**: familiarize yourself with the
+  [schema](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data.schema.json)
+  and read the
+  [schema docs](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md)
+  and [data guidelines](data-guidelines.md) to add new files.
+- **Fix existing compat data**: maybe a browser now supports a certain feature.
+  Yay! If you open a PR to fix a browser's data, it would be most helpful if you
+  include a link to a bug report or similar so that we can double-check the good
+  news.
+- **Fix a bug:** we have a list of
+  [issues](https://github.com/mdn/browser-compat-data/issues), or maybe you
+  found your own.
+- **Review a pull request:** there is a list of
+  [PRs](https://github.com/mdn/browser-compat-data/pulls). Let us know if these
+  look good to you.
 
 ## Updating compatibility tables on MDN
 
-It takes up to four weeks for BCD changes to be reflected in MDN's browser compatibility tables.
-The process is:
+It takes up to four weeks for BCD changes to be reflected in MDN's browser
+compatibility tables. The process is:
 
 1. A pull request is reviewed and merged to `master`.
-2. Project owners publish a new release of [mdn-browser-compat-data](https://www.npmjs.com/package/mdn-browser-compat-data).
-   See [Publishing a new version of `mdn-browser-compat-data`](publishing.md) for details.
-3. MDN staff build and deploy a new image of [Kumascript](https://github.com/mdn/kumascript), which includes the BCD release, to production.
-   This typically happens within a day of the release of the npm package.
+2. Project owners publish a new release of
+   [mdn-browser-compat-data](https://www.npmjs.com/package/mdn-browser-compat-data).
+   See [Publishing a new version of `mdn-browser-compat-data`](publishing.md)
+   for details.
+3. MDN staff build and deploy a new image of
+   [Kumascript](https://github.com/mdn/kumascript), which includes the BCD
+   release, to production. This typically happens within a day of the release of
+   the npm package.
 4. Tables are generated on MDN:
+   - Existing tables automatically regenerate monthly. Alternatively, logged-in
+     MDN users can
+     [force-refresh a page](https://en.wikipedia.org/wiki/Wikipedia:Bypass_your_cache#Bypassing_cache)
+     to regenerate it.
+   - For new pages, you must add the
+     [`{{Compat}}`](https://github.com/mdn/kumascript/blob/master/macros/Compat.ejs)
+     macro to the page. For instructions, see
+     [Inserting the data into MDN pages](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Structures/Compatibility_tables#Inserting_the_data_into_MDN_pages).
 
-   * Existing tables automatically regenerate monthly.
-     Alternatively, logged-in MDN users can [force-refresh a page](https://en.wikipedia.org/wiki/Wikipedia:Bypass_your_cache#Bypassing_cache) to regenerate it.
-   * For new pages, you must add the [`{{Compat}}`](https://github.com/mdn/kumascript/blob/master/macros/Compat.ejs) macro to the page.
-     For instructions, see [Inserting the data into MDN pages](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Structures/Compatibility_tables#Inserting_the_data_into_MDN_pages).
-
-Large-scale changes follow a different process. See [Migrations](migrations.md) for details.
+Large-scale changes follow a different process. See [Migrations](migrations.md)
+for details.
 
 ## Opening issues and pull requests
 
-Before submitting your pull request, [validate your new data against the schema](testing.md).
+Before submitting your pull request,
+[validate your new data against the schema](testing.md).
 
-Not everything is enforced or validated by the schema. A few things to pay attention to:
+Not everything is enforced or validated by the schema. A few things to pay
+attention to:
 
-* Feature identifiers (the data namespaces, like `css.properties.background`) should make sense and are spelled correctly.
-* Nesting of feature identifiers should make sense.
-* Notes use correct grammar and spelling. They should be complete sentences ending with a period.
+- Feature identifiers (the data namespaces, like `css.properties.background`)
+  should make sense and are spelled correctly.
+- Nesting of feature identifiers should make sense.
+- Notes use correct grammar and spelling. They should be complete sentences
+  ending with a period.
 
 ### Optional: Generating data using the Web API Confluence Dashboard
 
-If the feature you're interested in is a JavaScript API, you can cross-reference data against [Web API Confluence](https://web-confluence.appspot.com/) using the `confluence` command. This command overwrites data in your current working tree according to data from the dashboard. See [Using Confluence](using-confluence.md) for instructions.
+If the feature you're interested in is a JavaScript API, you can cross-reference
+data against [Web API Confluence](https://web-confluence.appspot.com/) using the
+`confluence` command. This command overwrites data in your current working tree
+according to data from the dashboard. See
+[Using Confluence](using-confluence.md) for instructions.
 
 ## Getting help
 
-If you need help with this repository or have any questions, contact the MDN team
-in the [#mdn](irc://irc.mozilla.org/mdn) IRC channel on irc.mozilla.org or write us on [discourse](https://discourse.mozilla-community.org/c/mdn).
+If you need help with this repository or have any questions, contact the MDN
+team in the [#mdn](irc://irc.mozilla.org/mdn) IRC channel on irc.mozilla.org or
+write us on [discourse](https://discourse.mozilla-community.org/c/mdn).

--- a/docs/data-guidelines.md
+++ b/docs/data-guidelines.md
@@ -1,31 +1,41 @@
 # Data guidelines
 
-This file contains recommendations to help you record data in a consistent and understandable way. It covers the project's preferences for the way features should be represented, rather than hard requirements encoded in the schema definitions or linter logic.
+This file contains recommendations to help you record data in a consistent and
+understandable way. It covers the project's preferences for the way features
+should be represented, rather than hard requirements encoded in the schema
+definitions or linter logic.
 
 - [Data guidelines](#data-guidelines)
-  * [Constructors](#constructors)
-  * [DOM events (`eventname_event`)](#dom-events-eventname_event)
-  * [Secure context required (`secure_context_required`)](#secure-context-required-secure_context_required)
-  * [Web Workers (`worker_support`)](#web-workers-worker_support)
-  * [Non-functional defined names imply `partial_implementation`](#non-functional-defined-names-imply-partial_implementation)
-  * [Release lines and backported features](#release-lines-and-backported-features)
-  * [Safari for iOS versioning](#safari-for-ios-versioning)
+  - [Constructors](#constructors)
+  - [DOM events (`eventname_event`)](#dom-events-eventname_event)
+  - [Secure context required (`secure_context_required`)](#secure-context-required-secure_context_required)
+  - [Web Workers (`worker_support`)](#web-workers-worker_support)
+  - [Non-functional defined names imply `partial_implementation`](#non-functional-defined-names-imply-partial_implementation)
+  - [Release lines and backported features](#release-lines-and-backported-features)
+  - [Safari for iOS versioning](#safari-for-ios-versioning)
 
 <!-- BEGIN TEMPLATE
 
 ## Short title in sentence case
 
-A description of what to do, preferably in the imperative. If applicable, include an example to illustrate the rule.
+A description of what to do, preferably in the imperative. If applicable,
+include an example to illustrate the rule.
 
-If it's helpful to understanding the rule, summarize the rationale. Definitely cite the issue or pull request where this was decided (it may be the PR that merges the policy).
+If it's helpful to understanding the rule, summarize the rationale. Definitely
+cite the issue or pull request where this was decided (it may be the PR that
+merges the policy).
 
 -- END TEMPLATE -->
 
 ## Constructors
 
-Name a constructor for an API feature the same as the parent feature (unless the constructor doesn't share the name of its parent feature) and have a description with text in the form of `<code>Name()</code> constructor`.
+Name a constructor for an API feature the same as the parent feature (unless the
+constructor doesn't share the name of its parent feature) and have a description
+with text in the form of `<code>Name()</code> constructor`.
 
-For example, the `ImageData` constructor, `ImageData()`, is represented as `api.ImageData.ImageData`. It has the description `<code>ImageData()</code> constructor`, like this:
+For example, the `ImageData` constructor, `ImageData()`, is represented as
+`api.ImageData.ImageData`. It has the description
+`<code>ImageData()</code> constructor`, like this:
 
 ```json
 {
@@ -43,12 +53,16 @@ For example, the `ImageData` constructor, `ImageData()`, is represented as `api.
 }
 ```
 
-
 ## DOM events (`eventname_event`)
 
-Add DOM events as features of their target interfaces, using the name _eventname_\_event with the description text set to `<code>eventname</code> event`. If an event can be sent to multiple interfaces, add the event as a feature of each interface that can receive it.
+Add DOM events as features of their target interfaces, using the name
+_eventname_\_event with the description text set to
+`<code>eventname</code> event`. If an event can be sent to multiple interfaces,
+add the event as a feature of each interface that can receive it.
 
-For example, the feature for a `focus` event targeting the `Element` interface would be named `focus_event` with the description text `<code>focus</code> event`, like this:
+For example, the feature for a `focus` event targeting the `Element` interface
+would be named `focus_event` with the description text
+`<code>focus</code> event`, like this:
 
 ```json
 {
@@ -66,18 +80,21 @@ For example, the feature for a `focus` event targeting the `Element` interface w
 }
 ```
 
-This rule applies to the event features themselves, not the features for the event handlers. For example, `focus_event` and `onfocus` are two separate features.
+This rule applies to the event features themselves, not the features for the
+event handlers. For example, `focus_event` and `onfocus` are two separate
+features.
 
 This practice emerged through several discussions:
 
-* [#935](https://github.com/mdn/browser-compat-data/issues/935#issuecomment-464691417)
-* [#3420](https://github.com/mdn/browser-compat-data/pull/3420)
-* [#3469](https://github.com/mdn/browser-compat-data/pull/3469)
-
+- [#935](https://github.com/mdn/browser-compat-data/issues/935#issuecomment-464691417)
+- [#3420](https://github.com/mdn/browser-compat-data/pull/3420)
+- [#3469](https://github.com/mdn/browser-compat-data/pull/3469)
 
 ## Secure context required (`secure_context_required`)
 
-Use a subfeature named `secure_context_required` with the description text `Secure context required` to record data about whether a feature requires HTTPS. For example, the `ImageData` API requires a secure context, recorded like this:
+Use a subfeature named `secure_context_required` with the description text
+`Secure context required` to record data about whether a feature requires HTTPS.
+For example, the `ImageData` API requires a secure context, recorded like this:
 
 ```json
 {
@@ -95,12 +112,13 @@ Use a subfeature named `secure_context_required` with the description text `Secu
 }
 ```
 
-This convention is discussed in more detail in [#190](https://github.com/mdn/browser-compat-data/issues/190).
-
+This convention is discussed in more detail in
+[#190](https://github.com/mdn/browser-compat-data/issues/190).
 
 ## Web Workers (`worker_support`)
 
-Use a subfeature named `worker_support` with description text `Available in workers` to record data about an API's support for Web Workers.
+Use a subfeature named `worker_support` with description text
+`Available in workers` to record data about an API's support for Web Workers.
 
 For example, the `ImageData` API has worker support, recorded like this:
 
@@ -120,31 +138,51 @@ For example, the `ImageData` API has worker support, recorded like this:
 }
 ```
 
-Formerly named `available_in_workers`, this policy was set in [#2362](https://github.com/mdn/browser-compat-data/pull/2362).
-
+Formerly named `available_in_workers`, this policy was set in
+[#2362](https://github.com/mdn/browser-compat-data/pull/2362).
 
 ## Non-functional defined names imply `partial_implementation`
 
-If a browser recognizes an API name, but the API doesn’t have any discernable behavior, use `"partial_implementation": true` instead of `"version_added": false`, as if the feature has non-standard support, rather than no support.
+If a browser recognizes an API name, but the API doesn’t have any discernable
+behavior, use `"partial_implementation": true` instead of
+`"version_added": false`, as if the feature has non-standard support, rather
+than no support.
 
-For example, suppose there is some specification for a Web API `NewFeature.method()`. Running `typeof NewFeature.method` in some browser returns `function` (not `undefined`), but the method, when called, returns `null` instead of an expected value. For that feature, set `"partial_implementation": true` and write a note describing the feature’s misbehavior.
+For example, suppose there is some specification for a Web API
+`NewFeature.method()`. Running `typeof NewFeature.method` in some browser
+returns `function` (not `undefined`), but the method, when called, returns
+`null` instead of an expected value. For that feature, set
+`"partial_implementation": true` and write a note describing the feature’s
+misbehavior.
 
-See [#3904](https://github.com/mdn/browser-compat-data/pull/3904#issuecomment-484433603) for additional background (and nuance).
-
+See
+[#3904](https://github.com/mdn/browser-compat-data/pull/3904#issuecomment-484433603)
+for additional background (and nuance).
 
 ## Release lines and backported features
 
-Use version numbers to reflect which _release line_ (major or minor but not patch-level releases) first supported a feature, rather than absolute version numbers.
+Use version numbers to reflect which _release line_ (major or minor but not
+patch-level releases) first supported a feature, rather than absolute version
+numbers.
 
-Typically, BCD does not record absolute version numbers (such as Chrome 76.0.3809.46; instead BCD records significant releases (such as Chrome 76). Use the earliest applicable release line for recording support for a given feature, even when that support change was backported to a previous release of the browser.
+Typically, BCD does not record absolute version numbers (such as Chrome
+76.0.3809.46; instead BCD records significant releases (such as Chrome 76). Use
+the earliest applicable release line for recording support for a given feature,
+even when that support change was backported to a previous release of the
+browser.
 
-For example, if the current release of browser X is version 10.2, but a new feature was backported to previous versions including a new 9.7.1 release, then the supported version is 9.7 (not 10.2 or 9.7.1).
+For example, if the current release of browser X is version 10.2, but a new
+feature was backported to previous versions including a new 9.7.1 release, then
+the supported version is 9.7 (not 10.2 or 9.7.1).
 
-This decision was made in [#3953, under the expectation that most users are likely to run the latest minor version of their browser](https://github.com/mdn/browser-compat-data/pull/3953#issuecomment-485847399), but not necessarily the latest version overall.
-
+This decision was made in
+[#3953, under the expectation that most users are likely to run the latest minor version of their browser](https://github.com/mdn/browser-compat-data/pull/3953#issuecomment-485847399),
+but not necessarily the latest version overall.
 
 ## Safari for iOS versioning
 
-For Safari for iOS, use the iOS version number, not the Safari version number or WebKit version number.
+For Safari for iOS, use the iOS version number, not the Safari version number or
+WebKit version number.
 
-This versioning scheme came at [Apple's request, in #2006](https://github.com/mdn/browser-compat-data/issues/2006#issuecomment-457277312).
+This versioning scheme came at
+[Apple's request, in #2006](https://github.com/mdn/browser-compat-data/issues/2006#issuecomment-457277312).

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -1,33 +1,60 @@
 # Migrations
 
-From time to time, we make changes that must modify many files in [mdn/browser-compat-data](https://github.com/mdn/browser-compat-data/). We approach such changes like database migrations: automate the change, test that it works, and apply the change at a time that minimizes disruption to others. Using this process saves time (compared to manually creating and reviewing changes) and improves data quality.
+From time to time, we make changes that must modify many files in
+[mdn/browser-compat-data](https://github.com/mdn/browser-compat-data/). We
+approach such changes like database migrations: automate the change, test that
+it works, and apply the change at a time that minimizes disruption to others.
+Using this process saves time (compared to manually creating and reviewing
+changes) and improves data quality.
 
-Follow this process for changes that are amenable to automation, affects many files, and modifies existing data. If you want to make smaller-scale changes or changes that aren’t compatible with automation, open a pull request or issue instead.
+Follow this process for changes that are amenable to automation, affects many
+files, and modifies existing data. If you want to make smaller-scale changes or
+changes that aren’t compatible with automation, open a pull request or issue
+instead.
 
 ## Step 1: Announce your intent
 
-In a new or existing issue, announce your intent to complete a migration. This issue is where the overall migration process will be discussed and tracked.
+In a new or existing issue, announce your intent to complete a migration. This
+issue is where the overall migration process will be discussed and tracked.
 
-A good migration starts with a clear description of the changes to be made, with a focus on one kind of change at a time. Using a checklist to plan and track progress can be helpful. Finally, consider awaiting feedback before proceeding to the next step.
+A good migration starts with a clear description of the changes to be made, with
+a focus on one kind of change at a time. Using a checklist to plan and track
+progress can be helpful. Finally, consider awaiting feedback before proceeding
+to the next step.
 
 ## Step 2: Create and test the migration scripts
 
 Next, create a migration script and tests for that script.
 
-Put migration scripts in the [`/scripts/migrations/`](https://github.com/mdn/browser-compat-data/tree/master/scripts/migrations) directory. Name the scripts in the pattern `###-<description>.js` where `###` is the sequential number of the migration and `<description>` is a short name for the migration. For example, the first migration was `001-sort-features.js`.
+Put migration scripts in the
+[`/scripts/migrations/`](https://github.com/mdn/browser-compat-data/tree/master/scripts/migrations)
+directory. Name the scripts in the pattern `###-<description>.js` where `###` is
+the sequential number of the migration and `<description>` is a short name for
+the migration. For example, the first migration was `001-sort-features.js`.
 
-The script must be accompanied by one or more tests that demonstrate that the migration makes the changes described and doesn’t introduce other, unrelated changes. Typically, tests in the `/scripts/migrations/` directory are named in the form `###-<description>.test.js`.
+The script must be accompanied by one or more tests that demonstrate that the
+migration makes the changes described and doesn’t introduce other, unrelated
+changes. Typically, tests in the `/scripts/migrations/` directory are named in
+the form `###-<description>.test.js`.
 
-When the script and tests are ready, open a pull request. To be accepted, the PR must be reviewed and approved by at least one [project owner](https://github.com/mdn/browser-compat-data/blob/master/GOVERNANCE.md#owners).
+When the script and tests are ready, open a pull request. To be accepted, the PR
+must be reviewed and approved by at least one
+[project owner](https://github.com/mdn/browser-compat-data/blob/master/GOVERNANCE.md#owners).
 
 ## Step 3: Migrate
 
-After the migration script is merged, schedule a time with a project owner to complete the migration. At the scheduled time, one project participant will run the migration script and open a PR; the owner will merge it.
+After the migration script is merged, schedule a time with a project owner to
+complete the migration. At the scheduled time, one project participant will run
+the migration script and open a PR; the owner will merge it.
 
-To find a good time to run the migration, review open pull requests for potential conflicts. If there are large manual PRs still in review, consider allowing time for those to be merged before completing the migration.
+To find a good time to run the migration, review open pull requests for
+potential conflicts. If there are large manual PRs still in review, consider
+allowing time for those to be merged before completing the migration.
 
 ## Step 4: Wrap up
 
-If applicable, follow the migration with a pull request to apply new linter checks or other quality enforcement tools related to the migration.
+If applicable, follow the migration with a pull request to apply new linter
+checks or other quality enforcement tools related to the migration.
 
-Finally, celebrate by announcing the completion of the project in the original issue!
+Finally, celebrate by announcing the completion of the project in the original
+issue!

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,19 +1,37 @@
 # Publishing a new version of `mdn-browser-compat-data`
 
-[Project owners](/GOVERNANCE.md#owners) publish new releases of [mdn-browser-compat-data](https://www.npmjs.com/package/mdn-browser-compat-data) on npm.
-MDN staff [deploy the package to the MDN site](contributing.md#updating-compatibility-tables-on-mdn).
-Usually, this happens every Thursday (MDN never deploys to production on Fridays).
+[Project owners](/GOVERNANCE.md#owners) publish new releases of
+[mdn-browser-compat-data](https://www.npmjs.com/package/mdn-browser-compat-data)
+on npm. MDN staff
+[deploy the package to the MDN site](contributing.md#updating-compatibility-tables-on-mdn).
+Usually, this happens every Thursday (MDN never deploys to production on
+Fridays).
 
-Any owner can complete the following steps to publish a new version, but please coordinate releases with [Florian Scholz](https://github.com/Elchi3).
+Any owner can complete the following steps to publish a new version, but please
+coordinate releases with [Florian Scholz](https://github.com/Elchi3).
 
 To create and publish a new version of `mdn-browser-compat-data`:
 
-1. Figure out the new version number by looking at [past releases](https://github.com/mdn/browser-compat-data/releases). The project is in alpha, so we're using only patch versions. Lets assume the next version should be `0.0.43`.
-2. On your updated and clean master branch, run `npm version patch -m "43rd alpha version"`. Locally, this updates `package.json`, creates a new commit, and creates a new release tag (see also the docs for [npm version](https://docs.npmjs.com/cli/version)).
+1. Figure out the new version number by looking at
+   [past releases](https://github.com/mdn/browser-compat-data/releases). The
+   project is in alpha, so we're using only patch versions. Lets assume the next
+   version should be `0.0.43`.
+2. On your updated and clean master branch, run
+   `npm version patch -m "43rd alpha version"`. Locally, this updates
+   `package.json`, creates a new commit, and creates a new release tag (see also
+   the docs for [npm version](https://docs.npmjs.com/cli/version)).
 3. Push the commit to `master`: `git push origin master`.
-4. Check if the commit passes fine on [Travis CI](https://travis-ci.org/mdn/browser-compat-data).
+4. Check if the commit passes fine on
+   [Travis CI](https://travis-ci.org/mdn/browser-compat-data).
 5. If Travis is alright, push the git tag as well: `git push origin v0.0.43`.
-This step will trigger Travis to publish to npm automatically (see our [.travis.yml file](https://github.com/mdn/browser-compat-data/blob/master/.travis.yml)).
-6. Check [Travis CI](https://travis-ci.org/mdn/browser-compat-data) again for the v0.0.43 build and also check [mdn-browser-compat-data on npm](https://www.npmjs.com/package/mdn-browser-compat-data) to see if `0.0.43` shows up correctly once Travis has finished its work.
-7. Notify the [#mdndev](irc://irc.mozilla.org/mdndev) IRC channel on irc.mozilla.org about the new release.
-8. Create a new [release on GitHub](https://github.com/mdn/browser-compat-data/releases) by running `npm run release-notes -- v0.0.43`).
+   This step will trigger Travis to publish to npm automatically (see our
+   [.travis.yml file](https://github.com/mdn/browser-compat-data/blob/master/.travis.yml)).
+6. Check [Travis CI](https://travis-ci.org/mdn/browser-compat-data) again for
+   the v0.0.43 build and also check
+   [mdn-browser-compat-data on npm](https://www.npmjs.com/package/mdn-browser-compat-data)
+   to see if `0.0.43` shows up correctly once Travis has finished its work.
+7. Notify the [#mdndev](irc://irc.mozilla.org/mdndev) IRC channel on
+   irc.mozilla.org about the new release.
+8. Create a new
+   [release on GitHub](https://github.com/mdn/browser-compat-data/releases) by
+   running `npm run release-notes -- v0.0.43`).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2,25 +2,58 @@
 
 ## Code style
 
-The JSON files should be formatted according to the [.editorconfig](https://github.com/mdn/browser-compat-data/blob/master/.editorconfig) file.
+The JSON files should be formatted according to the
+[.editorconfig](https://github.com/mdn/browser-compat-data/blob/master/.editorconfig)
+file.
 
 ## Validating the data
 
-All data in the repo must conform to the schema. The formal feature data schema is defined in [`compat-data.schema.json`](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data.schema.json); see [`compat-data-schema.md`](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md) for more info. The browser data schema is defined in [`browsers.schema.json`](https://github.com/mdn/browser-compat-data/blob/master/schemas/browsers.schema.json); see [`browsers-schema.md`](https://github.com/mdn/browser-compat-data/blob/master/schemas/browsers-schema.md) for more info.
+All data in the repo must conform to the schema. The formal feature data schema
+is defined in
+[`compat-data.schema.json`](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data.schema.json);
+see
+[`compat-data-schema.md`](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md)
+for more info. The browser data schema is defined in
+[`browsers.schema.json`](https://github.com/mdn/browser-compat-data/blob/master/schemas/browsers.schema.json);
+see
+[`browsers-schema.md`](https://github.com/mdn/browser-compat-data/blob/master/schemas/browsers-schema.md)
+for more info.
 
-You can use `npm test` to validate data against the schema. You might need to install the `devDependencies` using `npm install`.
-The JSON data is validated against the schema using [`ajv`](http://epoberezkin.github.io/ajv/).
+You can use `npm test` to validate data against the schema. You might need to
+install the `devDependencies` using `npm install`. The JSON data is validated
+against the schema using [`ajv`](http://epoberezkin.github.io/ajv/).
 
 ## Rendering
 
-You can use `npm run render $query $depth $aggregateMode` to output an HTML like it would be rendered on MDN.
-The parameters are the same as the [`{{compat}}` macro](https://github.com/mdn/kumascript/blob/master/macros/Compat.ejs).
+You can use `npm run render $query $depth $aggregateMode` to output an HTML like
+it would be rendered on MDN. The parameters are the same as the
+[`{{compat}}` macro](https://github.com/mdn/kumascript/blob/master/macros/Compat.ejs).
 
-Paste the generated HTML into the MDN editor (source mode). You can use a new page, for example: https://developer.mozilla.org/en-US/docs/new and verify if the output looks correct.
+Paste the generated HTML into the MDN editor (source mode). You can use a new
+page, for example: https://developer.mozilla.org/en-US/docs/new and verify if
+the output looks correct.
 
 ## Statistics
 
-To see how changes will affect the statistics of real (either `false` or a version number, as defined in [#3555](https://github.com/mdn/browser-compat-data/issues/3555)), true, and null values, you can run `npm run stats [folder]`.  This generates a Markdown-formatted table of the percentages of real, true, and null values for the eight primary browsers that browser-compat-data is focusing on.  The script also takes an optional argument regarding a specific folder (such as `api` or `javascript`), which will print statistics result for only that folder.
+To see how changes will affect the statistics of real (either `false` or a
+version number, as defined in
+[#3555](https://github.com/mdn/browser-compat-data/issues/3555)), true, and null
+values, you can run `npm run stats [folder]`.  This generates a
+Markdown-formatted table of the percentages of real, true, and null values for
+the eight primary browsers that browser-compat-data is focusing on.  The script
+also takes an optional argument regarding a specific folder (such as `api` or
+`javascript`), which will print statistics result for only that folder.
 
 ## Traverse
-To find all the entries that are non-real, or of a specified value, you can run `npm run traverse <browser> [folder] [value]`.  The browser may be any single browser defined in the [`browsers/` folder](https://github.com/mdn/browser-compat-data/blob/master/browsers/).  The folder may be omitted to search through all data folders, or a comma-separated list of folders to search through.  The value may be omitted to search for all non-real values (or more specifically, `true` and `null` values), or any value accepted by `version_added` and `version_removed`.  For example, to search for all Safari entries that are non-real, run `npm run traverse safari`.  To search for all WebView entries that are marked as `true` in `api` and `javascript`, run `npm run traverse webview_android api,javascript true`.
+
+To find all the entries that are non-real, or of a specified value, you can run
+`npm run traverse <browser> [folder] [value]`. The browser may be any single
+browser defined in the
+[`browsers/` folder](https://github.com/mdn/browser-compat-data/blob/master/browsers/).
+The folder may be omitted to search through all data folders, or a
+comma-separated list of folders to search through.  The value may be omitted to
+search for all non-real values (or more specifically, `true` and `null` values),
+or any value accepted by `version_added` and `version_removed`.  For example, to
+search for all Safari entries that are non-real, run `npm run traverse safari`.
+To search for all WebView entries that are marked as `true` in `api` and
+`javascript`, run `npm run traverse webview_android api,javascript true`.

--- a/docs/using-confluence.md
+++ b/docs/using-confluence.md
@@ -1,30 +1,40 @@
 # Using Confluence
 
-[Web API Confluence Dashboard](http://web-confluence.appspot.com/#!/) provides metrics and support data about web platform features across multiple browsers. The `npm run confluence` command uses Web API Confluence to generate new or improved browser compatibility data ready for submission in pull requests. This page explains how to do this.
+[Web API Confluence Dashboard](http://web-confluence.appspot.com/#!/) provides
+metrics and support data about web platform features across multiple browsers.
+The `npm run confluence` command uses Web API Confluence to generate new or
+improved browser compatibility data ready for submission in pull requests. This
+page explains how to do this.
 
 ## Prerequisites
 
 Before using the `confluence` command make sure you have done the following:
 
-* On GitHub fork [mdn/browser-compat-data](https://github.com/mdn/browser-compat-data/).
-* In this repo, add your fork as a remote repo: `git remote add fork-name path-to-fork`
-* In the root of your clone, run `npm install`.
-* Configure a Git [difftool](https://git-scm.com/docs/git-difftool).
+- On GitHub fork
+  [mdn/browser-compat-data](https://github.com/mdn/browser-compat-data/).
+- In this repo, add your fork as a remote repo:
+  `git remote add fork-name path-to-fork`
+- In the root of your clone, run `npm install`.
+- Configure a Git [difftool](https://git-scm.com/docs/git-difftool).
 
 ## Basic procedure
 
 1. On your local `master` branch run `git pull` to update your local data.
-1. Create a new branch using `git checkout -b my-new-branch-name`.
-1. Run the `confluence` command, passing in the name of web platform interface. For example:
-
-   `npm run confluence -- --interfaces=ServiceWorker`
-
-   If the confluence command finds any differences between existing browser compatibility data and Web API Confluence, it will write a new file. Confirm that it did so by running `git status`.
-1. Open the file that changed and manually copy values from `chrome` to `chrome_android` and `webview_android`. Read [Only Desktop Data is Available](#only-desktop-data-is-available) for an explanation. Save the file.
-1. To review changes made to a JSON file, run `git difftool`. Save the file.
-1. Commit your changes using `git add .` then `git commit`.
-1. Push the branch containing your changes to your fork: `git push --set-upstream origin branch-name`.
-1. On GitHub open a pull request from your fork to mdn/browswer-compat-data.
+2. Create a new branch using `git checkout -b my-new-branch-name`.
+3. Run the `confluence` command, passing in the name of web platform interface.
+   For example: `npm run confluence -- --interfaces=ServiceWorker`. If the
+   confluence command finds any differences between existing browser
+   compatibility data and Web API Confluence, it will write a new file. Confirm
+   that it did so by running `git status`.
+4. Open the file that changed and manually copy values from `chrome` to
+   `chrome_android` and `webview_android`. Read
+   [Only Desktop Data is Available](#only-desktop-data-is-available) for an
+   explanation. Save the file.
+5. To review changes made to a JSON file, run `git difftool`. Save the file.
+6. Commit your changes using `git add .` then `git commit`.
+7. Push the branch containing your changes to your fork:
+   `git push --set-upstream origin branch-name`.
+8. On GitHub open a pull request from your fork to mdn/browswer-compat-data.
 
 ## Displaying help
 
@@ -52,26 +62,47 @@ npm run confluence -- --browsers=firefox
 
 # Limitations
 
-Although it is a useful and, to date, the most automated source of web platform compatibility data, it has limitations you must understand before using it as a source for pull requests. Those limitations are described below.
+Although it is a useful and, to date, the most automated source of web platform
+compatibility data, it has limitations you must understand before using it as a
+source for pull requests. Those limitations are described below.
 
 ## Only Web Platform APIs are available
 
-Web Platform APIs generally refer to features you would use in JavaScript that are not JavaScript itself. You can only use Confluence to verify data in the repo's [api/](https://github.com/mdn/browser-compat-data/tree/master/api) directory.
+Web Platform APIs generally refer to features you would use in JavaScript that
+are not JavaScript itself. You can only use Confluence to verify data in the
+repo's [api/](https://github.com/mdn/browser-compat-data/tree/master/api)
+directory.
 
 ## Only prototype-exposed interfaces are available
 
-The dashboard derives its data from the JavaScript object graph on a sample page loaded in each browser. For example, an own-property named `URL` on `Document.prototype` implies the `Document` interface has a member named `URL`. For various reasons, not all APIs are exposed on JavaScript prototypes, even when the API is available in the browser.
+The dashboard derives its data from the JavaScript object graph on a sample page
+loaded in each browser. For example, an own-property named `URL` on
+`Document.prototype` implies the `Document` interface has a member named `URL`.
+For various reasons, not all APIs are exposed on JavaScript prototypes, even
+when the API is available in the browser.
 
 ## Only desktop data is available
 
-This means that non-desktop data must be set by hand. For example a page generated by Confluence will only contain values for Chrome desktop (labeled `chrome` in the JSON files). The values supplied for Chrome must be manually copied to the fields named `chrome_android` and `webview_android`.
+This means that non-desktop data must be set by hand. For example a page
+generated by Confluence will only contain values for Chrome desktop (labeled
+`chrome` in the JSON files). The values supplied for Chrome must be manually
+copied to the fields named `chrome_android` and `webview_android`.
 
-These values are usually the same, but not always. You can check this by looking for the feature on [chromestatus.com](https://www.chromestatus.com/features). Although we don't recommend this site as a primary source for compatibility data, it is generally reliable with regards to parity between desktop and Android.
+These values are usually the same, but not always. You can check this by looking
+for the feature on [chromestatus.com](https://www.chromestatus.com/features).
+Although we don't recommend this site as a primary source for compatibility
+data, it is generally reliable with regards to parity between desktop and
+Android.
 
 ## No data before Chrome 40
 
-This means that if a feature landed before Chrome 40, then `40` is what will be in the JSON file.
+This means that if a feature landed before Chrome 40, then `40` is what will be
+in the JSON file.
 
 ## Chrome 43 contains false positives
 
-Because of a change in internal architecture, Chrome 43 shows features being added in that version that have been supported much longer. If Confluence says something landed in Chrome 43, you should confirm them in [Chrome's commit history](https://cs.chromium.org/chromium/src/third_party/blink/renderer/). If you're uncomfortable with that, contact jmedley@google.com.
+Because of a change in internal architecture, Chrome 43 shows features being
+added in that version that have been supported much longer. If Confluence says
+something landed in Chrome 43, you should confirm them in
+[Chrome's commit history](https://cs.chromium.org/chromium/src/third_party/blink/renderer/).
+If you're uncomfortable with that, contact jmedley@google.com.

--- a/schemas/browsers-schema.md
+++ b/schemas/browsers-schema.md
@@ -1,12 +1,18 @@
 # The browser JSON schema
 
-This document helps you to understand the structure of the [browser JSON](https://github.com/mdn/browser-compat-data/tree/master/browsers) files.
+This document helps you to understand the structure of the
+[browser JSON](https://github.com/mdn/browser-compat-data/tree/master/browsers)
+files.
 
 #### Browser identifiers
 
-The currently accepted browser identifiers are [defined in the compat-data schema](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md#browser-identifiers). They are re-used for the browser data scheme. No other identifiers are allowed and the file names should also use the browser identifiers.
+The currently accepted browser identifiers are
+[defined in the compat-data schema](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md#browser-identifiers).
+They are re-used for the browser data scheme. No other identifiers are allowed
+and the file names should also use the browser identifiers.
 
-For example, for the browser identifier `firefox`, the file name is `firefox.json`.
+For example, for the browser identifier `firefox`, the file name is
+`firefox.json`.
 
 #### File structure
 
@@ -32,37 +38,45 @@ The file `firefox.json` is structured like this:
 }
 ```
 
-It contains an object with the property `browsers` which then contains an object with the browser identifier as the property name (`firefox`).
+It contains an object with the property `browsers` which then contains an object
+with the browser identifier as the property name (`firefox`).
 
-Underneath, there is a `releases` object which will hold the various releases of a given browser by their release version number (`"1.5"`).
+Underneath, there is a `releases` object which will hold the various releases of
+a given browser by their release version number (`"1.5"`).
 
 ### `name`
 
-The `name` string is a required property which should use the browser brand name and avoid English words if possible, for example `"Firefox"`, `"Firefox Android"`, `"Safari"`, `"iOS Safari"`, etc.
+The `name` string is a required property which should use the browser brand name
+and avoid English words if possible, for example `"Firefox"`,
+`"Firefox Android"`, `"Safari"`, `"iOS Safari"`, etc.
 
 ### `pref_url`
 
-An optional string containing the URL of the page where feature flags can be changed (e.g. `"about:config"` for Firefox or `"chrome://flags"` for Chrome).
+An optional string containing the URL of the page where feature flags can be
+changed (e.g. `"about:config"` for Firefox or `"chrome://flags"` for Chrome).
 
 ### Release objects
+
 The release objects consist of the following properties:
 
-* A mandatory `status` property indicating where in the lifetime cycle this release is in. It's an enum accepting these values:
-  * `retired`: This release is no longer supported (EOL).
-  * `current`: This release is the official latest release.
-  * `exclusive`: This is an exclusive release (for example on a flagship device), not generally available.
-  * `beta`: This release will the next official release.
-  * `nightly`: This release is the current alpha / experimental release (like Firefox Nightly, Chrome Canary).
-  * `esr`: This release is an Extended Support Release.
-  * `planned`: This release is planned in the future.
-
-* An optional `release_date` property with the `YYYY-MM-DD` release date of the browser's release.
-
-* An optional `release_notes` property which points to release notes. It needs to be a valid URL.
-
-* An optional `engine` property which is the name of the browser's engine.
-
-* An optional `engine_version` property which is the version of the browser's engine. This may or may not differ from the browser version.
+- A mandatory `status` property indicating where in the lifetime cycle this
+  release is in. It's an enum accepting these values:
+  - `retired`: This release is no longer supported (EOL).
+  - `current`: This release is the official latest release.
+  - `exclusive`: This is an exclusive release (for example on a flagship
+    device), not generally available.
+  - `beta`: This release will the next official release.
+  - `nightly`: This release is the current alpha / experimental release (like
+    Firefox Nightly, Chrome Canary).
+  - `esr`: This release is an Extended Support Release.
+  - `planned`: This release is planned in the future.
+- An optional `release_date` property with the `YYYY-MM-DD` release date of the
+  browser's release.
+- An optional `release_notes` property which points to release notes. It needs
+  to be a valid URL.
+- An optional `engine` property which is the name of the browser's engine.
+- An optional `engine_version` property which is the version of the browser's
+  engine. This may or may not differ from the browser version.
 
 ### Exports
 

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -1,51 +1,69 @@
 # The mdn-browser-compat-data JSON schema
 
-This document helps you to understand how mdn-browser-compat-data is organized and structured.
+This document helps you to understand how mdn-browser-compat-data is organized
+and structured.
 
 ## Where to find compat data
+
 ### The folder structure
 
-Compatibility data is organized in top-level directories for each broad area covered: for example, `http`,
-`javascript`, and `webextensions`. Inside each of these directories is one or more
-JSON files containing the compatibility data.
+Compatibility data is organized in top-level directories for each broad area
+covered: for example, `http`, `javascript`, and `webextensions`. Inside each of
+these directories is one or more JSON files containing the compatibility data.
 
-- [api/](https://github.com/mdn/browser-compat-data/tree/master/api) contains data for each [Web API](https://developer.mozilla.org/en-US/docs/Web/API) interface.
-
-- [css/](https://github.com/mdn/browser-compat-data/tree/master/css) contains data for [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS) properties, selectors, and at-rules.
-
-- [html/](https://github.com/mdn/browser-compat-data/tree/master/html) contains data for [HTML](https://developer.mozilla.org/en-US/docs/Web/HTML) elements, attributes, and global attributes.
-
-- [http/](https://github.com/mdn/browser-compat-data/tree/master/http) contains data for [HTTP](https://developer.mozilla.org/en-US/docs/Web/HTTP) headers, statuses, and methods.
-
-- [javascript/](https://github.com/mdn/browser-compat-data/tree/master/javascript) contains data for [JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript) built-in Objects, statement, operators, and other ECMAScript language features.
-
-- [mathml/](https://github.com/mdn/browser-compat-data/tree/master/mathml) contains data for [MathML](https://developer.mozilla.org/docs/Web/MathML) elements, attributes, and global attributes.
-
-- [svg/](https://github.com/mdn/browser-compat-data/tree/master/svg) contains data for [SVG](https://developer.mozilla.org/en-US/docs/Web/SVG) elements, attributes, and global attributes.
-
-- [webdriver/](https://github.com/mdn/browser-compat-data/tree/master/webdriver) contains data for [WebDriver](https://developer.mozilla.org/en-US/docs/Web/WebDriver) commands.
-
-- [webextensions/](https://github.com/mdn/browser-compat-data/tree/master/webextensions) contains data for [WebExtensions](https://developer.mozilla.org/en-US/Add-ons/WebExtensions) JavaScript APIs and manifest keys.
-
-- [xpath/](https://github.com/mdn/browser-compat-data/tree/master/xpath) contains data for [XPath](https://developer.mozilla.org/docs/Web/XPath) axes, and functions.
-
-- [xslt/](https://github.com/mdn/browser-compat-data/tree/master/xslt) contains data for [XSLT](https://developer.mozilla.org/docs/Web/XSLT) elements, attributes, and global attributes.
+- [api/](https://github.com/mdn/browser-compat-data/tree/master/api) contains
+  data for each [Web API](https://developer.mozilla.org/en-US/docs/Web/API)
+  interface.
+- [css/](https://github.com/mdn/browser-compat-data/tree/master/css) contains
+  data for [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS) properties,
+  selectors, and at-rules.
+- [html/](https://github.com/mdn/browser-compat-data/tree/master/html) contains
+  data for [HTML](https://developer.mozilla.org/en-US/docs/Web/HTML) elements,
+  attributes, and global attributes.
+- [http/](https://github.com/mdn/browser-compat-data/tree/master/http) contains
+  data for [HTTP](https://developer.mozilla.org/en-US/docs/Web/HTTP) headers,
+  statuses, and methods.
+- [javascript/](https://github.com/mdn/browser-compat-data/tree/master/javascript)
+  contains data for
+  [JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript) built-in
+  Objects, statement, operators, and other ECMAScript language features.
+- [mathml/](https://github.com/mdn/browser-compat-data/tree/master/mathml)
+  contains data for [MathML](https://developer.mozilla.org/docs/Web/MathML)
+  elements, attributes, and global attributes.
+- [svg/](https://github.com/mdn/browser-compat-data/tree/master/svg) contains
+  data for [SVG](https://developer.mozilla.org/en-US/docs/Web/SVG) elements,
+  attributes, and global attributes.
+- [webdriver/](https://github.com/mdn/browser-compat-data/tree/master/webdriver)
+  contains data for
+  [WebDriver](https://developer.mozilla.org/en-US/docs/Web/WebDriver) commands.
+- [webextensions/](https://github.com/mdn/browser-compat-data/tree/master/webextensions)
+  contains data for
+  [WebExtensions](https://developer.mozilla.org/en-US/Add-ons/WebExtensions)
+  JavaScript APIs and manifest keys.
+- [xpath/](https://github.com/mdn/browser-compat-data/tree/master/xpath)
+  contains data for [XPath](https://developer.mozilla.org/docs/Web/XPath) axes,
+  and functions.
+- [xslt/](https://github.com/mdn/browser-compat-data/tree/master/xslt) contains
+  data for [XSLT](https://developer.mozilla.org/docs/Web/XSLT) elements,
+  attributes, and global attributes.
 
 ### File and folder breakdown
-The JSON files contain [feature identifiers](#feature-identifiers),
-which are relevant for accessing the data. Except for the top-level directories,
-the file and sub-folder hierarchies aren't of any meaning for the exports.
-Compatibility data can be stored in a single large file or might be divided in
-smaller files and put into sub folders.
+
+The JSON files contain [feature identifiers](#feature-identifiers), which are
+relevant for accessing the data. Except for the top-level directories, the file
+and sub-folder hierarchies aren't of any meaning for the exports. Compatibility
+data can be stored in a single large file or might be divided in smaller files
+and put into sub folders.
 
 ## Understanding the schema
 
 #### Feature hierarchies
 
-Each feature is identified by a unique hierarchy of strings.
-E.g the `text-align` property is identified by `css.properties.text-align`.
+Each feature is identified by a unique hierarchy of strings. E.g the
+`text-align` property is identified by `css.properties.text-align`.
 
 In the JSON file it looks like this:
+
 ```json
 {
   "css": {
@@ -71,76 +89,103 @@ the project using the schema.
 
 #### Features
 
-A feature is described by an identifier containing the `__compat` property. In other words, identifiers without `__compat` aren't necessarily features, but help to nest the features properly.
+A feature is described by an identifier containing the `__compat` property. In
+other words, identifiers without `__compat` aren't necessarily features, but
+help to nest the features properly.
 
-When an identifier has a `__compat` block, it represents its basic support, indicating that a minimal implementation of a functionality is included.
-What it represents exactly depends of the evolution of the feature over time, both in terms of specifications and of browser support.
+When an identifier has a `__compat` block, it represents its basic support,
+indicating that a minimal implementation of a functionality is included. What it
+represents exactly depends of the evolution of the feature over time, both in
+terms of specifications and of browser support.
 
 #### Sub-features
 
-To add a sub-feature, a new identifier is added below the main feature at the level of a `__compat` object (see the sub-features "start" and "end" above). The same could be done for sub-sub-features. There is no depth limit.
+To add a sub-feature, a new identifier is added below the main feature at the
+level of a `__compat` object (see the sub-features "start" and "end" above). The
+same could be done for sub-sub-features. There is no depth limit.
 
-See [Data guidelines](/docs/data-guidelines.md) for more information about feature naming conventions and other best practices.
+See [Data guidelines](/docs/data-guidelines.md) for more information about
+feature naming conventions and other best practices.
 
 ### The `__compat` object
+
 The `__compat` object consists of the following:
 
-* A mandatory `support` property for __compat information__.
-An object listing the compatibility information for each browser ([see below](#the-support-object)).
-
-* An optional `description` property to __describe the feature__.
-A string containing a human-readable description of the feature.
-It is intended to be used as a caption or title and should be kept short.
-The `<code>` and `<a>` HTML elements can be used.
-
-* An optional `matches` property to __help match the feature to source code__ ([see below](#the-matches-object))
-An object that contains a keyword list or regex that can match values or tokens which correspond to the feature.
-
-* An optional `status` property for __status information__.
-An object containing information about the stability of the feature:
-Is it a functionality that is standard? Is it stable? Has it been deprecated and shouldn't be used anymore? ([see below](#status-information))
-
-* An optional `mdn_url` property which __points to an MDN reference page documenting the feature__.
-It needs to be a valid URL, and should be the language-neutral URL (e.g. use `https://developer.mozilla.org/docs/Web/CSS/text-align` instead of `https://developer.mozilla.org/en-US/docs/Web/CSS/text-align`).
-
-* An optional `spec_url` property as a URL or an array of URLs, each of which is for a specific part of a specification in which this feature is defined. Each URL must contain a fragment identifier (e.g. `https://tc39.es/proposal-promise-allSettled/#sec-promise.allsettled`).
+- A mandatory `support` property for __compat information__. An object listing
+  the compatibility information for each browser
+  ([see below](#the-support-object)).
+- An optional `description` property to __describe the feature__. A string
+  containing a human-readable description of the feature. It is intended to be
+  used as a caption or title and should be kept short. The `<code>` and `<a>`
+  HTML elements can be used.
+- An optional `matches` property to __help match the feature to source code__
+  ([see below](#the-matches-object)) An object that contains a keyword list or
+  regex that can match values or tokens which correspond to the feature.
+- An optional `status` property for __status information__. An object containing
+  information about the stability of the feature: Is it a functionality that is
+  standard? Is it stable? Has it been deprecated and shouldn't be used anymore?
+  ([see below](#status-information))
+- An optional `mdn_url` property which __points to an MDN reference page
+  documenting the feature__. It needs to be a valid URL, and should be the
+  language-neutral URL (e.g. use
+  `https://developer.mozilla.org/docs/Web/CSS/text-align` instead of
+  `https://developer.mozilla.org/en-US/docs/Web/CSS/text-align`).
+- An optional `spec_url` property as a URL or an array of URLs, each of which is
+  for a specific part of a specification in which this feature is defined. Each
+  URL must contain a fragment identifier (e.g.
+  `https://tc39.es/proposal-promise-allSettled/#sec-promise.allsettled`).
 
 ### The `support` object
-Each `__compat` object contains support information. For each browser identifier, it contains a [`support_statement`](#the-support_statement-object) object with
-information about versions, prefixes, or alternate names, as well as notes.
+
+Each `__compat` object contains support information. For each browser
+identifier, it contains a [`support_statement`](#the-support_statement-object)
+object with information about versions, prefixes, or alternate names, as well as
+notes.
 
 #### Browser identifiers
 
-The currently accepted browser identifiers should be declared in alphabetical order:
-* `chrome`, Google Chrome (on desktops)
-* `chrome_android`, Google Chrome (on Android)
-* `edge`, MS Edge (on Windows), based on the EdgeHTML version
-* `firefox`, Mozilla Firefox (on desktops)
-* `firefox_android`, Firefox for Android, sometimes nicknamed Fennec
-* `ie`, Microsoft Internet Explorer (discontinued)
-* `nodejs` Node.js JavaScript runtime built on Chrome's V8 JavaScript engine
-* `opera`, the Opera browser (desktop), based on Blink since Opera 15
-* `opera_android`, the Opera browser (Android version)
-* `qq_android`, the QQ browser (Android version)
-* `safari`, Safari on macOS
-* `safari_ios`, Safari on iOS, based on the iOS version
-* `samsunginternet_android`, the Samsung Internet browser (Android version)
-* `uc_android`, UC Browser (Android version)
-* `uc_chinese_android`, UC Browser (Chinese Android version)
-* `webview_android`, Webview, the former stock browser on Android
+The currently accepted browser identifiers should be declared in alphabetical
+order:
 
-Desktop browser identifiers are mandatory, with the `version_added` property set to `null` if support is unknown.
+- `chrome`, Google Chrome (on desktops)
+- `chrome_android`, Google Chrome (on Android)
+- `edge`, MS Edge (on Windows), based on the EdgeHTML version
+- `firefox`, Mozilla Firefox (on desktops)
+- `firefox_android`, Firefox for Android, sometimes nicknamed Fennec
+- `ie`, Microsoft Internet Explorer (discontinued)
+- `nodejs` Node.js JavaScript runtime built on Chrome's V8 JavaScript engine
+- `opera`, the Opera browser (desktop), based on Blink since Opera 15
+- `opera_android`, the Opera browser (Android version)
+- `qq_android`, the QQ browser (Android version)
+- `safari`, Safari on macOS
+- `safari_ios`, Safari on iOS, based on the iOS version
+- `samsunginternet_android`, the Samsung Internet browser (Android version)
+- `uc_android`, UC Browser (Android version)
+- `uc_chinese_android`, UC Browser (Chinese Android version)
+- `webview_android`, Webview, the former stock browser on Android
+
+Desktop browser identifiers are mandatory, with the `version_added` property set
+to `null` if support is unknown.
 
 #### The `support_statement` object
-The `support_statement` object describes the support provided by a single browser type for the given subfeature.
-It is an array of `simple_support_statement` objects, but if there
-is only one of them, the array must be omitted.
 
-If there is an array, the `simple_support_statement` objects should be sorted with the most relevant and general entries first.
-In other words, sort such arrays with entries applying to the most recent browser releases first and sort entries with prefixes or flags after those without.
-If in doubt, reverse-chronological order with respect to the `"version_removed"` and then `"version_added"` values usually works well. For more information on sorting support statements, see [#1596](https://github.com/mdn/browser-compat-data/issues/1596).
+The `support_statement` object describes the support provided by a single
+browser type for the given subfeature. It is an array of
+`simple_support_statement` objects, but if there is only one of them, the array
+must be omitted.
 
-Example of a `support` compat object (with an `array_support_statement` containing 2 entries):
+If there is an array, the `simple_support_statement` objects should be sorted
+with the most relevant and general entries first. In other words, sort such
+arrays with entries applying to the most recent browser releases first and sort
+entries with prefixes or flags after those without. If in doubt,
+reverse-chronological order with respect to the `"version_removed"` and then
+`"version_added"` values usually works well. For more information on sorting
+support statements, see
+[#1596](https://github.com/mdn/browser-compat-data/issues/1596).
+
+Example of a `support` compat object (with an `array_support_statement`
+containing 2 entries):
+
 ```json
 "support": {
   "firefox": [
@@ -157,6 +202,7 @@ Example of a `support` compat object (with an `array_support_statement` containi
 ```
 
 Example of a `support` compat object (with 1 entry, array omitted):
+
 ```json
 "support": {
   "ie": { "version_added": "6.0" }
@@ -164,72 +210,83 @@ Example of a `support` compat object (with 1 entry, array omitted):
 ```
 
 ### Compat data in support statements
-The `simple_support_statement` object is the core object containing the compatibility information for a browser.
-It consist of the following properties:
+
+The `simple_support_statement` object is the core object containing the
+compatibility information for a browser. It consist of the following properties:
 
 #### `version_added`
-This is the only mandatory property and it contains a string with the version
-number indicating when a sub-feature has been added (and is therefore supported).
-The Boolean values indicate that a sub-feature is supported (`true`, with the
-additional meaning that it is unknown in which version support was added) or
-not supported (`false`). A value of `null` indicates that support information is
-entirely unknown. Examples:
 
-* Support from version 3.5 (inclusive):
-```json
-{
- "version_added": "3.5"
-}
-```
-* Supported, but version unknown:
-```json
-{
-  "version_added": true
-}
-```
-* No support:
-```json
-{
-  "version_added": false
-}
-```
-* Support unknown (default value, if browser omitted):
-```json
-{
-  "version_added": null
-}
-```
+This is the only mandatory property and it contains a string with the version
+number indicating when a sub-feature has been added (and is therefore
+supported). The Boolean values indicate that a sub-feature is supported (`true`,
+with the additional meaning that it is unknown in which version support was
+added) or not supported (`false`). A value of `null` indicates that support
+information is entirely unknown. Examples:
+
+- Support from version 3.5 (inclusive):
+  ```json
+  {
+    "version_added": "3.5"
+  }
+  ```
+- Supported, but version unknown:
+  ```json
+  {
+    "version_added": true
+  }
+  ```
+- No support:
+  ```json
+  {
+    "version_added": false
+  }
+  ```
+- Support unknown (default value, if browser omitted):
+  ```json
+  {
+    "version_added": null
+  }
+  ```
 
 #### `version_removed`
-Contains a string with the version number the sub-feature was
-removed in. It may also be a Boolean value of (`true` or `false`), or the
-`null` value.
+
+Contains a string with the version number the sub-feature was removed in. It may
+also be a Boolean value of (`true` or `false`), or the `null` value.
 
 Default values:
-* If `version_added` is set to `true`, `false`, or a string, `version_removed` defaults to `false`.
-* if `version_added` is set to `null`, the default value of `version_removed` is also `null`.
+
+- If `version_added` is set to `true`, `false`, or a string, `version_removed`
+  defaults to `false`.
+- if `version_added` is set to `null`, the default value of `version_removed` is
+  also `null`.
 
 Examples:
 
-* Removed in version 10 (added in 3.5):
-```json
-{
-  "version_added": "3.5",
-  "version_removed": "10"
-}
-```
-* Not removed (default if `version_added` is not `null`):
-```json
-{
-  "version_added": "3.5",
-  "version_removed": false
-}
-```
+- Removed in version 10 (added in 3.5):
+  ```json
+  {
+    "version_added": "3.5",
+    "version_removed": "10"
+  }
+  ```
+- Not removed (default if `version_added` is not `null`):
+  ```json
+  {
+    "version_added": "3.5",
+    "version_removed": false
+  }
+  ```
 
 ### Ranged versions
 
-For certain browsers, ranged versions are allowed as it is sometimes impossible to find out in which early version of a browser a feature shipped. The statement below means "supported in at least version 37 and probably in earlier versions as well".
-Currently, the only allowed ranged version is `"≤37"` for `webview_android`. There will be more ranged versions for other browsers in the future but ranged versions aren't generally allowed for every version string. Ranged versions should be used sparingly and only when it is impossible to find out the version number a feature initially shipped in.
+For certain browsers, ranged versions are allowed as it is sometimes impossible
+to find out in which early version of a browser a feature shipped. The statement
+below means "supported in at least version 37 and probably in earlier versions
+as well". Currently, the only allowed ranged version is `"≤37"` for
+`webview_android`. There will be more ranged versions for other browsers in the
+future but ranged versions aren't generally allowed for every version string.
+Ranged versions should be used sparingly and only when it is impossible to find
+out the version number a feature initially shipped in.
 
 ```json
 {
@@ -238,54 +295,64 @@ Currently, the only allowed ranged version is `"≤37"` for `webview_android`. T
 ```
 
 #### `prefix`
-A prefix to add to the sub-feature name (defaults to empty string).
-If applicable, leading and trailing `-` must be included.
+
+A prefix to add to the sub-feature name (defaults to empty string). If
+applicable, leading and trailing `-` must be included.
 
 Examples:
 
-* A CSS property with a standard name of `prop-name` and a vendor-prefixed name of `-moz-prop-name`:
-```json
-{
-  "prefix": "-moz-",
-  "version_added": "3.5"
-}
-```
-
-* An API with a standard name of `FeatureName` and a vendor-prefixed name of `webkitFeatureName`:
-```json
-{
-  "prefix": "webkit",
-  "version_added": "9"
-}
-```
+- A CSS property with a standard name of `prop-name` and a vendor-prefixed name
+  of `-moz-prop-name`:
+  ```json
+  {
+    "prefix": "-moz-",
+    "version_added": "3.5"
+  }
+  ```
+- An API with a standard name of `FeatureName` and a vendor-prefixed name of
+  `webkitFeatureName`:
+  ```json
+  {
+    "prefix": "webkit",
+    "version_added": "9"
+  }
+  ```
 
 #### `alternative_name`
-In some cases features are named entirely differently and not just prefixed. Example:
 
-* Prefixed version had a different capitalization
-```json
-{
-  "alternative_name": "mozRequestFullScreen",
-  "version_added": "true",
-  "version_removed": "9.0"
-}
-```
+In some cases features are named entirely differently and not just prefixed.
+Example:
+
+- Prefixed version had a different capitalization
+  ```json
+  {
+    "alternative_name": "mozRequestFullScreen",
+    "version_added": "true",
+    "version_removed": "9.0"
+  }
+  ```
 
 Note that you can’t have both `prefix` and `alternative_name`.
 
 #### `flags`
-An optional array of objects describing flags that must be configured for this browser to support this feature. Usually this
-array will have one item, but there are cases where two or more flags can be required to activate a feature.
+
+An optional array of objects describing flags that must be configured for this
+browser to support this feature. Usually this array will have one item, but
+there are cases where two or more flags can be required to activate a feature.
 An object in the `flags` array consists of three properties:
-* `type` (mandatory): an enum that indicates the flag type:
-  * `preference` a flag the user can set (like in `about:config` in Firefox).
-  * `runtime_flag` a flag to be set before starting the browser.
-* `name` (mandatory): a string giving the value which the specified flag must be set to for this feature to work.
-* `value_to_set` (optional): representing the actual value to set the flag to.
-It is a string, that may be converted to the right type
-(that is `true` or `false` for Boolean value, or `4` for an integer value). It doesn't need to be enclosed in `<code>` tags.
+
+- `type` (mandatory): an enum that indicates the flag type:
+  - `preference` a flag the user can set (like in `about:config` in Firefox).
+  - `runtime_flag` a flag to be set before starting the browser.
+- `name` (mandatory): a string giving the value which the specified flag must be
+  set to for this feature to work.
+- `value_to_set` (optional): representing the actual value to set the flag to.
+  It is a string, that may be converted to the right type (that is `true` or
+  `false` for Boolean value, or `4` for an integer value). It doesn't need to be
+  enclosed in `<code>` tags.
 
 Example for one flag required:
+
 ```json
 {
   "version_added": true,
@@ -298,7 +365,9 @@ Example for one flag required:
   ]
 }
 ```
+
 Example for two flags required:
+
 ```json
 {
   "version_added": true,
@@ -318,68 +387,93 @@ Example for two flags required:
 ```
 
 #### `partial_implementation`
-A `boolean` value indicating whether or not the implementation of the sub-feature
-deviates from the specification in a way that may cause significant compatibility problems.
-It defaults to `false` (no interoperability problems expected). If set to `true`, it is
-recommended that you add a note explaining how it diverges from the standard (such as
-that it implements an old version of the standard, for example).
+
+A `boolean` value indicating whether or not the implementation of the
+sub-feature deviates from the specification in a way that may cause significant
+compatibility problems. It defaults to `false` (no interoperability problems
+expected). If set to `true`, it is recommended that you add a note explaining
+how it diverges from the standard (such as that it implements an old version of
+the standard, for example).
 
 #### `notes`
-A string or `array` of strings containing additional information. If there is only one
-entry, the value of `notes` must simply be a string instead of an array.
+
+A string or `array` of strings containing additional information. If there is
+only one entry, the value of `notes` must simply be a string instead of an
+array.
 
 Example:
 
-* Indicating a restriction:
-```json
-{
-  "version_added": "3.5",
-  "notes": [
-    "Does not work on ::first-letter pseudo-elements.",
-    "Has not been updated to the latest specification, see <a href='https://bugzil.la/1234567'>bug 1234567</a>."
-  ]
-}
-```
-The `<code>` and `<a>` HTML elements can be used.
+- Indicating a restriction:
+  ```json
+  {
+    "version_added": "3.5",
+    "notes": [
+      "Does not work on ::first-letter pseudo-elements.",
+      "Has not been updated to the latest specification, see <a href='https://bugzil.la/1234567'>bug 1234567</a>."
+    ]
+  }
+  ```
+  The `<code>` and `<a>` HTML elements can be used.
 
 ### The `matches` object
 
-A `matches` object contains hints to help automatically detect whether source code corresponds to a feature, such as a list of keywords or a regular expression. A `matches` object may have one of the following properties (in order of preference):
+A `matches` object contains hints to help automatically detect whether source
+code corresponds to a feature, such as a list of keywords or a regular
+expression. A `matches` object may have one of the following properties (in
+order of preference):
 
-* `keywords`: an array of one or more literal strings that correspond to the feature.
-
-  Examples:
-
-  - In CSS selector features, they can be literal selectors. See [`css.selectors.backdrop`](../css/selectors/backdrop.json)).
-  - In CSS property subfeatures, they can be data type keywords or function keywords. See [`css.properties.transform.3d`](../css/properties/transform.json)).
-
-* `regex_token`: a string containing a regular expression that matches a single token (i.e., text delimited by characters that are excluded from the text to be matched) corresponding to the feature.
-
-  Tests are required for all regular expressions. See [`test-regexes.js`](../tests/test-regexes.js).
+- `keywords`: an array of one or more literal strings that correspond to the
+  feature.
 
   Examples:
 
-  - In CSS property subfeatures, they can be regular expressions that match component value types. See [`css.properties.color.alpha_hexadecimal_notation`](../css/properties/color.json) and corresponding tests.
+  - In CSS selector features, they can be literal selectors. See
+    [`css.selectors.backdrop`](../css/selectors/backdrop.json)).
+  - In CSS property subfeatures, they can be data type keywords or function
+    keywords. See
+    [`css.properties.transform.3d`](../css/properties/transform.json)).
 
-* `regex_value`: a string containing a regular expression that matches a complete value corresponding to the feature.
+- `regex_token`: a string containing a regular expression that matches a single
+  token (i.e., text delimited by characters that are excluded from the text to
+  be matched) corresponding to the feature.
 
-  Tests are required for all regular expressions. See [`test-regexes.js`](../tests/test-regexes.js).
+  Tests are required for all regular expressions. See
+  [`test-regexes.js`](../tests/test-regexes.js).
 
   Examples:
 
-  - In CSS property subfeatures, these can be regular expressions that match whole declaration values. See [`css.properties.transform-origin.three_value_syntax`](../css/properties/transform.json) and corresponding tests.
+  - In CSS property subfeatures, they can be regular expressions that match
+    component value types. See
+    [`css.properties.color.alpha_hexadecimal_notation`](../css/properties/color.json)
+    and corresponding tests.
+
+- `regex_value`: a string containing a regular expression that matches a
+  complete value corresponding to the feature.
+
+  Tests are required for all regular expressions. See
+  [`test-regexes.js`](../tests/test-regexes.js).
+
+  Examples:
+
+  - In CSS property subfeatures, these can be regular expressions that match
+    whole declaration values. See
+    [`css.properties.transform-origin.three_value_syntax`](../css/properties/transform.json)
+    and corresponding tests.
 
 ### Status information
+
 The status property contains information about stability of the feature. It is
 an optional object named `status` and has three mandatory properties:
-* `experimental`: a `boolean` value that indicates this functionality is
-intended to be an addition to the Web platform. Some features are added to
-conduct tests. Set to `false`, it means the functionality is mature, and no
-significant incompatible changes are expected in the future.
-* `standard_track`: a `boolean` value indicating if the feature is part of an
-active specification or specification process.
-* `deprecated`: a `boolean` value that indicates if the feature is no longer recommended.
-It might be removed in the future or might only be kept for compatibility purposes. Avoid using this functionality.
+
+- `experimental`: a `boolean` value that indicates this functionality is
+  intended to be an addition to the Web platform. Some features are added to
+  conduct tests. Set to `false`, it means the functionality is mature, and no
+  significant incompatible changes are expected in the future.
+- `standard_track`: a `boolean` value indicating if the feature is part of an
+  active specification or specification process.
+- `deprecated`: a `boolean` value that indicates if the feature is no longer
+  recommended. It might be removed in the future or might only be kept for
+  compatibility purposes. Avoid using this functionality.
 
 ```json
 "__compat": {
@@ -392,6 +486,8 @@ It might be removed in the future or might only be kept for compatibility purpos
 ```
 
 ### Localization
-We are planning to localize some of this data (e.g. notes, descriptions).
-At this point we haven't decided how or when we are going to do that.
-See [issue 114](https://github.com/mdn/browser-compat-data/issues/114) for more information.
+
+We are planning to localize some of this data (e.g. notes, descriptions). At
+this point we haven't decided how or when we are going to do that. See
+[issue 114](https://github.com/mdn/browser-compat-data/issues/114) for more
+information.


### PR DESCRIPTION
This patch aims to improve the Markdown documentation files in the following areas.

1. Consistency. The files, while written in the same language, differed a lot in formatting. Some have blank lines before/after headers, some not; some used hyphen‐minus as list delimiters, while others had asterisks.
2. Readability. The files were unreadable in text editors that don’t understand “word wrapping” on wide screen. Moreover, such long lines make reviewing diffs much too hard. I’ve reformatted the files to fit in 80 Unicode characters per line, except links as none of the editors I’ve tried supports line breaks in links. Adding line breaks in links is still something worth consideration as they seem to be allowed both in CommonMark and Pandoc Markdown.

I purposely haven’t fixed any punctuation/grammar errors or inconsistencies.

Unfortunately, this patch may break other pending documentation patches.