### PR TITLE
Add additional NodeJS versions

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -3,6 +3,24 @@
     "nodejs": {
       "name": "Node.js",
       "releases": {
+         "0.1.100": {
+          "release_date": "2010-07-03",
+          "release_notes": "https://github.com/nodejs/node-v0.x-archive/blob/v0.1.100/ChangeLog",
+          "engine": "V8",
+          "engine_version": "2.2"
+        },
+        "0.1.101": {
+          "release_date": "2010-07-16",
+          "release_notes": "https://github.com/nodejs/node-v0.x-archive/blob/v0.1.101/ChangeLog",
+          "engine": "V8",
+          "engine_version": "2.2"
+        },
+        "0.1.104": {
+          "release_date": "2010-08-13",
+          "release_notes": "https://github.com/nodejs/node-v0.x-archive/blob/v0.1.104/ChangeLog",
+          "engine": "V8",
+          "engine_version": "2.2"
+        },
         "0.10": {
           "release_date": "2013-03-11",
           "release_notes": "https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V010.md",
@@ -45,9 +63,27 @@
           "engine": "V8",
           "engine_version": "5.4"
         },
+        "7.5.0": {
+          "release_date": "2017-01-31",
+          "release_notes": "https://nodejs.org/en/blog/release/v7.5.0/",
+          "engine": "V8",
+          "engine_version": "5.4"
+        },
         "7.6.0": {
           "release_date": "2017-02-21",
           "release_notes": "https://nodejs.org/en/blog/release/v7.6.0/",
+          "engine": "V8",
+          "engine_version": "5.5"
+        },
+        "7.7.0": {
+          "release_date": "2017-02-28",
+          "release_notes": "https://nodejs.org/en/blog/release/v7.7.0/",
+          "engine": "V8",
+          "engine_version": "5.5"
+        },
+        "7.10.0": {
+          "release_date": "2017-05-02",
+          "release_notes": "https://nodejs.org/en/blog/release/v7.10.0/",
           "engine": "V8",
           "engine_version": "5.5"
         },
@@ -81,6 +117,12 @@
           "engine": "V8",
           "engine_version": "6.2"
         },
+        "9.3.0": {
+          "release_date": "2017-12-12",
+          "release_notes": "https://nodejs.org/en/blog/release/v9.3.0/",
+          "engine": "V8",
+          "engine_version": "6.2"
+        },
         "10.0.0": {
           "release_date": "2018-04-24",
           "release_notes": "https://nodejs.org/en/blog/release/v10.0.0/",
@@ -93,6 +135,18 @@
           "engine": "V8",
           "engine_version": "6.7"
         },
+        "10.5.0": {
+          "release_date": "2018-06-20",
+          "release_notes": "https://nodejs.org/en/blog/release/v10.5.0/",
+          "engine": "V8",
+          "engine_version": "6.7"
+        },
+        "10.7.0": {
+          "release_date": "2018-07-18",
+          "release_notes": "https://nodejs.org/en/blog/release/v10.7.0/",
+          "engine": "V8",
+          "engine_version": "6.7"
+        },
         "10.9.0": {
           "release_date": "2018-08-16",
           "release_notes": "https://nodejs.org/en/blog/release/v10.9.0/",
@@ -102,6 +156,12 @@
         "11.0.0": {
           "release_date": "2018-10-23",
           "release_notes": "https://nodejs.org/en/blog/release/v11.0.0/",
+          "engine": "V8",
+          "engine_version": "7.0"
+        },
+        "11.7.0": {
+          "release_date": "2019-01-18",
+          "release_notes": "https://nodejs.org/en/blog/release/v11.7.0/",
           "engine": "V8",
           "engine_version": "7.0"
         },


### PR DESCRIPTION
This breaks out the data changes from #4264 and #3160, as requested by @ddbeck, which will unblock #3160.  Both @freaktechnik and @ExE-Boss have been marked as co-authors for this data.