### PR TITLE
grid-auto-column and -rows track listing

### DIFF
--- a/css/properties/grid-auto-columns.json
+++ b/css/properties/grid-auto-columns.json
@@ -44,9 +44,13 @@
             ],
             "firefox": [
               {
+                "version_added": "70"
+              },
+              {
                 "version_added": "52",
+                "version_removed": "70",
                 "partial_implementation": true,
-                "notes": "Does not accept multiple track-size values. See <a href='https://bugzil.la/1339672'>bug 1339672</a>."
+                "notes": "Does not accept multiple track-size values.  See <a href='https://bugzil.la/1339672'>bug 1339672</a>."
               },
               {
                 "version_added": "40",

--- a/css/properties/grid-auto-rows.json
+++ b/css/properties/grid-auto-rows.json
@@ -44,7 +44,11 @@
             ],
             "firefox": [
               {
+                "version_added": "70"
+              },
+              {
                 "version_added": "52",
+                "version_removed": "70",
                 "partial_implementation": true,
                 "notes": "Does not accept multiple track-size values.  See <a href='https://bugzil.la/1339672'>bug 1339672</a>."
               },


### PR DESCRIPTION
Firefox 70 implements multiple track sizing for the `grid-auto-columns` and `grid-auto-rows` feature.

https://bugzilla.mozilla.org/show_bug.cgi?id=1339672
