### PR TITLE
compdat-data-helper: assign labels to JavaScript data correctly

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -11,7 +11,7 @@ data:html :page_facing_up::
 data:http :mountain_cableway::
   - "http/**"
 data:js :pager::
-  - "js/**"
+  - "javascript/**"
 data:mathml :heavy_division_sign::
   - "mathml/**"
 data:svg :paintbrush::


### PR DESCRIPTION
I entered the wrong path to the JS data folder in our label assignment config. This fixes that.

(Once this is merged, I'll re-enable the bot.)
