### PR TITLE
Update StaticRange and add AbstractRange

### DIFF
--- a/api/AbstractRange.json
+++ b/api/AbstractRange.json
@@ -1,21 +1,20 @@
 {
   "api": {
-    "StaticRange": {
+    "AbstractRange": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/StaticRange",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbstractRange",
         "support": {
           "chrome": {
-            "version_added": "60"
+            "version_added": false
           },
           "chrome_android": {
-            "version_added": "60"
+            "version_added": false
           },
           "edge": {
             "version_added": true
           },
           "firefox": {
-            "version_added": "69",
-            "notes": "In Firefox, <code>StaticRange</code> is only available to privileged code such as the browser itself"
+            "version_added": "69"
           },
           "firefox_android": {
             "version_added": false
@@ -24,22 +23,22 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "47"
+            "version_added": false
           },
           "opera_android": {
-            "version_added": "44"
+            "version_added": false
           },
           "safari": {
-            "version_added": "10.1"
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": "10.3"
+            "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": false
           },
           "webview_android": {
-            "version_added": "60"
+            "version_added": false
           }
         },
         "status": {
@@ -48,64 +47,15 @@
           "deprecated": false
         }
       },
-      "StaticRange": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StaticRange/StaticRange",
-          "description": "<code>StaticRange()</code> constructor",
-          "support": {
-            "chrome": {
-              "version_added": "60"
-            },
-            "chrome_android": {
-              "version_added": "60"
-            },
-            "edge": {
-              "version_added": true
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "47"
-            },
-            "opera_android": {
-              "version_added": "44"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": true
-            },
-            "webview_android": {
-              "version_added": "60"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "collapsed": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StaticRange/collapsed",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbstractRange/collapsed",
           "support": {
             "chrome": {
-              "version_added": "60"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "60"
+              "version_added": false
             },
             "edge": {
               "version_added": true
@@ -120,22 +70,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "47"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "44"
+              "version_added": false
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "10.3"
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "60"
+              "version_added": false
             }
           },
           "status": {
@@ -147,13 +97,13 @@
       },
       "endContainer": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StaticRange/endContainer",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbstractRange/endContainer",
           "support": {
             "chrome": {
-              "version_added": "60"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "60"
+              "version_added": false
             },
             "edge": {
               "version_added": true
@@ -168,22 +118,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "47"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "44"
+              "version_added": false
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "10.3"
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "60"
+              "version_added": false
             }
           },
           "status": {
@@ -195,13 +145,13 @@
       },
       "endOffset": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StaticRange/endOffset",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbstractRange/endOffset",
           "support": {
             "chrome": {
-              "version_added": "60"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "60"
+              "version_added": false
             },
             "edge": {
               "version_added": true
@@ -216,22 +166,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "47"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "44"
+              "version_added": false
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "10.3"
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "60"
+              "version_added": false
             }
           },
           "status": {
@@ -243,13 +193,13 @@
       },
       "startContainer": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StaticRange/startContainer",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbstractRange/startContainer",
           "support": {
             "chrome": {
-              "version_added": "60"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "60"
+              "version_added": false
             },
             "edge": {
               "version_added": true
@@ -264,22 +214,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "47"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "44"
+              "version_added": false
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "10.3"
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "60"
+              "version_added": false
             }
           },
           "status": {
@@ -291,13 +241,13 @@
       },
       "startOffset": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StaticRange/startOffset",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbstractRange/startOffset",
           "support": {
             "chrome": {
-              "version_added": "60"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "60"
+              "version_added": false
             },
             "edge": {
               "version_added": true
@@ -312,59 +262,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "47"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "44"
-            },
-            "safari": {
-              "version_added": "10.1"
-            },
-            "safari_ios": {
-              "version_added": "10.3"
-            },
-            "samsunginternet_android": {
-              "version_added": true
-            },
-            "webview_android": {
-              "version_added": "60"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "toRange": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StaticRange/toRange",
-          "description": "<code>toRange()</code>",
-          "support": {
-            "chrome": {
-              "version_added": "60"
-            },
-            "chrome_android": {
-              "version_added": "60"
-            },
-            "edge": {
-              "version_added": true
-            },
-            "firefox": {
               "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "47"
-            },
-            "opera_android": {
-              "version_added": "44"
             },
             "safari": {
               "version_added": false
@@ -373,10 +274,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "60"
+              "version_added": false
             }
           },
           "status": {

--- a/api/AbstractRange.json
+++ b/api/AbstractRange.json
@@ -11,7 +11,7 @@
             "version_added": false
           },
           "edge": {
-            "version_added": true
+            "version_added": "18"
           },
           "firefox": {
             "version_added": "69"
@@ -58,7 +58,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "18"
             },
             "firefox": {
               "version_added": "69"
@@ -106,7 +106,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "18"
             },
             "firefox": {
               "version_added": "69"
@@ -154,7 +154,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "18"
             },
             "firefox": {
               "version_added": "69"
@@ -202,7 +202,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "18"
             },
             "firefox": {
               "version_added": "69"
@@ -250,7 +250,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "18"
             },
             "firefox": {
               "version_added": "69"

--- a/api/StaticRange.json
+++ b/api/StaticRange.json
@@ -11,11 +11,11 @@
             "version_added": "60"
           },
           "edge": {
-            "version_added": true
+            "version_added": "18"
           },
           "firefox": {
             "version_added": "69",
-            "notes": "In Firefox, <code>StaticRange</code> is only available to privileged code such as the browser itself"
+            "notes": "In Firefox, <code>StaticRange</code> can currently only be used by browser-internal code or code with enhanced permissions; it is not yet exposed to the web."
           },
           "firefox_android": {
             "version_added": false
@@ -60,7 +60,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": true
+              "version_added": "18"
             },
             "firefox": {
               "version_added": false
@@ -108,7 +108,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": true
+              "version_added": "18"
             },
             "firefox": {
               "version_added": "69"
@@ -156,7 +156,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": true
+              "version_added": "18"
             },
             "firefox": {
               "version_added": "69"
@@ -204,7 +204,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": true
+              "version_added": "18"
             },
             "firefox": {
               "version_added": "69"
@@ -252,7 +252,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": true
+              "version_added": "18"
             },
             "firefox": {
               "version_added": "69"
@@ -300,7 +300,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": true
+              "version_added": "18"
             },
             "firefox": {
               "version_added": "69"
@@ -349,7 +349,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": true
+              "version_added": "18"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
* Added AbstractRange; supported by Firefox 69 and Edge
only at this time, though there has been a patch merged
to WebKit to implement it there as well.
* Updated StaticRange; now supported in Firefox 69.
Removed experimental flags. Replaced all null values.

Sources:
* Confirmed Chrome and Safari don't have AbstractRange
by looking at trunk on Chromium and finding it's not
there.
* Confirmed Safari doesn't have StaticRange() constructor
by looking at current release sources and finding it's
not there. [source](https://trac.webkit.org/browser/webkit/releases/Apple/Safari%2012.1.2/WebCore/dom/StaticRange.idl?rev=250093)
Note however that it's been added on trunk; see [this Webkit
bug](https://bugs.webkit.org/show_bug.cgi?id=201055).
* Edge platform status claims support for these, and
I confirmed them by just manually trying them out.
* Firefox information comes from [bug 1444847](https://bugzilla.mozilla.org/show_bug.cgi?id=1444847).

A checklist to help your pull request get merged faster:
- [ ] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
