### PR TITLE
Remove iOS 8.4 from data

### DIFF
--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -99,12 +99,6 @@
           "engine_version": "600.1.4",
           "release_date": "2014-10-20"
         },
-        "8.4": {
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "600.1.4",
-          "release_date": "2015-06-30"
-        },
         "9": {
           "status": "retired",
           "engine": "WebKit",


### PR DESCRIPTION
This removes Safari iOS 8.4 from the browser compatibility table, as it is the same WebKit version as Safari and Safari iOS 8.0.

Depends on #4831.