### PR TITLE
add flags for MediaDevices outputs

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -119,7 +119,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "Prior to Firefox 63, <code>enumerateDevices()</code> only returned input devices. Starting with Firefox 63, output devices are also included."
+                "notes": "if the <code>media.setsinkid.enabled</code> preference is enabled."
               },
               {
                 "version_added": "39"
@@ -135,7 +135,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "Prior to Firefox 63, <code>enumerateDevices()</code> only returned input devices. Starting with Firefox 63, output devices are also included."
+                "notes": "if the <code>media.setsinkid.enabled</code> preference is enabled."
               },
               {
                 "version_added": "39"

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -119,7 +119,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "if the <code>media.setsinkid.enabled</code> preference is enabled."
+                "notes": "Prior to Firefox 63, <code>enumerateDevices()</code> only returned input devices. Starting with Firefox 63, output devices are also included if the <code>media.setsinkid.enabled</code> preference is enabled."
               },
               {
                 "version_added": "39"
@@ -135,7 +135,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "if the <code>media.setsinkid.enabled</code> preference is enabled."
+                "notes": "Prior to Firefox 63, <code>enumerateDevices()</code> only returned input devices. Starting with Firefox 63, output devices are also included if the <code>media.setsinkid.enabled</code> preference is enabled."
               },
               {
                 "version_added": "39"

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -112,15 +112,35 @@
             "firefox": [
               {
                 "version_added": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.setsinkid.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
                 "notes": "Prior to Firefox 63, <code>enumerateDevices()</code> only returned input devices. Starting with Firefox 63, output devices are also included."
               },
               {
                 "version_added": "39"
               }
             ],
-            "firefox_android": {
-              "version_added": "39"
-            },
+            "firefox_android": [
+              {
+                "version_added": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.setsinkid.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "Prior to Firefox 63, <code>enumerateDevices()</code> only returned input devices. Starting with Firefox 63, output devices are also included."
+              },
+              {
+                "version_added": "39"
+              }
+            ],
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
Hi 👋 ,

I noticed that the `enumerateDevices` method was lacking some info about its behaviour on Firefox. According the [ticket#1152401](https://bugzilla.mozilla.org/show_bug.cgi?id=1152401#c96) on bugzilla the output devices are only listed if a feature flag is set to true.

You can test the behaviour on a [JSFiddle](https://jsfiddle.net/jib1/LbtxeLvw/) listed in the ticket thread too.

PS: I'll be attending [View Source Conf](https://2019.viewsourceconf.org/) at the end of the month. I hope that I'll be able to see some of you out there. Would love to buy you a beer/coffee/juice for the amazing work done with this project
