### PR TITLE
Set Edge version for flat & flatMap array methods

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -513,7 +513,7 @@
                 "version_added": "69"
               },
               "edge": {
-                "version_added": false
+                "version_added": "76"
               },
               "firefox": {
                 "version_added": "62"
@@ -565,7 +565,7 @@
                 "version_added": "69"
               },
               "edge": {
-                "version_added": false
+                "version_added": "76"
               },
               "firefox": {
                 "version_added": "62"


### PR DESCRIPTION
Updated Edge support of the Array methods i.e.

Array.prototype.flat()
Array.prototype.flatMap()