### PR TITLE
Add Opera Android version to DateTimeFormat

### DIFF
--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -393,7 +393,7 @@
                 "version_added": "15"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "10"


### PR DESCRIPTION
This adds the Opera Android version to Intl.DateTimeFormat.