### PR TITLE
Update Opera support for width: fit-content

### DIFF
--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -270,10 +270,15 @@
               "ie": {
                 "version_added": false
               },
-              "opera": {
-                "prefix": "-webkit-",
-                "version_added": "15"
-              },
+              "opera": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "15"
+                }
+              ],
               "opera_android": {
                 "version_added": null
               },


### PR DESCRIPTION
Opera mirrors Chromium support, which un-prefixed ``fit-content`` a while ago. Opera version 33 corresponds with Chromium 46 -- the version of Chromium that un-prefixed ``fit-content``: https://bugs.chromium.org/p/chromium/issues/detail?id=245157
