### PR TITLE
Add static class fields data

### DIFF
--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -294,7 +294,9 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "69"
+              "version_added": "69",
+              "partial_implementation": true,
+              "notes": "Static fields aren't supported, will fixed in <a href='https://bugzil.la/1535804'>bug 1535804</a> issue."
             },
             "firefox_android": {
               "version_added": false

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -294,9 +294,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "69",
-              "partial_implementation": true,
-              "notes": "Static fields aren't supported, see <a href='https://bugzil.la/1535804'>bug 1535804</a>."
+              "version_added": "69"
             },
             "firefox_android": {
               "version_added": false
@@ -398,6 +396,60 @@
             "webview_android": {
               "version_added": "49",
               "notes": "From Chrome 42 to 48 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "static_class_fields": {
+        "__compat": {
+          "description": "Static class fields",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/Class_fields",
+          "spec_url": "https://tc39.es/proposal-class-fields/#prod-FieldDefinition",
+          "support": {
+            "chrome": {
+              "version_added": "72"
+            },
+            "chrome_android": {
+              "version_added": "72"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "Static fields aren't supported, see <a href='https://bugzil.la/1535804'>bug 1535804</a>."
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": "12.0.0"
+            },
+            "opera": {
+              "version_added": "60"
+            },
+            "opera_android": {
+              "version_added": "51"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "72"
             }
           },
           "status": {

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -296,7 +296,7 @@
             "firefox": {
               "version_added": "69",
               "partial_implementation": true,
-              "notes": "Static fields aren't supported, will fixed in <a href='https://bugzil.la/1535804'>bug 1535804</a> issue."
+              "notes": "Static fields aren't supported, see <a href='https://bugzil.la/1535804'>bug 1535804</a>."
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
Next code:
```js
class SomeClass {
  static field = 'value';
}
console.log(SomeClass.field);
```
Works well in chrome 76, but throws error 'SyntaxError: bad method definition' in firefox 69.

Non-static fields work ok in both browsers:
```js
class SomeClass {
  field = 'value';
}
const someObject = new SomeClass();
console.log(someObject.field);
```
