### PR TITLE
Chrome 71+ supports Permission API "persistent-storage" property

### DIFF
--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -724,10 +724,10 @@
           "description": "<code>persistent-storage</code> permission",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "71"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "71"
             },
             "edge": {
               "version_added": null
@@ -757,7 +757,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "71"
             }
           },
           "status": {

--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -742,10 +742,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": false
+              "version_added": "58"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "50"
             },
             "safari": {
               "version_added": false
@@ -754,7 +754,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "71"


### PR DESCRIPTION
## Summary

Chrome 71 added Permission API "persistent-storage" property on all platforms (desktop, Android, WebView).

## Data
Chrome Platform Status:
https://chromestatus.com/feature/4770049554382848
Chromium bug:
https://crbug.com/878525

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
