### PR TITLE
Update content-security-policy.json 

### DIFF
--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -1610,7 +1610,7 @@
               "support": {
                 "chrome": [
                   {
-                    "version_added": null
+                    "version_added": "77"
                   },
                   {
                     "version_added": "73",


### PR DESCRIPTION
trusted-types API is Enabled by default on Chrome 77
