### PR TITLE
Fix Safari iOS versions for WebGL per CanIUse

### DIFF
--- a/api/WebGLActiveInfo.json
+++ b/api/WebGLActiveInfo.json
@@ -32,7 +32,7 @@
             "version_added": "5.1"
           },
           "safari_ios": {
-            "version_added": "8.1"
+            "version_added": "8"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -79,7 +79,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -127,7 +127,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -175,7 +175,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/WebGLBuffer.json
+++ b/api/WebGLBuffer.json
@@ -32,7 +32,7 @@
             "version_added": "5.1"
           },
           "safari_ios": {
-            "version_added": "8.1"
+            "version_added": "8"
           },
           "samsunginternet_android": {
             "version_added": true

--- a/api/WebGLContextEvent.json
+++ b/api/WebGLContextEvent.json
@@ -32,7 +32,7 @@
             "version_added": "5.1"
           },
           "safari_ios": {
-            "version_added": "8.1"
+            "version_added": "8"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -79,7 +79,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/WebGLFramebuffer.json
+++ b/api/WebGLFramebuffer.json
@@ -32,7 +32,7 @@
             "version_added": "5.1"
           },
           "safari_ios": {
-            "version_added": "8.1"
+            "version_added": "8"
           },
           "samsunginternet_android": {
             "version_added": true

--- a/api/WebGLProgram.json
+++ b/api/WebGLProgram.json
@@ -32,7 +32,7 @@
             "version_added": "5.1"
           },
           "safari_ios": {
-            "version_added": "8.1"
+            "version_added": "8"
           },
           "samsunginternet_android": {
             "version_added": true

--- a/api/WebGLRenderbuffer.json
+++ b/api/WebGLRenderbuffer.json
@@ -32,7 +32,7 @@
             "version_added": "5.1"
           },
           "safari_ios": {
-            "version_added": "8.1"
+            "version_added": "8"
           },
           "samsunginternet_android": {
             "version_added": true

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -34,7 +34,7 @@
             "version_added": "5.1"
           },
           "safari_ios": {
-            "version_added": "8.1"
+            "version_added": "8"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -81,7 +81,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -129,7 +129,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -177,7 +177,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -225,7 +225,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -320,7 +320,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -415,7 +415,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -463,7 +463,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -558,7 +558,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -606,7 +606,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -701,7 +701,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -796,7 +796,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -844,7 +844,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -940,7 +940,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1035,7 +1035,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1130,7 +1130,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1232,7 +1232,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1327,7 +1327,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1375,7 +1375,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1423,7 +1423,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1471,7 +1471,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1519,7 +1519,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1622,7 +1622,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1670,7 +1670,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1813,7 +1813,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1956,7 +1956,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2004,7 +2004,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2052,7 +2052,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2100,7 +2100,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2148,7 +2148,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2196,7 +2196,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2244,7 +2244,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2292,7 +2292,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2340,7 +2340,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2388,7 +2388,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2436,7 +2436,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2484,7 +2484,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2532,7 +2532,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2580,7 +2580,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2628,7 +2628,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2676,7 +2676,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2724,7 +2724,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2772,7 +2772,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2820,7 +2820,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2868,7 +2868,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2916,7 +2916,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -2964,7 +2964,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3012,7 +3012,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3060,7 +3060,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3108,7 +3108,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3156,7 +3156,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3204,7 +3204,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3252,7 +3252,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3300,7 +3300,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3348,7 +3348,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3443,7 +3443,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3538,7 +3538,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3586,7 +3586,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3681,7 +3681,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3729,7 +3729,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3777,7 +3777,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3825,7 +3825,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3873,7 +3873,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -3968,7 +3968,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4016,7 +4016,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4064,7 +4064,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4112,7 +4112,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4207,7 +4207,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4255,7 +4255,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4303,7 +4303,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4398,7 +4398,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4493,7 +4493,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4541,7 +4541,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4589,7 +4589,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4637,7 +4637,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4685,7 +4685,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4733,7 +4733,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4828,7 +4828,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4923,7 +4923,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4971,7 +4971,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -5066,7 +5066,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -5114,7 +5114,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -5162,7 +5162,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -5210,7 +5210,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -5258,7 +5258,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -5353,7 +5353,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -5401,7 +5401,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -5449,7 +5449,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -5497,7 +5497,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -5545,7 +5545,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -5641,7 +5641,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -5689,7 +5689,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -5784,7 +5784,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -5832,7 +5832,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -5975,7 +5975,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -6070,7 +6070,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -6118,7 +6118,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -6166,7 +6166,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -6214,7 +6214,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -6262,7 +6262,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -6310,7 +6310,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -6358,7 +6358,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -6406,7 +6406,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -6454,7 +6454,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -6502,7 +6502,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -6645,7 +6645,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -6740,7 +6740,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -6835,7 +6835,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -6978,7 +6978,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -7026,7 +7026,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -7074,7 +7074,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -7122,7 +7122,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -7170,7 +7170,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -7218,7 +7218,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -7266,7 +7266,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -7314,7 +7314,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -7362,7 +7362,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -7410,7 +7410,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -7458,7 +7458,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -7506,7 +7506,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -7554,7 +7554,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -7602,7 +7602,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -7650,7 +7650,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -7698,7 +7698,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -7746,7 +7746,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -7889,7 +7889,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -8032,7 +8032,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -8175,7 +8175,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -8223,7 +8223,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -8271,7 +8271,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -8319,7 +8319,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -8415,7 +8415,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -8463,7 +8463,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -8559,7 +8559,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -8607,7 +8607,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -8703,7 +8703,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -8751,7 +8751,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -8847,7 +8847,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -8895,7 +8895,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/WebGLShader.json
+++ b/api/WebGLShader.json
@@ -32,7 +32,7 @@
             "version_added": "5.1"
           },
           "safari_ios": {
-            "version_added": "8.1"
+            "version_added": "8"
           },
           "samsunginternet_android": {
             "version_added": true

--- a/api/WebGLShaderPrecisionFormat.json
+++ b/api/WebGLShaderPrecisionFormat.json
@@ -32,7 +32,7 @@
             "version_added": "5.1"
           },
           "safari_ios": {
-            "version_added": "8.1"
+            "version_added": "8"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -79,7 +79,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -127,7 +127,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -175,7 +175,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "8.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/WebGLTexture.json
+++ b/api/WebGLTexture.json
@@ -32,7 +32,7 @@
             "version_added": "5.1"
           },
           "safari_ios": {
-            "version_added": "8.1"
+            "version_added": "8"
           },
           "samsunginternet_android": {
             "version_added": true

--- a/api/WebGLUniformLocation.json
+++ b/api/WebGLUniformLocation.json
@@ -32,7 +32,7 @@
             "version_added": "5.1"
           },
           "safari_ios": {
-            "version_added": "8.1"
+            "version_added": "8"
           },
           "samsunginternet_android": {
             "version_added": true


### PR DESCRIPTION
While working on stripping out Safari iOS versions, I found Safari iOS 8.1 was set for all WebGL APIs.  However, iOS 8.0 and 8.1 have the same WebKit version.  [CanIUse also states](https://caniuse.com/#feat=webgl) that WebGL was introduced in iOS 8.0.

This PR sets all iOS 8.1 entries for WebGL to iOS 8.0, allowing us to remove Safari iOS 8.1 as an option.