### PR TITLE
[Chrome] Bug 979041: Track `@⁠supports selector()` implementation

### DIFF
--- a/css/at-rules/supports.json
+++ b/css/at-rules/supports.json
@@ -119,10 +119,12 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/979041'>bug 979041</a>."
               },
               "opera_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/979041'>bug 979041</a>."
               },
               "safari": {
                 "version_added": false
@@ -131,7 +133,8 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/979041'>bug 979041</a>."
               },
               "webview_android": {
                 "version_added": false,

--- a/css/at-rules/supports.json
+++ b/css/at-rules/supports.json
@@ -80,10 +80,12 @@
             "description": "<code>selector()</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/979041'>bug 979041</a>."
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/979041'>bug 979041</a>."
               },
               "edge": {
                 "version_added": false
@@ -132,7 +134,8 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/979041'>bug 979041</a>."
               }
             },
             "status": {


### PR DESCRIPTION
**Chromium** has [bug 979041](https://bugs.chromium.org/p/chromium/issues/detail?id=979041) open to implement this.

---

review?(@jpmedley)