### PR TITLE
Update IE/Edge compatibility of String JavaScript

### DIFF
--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -13,7 +13,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -22,7 +22,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "nodejs": {
               "version_added": true
@@ -1203,7 +1203,7 @@
                   "version_added": "26"
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": "12"
                 },
                 "firefox": {
                   "version_added": "29"
@@ -1253,7 +1253,7 @@
                   "version_added": "26"
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": "12"
                 },
                 "firefox": {
                   "version_added": "29"
@@ -1640,7 +1640,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -1649,7 +1649,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -2559,7 +2559,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "5.5"
               },
               "nodejs": {
                 "version_added": true
@@ -2599,7 +2599,7 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": "12"
                 },
                 "firefox": {
                   "version_added": "55"
@@ -2608,7 +2608,7 @@
                   "version_added": "55"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": "6"
                 },
                 "nodejs": {
                   "version_added": null
@@ -2664,7 +2664,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "5.5"
               },
               "nodejs": {
                 "version_added": true
@@ -2704,7 +2704,7 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": "12"
                 },
                 "firefox": {
                   "version_added": "55"
@@ -2713,7 +2713,7 @@
                   "version_added": "55"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": "6"
                 },
                 "nodejs": {
                   "version_added": null
@@ -2860,7 +2860,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -2869,7 +2869,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -3028,7 +3028,8 @@
                 }
               ],
               "edge": {
-                "version_added": null
+                "version_added": "12",
+                "alternative_name": "trimRight"
               },
               "firefox": [
                 {
@@ -3122,7 +3123,8 @@
                 }
               ],
               "edge": {
-                "version_added": null
+                "version_added": "12",
+                "alternative_name": "trimLeft"
               },
               "firefox": [
                 {
@@ -3203,7 +3205,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "40"
@@ -3212,7 +3214,7 @@
                 "version_added": "40"
               },
               "ie": {
-                "version_added": null
+                "version_added": "4"
               },
               "nodejs": {
                 "version_added": true
@@ -3255,7 +3257,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -3264,7 +3266,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "4"
               },
               "nodejs": {
                 "version_added": true
@@ -3307,7 +3309,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": [
                 {


### PR DESCRIPTION
This PR updates the JavaScript `String` builtin for IE and Edge based upon manual testing.  Data is as follows:

javascript.builtins.String - 3
javascript.builtins.String.localeCompare.locales - 11 (already in data)
javascript.builtins.String.localeCompare.options - 11 (already in data)
javascript.builtins.String.prototype - 3
javascript.builtins.String.toLocaleLowerCase - 5.5
javascript.builtins.String.toLocaleLowerCase.locale - 6
javascript.builtins.String.toLocaleUpperCase - 5.5
javascript.builtins.String.toLocaleUpperCase.locale - 6
javascript.builtins.String.toString - 3
javascript.builtins.String.trimEnd - 12 (as "trimRigft")
javascript.builtins.String.trimStart - 12 (as "trimLeft")
javascript.builtins.String.unicode_code_point_escapes - 4
javascript.builtins.String.valueOf - 4
javascript.builtins.String.@@iterator - 12