### PR TITLE
Added Safari support for trimStart and trimEnd

### DIFF
--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -3067,10 +3067,10 @@
                 "version_added": "47"
               },
               "safari": {
-                "version_added": "13"
+                "version_added": "12"
               },
               "safari_ios": {
-                "version_added": "13"
+                "version_added": "12"
               },
               "samsunginternet_android": [
                 {
@@ -3161,10 +3161,10 @@
                 "version_added": "47"
               },
               "safari": {
-                "version_added": "13"
+                "version_added": "12"
               },
               "safari_ios": {
-                "version_added": "13"
+                "version_added": "12"
               },
               "samsunginternet_android": [
                 {

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -3067,10 +3067,10 @@
                 "version_added": "47"
               },
               "safari": {
-                "version_added": null
+                "version_added": "13"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "13"
               },
               "samsunginternet_android": [
                 {
@@ -3161,10 +3161,10 @@
                 "version_added": "47"
               },
               "safari": {
-                "version_added": null
+                "version_added": "13"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "13"
               },
               "samsunginternet_android": [
                 {


### PR DESCRIPTION
Tested on Safari 13 on macOS Mojave 10.14.6

Based on when this change was made to WebKit, I'd guess this was in Safari 12, but I don't have any way to confirm it because I don't have Safari 12 running anywhere.

Source: https://trac.webkit.org/changeset/227779/webkit
