### PR TITLE
Fix Safari iOS version in Strict-Transport-Security HTTP header

### DIFF
--- a/http/headers/strict-transport-security.json
+++ b/http/headers/strict-transport-security.json
@@ -33,7 +33,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "8.4"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR fixes the Safari iOS version of http.headers.Strict-Transport-Security.  While working on removing excess Safari iOS versions, I found that this data was initially added from the MDN docs -- as such, I question its validity.  I wouldn't expect that HTTPs headers are added in the different platforms.