### PR TITLE
[Firefox] Bug 1548530: Remove support for MathML alignment attributes

### DIFF
--- a/mathml/elements/mfrac.json
+++ b/mathml/elements/mfrac.json
@@ -89,6 +89,51 @@
             }
           }
         },
+        "denomalign": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "1",
+                "notes": "Removed from Firefox Nightly 71 in <a href='https://bugzil.la/1548530'>bug 1548530</a>."
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
         "href": {
           "__compat": {
             "support": {
@@ -218,6 +263,51 @@
               "experimental": false,
               "standard_track": true,
               "deprecated": false
+            }
+          }
+        },
+        "numalign": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "1",
+                "notes": "Removed from Firefox Nightly 71 in <a href='https://bugzil.la/1548530'>bug 1548530</a>."
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
             }
           }
         }

--- a/mathml/elements/mover.json
+++ b/mathml/elements/mover.json
@@ -102,7 +102,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "12"
+                "version_added": "12",
+                "notes": "Removed from Firefox Nightly 71 in <a href='https://bugzil.la/1548530'>bug 1548530</a>."
               },
               "firefox_android": {
                 "version_added": "14"
@@ -129,7 +130,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },

--- a/mathml/elements/munder.json
+++ b/mathml/elements/munder.json
@@ -102,7 +102,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "12"
+                "version_added": "12",
+                "notes": "Removed from Firefox Nightly 71 in <a href='https://bugzil.la/1548530'>bug 1548530</a>."
               },
               "firefox_android": {
                 "version_added": "14"
@@ -129,7 +130,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },

--- a/mathml/elements/munderover.json
+++ b/mathml/elements/munderover.json
@@ -146,7 +146,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "12"
+                "version_added": "12",
+                "notes": "Removed from Firefox Nightly 71 in <a href='https://bugzil.la/1548530'>bug 1548530</a>."
               },
               "firefox_android": {
                 "version_added": "14"
@@ -173,7 +174,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },


### PR DESCRIPTION
See [bug 1548530](https://bugzilla.mozilla.org/show_bug.cgi?id=1548530) for details.

---

I have tracked down the adding of `denomalign` and `numalign` to a commit from **2000‑05‑12**: https://github.com/mozilla/gecko-dev/commit/8d4562f62573ed48a6fca17d52bb2d3be3b5ee4d