### PR TITLE
adding 2D canvas getTransform() and setTransform() data

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -2203,7 +2203,7 @@
               "version_added": "55"
             },
             "opera_android": {
-              "version_added": "53"
+              "version_added": "48"
             },
             "safari": {
               "version_added": "11"
@@ -2212,7 +2212,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "7.4"
+              "version_added": false
             },
             "webview_android": {
               "version_added": "68"
@@ -3666,7 +3666,7 @@
                 "version_added": "55"
               },
               "opera_android": {
-                "version_added": "53"
+                "version_added": "48"
               },
               "safari": {
                 "version_added": "11"
@@ -3675,7 +3675,7 @@
                 "version_added": "11"
               },
               "samsunginternet_android": {
-                "version_added": "7.4"
+                "version_added": false
               },
               "webview_android": {
                 "version_added": "68"

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -2177,6 +2177,54 @@
           }
         }
       },
+      "getTransform": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/getTransform",
+          "support": {
+            "chrome": {
+              "version_added": "68"
+            },
+            "chrome_android": {
+              "version_added": "68"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "70"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "55"
+            },
+            "opera_android": {
+              "version_added": "53"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "7.4"
+            },
+            "webview_android": {
+              "version_added": "68"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "globalAlpha": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/globalAlpha",
@@ -3590,6 +3638,54 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "matrix_parameter": {
+          "__compat": {
+            "description": "Accept matrix object as parameter",
+            "support": {
+              "chrome": {
+                "version_added": "68"
+              },
+              "chrome_android": {
+                "version_added": "68"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "70"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "55"
+              },
+              "opera_android": {
+                "version_added": "53"
+              },
+              "safari": {
+                "version_added": "11"
+              },
+              "safari_ios": {
+                "version_added": "11"
+              },
+              "samsunginternet_android": {
+                "version_added": "7.4"
+              },
+              "webview_android": {
+                "version_added": "68"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=928150

I got the compat data versions by testing my [example](https://mdn.github.io/dom-examples/canvas/transforms/canvas-gettransform-settransform.html) on some browsers, and doing educated guesses on the others:

* Fx - 70
* Chrome - 68 (chrome status)
* Safari - 11 (tested on SauceLabs)
* iOS - 11 (kinda guessed)
* Opera - 55 (worked out from Chrome 68)
* Opera Android - 53 (kinda guessed)
* IE - no (tested on SauceLabs)
* Edge - no (tested on SauceLabs)
* Samsung Internet - 74 (guessed by comparing the SI release dates on https://en.wikipedia.org/wiki/Samsung_Internet with the Chrome 68 release date on https://en.wikipedia.org/wiki/Google_Chrome_version_history)
