### PR TITLE
Update scrollIntoView + scrollIntoViewOptions

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -6511,7 +6511,7 @@
             "edge": [
               {
                 "version_added": "18",
-                "notes": "No support for <code>smooth</code> behavior."
+                "notes": "Parameter <code>alignToTop</code> is supported. No support for <code>smooth</code> behavior."
               },
               {
                 "version_added": "12",
@@ -6574,7 +6574,7 @@
                 "notes": "The <code>block</code> and <code>inline</code> options support the values <code>start</code>, <code>center</code>, <code>end</code>, <code>nearest</code>."
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "36",
@@ -6593,10 +6593,15 @@
               "ie": {
                 "version_added": false
               },
-              "opera": {
-                "version_added": "48",
-                "notes": "The <code>block</code> and <code>inline</code> options support the values <code>start</code>, <code>center</code>, <code>end</code>, <code>nearest</code>."
-              },
+              "opera": [
+                {
+                  "version_added": "48",
+                  "notes": "The <code>block</code> and <code>inline</code> options support the values <code>start</code>, <code>center</code>, <code>end</code>, <code>nearest</code>."
+                },
+                {
+                  "version_added": true
+                }
+              ],
               "opera_android": {
                 "version_added": "45",
                 "notes": "The <code>block</code> and <code>inline</code> options support the values <code>start</code>, <code>center</code>, <code>end</code>, <code>nearest</code>."


### PR DESCRIPTION
Update scrollIntoView + scrollIntoViewOptions compatibility for Microsoft Edge and Opera for PC.
Opera fully supports scrollIntoViewOptions (in newest version 63). Edge only supports alignToTop parameter.