### PR TITLE
Firefox for Android themes update

### DIFF
--- a/webextensions/manifest/theme.json
+++ b/webextensions/manifest/theme.json
@@ -986,8 +986,7 @@
                   "notes": "Use <code>theme_frame</code> instead."
                 },
                 "firefox_android": {
-                  "version_added": "65",
-                  "notes": "This property is required."
+                  "version_added": false
                 },
                 "opera": {
                   "version_added": false
@@ -1013,7 +1012,8 @@
                   "version_added": "55"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": true,
+                  "notes": "This property is required."
                 },
                 "opera": {
                   "version_added": false


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1548776#c29 However, noting there was no information on the version of Firefox for Android where the key requirements changed. Therefore, I have marked `headerURL` as unsupported and `theme_frame` as supported. `additional_background` is already marked is not supported for Firefox for Android.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
