### PR TITLE
Remove iOS 9.1 from data

### DIFF
--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -111,12 +111,6 @@
           "engine_version": "601.1.56",
           "release_date": "2015-09-16"
         },
-        "9.1": {
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "601.1.56",
-          "release_date": "2015-10-21"
-        },
         "9.2": {
           "status": "retired",
           "engine": "WebKit",

--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -66,7 +66,7 @@
             ],
             "safari_ios": [
               {
-                "version_added": "9.1"
+                "version_added": "9.3"
               },
               {
                 "prefix": "-webkit-",

--- a/css/properties/color.json
+++ b/css/properties/color.json
@@ -176,7 +176,7 @@
                 "version_added": "9.1"
               },
               "safari_ios": {
-                "version_added": "9.1"
+                "version_added": "9.3"
               },
               "samsunginternet_android": {
                 "version_added": null

--- a/css/properties/custom-property.json
+++ b/css/properties/custom-property.json
@@ -86,7 +86,7 @@
               "version_added": "9.1"
             },
             "safari_ios": {
-              "version_added": "9.1"
+              "version_added": "9.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -239,7 +239,7 @@
                 "version_added": "9.1"
               },
               "safari_ios": {
-                "version_added": "9.1"
+                "version_added": "9.3"
               },
               "samsunginternet_android": {
                 "version_added": null

--- a/css/properties/font-synthesis.json
+++ b/css/properties/font-synthesis.json
@@ -46,7 +46,7 @@
               "version_added": "9"
             },
             "safari_ios": {
-              "version_added": "9.1"
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/font-variant-numeric.json
+++ b/css/properties/font-variant-numeric.json
@@ -59,7 +59,7 @@
               "version_added": "9.1"
             },
             "safari_ios": {
-              "version_added": "9.1"
+              "version_added": "9.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/css/properties/hyphens.json
+++ b/css/properties/hyphens.json
@@ -317,7 +317,7 @@
                 "version_added": "9.1"
               },
               "safari_ios": {
-                "version_added": "9.1"
+                "version_added": "9.3"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -365,7 +365,7 @@
                 "version_added": "9.1"
               },
               "safari_ios": {
-                "version_added": "9.1"
+                "version_added": "9.3"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -657,7 +657,7 @@
                 "version_added": "9.1"
               },
               "safari_ios": {
-                "version_added": "9.1"
+                "version_added": "9.3"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -945,7 +945,7 @@
                 "version_added": "9.1"
               },
               "safari_ios": {
-                "version_added": "9.1"
+                "version_added": "9.3"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -1425,7 +1425,7 @@
                 "version_added": "9.1"
               },
               "safari_ios": {
-                "version_added": "9.1"
+                "version_added": "9.3"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -1473,7 +1473,7 @@
                 "version_added": "9.1"
               },
               "safari_ios": {
-                "version_added": "9.1"
+                "version_added": "9.3"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -1811,7 +1811,7 @@
                 "version_added": "9.1"
               },
               "safari_ios": {
-                "version_added": "9.1"
+                "version_added": "9.3"
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
This PR removes Safari iOS 9.1 from the browser compatibility data.  iOS 9.1 used Safari 9.0, and it seems that keeping iOS 9.1 introduces confusion about whether to use the iOS version or the Safari version.

Furthermore, this fixes all the entries that have Safari iOS 9.1 set, replacing them with "9.3" (or for one, "9" based upon the desktop edition).