### PR TITLE
fix(:placeholder-shown): FF non-text input support

### DIFF
--- a/css/selectors/placeholder-shown.json
+++ b/css/selectors/placeholder-shown.json
@@ -79,10 +79,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "51"
+                "version_added": "59"
               },
               "firefox_android": {
-                "version_added": "51"
+                "version_added": "59"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
Firefox support of `:placeholder-shown` for non-text inputs is incorrect.  Firefox didn't add support for `input[type="number"]:placeholder-shown` until version 59 (not v51).

Screenshots: [Firefox 58 vs 59](https://app.crossbrowsertesting.com/public/i8faa3138bf88a28/screenshots/z17410a1a9beef55aba0?size=small&type=windowed) (compare background of the number input)


Other non-text input types don't make sense to support `:placeholder-shown`, because there's no way to display a placeholder.  As such, the following input types were excluded from the data set:

* checkbox
* color
* date
* datetime / datetime-local
* file
* hidden
* image
* month
* radio
* range
* time
* week