### PR TITLE
Update Chromium (+ Safari values) for Array and ArrayBuffer built-ins

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -1913,10 +1913,10 @@
               "description": "Optional <code>locales</code> parameter",
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": "24"
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": "25"
                 },
                 "edge": {
                   "version_added": null
@@ -1934,22 +1934,22 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "15"
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": "14"
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": "6.1"
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": "6.1"
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "2.0"
                 },
                 "webview_android": {
-                  "version_added": null
+                  "version_added": "≤37"
                 }
               },
               "status": {
@@ -1964,10 +1964,10 @@
               "description": "Optional <code>options</code> parameter",
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": "24"
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": "25"
                 },
                 "edge": {
                   "version_added": null
@@ -1985,22 +1985,22 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "15"
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": "14"
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": "6.1"
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": "6.1"
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "2.0"
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "≤37"
                 }
               },
               "status": {
@@ -2372,10 +2372,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-get-array-@@species",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "51"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "51"
               },
               "edge": {
                 "version_added": false
@@ -2404,10 +2404,10 @@
                 }
               ],
               "opera": {
-                "version_added": null
+                "version_added": "38"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "41"
               },
               "safari": {
                 "version_added": null
@@ -2416,10 +2416,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "51"
               }
             },
             "status": {
@@ -2435,10 +2435,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-array.prototype-@@unscopables",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "38"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "12"
@@ -2456,10 +2456,10 @@
                 "version_added": "0.12"
               },
               "opera": {
-                "version_added": null
+                "version_added": "25"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "25"
               },
               "safari": {
                 "version_added": null
@@ -2468,10 +2468,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "3.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "38"
               }
             },
             "status": {

--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -371,10 +371,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-get-arraybuffer-@@species",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "51"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "51"
               },
               "edge": {
                 "version_added": "13"
@@ -403,10 +403,10 @@
                 }
               ],
               "opera": {
-                "version_added": null
+                "version_added": "38"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "38"
               },
               "safari": {
                 "version_added": null
@@ -415,10 +415,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "51"
               }
             },
             "status": {

--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -406,7 +406,7 @@
                 "version_added": "38"
               },
               "opera_android": {
-                "version_added": "38"
+                "version_added": "41"
               },
               "safari": {
                 "version_added": null


### PR DESCRIPTION
This PR sets Chromium values (and a Safari value) for `Array` and `ArrayBuffer` built-ins.  Values were determined via manual testing in Chrome.

`javascript.builtins.Array.toLocaleString.locales` - 24
`javascript.builtins.Array.toLocaleString.options` - 24
`javascript.builtins.Array.@@species` - 51
`javascript.builtins.Array.@@unscopables` - 38
`javascript.builtins.ArrayBuffer.@@species` - 51