### PR TITLE
Update Chrome compatibility for color picker

### DIFF
--- a/html/elements/input/color.json
+++ b/html/elements/input/color.json
@@ -11,7 +11,7 @@
                 "version_added": "20"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": "14"


### PR DESCRIPTION
I verified in Android 10 running Chrome 76 that the color picker element is supported.
