### PR TITLE
compat-data-helper: stop trying to apply an empty list of labels

### DIFF
--- a/.github/compat-data-helper/index.js
+++ b/.github/compat-data-helper/index.js
@@ -40,7 +40,9 @@ module.exports = app => {
     const filenames = fileList.map(f => f.filename)
 
     const labels = match(filenames, config)
-    await context.github.issues.addLabels({ ...prAsIssue, labels: { labels } })
-    context.log(`PR ${prString}: Added labels`, labels)
+    if (labels.length) {
+      await context.github.issues.addLabels({ ...prAsIssue, labels })
+      context.log(`PR ${prString}: Added labels`, labels)
+    }
   })
 }


### PR DESCRIPTION
If no labels apply to any of the files in a PR, compat-data-helper bot still tries to get the GitHub API to apply an empty list of labels to the PR. Not only is this pointless, but the GitHub API rejects request as an error.