### PR TITLE
Remove iOS 10.1 from data

### DIFF
--- a/api/Crypto.json
+++ b/api/Crypto.json
@@ -161,7 +161,7 @@
             ],
             "safari_ios": [
               {
-                "version_added": "10.1"
+                "version_added": "10.3"
               },
               {
                 "version_added": "7",

--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -91,7 +91,7 @@
             "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": "10.1"
+            "version_added": "10.3"
           },
           "samsunginternet_android": {
             "version_added": "6.0"
@@ -332,7 +332,7 @@
               "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
             },
             "safari_ios": {
-              "version_added": "10.1",
+              "version_added": "10.3",
               "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
             },
             "samsunginternet_android": {
@@ -477,7 +477,7 @@
               "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
             },
             "safari_ios": {
-              "version_added": "10.1",
+              "version_added": "10.3",
               "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
             },
             "samsunginternet_android": {
@@ -670,7 +670,7 @@
               "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
             },
             "safari_ios": {
-              "version_added": "10.1",
+              "version_added": "10.3",
               "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
             },
             "samsunginternet_android": {

--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -40,12 +40,12 @@
           ],
           "safari_ios": [
             {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             {
               "version_added": "1",
-              "version_removed": "10.1",
-              "notes": "<code>Window.EventTarget</code> did not exist on versions of Safari iOS before 10.1."
+              "version_removed": "10.3",
+              "notes": "<code>Window.EventTarget</code> did not exist on versions of Safari iOS before 10.3."
             }
           ],
           "samsunginternet_android": {

--- a/api/HTMLSlotElement.json
+++ b/api/HTMLSlotElement.json
@@ -91,7 +91,7 @@
             "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": "10.1"
+            "version_added": "10.3"
           },
           "samsunginternet_android": {
             "version_added": "6.0"
@@ -245,7 +245,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -352,7 +352,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -459,7 +459,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/IDBCursor.json
+++ b/api/IDBCursor.json
@@ -262,7 +262,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -498,7 +498,7 @@
                 "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": "10.1"
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": "7.0"

--- a/api/IDBDatabase.json
+++ b/api/IDBDatabase.json
@@ -243,7 +243,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -671,7 +671,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -267,7 +267,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -327,7 +327,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/IDBKeyRange.json
+++ b/api/IDBKeyRange.json
@@ -157,7 +157,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/IDBObjectStore.json
+++ b/api/IDBObjectStore.json
@@ -793,7 +793,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -841,7 +841,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -889,7 +889,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/InputEvent.json
+++ b/api/InputEvent.json
@@ -32,7 +32,7 @@
             "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": "10.1"
+            "version_added": "10.3"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -224,7 +224,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -272,7 +272,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -1380,7 +1380,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1820,7 +1820,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/Node.json
+++ b/api/Node.json
@@ -574,7 +574,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "webview_android": {
               "version_added": "54"
@@ -801,7 +801,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/Request.json
+++ b/api/Request.json
@@ -65,7 +65,7 @@
             "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": "10.1"
+            "version_added": "10.3"
           },
           "samsunginternet_android": {
             "version_added": "4.0"
@@ -859,7 +859,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -59,7 +59,7 @@
             "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": "10.1"
+            "version_added": "10.3"
           },
           "samsunginternet_android": {
             "version_added": "6.0"
@@ -232,7 +232,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -307,7 +307,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -382,7 +382,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/Slotable.json
+++ b/api/Slotable.json
@@ -91,7 +91,7 @@
             "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": "10.1"
+            "version_added": "10.3"
           },
           "samsunginternet_android": {
             "version_added": "6.0"
@@ -197,7 +197,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/StaticRange.json
+++ b/api/StaticRange.json
@@ -32,7 +32,7 @@
             "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": "10.1"
+            "version_added": "10.3"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -128,7 +128,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -176,7 +176,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -224,7 +224,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -272,7 +272,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -320,7 +320,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -67,7 +67,7 @@
           ],
           "safari_ios": [
             {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             {
               "version_added": "7",

--- a/api/Text.json
+++ b/api/Text.json
@@ -119,7 +119,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/TextDecoder.json
+++ b/api/TextDecoder.json
@@ -46,7 +46,7 @@
             "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": "10.1"
+            "version_added": "10.3"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -108,7 +108,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -170,7 +170,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -232,7 +232,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -280,7 +280,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -328,7 +328,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -376,7 +376,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/TextEncoder.json
+++ b/api/TextEncoder.json
@@ -44,7 +44,7 @@
             "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": "10.1"
+            "version_added": "10.3"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -134,7 +134,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -194,7 +194,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -302,7 +302,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -350,7 +350,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/Window.json
+++ b/api/Window.json
@@ -1590,7 +1590,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -135,12 +135,6 @@
           "engine_version": "602.1.50",
           "release_date": "2016-09-13"
         },
-        "10.1": {
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "602.2",
-          "release_date": "2016-10-24"
-        },
         "10.2": {
           "status": "retired",
           "engine": "WebKit",

--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -190,7 +190,7 @@
                 "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": "10.1"
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"

--- a/html/elements/slot.json
+++ b/html/elements/slot.json
@@ -91,7 +91,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -195,7 +195,7 @@
                 "version_added": "10"
               },
               "safari_ios": {
-                "version_added": "10.1"
+                "version_added": "10"
               },
               "samsunginternet_android": {
                 "version_added": "6.0"

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1557,7 +1557,7 @@
               "prefix": "-webkit-"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/javascript/operators/arithmetic.json
+++ b/javascript/operators/arithmetic.json
@@ -205,7 +205,7 @@
                 "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": "10.1"
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": "6.0"

--- a/javascript/operators/assignment.json
+++ b/javascript/operators/assignment.json
@@ -309,7 +309,7 @@
                 "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": "10.1"
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": "6.0"

--- a/javascript/operators/async_function_expression.json
+++ b/javascript/operators/async_function_expression.json
@@ -49,7 +49,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/javascript/operators/await.json
+++ b/javascript/operators/await.json
@@ -48,7 +48,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -103,7 +103,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -261,7 +261,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -574,7 +574,7 @@
                 "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": "10.1"
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -768,7 +768,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -1619,7 +1619,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10.1"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
This PR removes Safari iOS 10.1 from the browser compatibility data. iOS 10.1 used Safari 10.0, and it seems that keeping iOS 10.1 introduces confusion about whether to use the iOS version or the Safari version.

Furthermore, this fixes all the entries that have Safari iOS 10.1 set, replacing them with "10.3" (or for some, "10" based upon the desktop edition).