### PR TITLE
Update Edge Number compat data

### DIFF
--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -13,7 +13,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -64,7 +64,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "25"
@@ -116,7 +116,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "31"
@@ -168,7 +168,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -220,7 +220,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "31"
@@ -272,7 +272,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -376,7 +376,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -428,7 +428,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -792,7 +792,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -1004,7 +1004,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -1053,7 +1053,7 @@
                   "version_added": "26"
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": "12"
                 },
                 "firefox": {
                   "version_added": "29"
@@ -1103,7 +1103,7 @@
                   "version_added": "26"
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": "12"
                 },
                 "firefox": {
                   "version_added": "29"
@@ -1259,7 +1259,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -1311,7 +1311,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"


### PR DESCRIPTION
The Number object was already in IE, so set basic functionality to version Edge 12. The newer ES6 additions also shipped in 12, see https://developer.microsoft.com/en-us/microsoft-edge/platform/status/numberbuiltinses6/