### PR TITLE
fix(browsers/firefox): De-localize Firefox release notes

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -13,35 +13,35 @@
         },
         "1.5": {
           "release_date": "2005-11-29",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/1.5",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/1.5",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "1.8"
         },
         "2": {
           "release_date": "2006-10-24",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/2",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/2",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "1.8.1"
         },
         "3": {
           "release_date": "2008-06-17",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/3",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/3",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "1.9"
         },
         "3.5": {
           "release_date": "2009-06-30",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/3.5",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/3.5",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "1.9.1"
         },
         "3.6": {
           "release_date": "2010-01-21",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/3.6",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/3.6",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "1.9.2"
@@ -55,476 +55,476 @@
         },
         "4": {
           "release_date": "2011-03-22",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/4",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/4",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "2"
         },
         "5": {
           "release_date": "2011-06-21",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/5",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/5",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "5"
         },
         "6": {
           "release_date": "2011-08-16",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/6",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/6",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "6"
         },
         "7": {
           "release_date": "2011-09-27",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/7",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/7",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "7"
         },
         "8": {
           "release_date": "2011-11-08",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/8",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/8",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "8"
         },
         "9": {
           "release_date": "2011-12-20",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/9",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/9",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "9"
         },
         "10": {
           "release_date": "2012-01-31",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/10",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/10",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "10"
         },
         "11": {
           "release_date": "2012-03-13",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/11",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/11",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "11"
         },
         "12": {
           "release_date": "2012-04-24",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/12",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/12",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "12"
         },
         "13": {
           "release_date": "2012-06-05",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/13",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/13",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "13"
         },
         "14": {
           "release_date": "2012-07-17",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/14",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/14",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "14"
         },
         "15": {
           "release_date": "2012-08-28",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/15",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/15",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "15"
         },
         "16": {
           "release_date": "2012-10-09",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/16",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/16",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "16"
         },
         "17": {
           "release_date": "2012-11-20",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/17",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/17",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "17"
         },
         "18": {
           "release_date": "2013-01-08",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/18",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/18",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "18"
         },
         "19": {
           "release_date": "2013-02-19",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/19",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/19",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "19"
         },
         "20": {
           "release_date": "2013-04-02",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/20",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/20",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "20"
         },
         "21": {
           "release_date": "2013-05-14",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/21",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/21",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "21"
         },
         "22": {
           "release_date": "2013-06-25",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/22",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/22",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "22"
         },
         "23": {
           "release_date": "2013-08-06",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/23",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/23",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "23"
         },
         "24": {
           "release_date": "2013-09-17",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/24",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/24",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "24"
         },
         "25": {
           "release_date": "2013-10-29",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/25",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/25",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "25"
         },
         "26": {
           "release_date": "2013-12-10",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/26",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/26",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "26"
         },
         "27": {
           "release_date": "2014-02-04",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/27",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/27",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "27"
         },
         "28": {
           "release_date": "2014-03-18",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/28",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/28",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "28"
         },
         "29": {
           "release_date": "2014-04-29",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/29",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/29",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "29"
         },
         "30": {
           "release_date": "2014-06-10",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/30",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/30",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "30"
         },
         "31": {
           "release_date": "2014-07-22",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/31",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/31",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "31"
         },
         "32": {
           "release_date": "2014-09-02",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/32",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/32",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "32"
         },
         "33": {
           "release_date": "2014-10-14",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/33",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/33",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "33"
         },
         "34": {
           "release_date": "2014-12-01",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/34",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/34",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "34"
         },
         "35": {
           "release_date": "2015-01-13",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/35",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/35",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "35"
         },
         "36": {
           "release_date": "2015-02-24",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/36",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/36",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "36"
         },
         "37": {
           "release_date": "2015-03-31",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/37",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/37",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "37"
         },
         "38": {
           "release_date": "2015-05-12",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/38",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/38",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "38"
         },
         "39": {
           "release_date": "2015-07-02",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/39",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/39",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "39"
         },
         "40": {
           "release_date": "2015-08-11",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/40",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/40",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "40"
         },
         "41": {
           "release_date": "2015-09-22",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/41",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/41",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "41"
         },
         "42": {
           "release_date": "2015-11-03",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/42",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/42",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "42"
         },
         "43": {
           "release_date": "2015-12-15",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/43",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/43",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "43"
         },
         "44": {
           "release_date": "2016-01-26",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/44",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/44",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "44"
         },
         "45": {
           "release_date": "2016-03-08",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/45",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/45",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "45"
         },
         "46": {
           "release_date": "2016-04-26",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/46",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/46",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "46"
         },
         "47": {
           "release_date": "2016-06-07",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/47",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/47",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "47"
         },
         "48": {
           "release_date": "2016-08-02",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/48",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/48",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "48"
         },
         "49": {
           "release_date": "2016-09-20",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/49",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/49",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "49"
         },
         "50": {
           "release_date": "2016-11-15",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/50",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/50",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "50"
         },
         "51": {
           "release_date": "2017-01-24",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/51",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/51",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "51"
         },
         "52": {
           "release_date": "2017-03-07",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/52",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/52",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "52"
         },
         "53": {
           "release_date": "2017-04-19",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/53",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/53",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "53"
         },
         "54": {
           "release_date": "2017-06-13",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/54",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/54",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "54"
         },
         "55": {
           "release_date": "2017-08-08",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/55",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/55",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "55"
         },
         "56": {
           "release_date": "2017-09-28",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/56",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/56",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "56"
         },
         "57": {
           "release_date": "2017-11-14",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/57",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/57",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "57"
         },
         "58": {
           "release_date": "2018-01-23",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/58",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/58",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "58"
         },
         "59": {
           "release_date": "2018-03-13",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/59",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/59",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "59"
         },
         "60": {
           "release_date": "2018-05-09",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/60",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/60",
           "status": "esr",
           "engine": "Gecko",
           "engine_version": "60"
         },
         "61": {
           "release_date": "2018-06-26",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/61",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/61",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "61"
         },
         "62": {
           "release_date": "2018-09-05",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/62",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/62",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "62"
         },
         "63": {
           "release_date": "2018-10-23",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/63",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/63",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "63"
         },
         "64": {
           "release_date": "2018-12-11",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/64",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/64",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "64"
         },
         "65": {
           "release_date": "2019-01-29",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/65",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/65",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "65"
         },
         "66": {
           "release_date": "2019-03-19",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/66",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/66",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "66"
         },
         "67": {
           "release_date": "2019-05-21",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/67",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/67",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "67"
         },
         "68": {
           "release_date": "2019-07-09",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/68",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/68",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "68"
         },
         "69": {
           "release_date": "2019-09-03",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/69",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/69",
           "status": "current",
           "engine": "Gecko",
           "engine_version": "69"
         },
         "70": {
           "release_date": "2019-10-22",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/70",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/70",
           "status": "beta",
           "engine": "Gecko",
           "engine_version": "70"
         },
         "71": {
           "release_date": "2019-12-10",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/71",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/71",
           "status": "nightly",
           "engine": "Gecko",
           "engine_version": "71"

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -6,434 +6,434 @@
       "releases": {
         "4": {
           "release_date": "2011-03-29",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/4",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/4",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "2"
         },
         "5": {
           "release_date": "2011-06-21",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/5",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/5",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "5"
         },
         "6": {
           "release_date": "2011-08-16",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/6",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/6",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "6"
         },
         "7": {
           "release_date": "2011-09-27",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/7",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/7",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "7"
         },
         "8": {
           "release_date": "2011-11-08",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/8",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/8",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "8"
         },
         "9": {
           "release_date": "2011-12-21",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/9",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/9",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "9"
         },
         "10": {
           "release_date": "2012-01-31",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/10",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/10",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "10"
         },
         "14": {
           "release_date": "2012-06-26",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/14",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/14",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "14"
         },
         "15": {
           "release_date": "2012-08-28",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/15",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/15",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "15"
         },
         "16": {
           "release_date": "2012-10-09",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/16",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/16",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "16"
         },
         "17": {
           "release_date": "2012-11-20",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/17",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/17",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "17"
         },
         "18": {
           "release_date": "2013-01-08",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/18",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/18",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "18"
         },
         "19": {
           "release_date": "2013-02-19",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/19",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/19",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "19"
         },
         "20": {
           "release_date": "2013-04-02",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/20",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/20",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "20"
         },
         "21": {
           "release_date": "2013-05-14",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/21",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/21",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "21"
         },
         "22": {
           "release_date": "2013-06-25",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/22",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/22",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "22"
         },
         "23": {
           "release_date": "2013-08-06",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/23",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/23",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "23"
         },
         "24": {
           "release_date": "2013-09-17",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/24",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/24",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "24"
         },
         "25": {
           "release_date": "2013-10-29",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/25",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/25",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "25"
         },
         "26": {
           "release_date": "2013-12-10",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/26",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/26",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "26"
         },
         "27": {
           "release_date": "2014-02-04",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/27",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/27",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "27"
         },
         "28": {
           "release_date": "2014-03-18",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/28",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/28",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "28"
         },
         "29": {
           "release_date": "2014-04-29",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/29",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/29",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "29"
         },
         "30": {
           "release_date": "2014-06-10",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/30",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/30",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "30"
         },
         "31": {
           "release_date": "2014-07-22",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/31",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/31",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "31"
         },
         "32": {
           "release_date": "2014-09-02",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/32",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/32",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "32"
         },
         "33": {
           "release_date": "2014-10-14",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/33",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/33",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "33"
         },
         "34": {
           "release_date": "2014-12-01",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/34",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/34",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "34"
         },
         "35": {
           "release_date": "2015-01-13",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/35",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/35",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "35"
         },
         "36": {
           "release_date": "2015-02-27",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/36",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/36",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "36"
         },
         "37": {
           "release_date": "2015-03-31",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/37",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/37",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "37"
         },
         "38": {
           "release_date": "2015-05-12",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/38",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/38",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "38"
         },
         "39": {
           "release_date": "2015-07-02",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/39",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/39",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "39"
         },
         "40": {
           "release_date": "2015-08-11",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/40",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/40",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "40"
         },
         "41": {
           "release_date": "2015-09-22",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/41",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/41",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "41"
         },
         "42": {
           "release_date": "2015-11-03",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/42",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/42",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "42"
         },
         "43": {
           "release_date": "2015-12-15",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/43",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/43",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "43"
         },
         "44": {
           "release_date": "2016-01-26",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/44",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/44",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "44"
         },
         "45": {
           "release_date": "2016-03-08",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/45",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/45",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "45"
         },
         "46": {
           "release_date": "2016-04-26",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/46",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/46",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "46"
         },
         "47": {
           "release_date": "2016-06-07",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/47",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/47",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "47"
         },
         "48": {
           "release_date": "2016-08-02",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/48",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/48",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "48"
         },
         "49": {
           "release_date": "2016-09-20",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/49",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/49",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "49"
         },
         "50": {
           "release_date": "2016-11-15",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/50",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/50",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "50"
         },
         "51": {
           "release_date": "2017-01-24",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/51",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/51",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "51"
         },
         "52": {
           "release_date": "2017-03-07",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/52",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/52",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "52"
         },
         "53": {
           "release_date": "2017-04-19",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/53",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/53",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "53"
         },
         "54": {
           "release_date": "2017-06-13",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/54",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/54",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "54"
         },
         "55": {
           "release_date": "2017-08-08",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/55",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/55",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "55"
         },
         "56": {
           "release_date": "2017-09-28",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/56",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/56",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "56"
         },
         "57": {
           "release_date": "2017-11-28",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/57",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/57",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "57"
         },
         "58": {
           "release_date": "2018-01-22",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/58",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/58",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "58"
         },
         "59": {
           "release_date": "2018-03-13",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/59",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/59",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "59"
         },
         "60": {
           "release_date": "2018-05-09",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/60",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/60",
           "status": "esr",
           "engine": "Gecko",
           "engine_version": "60"
         },
         "61": {
           "release_date": "2018-06-26",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/61",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/61",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "61"
         },
         "62": {
           "release_date": "2018-09-05",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/62",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/62",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "62"
         },
         "63": {
           "release_date": "2018-10-23",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/63",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/63",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "63"
         },
         "64": {
           "release_date": "2018-12-11",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/64",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/64",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "64"
         },
         "65": {
           "release_date": "2019-01-29",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/65",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/65",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "65"
         },
         "66": {
           "release_date": "2019-03-19",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/66",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/66",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "66"
         },
         "67": {
           "release_date": "2019-05-21",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/67",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/67",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "67"
         },
         "68": {
           "release_date": "2019-07-09",
-          "release_notes": "https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/68",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/68",
           "status": "current",
           "engine": "Gecko",
           "engine_version": "68"

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -3,7 +3,7 @@
     "nodejs": {
       "name": "Node.js",
       "releases": {
-         "0.1.100": {
+        "0.1.100": {
           "release_date": "2010-07-03",
           "release_notes": "https://github.com/nodejs/node-v0.x-archive/blob/v0.1.100/ChangeLog",
           "engine": "V8",


### PR DESCRIPTION
Prerequisite for: #4847

I’ve also fixed the extra space from https://github.com/mdn/browser-compat-data/pull/4799#pullrequestreview-290759310

---

review?(@vinyldarkscratch)