### PR TITLE
Fix consistency in javascript Function.name.inferred_names

### DIFF
--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -733,7 +733,7 @@
                   "version_added": "51"
                 },
                 "edge": {
-                  "version_added": "12",
+                  "version_added": "14",
                   "partial_implementation": true,
                   "notes": "Names for functions defined in a dictionary are properly assigned; however, anonymous functions defined on a var/let variable assignment have blank names."
                 },


### PR DESCRIPTION
This fixes the Edge version consistency for the inferred names of JavaScript inferred function names.  #4787 set this to "12", but it looks like I made a mistake, as it seems it's not supported in Edge 13.

(P.S. I was using the web editor and accidentally committed this directly to the master branch before quickly undoing it.  Sorry!  >~<)