### PR TITLE
Set values for IE/Edge for JavaScript Intl

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -1919,7 +1919,7 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "52"
@@ -1928,7 +1928,7 @@
                   "version_added": false
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "nodejs": {
                   "version_added": null
@@ -1970,7 +1970,7 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "52"
@@ -1979,7 +1979,7 @@
                   "version_added": false
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "nodejs": {
                   "version_added": null

--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -13,7 +13,7 @@
               "version_added": "26"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "29"
@@ -114,7 +114,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "55"
@@ -123,7 +123,7 @@
                   "version_added": "56"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "nodejs": {
                   "version_added": null
@@ -166,7 +166,7 @@
                   "version_added": "26"
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": "12"
                 },
                 "firefox": {
                   "version_added": "29"
@@ -218,7 +218,7 @@
                   "version_added": "26"
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": "12"
                 },
                 "firefox": {
                   "version_added": "29"
@@ -270,7 +270,7 @@
                   "version_added": "26"
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": "12"
                 },
                 "firefox": {
                   "version_added": "29"
@@ -322,7 +322,7 @@
                   "version_added": "26"
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": "12"
                 },
                 "firefox": {
                   "version_added": "29"
@@ -531,7 +531,7 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": "18"
                 },
                 "firefox": {
                   "version_added": "58"
@@ -540,7 +540,7 @@
                   "version_added": "58"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "nodejs": {
                   "version_added": null
@@ -582,7 +582,7 @@
                   "version_added": "26"
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": "14"
                 },
                 "firefox": {
                   "version_added": "52"
@@ -591,7 +591,7 @@
                   "version_added": "56"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "nodejs": {
                   "version_added": null
@@ -634,7 +634,7 @@
                   "version_added": "26"
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": "12"
                 },
                 "firefox": {
                   "version_added": "29"
@@ -789,7 +789,7 @@
                   "version_added": "26"
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": "12"
                 },
                 "firefox": {
                   "version_added": "29"
@@ -1985,7 +1985,7 @@
                   "version_added": "26"
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": "12"
                 },
                 "firefox": {
                   "version_added": "29"
@@ -2037,7 +2037,7 @@
                   "version_added": "64"
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": "12"
                 },
                 "firefox": {
                   "version_added": "58"
@@ -2046,7 +2046,7 @@
                   "version_added": "58"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": "11"
                 },
                 "nodejs": {
                   "version_added": null
@@ -2089,7 +2089,7 @@
                   "version_added": "26"
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": "12"
                 },
                 "firefox": {
                   "version_added": "29"
@@ -2193,7 +2193,7 @@
                   "version_added": "26"
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": "12"
                 },
                 "firefox": {
                   "version_added": "29"
@@ -2349,7 +2349,7 @@
                   "version_added": "63"
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": "18"
                 },
                 "firefox": {
                   "version_added": "58"
@@ -2400,7 +2400,7 @@
                   "version_added": "63"
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": "18"
                 },
                 "firefox": {
                   "version_added": "58"
@@ -2451,7 +2451,7 @@
                   "version_added": "63"
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": "18"
                 },
                 "firefox": {
                   "version_added": "58"
@@ -2502,7 +2502,7 @@
                   "version_added": "63"
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": "18"
                 },
                 "firefox": {
                   "version_added": "58"


### PR DESCRIPTION
This PR sets all the IE and Edge JavaScript values for the Intl built-ins (and corresponding Array.toLocaleString entries) based upon manual testing, or mirroring IE data onto Edge.  Data is as follows:

javascript.builtins.Array.toLocaleString.locales - false
javascript.builtins.Array.toLocaleString.options - false
javascript.builtins.Intl - already 11 in IE
javascript.builtins.Intl.Collator.caseFirst - false
javascript.builtins.Intl.Collator.compare - already 11 in IE
javascript.builtins.Intl.Collator.prototype - already 11 in IE
javascript.builtins.Intl.Collator.resolvedOptions - already 11 in IE
javascript.builtins.Intl.Collator.supportedLocalesOf - already 11 in IE
javascript.builtins.Intl.DateTimeFormat.hourCycle - 18
javascript.builtins.Intl.DateTimeFormat.iana_time_zone_names - 14
javascript.builtins.Intl.DateTimeFormat.prototype - already 11 in IE
javascript.builtins.Intl.DateTimeFormat.supportedLocalesOf - already 11 in IE
javascript.builtins.Intl.NumberFormat.format - already 11 in IE
javascript.builtins.Intl.NumberFormat.formatToParts - 11
javascript.builtins.Intl.NumberFormat.prototype - already 11 in IE
javascript.builtins.Intl.NumberFormat.supportedLocalesOf - already 11 in IE
javascript.builtins.Intl.PluralRules.PluralRules - 18
javascript.builtins.Intl.PluralRules.prototype - 18
javascript.builtins.Intl.PluralRules.resolvedOptions - 18
javascript.builtins.Intl.PluralRules.select - 18
javascript.builtins.Intl.PluralRules.supportedLocalesOf - 18