### PR TITLE
Set IE/Edge versions for JavaScript functions properties

### DIFF
--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -73,7 +73,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "5.5"
               },
               "nodejs": {
                 "version_added": true
@@ -114,7 +114,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": "12"
                 },
                 "firefox": {
                   "version_added": "4"
@@ -123,7 +123,7 @@
                   "version_added": "4"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": "9"
                 },
                 "nodejs": {
                   "version_added": null
@@ -579,7 +579,7 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": "12"
                 },
                 "firefox": {
                   "version_added": "37"
@@ -588,7 +588,7 @@
                   "version_added": "37"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "nodejs": {
                   "version_added": null
@@ -733,7 +733,9 @@
                   "version_added": "51"
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": "12",
+                  "partial_implementation": true,
+                  "notes": "Names for functions defined in a dictionary are properly assigned; however, anonymous functions defined on a var/let variable assignment have blank names."
                 },
                 "firefox": {
                   "version_added": "53"

--- a/javascript/builtins/GeneratorFunction.json
+++ b/javascript/builtins/GeneratorFunction.json
@@ -13,7 +13,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "26"
@@ -64,7 +64,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "26"

--- a/javascript/builtins/GeneratorFunction.json
+++ b/javascript/builtins/GeneratorFunction.json
@@ -13,7 +13,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "13"
             },
             "firefox": {
               "version_added": "26"
@@ -64,7 +64,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "12"
+                "version_added": "13"
               },
               "firefox": {
                 "version_added": "26"


### PR DESCRIPTION
This PR sets the Internet Explorer and Edge versions for the missing JavaScript Functions properties, both through manual testing (SauceLabs and VMs) and through reading developer documentation.

javascript.builtins.Function.apply - true 5.5
javascript.builtins.Function.apply.generic_arrays_as_arguments - true 9
javascript.builtins.Function.length.configurable_true - true 12
javascript.builtins.Function.name.configurable_true - true 12
javascript.builtins.Function.name.inferred_names - partial 12 Names for functions defined in a dictionary are properly assigned; however, anonymous functions defined on a var/let variable assignment have blank names.
javascript.builtins.GeneratorFunction - true 13 - https://developer.microsoft.com/en-us/microsoft-edge/platform/status/generatorses6
javascript.builtins.GeneratorFunction.prototype - true 13 - https://developer.microsoft.com/en-us/microsoft-edge/platform/status/generatorses6