### PR TITLE
removing support of three-value position

### DIFF
--- a/css/properties/mask-position.json
+++ b/css/properties/mask-position.json
@@ -81,6 +81,92 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "three_value_syntax": {
+          "__compat": {
+            "description": "Support for three-value syntax of position",
+            "support": {
+              "chrome": {
+                "prefix": "-webkit-",
+                "version_added": "1",
+                "version_removed": "68"
+              },
+              "chrome_android": {
+                "prefix": "-webkit-",
+                "version_added": "18",
+                "version_removed": "68"
+              },
+              "edge": {
+                "version_added": "18"
+              },
+              "firefox": [
+                {
+                  "version_added": "53",
+                  "version_removed": "70"
+                },
+                {
+                  "version_added": "20",
+                  "version_removed": "53",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.masking.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "53"
+                },
+                {
+                  "version_added": "20",
+                  "version_removed": "53",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.masking.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              "opera_android": {
+                "prefix": "-webkit-",
+                "version_added": "14"
+              },
+              "safari": {
+                "prefix": "-webkit-",
+                "version_added": "3.2"
+              },
+              "safari_ios": {
+                "prefix": "-webkit-",
+                "version_added": "3.2"
+              },
+              "samsunginternet_android": {
+                "prefix": "-webkit-",
+                "version_added": true
+              },
+              "webview_android": {
+                "prefix": "-webkit-",
+                "version_added": "2",
+                "version_removed": "68"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/mask-position.json
+++ b/css/properties/mask-position.json
@@ -137,11 +137,13 @@
               },
               "opera": {
                 "prefix": "-webkit-",
-                "version_added": "15"
+                "version_added": "15",
+                "version_removed": "55"
               },
               "opera_android": {
                 "prefix": "-webkit-",
-                "version_added": "14"
+                "version_added": "14",
+                "version_removed": "48"
               },
               "safari": {
                 "prefix": "-webkit-",

--- a/css/properties/object-position.json
+++ b/css/properties/object-position.json
@@ -87,7 +87,8 @@
               },
               "opera": [
                 {
-                  "version_added": "19"
+                  "version_added": "19",
+                  "version_removed": "55"
                 },
                 {
                   "prefix": "-o-",
@@ -96,7 +97,8 @@
               ],
               "opera_android": [
                 {
-                  "version_added": "19"
+                  "version_added": "19",
+                  "version_removed": "48"
                 },
                 {
                   "prefix": "-o-",

--- a/css/properties/object-position.json
+++ b/css/properties/object-position.json
@@ -59,6 +59,70 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "three_value_syntax": {
+          "__compat": {
+            "description": "Support for three-value syntax of position",
+            "support": {
+              "chrome": {
+                "version_added": "31",
+                "version_removed": "68"
+              },
+              "chrome_android": {
+                "version_added": "31",
+                "version_removed": "68"
+              },
+              "edge": {
+                "version_added": "16"
+              },
+              "firefox": {
+                "version_added": "36",
+                "version_removed": "70"
+              },
+              "firefox_android": {
+                "version_added": "36"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": [
+                {
+                  "version_added": "19"
+                },
+                {
+                  "prefix": "-o-",
+                  "version_added": "11.6"
+                }
+              ],
+              "opera_android": [
+                {
+                  "version_added": "19"
+                },
+                {
+                  "prefix": "-o-",
+                  "version_added": "12"
+                }
+              ],
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": {
+                "version_added": "10"
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": "4.4.3",
+                "version_removed": "68"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/perspective-origin.json
+++ b/css/properties/perspective-origin.json
@@ -215,11 +215,13 @@
               },
               "opera": {
                 "prefix": "-webkit-",
-                "version_added": "15"
+                "version_added": "15",
+                "version_removed": "55"
               },
               "opera_android": {
                 "prefix": "-webkit-",
-                "version_added": true
+                "version_added": true,
+                "version_removed": "48"
               },
               "safari": [
                 {

--- a/css/properties/perspective-origin.json
+++ b/css/properties/perspective-origin.json
@@ -127,6 +127,138 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "three_value_syntax": {
+          "__compat": {
+            "description": "Support for three-value syntax of position",
+            "support": {
+              "chrome": [
+                {
+                  "version_added": "36",
+                  "version_removed": "68"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "12"
+                }
+              ],
+              "chrome_android": [
+                {
+                  "version_added": "36",
+                  "version_removed": "68"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "18"
+                }
+              ],
+              "edge": [
+                {
+                  "version_added": "12"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "12"
+                }
+              ],
+              "firefox": [
+                {
+                  "version_added": "16",
+                  "version_removed": "70"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "10"
+                },
+                {
+                  "version_added": "49",
+                  "prefix": "-webkit-"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "45",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.prefixes.webkit",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "16"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "10"
+                },
+                {
+                  "version_added": "49",
+                  "prefix": "-webkit-"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "45",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.prefixes.webkit",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "ie": {
+                "version_added": "10"
+              },
+              "opera": {
+                "prefix": "-webkit-",
+                "version_added": "15"
+              },
+              "opera_android": {
+                "prefix": "-webkit-",
+                "version_added": true
+              },
+              "safari": [
+                {
+                  "version_added": "9"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "4"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "9"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "2"
+                }
+              ],
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": [
+                {
+                  "version_added": "37",
+                  "version_removed": "68"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "3"
+                }
+              ]
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/shape-outside.json
+++ b/css/properties/shape-outside.json
@@ -501,10 +501,12 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "24"
+                "version_added": "24",
+                "version_removed": "55"
               },
               "opera_android": {
-                "version_added": "24"
+                "version_added": "24",
+                "version_removed": "48"
               },
               "safari": {
                 "version_added": "10.1"

--- a/css/properties/shape-outside.json
+++ b/css/properties/shape-outside.json
@@ -448,6 +448,84 @@
               "deprecated": false
             }
           }
+        },
+        "three_value_syntax": {
+          "__compat": {
+            "description": "Support for three-value syntax of position in circle and ellipse",
+            "support": {
+              "chrome": {
+                "version_added": "37",
+                "version_removed": "68"
+              },
+              "chrome_android": {
+                "version_added": "37",
+                "version_removed": "68"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "62",
+                  "version_removed": "70"
+                },
+                {
+                  "version_added": "61",
+                  "version_removed": "62",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.shape-outside.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "62"
+                },
+                {
+                  "version_added": "61",
+                  "version_removed": "62",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.shape-outside.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "24"
+              },
+              "opera_android": {
+                "version_added": "24"
+              },
+              "safari": {
+                "version_added": "10.1"
+              },
+              "safari_ios": {
+                "version_added": "10.3"
+              },
+              "samsunginternet_android": {
+                "version_added": "4.0"
+              },
+              "webview_android": {
+                "version_added": "37",
+                "version_removed": "68"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/types/position.json
+++ b/css/types/position.json
@@ -97,6 +97,55 @@
             }
           }
         },
+        "keyword_value_syntax": {
+          "__compat": {
+            "description": "Syntax combining a keyword and <a href='https://developer.mozilla.org/docs/Web/CSS/length'><code>&lt;length&gt;</code></a> or <a href='https://developer.mozilla.org/docs/Web/CSS/percentage'><code>&lt;percentage&gt;</code></a>",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": "18"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "4"
+              },
+              "opera": {
+                "version_added": "3.5"
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": "1"
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": "≤37"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        ,
         "three_value_syntax": {
           "__compat": {
             "description": "Three-value syntax for properties other than background-position",
@@ -146,54 +195,6 @@
               "experimental": false,
               "standard_track": true,
               "deprecated": true
-            }
-          }
-        },
-        "keyword_value_syntax": {
-          "__compat": {
-            "description": "Syntax combining a keyword and <a href='https://developer.mozilla.org/docs/Web/CSS/length'><code>&lt;length&gt;</code></a> or <a href='https://developer.mozilla.org/docs/Web/CSS/percentage'><code>&lt;percentage&gt;</code></a>",
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": {
-                "version_added": "18"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "1"
-              },
-              "firefox_android": {
-                "version_added": "4"
-              },
-              "ie": {
-                "version_added": "4"
-              },
-              "opera": {
-                "version_added": "3.5"
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": "1"
-              },
-              "safari_ios": {
-                "version_added": "1"
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "≤37"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
             }
           }
         }

--- a/css/types/position.json
+++ b/css/types/position.json
@@ -102,43 +102,43 @@
             "description": "Three-value syntax for properties other than background-position",
             "support": {
               "chrome": {
-                "version_added": true,
+                "version_added": "25",
                 "version_removed": "68"
               },
               "chrome_android": {
-                "version_added": true,
+                "version_added": "25",
                 "version_removed": "68"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
-                "version_added": true,
+                "version_added": "13",
                 "version_removed": "70"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "14"
               },
               "ie": {
-                "version_added": true
+                "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "10.5"
               },
               "opera_android": {
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true,
+                "version_added": "≤37",
                 "version_removed": "68"
               }
             },

--- a/css/types/position.json
+++ b/css/types/position.json
@@ -97,6 +97,58 @@
             }
           }
         },
+        "three_value_syntax": {
+          "__compat": {
+            "description": "Three-value syntax for properties other than background-position",
+            "support": {
+              "chrome": {
+                "version_added": true,
+                "version_removed": "68"
+              },
+              "chrome_android": {
+                "version_added": true,
+                "version_removed": "68"
+              },
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": true,
+                "version_removed": "70"
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true,
+                "version_removed": "68"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
         "keyword_value_syntax": {
           "__compat": {
             "description": "Syntax combining a keyword and <a href='https://developer.mozilla.org/docs/Web/CSS/length'><code>&lt;length&gt;</code></a> or <a href='https://developer.mozilla.org/docs/Web/CSS/percentage'><code>&lt;percentage&gt;</code></a>",

--- a/css/types/position.json
+++ b/css/types/position.json
@@ -171,10 +171,12 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": "10.5"
+                "version_added": "10.5",
+                "version_removed": "55"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "48"
               },
               "safari": {
                 "version_added": "1"

--- a/css/types/position.json
+++ b/css/types/position.json
@@ -145,7 +145,6 @@
             }
           }
         },
-        ,
         "three_value_syntax": {
           "__compat": {
             "description": "Three-value syntax for properties other than background-position",


### PR DESCRIPTION
Support for three-value position has been removed in Firefox 70, also in Chrome 68.

This updates the position type, along with properties which use this type. An exception to this is background-position which continues to accept three values.

- https://www.fxsitecompat.dev/en-CA/docs/2019/3-valued-css-position-is-no-longer-supported-except-for-background-position/
- https://bugzilla.mozilla.org/show_bug.cgi?id=1559276
