### PR TITLE
updating Fx70 text property support information

### DIFF
--- a/css/properties/text-decoration-skip-ink.json
+++ b/css/properties/text-decoration-skip-ink.json
@@ -15,14 +15,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "70",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.text-decoration-skip-ink.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "70"
             },
             "firefox_android": {
               "version_added": false

--- a/css/properties/text-decoration-thickness.json
+++ b/css/properties/text-decoration-thickness.json
@@ -16,14 +16,7 @@
             },
             "firefox": [
               {
-                "version_added": "70",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.text-decoration-thickness.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "70"
               },
               {
                 "version_added": "69",

--- a/css/properties/text-decoration.json
+++ b/css/properties/text-decoration.json
@@ -161,6 +161,54 @@
               "deprecated": false
             }
           }
+        },
+        "text-decoration-thickness": {
+          "__compat": {
+            "description": "<code>text-decoration-thickness</code> included in shorthand",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "70"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/text-underline-offset.json
+++ b/css/properties/text-underline-offset.json
@@ -14,16 +14,21 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.text-underline-offset.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "70"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.text-underline-offset.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1573631

This bug updates the properties `text-decoration-skip-ink`, `text-decoration-thickness`, and `text-underline-offset` to be enabled by default in Fx70.

The main bug milestone says Firefox 71, but see https://bugzilla.mozilla.org/show_bug.cgi?id=1573631#c13