### PR TITLE
added tabs.goBack() and tabs.goForward()

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1460,6 +1460,48 @@
             }
           }
         },
+        "goBack": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "72"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "goForward": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "72"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
         "hide": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/hide",


### PR DESCRIPTION
Currently only supported on Chrome 72.
Source: https://developer.chrome.com/extensions/tabs#method-goBack