### PR TITLE
CSS opacity: add data for percentage values

### DIFF
--- a/css/properties/opacity.json
+++ b/css/properties/opacity.json
@@ -61,6 +61,54 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "percentages": {
+          "__compat": {
+            "description": "Support for percentage opacity values",
+            "support": {
+              "chrome": {
+                "version_added": "78"
+              },
+              "chrome_android": {
+                "version_added": "78"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "70"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "78"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/shape-image-threshold.json
+++ b/css/properties/shape-image-threshold.json
@@ -73,6 +73,54 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "percentages": {
+          "__compat": {
+            "description": "Support for percentage opacity values",
+            "support": {
+              "chrome": {
+                "version_added": "78"
+              },
+              "chrome_android": {
+                "version_added": "78"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "70"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "78"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Firefox 70 and Chrome 78 support percentages in opacity values as per Level 4 of the color specification.

This PR updates `opacity` and `shape-image-threshold` to indicate support.

https://bugzilla.mozilla.org/show_bug.cgi?id=1562086
https://bugzilla.mozilla.org/show_bug.cgi?id=1568615
https://www.chromestatus.com/feature/5167940859068416