### PR TITLE
Add Chromium versions for iterable in TypedArray + derivatives constructor

### DIFF
--- a/javascript/builtins/Float32Array.json
+++ b/javascript/builtins/Float32Array.json
@@ -108,10 +108,10 @@
             "description": "Iterable in constructor",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "39"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "39"
               },
               "edge": {
                 "version_added": null
@@ -129,10 +129,10 @@
                 "version_added": "4.0.0"
               },
               "opera": {
-                "version_added": null
+                "version_added": "26"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "26"
               },
               "safari": {
                 "version_added": null
@@ -141,10 +141,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "39"
               }
             },
             "status": {

--- a/javascript/builtins/Float64Array.json
+++ b/javascript/builtins/Float64Array.json
@@ -108,10 +108,10 @@
             "description": "Iterable in constructor",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "39"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "39"
               },
               "edge": {
                 "version_added": null
@@ -129,10 +129,10 @@
                 "version_added": "4.0.0"
               },
               "opera": {
-                "version_added": null
+                "version_added": "26"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "26"
               },
               "safari": {
                 "version_added": null
@@ -141,10 +141,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "39"
               }
             },
             "status": {

--- a/javascript/builtins/Int16Array.json
+++ b/javascript/builtins/Int16Array.json
@@ -108,10 +108,10 @@
             "description": "Iterable in constructor",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "39"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "39"
               },
               "edge": {
                 "version_added": null
@@ -129,10 +129,10 @@
                 "version_added": "4.0.0"
               },
               "opera": {
-                "version_added": null
+                "version_added": "26"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "26"
               },
               "safari": {
                 "version_added": null
@@ -141,10 +141,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "39"
               }
             },
             "status": {

--- a/javascript/builtins/Int32Array.json
+++ b/javascript/builtins/Int32Array.json
@@ -108,10 +108,10 @@
             "description": "Iterable in constructor",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "39"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "39"
               },
               "edge": {
                 "version_added": null
@@ -129,10 +129,10 @@
                 "version_added": "4.0.0"
               },
               "opera": {
-                "version_added": null
+                "version_added": "26"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "26"
               },
               "safari": {
                 "version_added": null
@@ -141,10 +141,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "39"
               }
             },
             "status": {

--- a/javascript/builtins/Int8Array.json
+++ b/javascript/builtins/Int8Array.json
@@ -108,10 +108,10 @@
             "description": "Iterable in constructor",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "39"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "39"
               },
               "edge": {
                 "version_added": null
@@ -129,10 +129,10 @@
                 "version_added": "4.0.0"
               },
               "opera": {
-                "version_added": null
+                "version_added": "26"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "26"
               },
               "safari": {
                 "version_added": null
@@ -141,10 +141,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "39"
               }
             },
             "status": {

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -958,10 +958,10 @@
             "description": "Iterable in constructor",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "39"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "39"
               },
               "edge": {
                 "version_added": null
@@ -979,10 +979,10 @@
                 "version_added": "4.0.0"
               },
               "opera": {
-                "version_added": null
+                "version_added": "26"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "26"
               },
               "safari": {
                 "version_added": null
@@ -991,10 +991,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "39"
               }
             },
             "status": {

--- a/javascript/builtins/Uint16Array.json
+++ b/javascript/builtins/Uint16Array.json
@@ -108,10 +108,10 @@
             "description": "Iterable in constructor",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "39"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "39"
               },
               "edge": {
                 "version_added": null
@@ -129,10 +129,10 @@
                 "version_added": "4.0.0"
               },
               "opera": {
-                "version_added": null
+                "version_added": "26"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "26"
               },
               "safari": {
                 "version_added": null
@@ -141,10 +141,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "39"
               }
             },
             "status": {

--- a/javascript/builtins/Uint32Array.json
+++ b/javascript/builtins/Uint32Array.json
@@ -108,10 +108,10 @@
             "description": "Iterable in constructor",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "39"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "39"
               },
               "edge": {
                 "version_added": null
@@ -129,10 +129,10 @@
                 "version_added": "4.0.0"
               },
               "opera": {
-                "version_added": null
+                "version_added": "26"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "26"
               },
               "safari": {
                 "version_added": null
@@ -141,10 +141,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "39"
               }
             },
             "status": {

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -108,10 +108,10 @@
             "description": "Iterable in constructor",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "39"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "39"
               },
               "edge": {
                 "version_added": null
@@ -129,10 +129,10 @@
                 "version_added": "4.0.0"
               },
               "opera": {
-                "version_added": null
+                "version_added": "26"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "26"
               },
               "safari": {
                 "version_added": null
@@ -141,10 +141,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "39"
               }
             },
             "status": {

--- a/javascript/builtins/Uint8ClampedArray.json
+++ b/javascript/builtins/Uint8ClampedArray.json
@@ -108,10 +108,10 @@
             "description": "Iterable in constructor",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "39"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "39"
               },
               "edge": {
                 "version_added": null
@@ -129,10 +129,10 @@
                 "version_added": "4.0.0"
               },
               "opera": {
-                "version_added": null
+                "version_added": "26"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "26"
               },
               "safari": {
                 "version_added": null
@@ -141,10 +141,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "39"
               }
             },
             "status": {


### PR DESCRIPTION
Based upon manual testing, this PR adds the `iterable_in_constructor` Chromium version for the `TypedArray` builtins.  (I've tested each interface independently.)