### PR TITLE
Remove iOS 9.2 from data

### DIFF
--- a/api/PerformanceTiming.json
+++ b/api/PerformanceTiming.json
@@ -32,7 +32,7 @@
             "version_added": "8"
           },
           "safari_ios": {
-            "version_added": "9.2"
+            "version_added": "8"
           },
           "webview_android": {
             "version_added": true
@@ -301,7 +301,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "9.2"
+              "version_added": "8"
             },
             "webview_android": {
               "version_added": true

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -117,12 +117,6 @@
           "engine_version": "601.1.56",
           "release_date": "2015-10-21"
         },
-        "9.2": {
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "601.1.56",
-          "release_date": "2015-12-08"
-        },
         "9.3": {
           "status": "retired",
           "engine": "WebKit",

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -82,7 +82,7 @@
                 "version_added": "9"
               },
               "safari_ios": {
-                "version_added": "9.2"
+                "version_added": "9"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -131,7 +131,7 @@
                 "version_added": "9"
               },
               "safari_ios": {
-                "version_added": "9.2"
+                "version_added": "9"
               },
               "webview_android": {
                 "version_added": "41"
@@ -719,7 +719,7 @@
                 "version_added": "9"
               },
               "safari_ios": {
-                "version_added": "9.2"
+                "version_added": "9"
               },
               "webview_android": {
                 "version_added": "38",
@@ -1156,7 +1156,7 @@
                 "version_added": "9"
               },
               "safari_ios": {
-                "version_added": "9.2"
+                "version_added": "9"
               },
               "webview_android": {
                 "version_added": "41"

--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -94,7 +94,7 @@
               ],
               "safari_ios": [
                 {
-                  "version_added": "9.2"
+                  "version_added": "9"
                 },
                 {
                   "prefix": "-webkit-",

--- a/css/properties/justify-items.json
+++ b/css/properties/justify-items.json
@@ -35,7 +35,7 @@
                 "version_added": "9"
               },
               "safari_ios": {
-                "version_added": "9.2"
+                "version_added": "9"
               },
               "samsunginternet_android": {
                 "version_added": null

--- a/html/elements/source.json
+++ b/html/elements/source.json
@@ -159,7 +159,7 @@
               ],
               "safari_ios": [
                 {
-                  "version_added": "9.2"
+                  "version_added": "9"
                 },
                 {
                   "version_added": "8",
@@ -289,7 +289,7 @@
               ],
               "safari_ios": [
                 {
-                  "version_added": "9.2"
+                  "version_added": "9"
                 },
                 {
                   "version_added": "8",


### PR DESCRIPTION
This PR removes Safari iOS 9.2 from the data.  As iOS 9.2 uses Safari 9.0, there's no need to keep it around separately.  Furthermore, this fixes the data using iOS 9.2 and replaces it by mirroring the desktop data.