### PR TITLE
Set Chromium versions for various JavaScript functions features

### DIFF
--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -431,10 +431,10 @@
           "description": "Block-level functions",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "49"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "edge": {
               "version_added": null
@@ -452,10 +452,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "36"
             },
             "safari": {
               "version_added": null
@@ -464,10 +464,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "49"
             }
           },
           "status": {
@@ -792,10 +792,10 @@
             "description": "Async generator methods",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "55"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "55"
               },
               "edge": {
                 "version_added": null
@@ -824,10 +824,10 @@
                 }
               ],
               "opera": {
-                "version_added": null
+                "version_added": "42"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "42"
               },
               "safari": {
                 "version_added": false
@@ -836,10 +836,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "6.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "55"
               }
             },
             "status": {
@@ -854,10 +854,10 @@
             "description": "Async methods",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "63"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "63"
               },
               "edge": {
                 "version_added": null
@@ -886,10 +886,10 @@
                 }
               ],
               "opera": {
-                "version_added": null
+                "version_added": "50"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "46"
               },
               "safari": {
                 "version_added": false
@@ -898,10 +898,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "8.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "63"
               }
             },
             "status": {
@@ -916,10 +916,10 @@
             "description": "Generator methods are not constructable (ES2016)",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "42"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "42"
               },
               "edge": {
                 "version_added": null
@@ -937,10 +937,10 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": "29"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "29"
               },
               "safari": {
                 "version_added": false
@@ -949,10 +949,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "42"
               }
             },
             "status": {

--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -792,10 +792,10 @@
             "description": "Async generator methods",
             "support": {
               "chrome": {
-                "version_added": "55"
+                "version_added": "63"
               },
               "chrome_android": {
-                "version_added": "55"
+                "version_added": "63"
               },
               "edge": {
                 "version_added": null
@@ -824,10 +824,10 @@
                 }
               ],
               "opera": {
-                "version_added": "42"
+                "version_added": "50"
               },
               "opera_android": {
-                "version_added": "42"
+                "version_added": "46"
               },
               "safari": {
                 "version_added": false
@@ -836,10 +836,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": "6.0"
+                "version_added": "8.0"
               },
               "webview_android": {
-                "version_added": "55"
+                "version_added": "63"
               }
             },
             "status": {
@@ -854,10 +854,10 @@
             "description": "Async methods",
             "support": {
               "chrome": {
-                "version_added": "63"
+                "version_added": "55"
               },
               "chrome_android": {
-                "version_added": "63"
+                "version_added": "55"
               },
               "edge": {
                 "version_added": null
@@ -886,10 +886,10 @@
                 }
               ],
               "opera": {
-                "version_added": "50"
+                "version_added": "42"
               },
               "opera_android": {
-                "version_added": "46"
+                "version_added": "42"
               },
               "safari": {
                 "version_added": false
@@ -898,10 +898,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": "8.0"
+                "version_added": "6.0"
               },
               "webview_android": {
-                "version_added": "63"
+                "version_added": "55"
               }
             },
             "status": {


### PR DESCRIPTION
This PR sets Chromium versions for several features in JavaScript functions features based upon manual testing.

`javascript.functions.block_level_functions` - 49
`javascript.functions.method_definitions.async_generator_methods` - 63
`javascript.functions.method_definitions.async_methods` - 55
`javascript.functions.method_definitions.generator_methods_not_constructable` - 42