### PR TITLE
Add result of test for RegExp with Edge

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -13,7 +13,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"


### PR DESCRIPTION
I tested and found that `new RegExp(…)` worked with Edge just as it did with IE (surprise, surprise).

Mostly I wanted to see if this would get assigned a label automatically. :-)