### PR TITLE
Remove iOS 10.2 from data

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -4375,7 +4375,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": "10.2"
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/ParentNode.json
+++ b/api/ParentNode.json
@@ -79,7 +79,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": "10.2"
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -141,12 +141,6 @@
           "engine_version": "602.2",
           "release_date": "2016-10-24"
         },
-        "10.2": {
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "602.4",
-          "release_date": "2016-12-12"
-        },
         "10.3": {
           "status": "retired",
           "engine": "WebKit",

--- a/css/properties/max-inline-size.json
+++ b/css/properties/max-inline-size.json
@@ -70,7 +70,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "10.2"
+                "version_added": "10.3"
               }
             ],
             "samsunginternet_android": {


### PR DESCRIPTION
This PR removes Safari iOS 10.2 from the data. As iOS 10.2 uses Safari 10.0, there's no need to keep it around separately. Furthermore, this fixes the data using iOS 10.2 and replaces it by mirroring the desktop data.