### PR TITLE
Edge 18 always report KeyboardEvent.repeat as false,

### DIFF
--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -1800,7 +1800,7 @@
             },
             "edge": {
               "version_added": null,
-              "notes": "Edge 18 currently implement this property, but only reporting false."
+              "notes": "Edge implements this property, however the return value is always <code>false</code>.  See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/17049017/'>bug 17049017</a>."
             },
             "firefox": {
               "version_added": "28"

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -1799,7 +1799,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": null,
+              "version_added": false,
               "notes": "Edge implements this property, however the return value is always <code>false</code>.  See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/17049017/'>bug 17049017</a>."
             },
             "firefox": {

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -1799,7 +1799,8 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "12"
+              "version_added": null,
+              "notes": "Edge 18 currently implement this property, but only reporting false."
             },
             "firefox": {
               "version_added": "28"


### PR DESCRIPTION
Test code :

    document.addEventListener('keydown', e=>console.log(e.repeat))
    document.addEventListener('keyup', e=>console.log(e.repeat))
    document.addEventListener('keypress', e=>console.log(e.repeat))