### PR TITLE
Remove iOS 8.1 from data

### DIFF
--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -93,12 +93,6 @@
           "engine_version": "600.1.4",
           "release_date": "2014-09-17"
         },
-        "8.1": {
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "600.1.4",
-          "release_date": "2014-10-20"
-        },
         "8.4": {
           "status": "retired",
           "engine": "WebKit",


### PR DESCRIPTION
Safari iOS 8.1 has the same WebKit version as Safari iOS 8.0.  The only reason iOS 8.1 was in our data was for the WebGL APIs, which was found to be implemented in iOS 8.0 anyways.

Depends on #4856.