### PR TITLE
add IE compatible version for removeChild

### DIFF
--- a/api/Node.json
+++ b/api/Node.json
@@ -1882,7 +1882,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
- Method `removeChild` can be seen in the early [DOM Level 1 SPEC](https://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#method-removeChild). `appendChild` listed compatible IE version is 5 and shares the same spec as `removeChild` linked above.
- Tested using Windows 98 Internet Explorer 5 (Yes really, see [screenshot](https://imgur.com/a/G5CGGfb)).