### PR TITLE
Update Opera Android + WebView data for datalist HTML element

### DIFF
--- a/html/elements/datalist.json
+++ b/html/elements/datalist.json
@@ -27,7 +27,7 @@
               "version_added": "9.5"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": "12.1"
@@ -39,7 +39,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {

--- a/html/elements/datalist.json
+++ b/html/elements/datalist.json
@@ -27,7 +27,9 @@
               "version_added": "9.5"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "The dropdown menu containing available options does not appear in Opera for Android."
             },
             "safari": {
               "version_added": "12.1"

--- a/html/elements/datalist.json
+++ b/html/elements/datalist.json
@@ -41,7 +41,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {


### PR DESCRIPTION
Opera for Android (53.1.2569.142848) does not support <datalist>
Android(Google) webview supports <datalist> (Android Nougat 7.1.1)

Tested by loading a page, using <datalist>.