### PR TITLE
Set Node.js version for Symbol.prototype.description 

### DIFF
--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -127,7 +127,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "11.0.0"
               },
               "opera": {
                 "version_added": "57"


### PR DESCRIPTION

This PR sets the Node.js version for the Javascript Builtin based on mannual testing and verified through https://node.green/

javascript.builtins.Symbol.prototype.description - "11.0.0"
