### PR TITLE
Update Edge and IE typed arrays compat data

### DIFF
--- a/javascript/builtins/Float32Array.json
+++ b/javascript/builtins/Float32Array.json
@@ -114,7 +114,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "52"

--- a/javascript/builtins/Float32Array.json
+++ b/javascript/builtins/Float32Array.json
@@ -63,7 +63,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "55"

--- a/javascript/builtins/Float32Array.json
+++ b/javascript/builtins/Float32Array.json
@@ -72,7 +72,7 @@
                 "version_added": "55"
               },
               "ie": {
-                "version_added": null
+                "version_added": "10"
               },
               "nodejs": {
                 "version_added": null
@@ -123,7 +123,7 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "nodejs": {
                 "version_added": "4.0.0"

--- a/javascript/builtins/Float64Array.json
+++ b/javascript/builtins/Float64Array.json
@@ -114,7 +114,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "52"

--- a/javascript/builtins/Float64Array.json
+++ b/javascript/builtins/Float64Array.json
@@ -63,7 +63,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "55"

--- a/javascript/builtins/Float64Array.json
+++ b/javascript/builtins/Float64Array.json
@@ -72,7 +72,7 @@
                 "version_added": "55"
               },
               "ie": {
-                "version_added": null
+                "version_added": "10"
               },
               "nodejs": {
                 "version_added": null
@@ -123,7 +123,7 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "nodejs": {
                 "version_added": "4.0.0"

--- a/javascript/builtins/Int16Array.json
+++ b/javascript/builtins/Int16Array.json
@@ -13,7 +13,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "4"

--- a/javascript/builtins/Int16Array.json
+++ b/javascript/builtins/Int16Array.json
@@ -165,7 +165,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "44"

--- a/javascript/builtins/Int16Array.json
+++ b/javascript/builtins/Int16Array.json
@@ -114,7 +114,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "52"

--- a/javascript/builtins/Int16Array.json
+++ b/javascript/builtins/Int16Array.json
@@ -63,7 +63,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "55"

--- a/javascript/builtins/Int16Array.json
+++ b/javascript/builtins/Int16Array.json
@@ -72,7 +72,7 @@
                 "version_added": "55"
               },
               "ie": {
-                "version_added": null
+                "version_added": "10"
               },
               "nodejs": {
                 "version_added": null
@@ -123,7 +123,7 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "nodejs": {
                 "version_added": "4.0.0"

--- a/javascript/builtins/Int32Array.json
+++ b/javascript/builtins/Int32Array.json
@@ -13,7 +13,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "4"

--- a/javascript/builtins/Int32Array.json
+++ b/javascript/builtins/Int32Array.json
@@ -165,7 +165,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "44"

--- a/javascript/builtins/Int32Array.json
+++ b/javascript/builtins/Int32Array.json
@@ -114,7 +114,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "52"

--- a/javascript/builtins/Int32Array.json
+++ b/javascript/builtins/Int32Array.json
@@ -63,7 +63,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "55"

--- a/javascript/builtins/Int32Array.json
+++ b/javascript/builtins/Int32Array.json
@@ -72,7 +72,7 @@
                 "version_added": "55"
               },
               "ie": {
-                "version_added": null
+                "version_added": "10"
               },
               "nodejs": {
                 "version_added": null
@@ -123,7 +123,7 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "nodejs": {
                 "version_added": "4.0.0"

--- a/javascript/builtins/Int8Array.json
+++ b/javascript/builtins/Int8Array.json
@@ -13,7 +13,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "4"

--- a/javascript/builtins/Int8Array.json
+++ b/javascript/builtins/Int8Array.json
@@ -165,7 +165,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "44"

--- a/javascript/builtins/Int8Array.json
+++ b/javascript/builtins/Int8Array.json
@@ -114,7 +114,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "52"

--- a/javascript/builtins/Int8Array.json
+++ b/javascript/builtins/Int8Array.json
@@ -63,7 +63,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "55"

--- a/javascript/builtins/Int8Array.json
+++ b/javascript/builtins/Int8Array.json
@@ -72,7 +72,7 @@
                 "version_added": "55"
               },
               "ie": {
-                "version_added": null
+                "version_added": "10"
               },
               "nodejs": {
                 "version_added": null
@@ -123,7 +123,7 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "nodejs": {
                 "version_added": "4.0.0"

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -13,7 +13,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "4"

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -855,7 +855,8 @@
                 "notes": "Negative integers are not considered as indexed properties and therefore return the value of the prototype property."
               },
               "edge": {
-                "version_added": null
+                "version_added": "12",
+                "notes": "Negative integers are not considered as indexed properties and therefore return the value of the prototype property."
               },
               "firefox": {
                 "version_added": "25"

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -964,7 +964,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "52"

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -1435,7 +1435,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "44"

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -64,7 +64,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "4"
@@ -1333,7 +1333,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "4"
@@ -1384,7 +1384,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "30"
@@ -1539,7 +1539,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "4"
@@ -2007,7 +2007,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "51"
@@ -2059,7 +2059,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "51"

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -271,7 +271,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "55"

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -2164,7 +2164,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": [
                 {
@@ -2244,7 +2244,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "13"
               },
               "firefox": {
                 "version_added": "48"

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -974,7 +974,7 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": "10"
+                "version_added": false
               },
               "nodejs": {
                 "version_added": "4.0.0"
@@ -2069,7 +2069,7 @@
                 "version_added": "51"
               },
               "ie": {
-                "version_added": false
+                "version_added": "10"
               },
               "nodejs": {
                 "version_added": null

--- a/javascript/builtins/Uint16Array.json
+++ b/javascript/builtins/Uint16Array.json
@@ -13,7 +13,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "4"

--- a/javascript/builtins/Uint16Array.json
+++ b/javascript/builtins/Uint16Array.json
@@ -165,7 +165,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "44"

--- a/javascript/builtins/Uint16Array.json
+++ b/javascript/builtins/Uint16Array.json
@@ -114,7 +114,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "52"

--- a/javascript/builtins/Uint16Array.json
+++ b/javascript/builtins/Uint16Array.json
@@ -63,7 +63,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "55"

--- a/javascript/builtins/Uint16Array.json
+++ b/javascript/builtins/Uint16Array.json
@@ -72,7 +72,7 @@
                 "version_added": "55"
               },
               "ie": {
-                "version_added": null
+                "version_added": "10"
               },
               "nodejs": {
                 "version_added": null
@@ -123,7 +123,7 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "nodejs": {
                 "version_added": "4.0.0"

--- a/javascript/builtins/Uint32Array.json
+++ b/javascript/builtins/Uint32Array.json
@@ -13,7 +13,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "4"

--- a/javascript/builtins/Uint32Array.json
+++ b/javascript/builtins/Uint32Array.json
@@ -165,7 +165,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "44"

--- a/javascript/builtins/Uint32Array.json
+++ b/javascript/builtins/Uint32Array.json
@@ -114,7 +114,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "52"

--- a/javascript/builtins/Uint32Array.json
+++ b/javascript/builtins/Uint32Array.json
@@ -63,7 +63,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "55"

--- a/javascript/builtins/Uint32Array.json
+++ b/javascript/builtins/Uint32Array.json
@@ -72,7 +72,7 @@
                 "version_added": "55"
               },
               "ie": {
-                "version_added": null
+                "version_added": "10"
               },
               "nodejs": {
                 "version_added": null
@@ -123,7 +123,7 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "nodejs": {
                 "version_added": "4.0.0"

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -13,7 +13,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "4"

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -165,7 +165,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "44"

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -114,7 +114,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "52"

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -63,7 +63,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "55"

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -72,7 +72,7 @@
                 "version_added": "55"
               },
               "ie": {
-                "version_added": null
+                "version_added": "10"
               },
               "nodejs": {
                 "version_added": null
@@ -123,7 +123,7 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "nodejs": {
                 "version_added": "4.0.0"

--- a/javascript/builtins/Uint8ClampedArray.json
+++ b/javascript/builtins/Uint8ClampedArray.json
@@ -13,7 +13,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "4"

--- a/javascript/builtins/Uint8ClampedArray.json
+++ b/javascript/builtins/Uint8ClampedArray.json
@@ -165,7 +165,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "44"

--- a/javascript/builtins/Uint8ClampedArray.json
+++ b/javascript/builtins/Uint8ClampedArray.json
@@ -114,7 +114,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "52"

--- a/javascript/builtins/Uint8ClampedArray.json
+++ b/javascript/builtins/Uint8ClampedArray.json
@@ -63,7 +63,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "55"

--- a/javascript/builtins/Uint8ClampedArray.json
+++ b/javascript/builtins/Uint8ClampedArray.json
@@ -72,7 +72,7 @@
                 "version_added": "55"
               },
               "ie": {
-                "version_added": null
+                "version_added": "10"
               },
               "nodejs": {
                 "version_added": null
@@ -123,7 +123,7 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "nodejs": {
                 "version_added": "4.0.0"


### PR DESCRIPTION
This is a test PR to measure how long it takes to update a chunk of Edge JS compat data. It updates 45 data points and I've spend 1h on it. Please let me know how long you spend reviewing.

Most of these things were figured out by testing in Saucelabs or by making sense of the data that was already provided. If have used several commits to record my thought process.