### PR TITLE
adding compat data entry for the fact that :visited no longer matches…

### DIFF
--- a/css/selectors/visited.json
+++ b/css/selectors/visited.json
@@ -49,6 +49,60 @@
             "deprecated": false
           }
         },
+        "not_match_link": {
+          "__compat": {
+            "description": "<code>:visited</code> <a href='https://groups.google.com/forum/#!msg/mozilla.dev.platform/1NP6oJzK6zg/ftAz_TajAAAJ'>no longer matches <code>&lt;link&gt;</code> elements</a>",
+            "support": {
+              "chrome": {
+                "version_added": "1",
+                "notes": "Chromium has never matched <code>&lt;link&gt;</code> elements with link pseudo-classes."
+              },
+              "chrome_android": {
+                "version_added": "18",
+                "notes": "Chromium has never matched <code>&lt;link&gt;</code> elements with link pseudo-classes."
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "70"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15",
+                "notes": "Chromium has never matched <code>&lt;link&gt;</code> elements with link pseudo-classes."
+              },
+              "opera_android": {
+                "version_added": "15",
+                "notes": "Chromium has never matched <code>&lt;link&gt;</code> elements with link pseudo-classes."
+              },
+              "safari": {
+                "version_added": "12"
+              },
+              "safari_ios": {
+                "version_added": "12"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0",
+                "notes": "Chromium has never matched <code>&lt;link&gt;</code> elements with link pseudo-classes."
+              },
+              "webview_android": {
+                "version_added": "1",
+                "notes": "Chromium has never matched <code>&lt;link&gt;</code> elements with link pseudo-classes."
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "privacy_measures": {
           "__compat": {
             "description": "Restrict CSS properties allowed in a statement using <code>:visited</code> for privacy",

--- a/css/selectors/visited.json
+++ b/css/selectors/visited.json
@@ -78,7 +78,7 @@
                 "notes": "Chromium has never matched <code>&lt;link&gt;</code> elements with link pseudo-classes."
               },
               "opera_android": {
-                "version_added": "15",
+                "version_added": "14",
                 "notes": "Chromium has never matched <code>&lt;link&gt;</code> elements with link pseudo-classes."
               },
               "safari": {


### PR DESCRIPTION
… <link> elements

As per https://bugzilla.mozilla.org/show_bug.cgi?id=1572246.

But https://groups.google.com/forum/#!msg/mozilla.dev.platform/1NP6oJzK6zg/ftAz_TajAAAJ explains what is going on here much better, and is more useful in terms of compat data. I guess at the values for Edge (already does it), and Safari (made the change recently), but wasn't sure how to get more accurate data than that.

And Emilio confirmed over mail that actually it is just `:visited` that no longer matches `<link>` elements.

