### PR TITLE
Updating ProgressEvent data based on testing

### DIFF
--- a/api/ProgressEvent.json
+++ b/api/ProgressEvent.json
@@ -80,7 +80,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -232,7 +232,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -280,7 +280,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/ProgressEvent.json
+++ b/api/ProgressEvent.json
@@ -56,7 +56,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": true
             },
             "edge": {
               "version_added": null
@@ -71,10 +71,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": false
@@ -205,10 +205,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ProgressEvent/loaded",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -223,19 +223,19 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -253,10 +253,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ProgressEvent/total",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -271,19 +271,19 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": false

--- a/api/ProgressEvent.json
+++ b/api/ProgressEvent.json
@@ -77,13 +77,13 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -238,7 +238,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {
@@ -286,7 +286,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {


### PR DESCRIPTION
I've updated the data for ProgressEvent based on testing with various browsers using the web platform tests [xhr/progressevent-constructor][1], [xhr/progressevent-interface][1], and [xhr/progress-events-response-data-gzip][2] as well as my own ad-hoc code and [this demo][3] from Jason Davies

I tested with the following versions, but used `true` rather than the version number since this seems to have been supported for some time but I was not able to determine when.

| Browser | Version Tested|
|------------|--------------------|
| Chrome | 78.0.3904.17 |
| Chrome for Android | 76.0.3809.132 |
| Opera | 63.0.3368.94 |
| Opera for Android | 53.1.2469.142848 |
| Samsung Internet | 10.1.00.27 |
| Safari | 13.0 (14608.1.49) |
| Android WebView | 77.0.3865.92 |

[0]: https://github.com/web-platform-tests/wpt/blob/master/xhr/progressevent-constructor.html
[1]: https://github.com/web-platform-tests/wpt/blob/master/xhr/progressevent-interface.html
[2]: https://github.com/web-platform-tests/wpt/blob/master/xhr/progress-events-response-data-gzip.htm
[3]: https://www.jasondavies.com/chrome-progress-bug/