### PR TITLE
Un-deprecate HTML ol type attribute per specs

### DIFF
--- a/html/elements/ol.json
+++ b/html/elements/ol.json
@@ -231,8 +231,8 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
-              "deprecated": true
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }


### PR DESCRIPTION
The "type" attribute of the "ol" HTML element was deprecated in HTML4, but then un-deprecated in HTML5 and Living Standard, for purpose of ordered list item markers which convey meaning. See MDN for more background and links to specs: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol