### PR TITLE
Remove iOS 11.1 from data

### DIFF
--- a/api/AbortController.json
+++ b/api/AbortController.json
@@ -34,7 +34,7 @@
             "notes": "Even though <code>window.AbortController</code> is defined, it doesn't really abort <code>fetch</code> requests. See <a href='https://webkit.org/b/174980'>bug 174980</a>."
           },
           "safari_ios": {
-            "version_added": "11.1",
+            "version_added": "11.3",
             "partial_implementation": true,
             "notes": "Even though <code>window.AbortController</code> is defined, it doesn't really abort <code>fetch</code> requests. See <a href='https://webkit.org/b/174980'>bug 174980</a>."
           },
@@ -84,7 +84,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -132,7 +132,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -180,7 +180,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -32,7 +32,7 @@
             "version_added": "11.1"
           },
           "safari_ios": {
-            "version_added": "11.1"
+            "version_added": "11.3"
           },
           "samsunginternet_android": {
             "version_added": false
@@ -80,7 +80,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -128,7 +128,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -176,7 +176,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1920,7 +1920,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1981,7 +1981,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/ServiceWorker.json
+++ b/api/ServiceWorker.json
@@ -44,7 +44,7 @@
             "version_added": "11.1"
           },
           "safari_ios": {
-            "version_added": "11.1"
+            "version_added": "11.3"
           },
           "samsunginternet_android": {
             "version_added": "4.0"
@@ -103,7 +103,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -163,7 +163,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -223,7 +223,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -44,7 +44,7 @@
             "version_added": "11.1"
           },
           "safari_ios": {
-            "version_added": "11.1"
+            "version_added": "11.3"
           },
           "samsunginternet_android": {
             "version_added": "4.0"
@@ -103,7 +103,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -163,7 +163,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -223,7 +223,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -284,7 +284,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -344,7 +344,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -404,7 +404,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -464,7 +464,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -572,7 +572,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -632,7 +632,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -33,7 +33,7 @@
             "version_added": "11.1"
           },
           "safari_ios": {
-            "version_added": "11.1"
+            "version_added": "11.3"
           },
           "samsunginternet_android": {
             "version_added": "4.0"
@@ -82,7 +82,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -131,7 +131,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -180,7 +180,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -230,7 +230,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -280,7 +280,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -330,7 +330,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -392,7 +392,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -441,7 +441,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -552,7 +552,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -601,7 +601,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -650,7 +650,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -747,7 +747,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -796,7 +796,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -907,7 +907,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -956,7 +956,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -1005,7 +1005,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -1055,7 +1055,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -1105,7 +1105,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -1154,7 +1154,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -44,7 +44,7 @@
             "version_added": "11.1"
           },
           "safari_ios": {
-            "version_added": "11.1"
+            "version_added": "11.3"
           },
           "samsunginternet_android": {
             "version_added": "4.0"
@@ -103,7 +103,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -163,7 +163,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -223,7 +223,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -283,7 +283,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -343,7 +343,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -513,7 +513,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -1077,7 +1077,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -741,7 +741,7 @@
                 "version_added": "11.1"
               },
               "safari_ios": {
-                "version_added": "11.1"
+                "version_added": "11.3"
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -159,12 +159,6 @@
           "engine_version": "604.2.4",
           "release_date": "2017-09-19"
         },
-        "11.1": {
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "604.3.5",
-          "release_date": "2017-10-31"
-        },
         "11.3": {
           "status": "retired",
           "engine": "WebKit",

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -256,7 +256,7 @@
                 "version_added": "11.1"
               },
               "safari_ios": {
-                "version_added": "11.1"
+                "version_added": "11.3"
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/css/properties/caret-color.json
+++ b/css/properties/caret-color.json
@@ -33,7 +33,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "7.0"

--- a/css/properties/custom-property.json
+++ b/css/properties/custom-property.json
@@ -139,11 +139,11 @@
               ],
               "safari_ios": [
                 {
-                  "version_added": "11.1"
+                  "version_added": "11.3"
                 },
                 {
                   "version_added": "11",
-                  "version_removed": "11.1",
+                  "version_removed": "11.3",
                   "alternative_name": "constant"
                 }
               ],

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -140,7 +140,7 @@
                 "version_added": "11.1"
               },
               "safari_ios": {
-                "version_added": "11.1"
+                "version_added": "11.3"
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/css/selectors/descendant.json
+++ b/css/selectors/descendant.json
@@ -101,7 +101,7 @@
               },
               "safari_ios": {
                 "version_added": "10",
-                "version_removed": "11.1"
+                "version_removed": "11.3"
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/css/types/max.json
+++ b/css/types/max.json
@@ -34,7 +34,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/types/min.json
+++ b/css/types/min.json
@@ -34,7 +34,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": "11.1"
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -1004,12 +1004,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "11.1",
-                "notes": "Currently only available on macOS High Sierra 10.13.4 beta, and in Safari Technology Preview 47+."
+                "version_added": "11.1"
               },
               "safari_ios": {
-                "version_added": "11.3",
-                "notes": "Currently only available on iOS 11.3 beta."
+                "version_added": "11.3"
               },
               "webview_android": {
                 "version_added": false

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -1008,7 +1008,7 @@
                 "notes": "Currently only available on macOS High Sierra 10.13.4 beta, and in Safari Technology Preview 47+."
               },
               "safari_ios": {
-                "version_added": "11.1",
+                "version_added": "11.3",
                 "notes": "Currently only available on iOS 11.3 beta."
               },
               "webview_android": {

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -306,7 +306,7 @@
                 "version_added": "11.1"
               },
               "safari_ios": {
-                "version_added": "11.1"
+                "version_added": "11.3"
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/javascript/operators/destructuring.json
+++ b/javascript/operators/destructuring.json
@@ -198,7 +198,7 @@
                 "version_added": "11.1"
               },
               "safari_ios": {
-                "version_added": "11.1"
+                "version_added": "11.3"
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/javascript/operators/object_initializer.json
+++ b/javascript/operators/object_initializer.json
@@ -241,7 +241,7 @@
                 "version_added": "11.1"
               },
               "safari_ios": {
-                "version_added": "11.1"
+                "version_added": "11.3"
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/javascript/operators/spread.json
+++ b/javascript/operators/spread.json
@@ -226,7 +226,7 @@
                 "version_added": "11.1"
               },
               "safari_ios": {
-                "version_added": "11.1"
+                "version_added": "11.3"
               },
               "samsunginternet_android": {
                 "version_added": "8.2"

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1696,7 +1696,7 @@
                 "version_added": "11.1"
               },
               "safari_ios": {
-                "version_added": "11.1"
+                "version_added": "11.3"
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
To help reduce some confusion, this PR removes Safari iOS 11.1 as an option.  Safari 11.1 was introduced in iOS 11.3, yet our compatibility data contains iOS 11.1, which seems to present confusion about whether to use the Safari or iOS versions.

Depends on #4834.