### PR TITLE
Update Edge support for JS operators

### DIFF
--- a/javascript/operators/arithmetic.json
+++ b/javascript/operators/arithmetic.json
@@ -14,7 +14,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -66,7 +66,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -118,7 +118,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -233,7 +233,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -285,7 +285,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -337,7 +337,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -389,7 +389,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -441,7 +441,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -493,7 +493,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"

--- a/javascript/operators/assignment.json
+++ b/javascript/operators/assignment.json
@@ -274,7 +274,7 @@
                 "version_added": "52"
               },
               "edge": {
-                "version_added": null
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "52"

--- a/javascript/operators/assignment.json
+++ b/javascript/operators/assignment.json
@@ -14,7 +14,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -66,7 +66,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -118,7 +118,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -170,7 +170,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -222,7 +222,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -337,7 +337,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -389,7 +389,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -441,7 +441,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -493,7 +493,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -545,7 +545,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -597,7 +597,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -649,7 +649,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"

--- a/javascript/operators/await.json
+++ b/javascript/operators/await.json
@@ -13,7 +13,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": true
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "52"

--- a/javascript/operators/bitwise.json
+++ b/javascript/operators/bitwise.json
@@ -14,7 +14,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -66,7 +66,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -118,7 +118,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -170,7 +170,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -222,7 +222,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -274,7 +274,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -326,7 +326,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"

--- a/javascript/operators/class.json
+++ b/javascript/operators/class.json
@@ -13,7 +13,7 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": true
+              "version_added": "13"
             },
             "firefox": {
               "version_added": "45"

--- a/javascript/operators/comma.json
+++ b/javascript/operators/comma.json
@@ -14,7 +14,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"

--- a/javascript/operators/comparison.json
+++ b/javascript/operators/comparison.json
@@ -14,7 +14,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -66,7 +66,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -118,7 +118,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -170,7 +170,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -222,7 +222,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -274,7 +274,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -326,7 +326,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -378,7 +378,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"

--- a/javascript/operators/conditional.json
+++ b/javascript/operators/conditional.json
@@ -14,7 +14,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"

--- a/javascript/operators/delete.json
+++ b/javascript/operators/delete.json
@@ -13,7 +13,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"

--- a/javascript/operators/delete.json
+++ b/javascript/operators/delete.json
@@ -51,57 +51,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "temporal_dead_zone": {
-          "__compat": {
-            "description": "Temporal dead zone",
-            "support": {
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": "36"
-              },
-              "firefox_android": {
-                "version_added": "36"
-              },
-              "ie": {
-                "version_added": null
-              },
-              "nodejs": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": null
-              },
-              "webview_android": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       }
     }

--- a/javascript/operators/function.json
+++ b/javascript/operators/function.json
@@ -13,7 +13,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"

--- a/javascript/operators/function_star.json
+++ b/javascript/operators/function_star.json
@@ -14,7 +14,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "26"

--- a/javascript/operators/function_star.json
+++ b/javascript/operators/function_star.json
@@ -64,7 +64,7 @@
                 "version_added": "58"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "52"

--- a/javascript/operators/grouping.json
+++ b/javascript/operators/grouping.json
@@ -14,7 +14,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"

--- a/javascript/operators/in.json
+++ b/javascript/operators/in.json
@@ -13,7 +13,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"

--- a/javascript/operators/instanceof.json
+++ b/javascript/operators/instanceof.json
@@ -13,7 +13,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"

--- a/javascript/operators/logical.json
+++ b/javascript/operators/logical.json
@@ -14,7 +14,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -66,7 +66,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -118,7 +118,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"

--- a/javascript/operators/new.json
+++ b/javascript/operators/new.json
@@ -13,7 +13,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"

--- a/javascript/operators/new_target.json
+++ b/javascript/operators/new_target.json
@@ -14,7 +14,7 @@
               "version_added": "46"
             },
             "edge": {
-              "version_added": true
+              "version_added": "13"
             },
             "firefox": {
               "version_added": "41"

--- a/javascript/operators/object_initializer.json
+++ b/javascript/operators/object_initializer.json
@@ -64,7 +64,7 @@
                 "version_added": "47"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "34"
@@ -115,7 +115,7 @@
                 "version_added": "47"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "34"
@@ -166,7 +166,7 @@
                 "version_added": "47"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "33"

--- a/javascript/operators/object_initializer.json
+++ b/javascript/operators/object_initializer.json
@@ -14,7 +14,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"

--- a/javascript/operators/property_accessors.json
+++ b/javascript/operators/property_accessors.json
@@ -14,7 +14,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"

--- a/javascript/operators/super.json
+++ b/javascript/operators/super.json
@@ -13,7 +13,7 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": true
+              "version_added": "13"
             },
             "firefox": {
               "version_added": "45"

--- a/javascript/operators/this.json
+++ b/javascript/operators/this.json
@@ -13,7 +13,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"

--- a/javascript/operators/typeof.json
+++ b/javascript/operators/typeof.json
@@ -13,7 +13,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"

--- a/javascript/operators/void.json
+++ b/javascript/operators/void.json
@@ -13,7 +13,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"

--- a/javascript/operators/yield.json
+++ b/javascript/operators/yield.json
@@ -17,11 +17,17 @@
             },
             "firefox": {
               "version_added": "26",
-              "notes": "Starting with Firefox 33, the parsing of the <code>yield</code> expression has been updated to conform with the ES2015 specification."
+              "notes": [
+                "Starting with Firefox 33, the parsing of the <code>yield</code> expression has been updated to conform with the ES2015 specification.",
+                "Starting with Firefox 29, an <code>IteratorResult</code> object returned for completed generator function."
+              ]
             },
             "firefox_android": {
               "version_added": "26",
-              "notes": "Starting with Firefox 33, the parsing of the <code>yield</code> expression has been updated to conform with the ES2015 specification."
+              "notes": [
+                "Starting with Firefox 33, the parsing of the <code>yield</code> expression has been updated to conform with the ES2015 specification.",
+                "Starting with Firefox 29, an <code>IteratorResult</code> object returned for completed generator function."
+              ]
             },
             "ie": {
               "version_added": false
@@ -63,57 +69,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "IteratorResult": {
-          "__compat": {
-            "description": "<code>IteratorResult</code> object instead of throwing",
-            "support": {
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": "29"
-              },
-              "firefox_android": {
-                "version_added": "29"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": "10"
-              },
-              "safari_ios": {
-                "version_added": "10"
-              },
-              "samsunginternet_android": {
-                "version_added": null
-              },
-              "webview_android": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       }

--- a/javascript/operators/yield.json
+++ b/javascript/operators/yield.json
@@ -13,7 +13,7 @@
               "version_added": "39"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "26",

--- a/javascript/operators/yield_star.json
+++ b/javascript/operators/yield_star.json
@@ -14,7 +14,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "27",


### PR DESCRIPTION
Many operators are basic JS functionality, so they have been set to 12.

For newer stuff, I have linked to the release notes in the commit messages.

For `IteratorResult`, I think it is better to have it as a Firefox note, since it is an implementation detail of Firefox really. The other browsers have the standard behavior from the start.