### PR TITLE
Microsoft IE and Edge do not support Permissions API

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1522,7 +1522,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "46"
@@ -1531,7 +1531,7 @@
               "version_added": "46"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true

--- a/api/PermissionStatus.json
+++ b/api/PermissionStatus.json
@@ -11,7 +11,7 @@
             "version_added": "43"
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
             "version_added": "46"
@@ -20,7 +20,7 @@
             "version_added": "46"
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": true
@@ -58,7 +58,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "46"
@@ -67,7 +67,7 @@
               "version_added": "46"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -120,7 +120,7 @@
               }
             ],
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "46"
@@ -129,7 +129,7 @@
               "version_added": "46"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true

--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -11,7 +11,7 @@
             "version_added": "43"
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
             "version_added": "46"
@@ -20,7 +20,7 @@
             "version_added": "46"
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": true
@@ -58,7 +58,7 @@
               "version_added": "62"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": null
@@ -67,7 +67,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -106,7 +106,7 @@
               "version_added": "62"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": null
@@ -115,7 +115,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -154,7 +154,7 @@
               "version_added": "62"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": null
@@ -163,7 +163,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -202,7 +202,7 @@
               "version_added": "62"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": null
@@ -211,7 +211,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -250,7 +250,7 @@
               "version_added": "64"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": null
@@ -259,7 +259,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -298,7 +298,7 @@
               "version_added": "64"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -307,7 +307,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -346,7 +346,7 @@
               "version_added": "64"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -355,7 +355,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -394,7 +394,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": null
@@ -403,7 +403,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "30"
@@ -442,7 +442,7 @@
               "version_added": "51"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": null
@@ -451,7 +451,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -490,7 +490,7 @@
               "version_added": "62"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": null
@@ -499,7 +499,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -538,7 +538,7 @@
               "version_added": "64"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": null
@@ -547,7 +547,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -586,7 +586,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": null
@@ -595,7 +595,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "30"
@@ -634,7 +634,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": null
@@ -643,7 +643,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "30"
@@ -682,7 +682,7 @@
               "version_added": "66"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": null
@@ -691,7 +691,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -730,7 +730,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "53"
@@ -739,7 +739,7 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -778,7 +778,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": null
@@ -787,7 +787,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "30"
@@ -826,7 +826,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "46"
@@ -835,7 +835,7 @@
               "version_added": "46"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -874,7 +874,7 @@
               "version_added": "46"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -883,7 +883,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -922,7 +922,7 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -931,7 +931,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -970,7 +970,7 @@
               "version_added": "46"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {
@@ -1005,7 +1005,7 @@
               }
             ],
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null


### PR DESCRIPTION
## Summary
Microsoft Edge and Microsoft Internet Explorer do not support Permissions API.

## Data
Microsoft Edge API Catalog:
https://developer.microsoft.com/en-us/microsoft-edge/platform/catalog/?page=1&q=permissions

## Manual tests
`navigator.permissions` is `undefined` in both IE and Edge on Windows 10 1903.

## Note
Should we add comments to some permissions that are accessible via other APIs? Edge  supports [`Notification.permission`](https://developer.mozilla.org/en-US/docs/Web/API/Notification/permission), which exposes equivalent of [`PermissionStatus.state`](https://developer.mozilla.org/en-US/docs/Web/API/PermissionStatus/state), but only for notifications. Also, Edge supposedly supports [`PushManager.permissionState`](https://developer.mozilla.org/en-US/docs/Web/API/PushManager/permissionState).

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
