### PR TITLE
Don't apply "infra" label to anything in test/*

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -39,6 +39,7 @@ infra :building_construction::
   - ".github/**"
   - "LICENSE"
   - "package*"
+  - "!test/**"
 linter :house_with_garden::
   - "test/**"
 schema :gear::


### PR DESCRIPTION
I noticed that the label bot set the `infra` label onto a linter PR, as the `test/` folder has all JavaScript files (which matches the `*.js` regex).  This PR aims to fix that by adding a line to ignore anything in the `test/` folder when applying the `infra` label.

Note: I'm assuming that the labels.yml file can take the NOT operand like in .gitignore, but I could be wrong, feel free to correct me!