### PR TITLE
update to flow-root value of display

### DIFF
--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -487,7 +487,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
display: flow-root is still marked as experimental, the spec is in CR and there are two interoperable implementations so I don't think it warrants being flagged as experimental at this point. So this PR removes the experimental flag.
