### PR TITLE
Fix webextensions path in .github/labels.yml

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -19,7 +19,7 @@ data:svg :paintbrush::
 data:webdriver :racing_car::
   - "webdriver/**"
 data:webext :game_die::
-  - "webext/**"
+  - "webextensions/**"
 data:xpath :railway_track::
   - "xpath/**"
 data:xslt :tractor::


### PR DESCRIPTION
I noticed that the webextensions path was incorrect in the new `labels.yml` file, and was typed out as the shortened version we use for the label name.  Luckily, this is a quick and easy fix!
