### PR TITLE
test(links): Check links in browser data

### DIFF
--- a/test/lint.js
+++ b/test/lint.js
@@ -80,6 +80,7 @@ function load(...files) {
         try {
           if (file.indexOf('browsers' + path.sep) !== -1) {
             hasSchemaErrors = testSchema(file, './../../schemas/browsers.schema.json');
+            hasStyleErrors = testLinks(file);
           } else {
             hasSchemaErrors = testSchema(file);
             hasStyleErrors = testStyle(file);
@@ -150,6 +151,7 @@ if (hasErrors) {
     try {
       if (file.indexOf('browsers' + path.sep) !== -1) {
         testSchema(file, './../../schemas/browsers.schema.json');
+        testLinks(file);
       } else {
         testSchema(file);
         testStyle(file);


### PR DESCRIPTION
This runs `test‑links.js` on files in the `browsers` directory.

I’ve also fixed the extra space from https://github.com/mdn/browser-compat-data/pull/4799#pullrequestreview-290759310

---

Depends on: #4852