### PR TITLE
Update IE/Edge compatibility of RegExp JavaScript

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -22,7 +22,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "nodejs": {
               "version_added": true
@@ -230,13 +230,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true,
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental JavaScript Features"
-                  }
-                ]
+                "version_added": false
               },
               "firefox": {
                 "version_added": "37"
@@ -338,7 +332,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": "12"
                 },
                 "firefox": {
                   "version_added": "38"
@@ -347,7 +341,7 @@
                   "version_added": "38"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": "5.5"
                 },
                 "nodejs": {
                   "version_added": true
@@ -441,7 +435,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": "12"
                 },
                 "firefox": {
                   "version_added": "38"
@@ -450,7 +444,7 @@
                   "version_added": "38"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": "5.5"
                 },
                 "nodejs": {
                   "version_added": true
@@ -857,7 +851,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": "12"
                 },
                 "firefox": {
                   "version_added": "38"
@@ -866,7 +860,7 @@
                   "version_added": "38"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": "5.5"
                 },
                 "nodejs": {
                   "version_added": true
@@ -910,7 +904,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -919,7 +913,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "4"
               },
               "nodejs": {
                 "version_added": true
@@ -1023,7 +1017,7 @@
                 "version_added": "64"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -1032,7 +1026,7 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "nodejs": [
                 {
@@ -1086,7 +1080,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -1095,7 +1089,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "4"
               },
               "nodejs": {
                 "version_added": true
@@ -1199,7 +1193,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "4"
               },
               "nodejs": {
                 "version_added": true
@@ -1240,7 +1234,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": "12"
                 },
                 "firefox": {
                   "version_added": "38"
@@ -1249,7 +1243,7 @@
                   "version_added": "38"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "nodejs": {
                   "version_added": null
@@ -1291,7 +1285,7 @@
                   "version_added": "73"
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": "12"
                 },
                 "firefox": {
                   "version_added": "38"
@@ -1300,7 +1294,7 @@
                   "version_added": "38"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": "10"
                 },
                 "nodejs": {
                   "version_added": null
@@ -1342,7 +1336,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": "12"
                 },
                 "firefox": {
                   "version_added": "41"
@@ -1351,7 +1345,7 @@
                   "version_added": "41"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": "4"
                 },
                 "nodejs": {
                   "version_added": true
@@ -1445,7 +1439,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": "13"
                 },
                 "firefox": {
                   "version_added": "44"
@@ -1496,7 +1490,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": "13"
                 },
                 "firefox": {
                   "version_added": "38"
@@ -1652,7 +1646,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -1661,7 +1655,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "4"
               },
               "nodejs": {
                 "version_added": true
@@ -1702,7 +1696,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": "12"
                 },
                 "firefox": {
                   "version_added": "38"
@@ -1711,7 +1705,7 @@
                   "version_added": "38"
                 },
                 "ie": {
-                  "version_added": true
+                  "version_added": "9"
                 },
                 "nodejs": {
                   "version_added": true
@@ -1808,7 +1802,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "13"
               },
               "firefox": {
                 "version_added": "49"
@@ -1912,7 +1906,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": false
               },
               "firefox": {
                 "version_added": "49"
@@ -1964,7 +1958,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "13"
               },
               "firefox": {
                 "version_added": "49"
@@ -2016,7 +2010,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": 13
               },
               "firefox": {
                 "version_added": "49"
@@ -2079,7 +2073,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": false
               },
               "firefox": {
                 "version_added": "49"

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -2010,7 +2010,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": 13
+                "version_added": "13"
               },
               "firefox": {
                 "version_added": "49"


### PR DESCRIPTION
This PR adds real values for the IE/Edge compatibility of JavaScript's regular expressions.  Data is as follows, and has been determined via manual testing in SauceLabs and local VMs (aside from `property_escapes` which has a GitHub issue link):

javascript.builtins.RegExp - 4
javascript.builtins.RegExp.flags - false (set to true with flag in #3142, but have disproven)
javascript.builtins.RegExp.global.prototype_accessor - 5.5
javascript.builtins.RegExp.ignoreCase.prototype_accessor - 5.5
javascript.builtins.RegExp.multiline.prototype_accessor - 5.5
javascript.builtins.RegExp.n - 4
javascript.builtins.RegExp.property_escapes - false (https://github.com/Microsoft/ChakraCore/issues/2969)
javascript.builtins.RegExp.prototype - 4
javascript.builtins.RegExp.source - 4
javascript.builtins.RegExp.source.empty_regex_string - 12
javascript.builtins.RegExp.source.escaping - 10
javascript.builtins.RegExp.source.prototype_accessor - 4
javascript.builtins.RegExp.sticky.anchored_sticky_flag - 13
javascript.builtins.RegExp.sticky.prototype_accessor - 13
javascript.builtins.RegExp.toString - 4
javascript.builtins.RegExp.toString.escaping - 9
javascript.builtins.RegExp.@@match - 13
javascript.builtins.RegExp.@@replace - false
javascript.builtins.RegExp.@@search - 13
javascript.builtins.RegExp.@@species - 13
javascript.builtins.RegExp.@@split - false