### PR TITLE
Update compatibility of some AudioParam APIs

### DIFF
--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -282,7 +282,9 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "18",
+              "partial_implementation": true,
+              "notes": "Does not work."
             },
             "edge": {
               "version_added": "12"
@@ -334,7 +336,9 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "18",
+              "partial_implementation": true,
+              "notes": "Does not work."
             },
             "edge": {
               "version_added": "12"
@@ -362,7 +366,9 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": null,
+              "partial_implementation": true,
+              "notes": "This sets the targer volume at the specified time, but it doesn’t ramp to it."
             },
             "samsunginternet_android": {
               "version_added": true
@@ -530,7 +536,9 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "18",
+              "partial_implementation": true,
+              "notes": "Does not work."
             },
             "edge": {
               "version_added": "12"

--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -534,9 +534,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": "18",
-              "partial_implementation": true,
-              "notes": "This sets the target volume at the specified time, but it doesn’t ramp to it, causing this function to behave like <code>setValueAtTime()</code>."
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -284,7 +284,7 @@
             "chrome_android": {
               "version_added": "18",
               "partial_implementation": true,
-              "notes": "This sets the target volume at the specified time, but it doesn’t ramp to it, causing this function to behave like <code>setValueAtTime</code>."
+              "notes": "This sets the target volume at the specified time, but it doesn’t ramp to it, causing this function to behave like <code>setValueAtTime()</code>."
             },
             "edge": {
               "version_added": "12"
@@ -338,7 +338,7 @@
             "chrome_android": {
               "version_added": "18",
               "partial_implementation": true,
-              "notes": "This sets the target volume at the specified time, but it doesn’t ramp to it, causing this function to behave like <code>setValueAtTime</code>."
+              "notes": "This sets the target volume at the specified time, but it doesn’t ramp to it, causing this function to behave like <code>setValueAtTime()</code>."
             },
             "edge": {
               "version_added": "12"
@@ -536,7 +536,7 @@
             "chrome_android": {
               "version_added": "18",
               "partial_implementation": true,
-              "notes": "This sets the target volume at the specified time, but it doesn’t ramp to it, causing this function to behave like <code>setValueAtTime</code>."
+              "notes": "This sets the target volume at the specified time, but it doesn’t ramp to it, causing this function to behave like <code>setValueAtTime()</code>."
             },
             "edge": {
               "version_added": "12"

--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -284,7 +284,7 @@
             "chrome_android": {
               "version_added": "18",
               "partial_implementation": true,
-              "notes": "Does not work."
+              "notes": "This sets the target volume at the specified time, but it doesn’t ramp to it, causing this function to behave like <code>setValueAtTime</code>."
             },
             "edge": {
               "version_added": "12"
@@ -338,7 +338,7 @@
             "chrome_android": {
               "version_added": "18",
               "partial_implementation": true,
-              "notes": "Does not work."
+              "notes": "This sets the target volume at the specified time, but it doesn’t ramp to it, causing this function to behave like <code>setValueAtTime</code>."
             },
             "edge": {
               "version_added": "12"
@@ -366,9 +366,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null,
-              "partial_implementation": true,
-              "notes": "This sets the targer volume at the specified time, but it doesn’t ramp to it."
+              "version_added": null
             },
             "samsunginternet_android": {
               "version_added": true
@@ -538,7 +536,7 @@
             "chrome_android": {
               "version_added": "18",
               "partial_implementation": true,
-              "notes": "Does not work."
+              "notes": "This sets the target volume at the specified time, but it doesn’t ramp to it, causing this function to behave like <code>setValueAtTime</code>."
             },
             "edge": {
               "version_added": "12"


### PR DESCRIPTION
I ran into some quirks using the gain API on iOS Safari (latest and beta) and the latest Chrome on Android Q. I noticed mdn stated these functions are supported, but from my testing using the latest versions of those browsers I found out they didn’t work.

Everything worked fine on Chrome on Linux, so I’m confident these are issues in the platform specific implementations and my test code was correct.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
