### PR TITLE
Allow number for value of ratio

### DIFF
--- a/css/types/ratio.json
+++ b/css/types/ratio.json
@@ -48,6 +48,54 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "as_number": {
+          "__compat": {
+            "description": "Accepts &lt;number&gt; / &lt;number&gt; or single &lt;number&gt; as a value.",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "70"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/types/ratio.json
+++ b/css/types/ratio.json
@@ -49,7 +49,7 @@
             "deprecated": false
           }
         },
-        "as_number": {
+        "number_value": {
           "__compat": {
             "description": "Accepts &lt;number&gt; / &lt;number&gt; or single &lt;number&gt; as a value.",
             "support": {


### PR DESCRIPTION
BCD for ratio due to ratio being updated in Firefox 70 based on CSSWG resolution:

- https://bugzilla.mozilla.org/show_bug.cgi?id=1565562
- https://github.com/w3c/csswg-drafts/issues/3757#issuecomment-499625710