### PR TITLE
Updates to DOMPoint*, DOMRect*, and DOMQuad

### DIFF
--- a/api/DOMPoint.json
+++ b/api/DOMPoint.json
@@ -32,7 +32,7 @@
             "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": "10.1"
+            "version_added": "10.3"
           },
           "webview_android": {
             "version_added": "58"
@@ -77,7 +77,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "webview_android": {
               "version_added": "58"
@@ -113,16 +113,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "45"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "webview_android": {
               "version_added": "58"

--- a/api/DOMPoint.json
+++ b/api/DOMPoint.json
@@ -89,6 +89,51 @@
             "deprecated": false
           }
         }
+      },
+      "worker_support": {
+        "__compat": {
+          "description": "Available in workers",
+          "support": {
+            "chrome": {
+              "version_added": "58"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "69"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.1"
+            },
+            "webview_android": {
+              "version_added": "58"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/DOMPointReadOnly.json
+++ b/api/DOMPointReadOnly.json
@@ -32,7 +32,7 @@
             "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": "10.1"
+            "version_added": "10.3"
           },
           "webview_android": {
             "version_added": "61"
@@ -77,7 +77,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -123,7 +123,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -169,7 +169,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -215,7 +215,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -260,7 +260,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -296,16 +296,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "45"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "webview_android": {
               "version_added": "58"
@@ -350,7 +350,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -395,7 +395,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "webview_android": {
               "version_added": "61"
@@ -440,7 +440,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "webview_android": {
               "version_added": "61"

--- a/api/DOMPointReadOnly.json
+++ b/api/DOMPointReadOnly.json
@@ -93,6 +93,7 @@
       "fromPoint": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPointReadOnly/fromPoint",
+          "description": "<code>fromPoint()</code> static function",
           "support": {
             "chrome": {
               "version_added": "61"
@@ -138,6 +139,7 @@
       "matrixTransform": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPointReadOnly/matrixTransform",
+          "description": "<code>matrixTransform()</code>",
           "support": {
             "chrome": {
               "version_added": "61"
@@ -183,6 +185,7 @@
       "toJSON": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPointReadOnly/toJSON",
+          "description": "<code>toJSON()</code>",
           "support": {
             "chrome": {
               "version_added": "61"
@@ -261,6 +264,51 @@
             },
             "webview_android": {
               "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "worker_support": {
+        "__compat": {
+          "description": "Available in workers",
+          "support": {
+            "chrome": {
+              "version_added": "58"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "69"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.1"
+            },
+            "webview_android": {
+              "version_added": "58"
             }
           },
           "status": {

--- a/api/DOMQuad.json
+++ b/api/DOMQuad.json
@@ -11,16 +11,16 @@
             "version_added": "61"
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
-            "version_added": true
+            "version_added": "31"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "31"
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": "48"
@@ -29,10 +29,10 @@
             "version_added": "45"
           },
           "safari": {
-            "version_added": true
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "11"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -42,7 +42,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -53,44 +53,44 @@
           "description": "<code>DOMQuad()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "61"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "31"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "45"
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "61"
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -99,6 +99,7 @@
       "fromQuad": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMQuad/fromQuad",
+          "description": "<code>fromQuad()</code> static function",
           "support": {
             "chrome": {
               "version_added": true
@@ -107,16 +108,16 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": "69"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -125,10 +126,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -138,7 +139,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -147,6 +148,7 @@
       "fromRect": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMQuad/fromRect",
+          "description": "<code>fromRect()</code> static function",
           "support": {
             "chrome": {
               "version_added": true
@@ -155,16 +157,16 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": "69"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -173,10 +175,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -186,7 +188,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -195,6 +197,7 @@
       "getBounds": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMQuad/getBounds",
+          "description": "<code>getBounds()</code>",
           "support": {
             "chrome": {
               "version_added": true
@@ -203,16 +206,16 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "62"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "62"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -221,10 +224,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -234,7 +237,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -251,16 +254,18 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "31",
+              "notes": "Prior to Firefox 69, the default value of <code>p1</code> through <code>p4</code> was undefined; now <code>DOMQuadInit</code> defines these as <code>false</code>."
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "31",
+              "notes": "Prior to Firefox 69, the default value of <code>p1</code> through <code>p4</code> was undefined; now <code>DOMQuadInit</code> defines these as <code>false</code>."
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -269,10 +274,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -282,7 +287,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -299,16 +304,18 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "31",
+              "notes": "Prior to Firefox 69, the default value of <code>p1</code> through <code>p4</code> was undefined; now <code>DOMQuadInit</code> defines these as <code>false</code>."
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "31",
+              "notes": "Prior to Firefox 69, the default value of <code>p1</code> through <code>p4</code> was undefined; now <code>DOMQuadInit</code> defines these as <code>false</code>."
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -317,10 +324,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -330,7 +337,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -347,16 +354,18 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "31",
+              "notes": "Prior to Firefox 69, the default value of <code>p1</code> through <code>p4</code> was undefined; now <code>DOMQuadInit</code> defines these as <code>false</code>."
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "31",
+              "notes": "Prior to Firefox 69, the default value of <code>p1</code> through <code>p4</code> was undefined; now <code>DOMQuadInit</code> defines these as <code>false</code>."
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -365,10 +374,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -378,7 +387,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -395,16 +404,18 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "31",
+              "notes": "Prior to Firefox 69, the default value of <code>p1</code> through <code>p4</code> was undefined; now <code>DOMQuadInit</code> defines these as <code>false</code>."
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "31",
+              "notes": "Prior to Firefox 69, the default value of <code>p1</code> through <code>p4</code> was undefined; now <code>DOMQuadInit</code> defines these as <code>false</code>."
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -426,7 +437,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -435,6 +446,7 @@
       "toJSON": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMQuad/toJSON",
+          "description": "<code>toJSON()</code>",
           "support": {
             "chrome": {
               "version_added": true
@@ -443,16 +455,16 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "62"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "62"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -461,10 +473,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -474,7 +486,55 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "worker_support": {
+        "__compat": {
+          "description": "Available in workers",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "69"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/DOMQuad.json
+++ b/api/DOMQuad.json
@@ -83,7 +83,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "61"
@@ -527,7 +527,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "61"

--- a/api/DOMRect.json
+++ b/api/DOMRect.json
@@ -101,6 +101,51 @@
             "deprecated": false
           }
         }
+      },
+      "worker_support": {
+        "__compat": {
+          "description": "Available in workers",
+          "support": {
+            "chrome": {
+              "version_added": "58"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "69"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.1"
+            },
+            "webview_android": {
+              "version_added": "58"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/DOMRect.json
+++ b/api/DOMRect.json
@@ -44,7 +44,7 @@
             "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": "10.1"
+            "version_added": "10.3"
           },
           "webview_android": {
             "version_added": true
@@ -89,7 +89,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "webview_android": {
               "version_added": true
@@ -125,16 +125,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "45"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "webview_android": {
               "version_added": "58"

--- a/api/DOMRectReadOnly.json
+++ b/api/DOMRectReadOnly.json
@@ -152,6 +152,7 @@
       "fromRect": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/fromRect",
+          "description": "<code>fromRect()</code> static function",
           "support": {
             "chrome": {
               "version_added": "57"
@@ -160,16 +161,16 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": "69"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "44"
@@ -178,10 +179,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -191,7 +192,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -423,6 +424,51 @@
             },
             "webview_android": {
               "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "worker_support": {
+        "__compat": {
+          "description": "Available in workers",
+          "support": {
+            "chrome": {
+              "version_added": "58"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "69"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.1"
+            },
+            "webview_android": {
+              "version_added": "58"
             }
           },
           "status": {

--- a/api/DOMRectReadOnly.json
+++ b/api/DOMRectReadOnly.json
@@ -44,7 +44,7 @@
             "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": "10.1"
+            "version_added": "10.3"
           },
           "webview_android": {
             "version_added": true
@@ -89,7 +89,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "webview_android": {
               "version_added": true
@@ -136,7 +136,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "webview_android": {
               "version_added": true
@@ -182,7 +182,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -232,7 +232,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "webview_android": {
               "version_added": true
@@ -279,7 +279,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "webview_android": {
               "version_added": true
@@ -326,7 +326,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "webview_android": {
               "version_added": true
@@ -373,7 +373,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "webview_android": {
               "version_added": true
@@ -420,7 +420,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "webview_android": {
               "version_added": true
@@ -456,16 +456,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "45"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "webview_android": {
               "version_added": "58"
@@ -510,7 +510,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "webview_android": {
               "version_added": true
@@ -555,7 +555,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "webview_android": {
               "version_added": true


### PR DESCRIPTION
Firefox 69 introduced several changes to these. In
addition, a number of the existing entries were either
missing or wrong, and several members that were
added in the past were not listed. This should bring
everything up to date.

For the changes made, the sources are below.

*For all of these, Edge is not available as the entire
Geometry Interfaces API is under consideration still.
For Safari, the API was almost completely implemented on
first addition in Safari 10.1, with some stuff added in
Safari 11.*

Worker support information:
* [Safari](https://trac.webkit.org/browser/webkit/branches/safari-603.1.30.0-branch/Source/WebCore/dom/DOMPoint.idl)
* [Chrome](https://codereview.chromium.org/2650583009)
* [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1420580)

Addition of DOMQuad:
* [Safari](https://trac.webkit.org/browser/webkit/branches/safari-603.1.30.0-branch/Source/WebCore/dom/DOMRect.idl)
* [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=917755)

Addition of static constructors (fromPoint(), fromRect(), fromQuad()):
* Safari: Present from the beginning
* [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1558101)

Thankfully, it's easy to bop around the WebKit code
to isolate versions. I adore how well they've tagged
and set up branches and releases to make it easy
to identify releases that implement things.

A checklist to help your pull request get merged faster:
- [ ] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
