### PR TITLE
JavaScript classes: rename "static" to "static_class_methods"

### DIFF
--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -331,8 +331,63 @@
           }
         }
       },
-      "static": {
+      "static_class_fields": {
         "__compat": {
+          "description": "Static class fields",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/Class_fields",
+          "spec_url": "https://tc39.es/proposal-class-fields/#prod-FieldDefinition",
+          "support": {
+            "chrome": {
+              "version_added": "72"
+            },
+            "chrome_android": {
+              "version_added": "72"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "Static fields aren't supported, see <a href='https://bugzil.la/1535804'>bug 1535804</a>."
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": "12.0.0"
+            },
+            "opera": {
+              "version_added": "60"
+            },
+            "opera_android": {
+              "version_added": "51"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "72"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "static_class_methods": {
+        "__compat": {
+          "description": "Static class methods",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/static",
           "spec_url": "https://tc39.es/ecma262/#sec-class-definitions",
           "support": {
@@ -396,60 +451,6 @@
             "webview_android": {
               "version_added": "49",
               "notes": "From Chrome 42 to 48 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "static_class_fields": {
-        "__compat": {
-          "description": "Static class fields",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/Class_fields",
-          "spec_url": "https://tc39.es/proposal-class-fields/#prod-FieldDefinition",
-          "support": {
-            "chrome": {
-              "version_added": "72"
-            },
-            "chrome_android": {
-              "version_added": "72"
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": false,
-              "notes": "Static fields aren't supported, see <a href='https://bugzil.la/1535804'>bug 1535804</a>."
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "nodejs": {
-              "version_added": "12.0.0"
-            },
-            "opera": {
-              "version_added": "60"
-            },
-            "opera_android": {
-              "version_added": "51"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": "72"
             }
           },
           "status": {


### PR DESCRIPTION
Since we've introduced the static class fields data point, having one called just "static" produces confusion.  This PR intends to resolve that by renaming "static" to what it actually is: static class methods.