### PR TITLE
Added information about Safari support for Clipboard API

### DIFF
--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -29,7 +29,7 @@
             "version_added": "47"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
             "version_added": null
@@ -92,7 +92,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": null
@@ -142,7 +142,7 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": null
@@ -206,7 +206,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": null
@@ -256,7 +256,7 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": null

--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -32,7 +32,7 @@
             "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": true
@@ -95,7 +95,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -145,7 +145,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true
@@ -209,7 +209,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null
@@ -259,7 +259,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -403,10 +403,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
Updated missing (`null`) information about Safari asynchronous Clipboard API support.
Tested in Safari Technology Preview release 91 (Safari 13.1, WebKit 14609.1.3)

![Console preview](https://user-images.githubusercontent.com/4144459/65000161-e5bfa600-d8ea-11e9-8142-f5b4df65d7d6.png)
![Safari version screenshot](https://user-images.githubusercontent.com/4144459/65000176-f5d78580-d8ea-11e9-838d-362ef46e0fad.png)
