### PR TITLE
Set Chromium versions for various JavaScript builtins

### DIFF
--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -418,10 +418,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/displayName",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
                 "version_added": false
@@ -436,13 +436,13 @@
                 "version_added": null
               },
               "nodejs": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": null
@@ -451,10 +451,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
-                "version_added": null
+                "version_added": false
               }
             },
             "status": {

--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -525,10 +525,10 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": "73"
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": "73"
                 },
                 "edge": {
                   "version_added": true
@@ -546,10 +546,10 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "60"
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": "52"
                 },
                 "safari": {
                   "version_added": null
@@ -558,10 +558,10 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "webview_android": {
-                  "version_added": null
+                  "version_added": "73"
                 }
               },
               "status": {

--- a/javascript/builtins/Proxy.json
+++ b/javascript/builtins/Proxy.json
@@ -528,10 +528,10 @@
               "spec_url": "https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-isextensible",
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": "49"
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": "49"
                 },
                 "edge": {
                   "version_added": null
@@ -549,10 +549,10 @@
                   "version_added": "6.0.0"
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "36"
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": "36"
                 },
                 "safari": {
                   "version_added": null
@@ -561,10 +561,10 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "5.0"
                 },
                 "webview_android": {
-                  "version_added": null
+                  "version_added": "49"
                 }
               },
               "status": {

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -1285,10 +1285,10 @@
               "description": "Escaping",
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": "73"
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": "73"
                 },
                 "edge": {
                   "version_added": null
@@ -1306,10 +1306,10 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "60"
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": "52"
                 },
                 "safari": {
                   "version_added": null
@@ -1318,10 +1318,10 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "webview_android": {
-                  "version_added": null
+                  "version_added": "73"
                 }
               },
               "status": {

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -1143,10 +1143,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-symbol.prototype-@@toprimitive",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "47"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "47"
               },
               "edge": {
                 "version_added": null
@@ -1164,10 +1164,10 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": "34"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "34"
               },
               "safari": {
                 "version_added": null
@@ -1176,10 +1176,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "47"
               }
             },
             "status": {


### PR DESCRIPTION
This PR sets Chromium versions for JavaScript builtins, based upon manual testing.

`javascript.builtins.Function.displayName` - false
`javascript.builtins.Intl.DateTimeFormat.hourCycle` - 73
`javascript.builtins.Proxy.handler.isExtensible` - 49
`javascript.builtins.RegExp.source.escaping` - 73
`javascript.builtins.Symbol.@@toPrimitive` - 47