### PR TITLE
adding data for quotes value of auto

### DIFF
--- a/css/properties/quotes.json
+++ b/css/properties/quotes.json
@@ -47,6 +47,64 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "quotes_auto": {
+          "__compat": {
+            "description": "<code>auto</code> keyword",
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "notes": "This value is not supported, but the default browser behavior is to choose appropriate quotes for the user's language setting"
+              },
+              "chrome_android": {
+                "version_added": false,
+                "notes": "This value is not supported, but the default browser behavior is to choose appropriate quotes for the user's language setting"
+              },
+              "edge": {
+                "version_added": false,
+                "notes": "This value is not supported, but the default browser behavior is to choose appropriate quotes for the user's language setting"
+              },
+              "firefox": {
+                "version_added": "70"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false,
+                "notes": "This value is not supported, but the default browser behavior is to choose appropriate quotes for the user's language setting"
+              },
+              "opera": {
+                "version_added": false,
+                "notes": "This value is not supported, but the default browser behavior is to choose appropriate quotes for the user's language setting"
+              },
+              "opera_android": {
+                "version_added": false,
+                "notes": "This value is not supported, but the default browser behavior is to choose appropriate quotes for the user's language setting"
+              },
+              "safari": {
+                "version_added": false,
+                "notes": "This value is not supported, but the default browser behavior is to choose appropriate quotes for the user's language setting"
+              },
+              "safari_ios": {
+                "version_added": false,
+                "notes": "This value is not supported, but the default browser behavior is to choose appropriate quotes for the user's language setting"
+              },
+              "samsunginternet_android": {
+                "version_added": false,
+                "notes": "This value is not supported, but the default browser behavior is to choose appropriate quotes for the user's language setting"
+              },
+              "webview_android": {
+                "version_added": false,
+                "notes": "This value is not supported, but the default browser behavior is to choose appropriate quotes for the user's language setting"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1421938.

Basically, the `quotes` property now has an `auto` value, which makes the browser automatically choose appropriate quotes depending on the `lang` attribute setting of the selected elements. The values may look a bit weird, as will the note, but basically:

* I did extensive testing on this, and Firefox desktop was the only browser that seemed to support the `auto` value for `quotes` (all other browsers said "value not recognised", or equivalent).
* Firefox 70+ has `auto` as the default value anyway.
* Other browsers don't support it, but this seems to be their default value anyhow. I tested the example at https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/quotes#Auto_quotes on all of the following, and this seemed to be their default behavior:
  * Edge 13
  * Newest Chrome
  * Newest Opera desktop
  * Newest Safari desktop, and version 8 via Saucelabs
  * IE 10 via Saucelabs
  * iOS 10.1 via Saucelabs

So I dunno, bit of a weird one.