### PR TITLE
Add Chrome/Opera Android versions for color input

### DIFF
--- a/html/elements/input/color.json
+++ b/html/elements/input/color.json
@@ -11,7 +11,7 @@
                 "version_added": "20"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "25"
               },
               "edge": {
                 "version_added": "14"
@@ -30,7 +30,7 @@
                 "version_added": "12"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "12"
               },
               "safari": {
                 "version_added": "12.1"


### PR DESCRIPTION
This PR adds both the Chrome Android and Opera Android for the `color` input type.  Supersedes #4792.