### PR TITLE
Remove iOS 7.1 from data

### DIFF
--- a/api/AudioTrackList.json
+++ b/api/AudioTrackList.json
@@ -74,7 +74,7 @@
             "version_added": "6.1"
           },
           "safari_ios": {
-            "version_added": "7.1"
+            "version_added": "7"
           },
           "samsunginternet_android": {
             "version_added": null
@@ -164,7 +164,7 @@
               "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -255,7 +255,7 @@
               "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -345,7 +345,7 @@
               "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -435,7 +435,7 @@
               "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -525,7 +525,7 @@
               "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -615,7 +615,7 @@
               "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -705,7 +705,7 @@
               "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -796,7 +796,7 @@
               "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/SharedWorker.json
+++ b/api/SharedWorker.json
@@ -34,7 +34,7 @@
           },
           "safari_ios": {
             "version_added": "5.1",
-            "version_removed": "7.1"
+            "version_removed": "7"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -84,7 +84,7 @@
             },
             "safari_ios": {
               "version_added": "5.1",
-              "version_removed": "7.1"
+              "version_removed": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -182,7 +182,7 @@
             },
             "safari_ios": {
               "version_added": "5.1",
-              "version_removed": "7.1"
+              "version_removed": "7"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/SharedWorkerGlobalScope.json
+++ b/api/SharedWorkerGlobalScope.json
@@ -32,7 +32,7 @@
             "version_added": "5"
           },
           "safari_ios": {
-            "version_added": "7.1"
+            "version_added": "7"
           },
           "samsunginternet_android": {
             "version_added": true

--- a/api/SpeechSynthesis.json
+++ b/api/SpeechSynthesis.json
@@ -45,7 +45,7 @@
             "version_added": "7"
           },
           "safari_ios": {
-            "version_added": "7.1"
+            "version_added": "7"
           },
           "webview_android": {
             "version_added": "4.4.3"
@@ -102,7 +102,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -160,7 +160,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -279,7 +279,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": "4.4.3",
@@ -338,7 +338,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -396,7 +396,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -454,7 +454,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -512,7 +512,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -570,7 +570,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -629,7 +629,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": "4.4.3"

--- a/api/SpeechSynthesisErrorEvent.json
+++ b/api/SpeechSynthesisErrorEvent.json
@@ -45,7 +45,7 @@
             "version_added": "7"
           },
           "safari_ios": {
-            "version_added": "7.1"
+            "version_added": "7"
           },
           "webview_android": {
             "version_added": false
@@ -102,7 +102,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": false

--- a/api/SpeechSynthesisEvent.json
+++ b/api/SpeechSynthesisEvent.json
@@ -45,7 +45,7 @@
             "version_added": "7"
           },
           "safari_ios": {
-            "version_added": "7.1"
+            "version_added": "7"
           },
           "webview_android": {
             "version_added": false
@@ -102,7 +102,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": false
@@ -160,7 +160,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": false
@@ -218,7 +218,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": false
@@ -276,7 +276,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": false

--- a/api/SpeechSynthesisUtterance.json
+++ b/api/SpeechSynthesisUtterance.json
@@ -45,7 +45,7 @@
             "version_added": "7"
           },
           "safari_ios": {
-            "version_added": "7.1"
+            "version_added": "7"
           },
           "webview_android": {
             "version_added": false
@@ -103,7 +103,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": false
@@ -162,7 +162,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": false
@@ -221,7 +221,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": false
@@ -280,7 +280,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": false
@@ -338,7 +338,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": false
@@ -397,7 +397,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": false
@@ -455,7 +455,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": false
@@ -513,7 +513,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": false
@@ -571,7 +571,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": false
@@ -629,7 +629,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": false
@@ -687,7 +687,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": false
@@ -745,7 +745,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": false
@@ -803,7 +803,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": false
@@ -862,7 +862,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": false
@@ -920,7 +920,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": false
@@ -978,7 +978,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": false
@@ -1037,7 +1037,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": false
@@ -1096,7 +1096,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": false
@@ -1154,7 +1154,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": false
@@ -1212,7 +1212,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": false
@@ -1270,7 +1270,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": false

--- a/api/SpeechSynthesisVoice.json
+++ b/api/SpeechSynthesisVoice.json
@@ -45,7 +45,7 @@
             "version_added": "7"
           },
           "safari_ios": {
-            "version_added": "7.1"
+            "version_added": "7"
           },
           "webview_android": {
             "version_added": "4.4.3"
@@ -102,7 +102,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -160,7 +160,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -218,7 +218,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -276,7 +276,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -334,7 +334,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "webview_android": {
               "version_added": "4.4.3"

--- a/api/TextTrack.json
+++ b/api/TextTrack.json
@@ -33,7 +33,7 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": "7.1"
+            "version_added": "7"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -81,7 +81,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -129,7 +129,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -224,7 +224,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -272,7 +272,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -320,7 +320,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -368,7 +368,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -416,7 +416,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -464,7 +464,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -513,7 +513,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -606,7 +606,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/VideoTrackList.json
+++ b/api/VideoTrackList.json
@@ -74,7 +74,7 @@
             "version_added": "6.1"
           },
           "safari_ios": {
-            "version_added": "7.1"
+            "version_added": "7"
           },
           "samsunginternet_android": {
             "version_added": null
@@ -164,7 +164,7 @@
               "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -255,7 +255,7 @@
               "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -345,7 +345,7 @@
               "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -435,7 +435,7 @@
               "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -525,7 +525,7 @@
               "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -615,7 +615,7 @@
               "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -705,7 +705,7 @@
               "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -796,7 +796,7 @@
               "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": null
@@ -886,7 +886,7 @@
               "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": null

--- a/api/Window.json
+++ b/api/Window.json
@@ -930,7 +930,7 @@
               }
             ],
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -6970,7 +6970,7 @@
             ],
             "safari_ios": [
               {
-                "version_added": "7.1"
+                "version_added": "7"
               },
               {
                 "version_added": "6.1",
@@ -8990,7 +8990,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -81,12 +81,6 @@
           "engine_version": "537.51",
           "release_date": "2013-09-18"
         },
-        "7.1": {
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "537.51",
-          "release_date": "2014-03-10"
-        },
         "8": {
           "status": "retired",
           "engine": "WebKit",

--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -98,7 +98,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "7.1"
+                  "version_added": "7"
                 }
               ],
               "samsunginternet_android": {

--- a/css/properties/box-decoration-break.json
+++ b/css/properties/box-decoration-break.json
@@ -66,7 +66,7 @@
               "notes": "This property is only supported for inline elements."
             },
             "safari_ios": {
-              "version_added": "7.1",
+              "version_added": "7",
               "notes": "This property is only supported for inline elements."
             },
             "samsunginternet_android": {

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -423,7 +423,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "7.1"
+                  "version_added": "7"
                 }
               ],
               "samsunginternet_android": {

--- a/css/properties/flex-flow.json
+++ b/css/properties/flex-flow.json
@@ -102,7 +102,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "7.1"
+                "version_added": "7"
               }
             ],
             "webview_android": [

--- a/css/properties/flex.json
+++ b/css/properties/flex.json
@@ -142,7 +142,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "7.1"
+                "version_added": "7"
               }
             ],
             "samsunginternet_android": {

--- a/css/properties/tab-size.json
+++ b/css/properties/tab-size.json
@@ -57,7 +57,7 @@
               "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": null

--- a/css/types/length-percentage.json
+++ b/css/types/length-percentage.json
@@ -181,7 +181,7 @@
                 "version_added": "7"
               },
               "safari_ios": {
-                "version_added": "7.1"
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -181,7 +181,7 @@
                 "version_added": "7"
               },
               "safari_ios": {
-                "version_added": "7.1"
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/css/types/position.json
+++ b/css/types/position.json
@@ -81,7 +81,7 @@
                 "version_added": "7"
               },
               "safari_ios": {
-                "version_added": "7.1"
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/html/elements/main.json
+++ b/html/elements/main.json
@@ -33,7 +33,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/http/headers/content-security-policy-report-only.json
+++ b/http/headers/content-security-policy-report-only.json
@@ -33,7 +33,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -55,7 +55,7 @@
               ],
               "safari_ios": [
                 {
-                  "version_added": "7.1"
+                  "version_added": "7"
                 },
                 {
                   "version_added": "5.1",
@@ -252,7 +252,7 @@
                   "version_added": "7"
                 },
                 "safari_ios": {
-                  "version_added": "7.1"
+                  "version_added": "7"
                 },
                 "samsunginternet_android": {
                   "version_added": true
@@ -300,7 +300,7 @@
                   "version_added": "7"
                 },
                 "safari_ios": {
-                  "version_added": "7.1"
+                  "version_added": "7"
                 },
                 "samsunginternet_android": {
                   "version_added": true
@@ -348,7 +348,7 @@
                   "version_added": "7"
                 },
                 "safari_ios": {
-                  "version_added": "7.1"
+                  "version_added": "7"
                 },
                 "samsunginternet_android": {
                   "version_added": true
@@ -494,7 +494,7 @@
                   "version_added": "7"
                 },
                 "safari_ios": {
-                  "version_added": "7.1"
+                  "version_added": "7"
                 },
                 "samsunginternet_android": {
                   "version_added": true
@@ -542,7 +542,7 @@
                   "version_added": "7"
                 },
                 "safari_ios": {
-                  "version_added": "7.1"
+                  "version_added": "7"
                 },
                 "samsunginternet_android": {
                   "version_added": true
@@ -638,7 +638,7 @@
                   "version_added": "7"
                 },
                 "safari_ios": {
-                  "version_added": "7.1"
+                  "version_added": "7"
                 },
                 "samsunginternet_android": {
                   "version_added": true
@@ -782,7 +782,7 @@
                   "version_added": "7"
                 },
                 "safari_ios": {
-                  "version_added": "7.1"
+                  "version_added": "7"
                 },
                 "samsunginternet_android": {
                   "version_added": true
@@ -1084,7 +1084,7 @@
                   "version_added": "7"
                 },
                 "safari_ios": {
-                  "version_added": "7.1"
+                  "version_added": "7"
                 },
                 "samsunginternet_android": {
                   "version_added": true
@@ -1196,7 +1196,7 @@
                   "version_added": "7"
                 },
                 "safari_ios": {
-                  "version_added": "7.1"
+                  "version_added": "7"
                 },
                 "samsunginternet_android": {
                   "version_added": true
@@ -1244,7 +1244,7 @@
                   "version_added": "7"
                 },
                 "safari_ios": {
-                  "version_added": "7.1"
+                  "version_added": "7"
                 },
                 "samsunginternet_android": {
                   "version_added": true
@@ -1488,7 +1488,7 @@
                   "version_added": "7"
                 },
                 "safari_ios": {
-                  "version_added": "7.1"
+                  "version_added": "7"
                 },
                 "samsunginternet_android": {
                   "version_added": true


### PR DESCRIPTION
This PR removes Safari iOS 7.1 from the data. As iOS 7.1 uses Safari 7.0, there's no need to keep it around separately. Furthermore, this fixes the data using iOS 7.1 and replaces it by mirroring the desktop data.