### PR TITLE
Updated Intl.PluralRules API support

### DIFF
--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -2273,7 +2273,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": "8.2"
+                "version_added": "8.0"
               },
               "webview_android": {
                 "version_added": "63"
@@ -2325,7 +2325,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": "8.2"
+                  "version_added": "8.0"
                 },
                 "webview_android": {
                   "version_added": "63"
@@ -2376,7 +2376,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": "8.2"
+                  "version_added": "8.0"
                 },
                 "webview_android": {
                   "version_added": "63"
@@ -2427,7 +2427,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": "8.2"
+                  "version_added": "8.0"
                 },
                 "webview_android": {
                   "version_added": "63"
@@ -2478,7 +2478,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": "8.2"
+                  "version_added": "8.0"
                 },
                 "webview_android": {
                   "version_added": "63"
@@ -2529,7 +2529,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": "8.2"
+                  "version_added": "8.0"
                 },
                 "webview_android": {
                   "version_added": "63"

--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -2273,7 +2273,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "8.2"
               },
               "webview_android": {
                 "version_added": "63"
@@ -2325,7 +2325,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "8.2"
                 },
                 "webview_android": {
                   "version_added": "63"
@@ -2376,7 +2376,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "8.2"
                 },
                 "webview_android": {
                   "version_added": "63"
@@ -2427,7 +2427,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "8.2"
                 },
                 "webview_android": {
                   "version_added": "63"
@@ -2478,7 +2478,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "8.2"
                 },
                 "webview_android": {
                   "version_added": "63"
@@ -2529,7 +2529,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "8.2"
                 },
                 "webview_android": {
                   "version_added": "63"


### PR DESCRIPTION
Updated **Intl.PluralRules API** support for the samsung Internet Android i.e.

**Standard built-in object**
-> PluralRules

**Properties**
-> Intl.PluralRules.prototype

**Methods**
-> Intl.PluralRules.prototype.resolvedOptions()
-> Intl.PluralRules.select()
-> Intl.PluralRules.supportedLocalesOf()