### PR TITLE
Safari 13 added support for VisualViewport.

### DIFF
--- a/api/VisualViewport.json
+++ b/api/VisualViewport.json
@@ -48,10 +48,10 @@
             "version_added": "45"
           },
           "safari": {
-            "version_added": false
+            "version_added": "13"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "13"
           },
           "samsunginternet_android": {
             "version_added": null
@@ -114,10 +114,10 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -181,10 +181,10 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -248,10 +248,10 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -339,10 +339,10 @@
               }
             ],
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -436,10 +436,10 @@
               }
             ],
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -509,10 +509,10 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -576,10 +576,10 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -668,10 +668,10 @@
               }
             ],
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -741,10 +741,10 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -833,10 +833,10 @@
               }
             ],
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -906,10 +906,10 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": null


### PR DESCRIPTION
Safari 13 has been released for iOS and desktop with full support for
the VisualViewport API. From quick testing on iOS and OS X all
properties appear to be properly populated and both events fire
(resize/scroll).

> Added support for the Visual Viewport API for adjusting web content to avoid overlays, such as the onscreen keyboard.

https://developer.apple.com/documentation/safari_release_notes/safari_13_release_notes

<img width="711" alt="Screen Shot 2019-09-20 at 5 23 31 PM" src="https://user-images.githubusercontent.com/72590/65359749-763c0600-dbcb-11e9-8f24-9495e469e908.png">
<img width="701" alt="Screen Shot 2019-09-20 at 5 23 48 PM" src="https://user-images.githubusercontent.com/72590/65359752-789e6000-dbcb-11e9-81da-85f17a611d79.png">
