### PR TITLE
Conform linter/test-compare-features to use common colors

### DIFF
--- a/test/test-compare-features.js
+++ b/test/test-compare-features.js
@@ -29,8 +29,8 @@ const testFeatureOrder = () => {
   if (errors) {
     console.error(chalk`{red compareFeatures() – {bold 1} error:}`);
     console.error(chalk`{red   Actual and expected orders do not match}`);
-    console.error(chalk`{red     Actual: {bold ${actual}}}`);
-    console.error(chalk`{red     Expected: {bold ${expected}}}`);
+    console.error(chalk`{red     Actual: {yellow ${actual}}}`);
+    console.error(chalk`{red     Expected: {green ${expected}}}`);
     return true;
   }
   return false;


### PR DESCRIPTION
In `test-style.js`, we are using yellow and green for actual and expected values respectively.  This PR updates `test-compare-features.js` to follow the same color scheme, therefore maintaining consistency of linter output.  Although this PR is entirely cosmetic, I feel that maintaining consistent color formatting across the linters will help maintain visual cues on linter output.