### PR TITLE
Document API: remove Safari notes and update Safari iOS version

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -5235,12 +5235,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "11.1",
-              "notes": "Currently only available on macOS High Sierra 10.13.4 beta, and in Safari Technology Preview 47+."
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1",
-              "notes": "Currently only available on iOS 11.3 beta."
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": false
@@ -8760,12 +8758,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "11.1",
-              "notes": "Currently only available on macOS High Sierra 10.13.4 beta, and in Safari Technology Preview 47+."
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1",
-              "notes": "Currently only available on iOS 11.3 beta."
+              "version_added": "11.3"
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
While double-checking Safari iOS entries, I found that, in the Document API, there were some notes regarding macOS and iOS editions the data was only available in.  However, there's two parts: 1) I see no real need for the notes if the data's already in `version_added`, and 2) since newer versions of Safari, macOS, and iOS have come out which support these features, the notes are invalidated.

This also fixes an issue where Safari iOS was set to 11.1 (the Safari version) when it should be 11.3 (the iOS version).