### PR TITLE
Add Samsung Internet version for :visited

### DIFF
--- a/css/selectors/visited.json
+++ b/css/selectors/visited.json
@@ -37,7 +37,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"


### PR DESCRIPTION
This adds the Samsung Internet version to the :visited CSS selector.