### PR TITLE
downloads.download header parameter support for Referer header

### DIFF
--- a/webextensions/api/downloads.json
+++ b/webextensions/api/downloads.json
@@ -783,6 +783,7 @@
                   "version_added": false
                 },
                 "firefox": {
+                  "notes": "<code>Referer</code> headers supported from version 70.",
                   "version_added": "47"
                 },
                 "firefox_android": {


### PR DESCRIPTION
Added a note to downloads.download header parameter about support for Referer header in version 70 as per https://bugzilla.mozilla.org/show_bug.cgi?id=1367626

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
