### PR TITLE
Update IE/Edge compatibility of misc. JavaScript data

### DIFF
--- a/javascript/builtins/JSON.json
+++ b/javascript/builtins/JSON.json
@@ -13,7 +13,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5"

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -877,7 +877,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": [
                 {

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -13,7 +13,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -22,7 +22,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "nodejs": {
               "version_added": true
@@ -273,7 +273,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1",
@@ -433,7 +433,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1",
@@ -1392,7 +1392,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -1445,7 +1445,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -1705,7 +1705,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": "12"
                 },
                 "firefox": {
                   "version_added": "35"
@@ -1811,7 +1811,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -1863,7 +1863,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -1872,7 +1872,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -13,7 +13,7 @@
               "version_added": "32"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "29"
@@ -65,7 +65,7 @@
                 "version_added": "32"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "29",
@@ -334,7 +334,7 @@
                 "version_added": "32"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "29"

--- a/javascript/builtins/Proxy.json
+++ b/javascript/builtins/Proxy.json
@@ -534,7 +534,7 @@
                   "version_added": "49"
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": "12"
                 },
                 "firefox": {
                   "version_added": "31"
@@ -744,7 +744,7 @@
                   "version_added": "49"
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": "12"
                 },
                 "firefox": {
                   "version_added": "49"

--- a/javascript/builtins/RangeError.json
+++ b/javascript/builtins/RangeError.json
@@ -13,7 +13,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -22,7 +22,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "nodejs": {
               "version_added": true

--- a/javascript/builtins/ReferenceError.json
+++ b/javascript/builtins/ReferenceError.json
@@ -13,7 +13,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -22,7 +22,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "nodejs": {
               "version_added": true

--- a/javascript/builtins/Set.json
+++ b/javascript/builtins/Set.json
@@ -773,7 +773,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": [
                 {

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -452,7 +452,7 @@
                 "version_added": "50"
               },
               "edge": {
-                "version_added": true
+                "version_added": false
               },
               "firefox": {
                 "version_added": "40"
@@ -608,7 +608,7 @@
                 "version_added": "50"
               },
               "edge": {
-                "version_added": true
+                "version_added": false
               },
               "firefox": {
                 "version_added": "49"
@@ -660,7 +660,7 @@
                 "version_added": "50"
               },
               "edge": {
-                "version_added": true
+                "version_added": false
               },
               "firefox": {
                 "version_added": "49"
@@ -775,7 +775,7 @@
                 "version_added": "50"
               },
               "edge": {
-                "version_added": true
+                "version_added": false
               },
               "firefox": {
                 "version_added": "49"

--- a/javascript/builtins/SyntaxError.json
+++ b/javascript/builtins/SyntaxError.json
@@ -13,7 +13,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -22,7 +22,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "nodejs": {
               "version_added": true

--- a/javascript/builtins/TypeError.json
+++ b/javascript/builtins/TypeError.json
@@ -13,7 +13,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -22,7 +22,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "nodejs": {
               "version_added": true

--- a/javascript/builtins/URIError.json
+++ b/javascript/builtins/URIError.json
@@ -13,7 +13,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -22,7 +22,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "nodejs": {
               "version_added": true

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -330,7 +330,7 @@
                 "version_added": "36"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "6"

--- a/javascript/builtins/WeakSet.json
+++ b/javascript/builtins/WeakSet.json
@@ -278,7 +278,7 @@
                 "version_added": "36"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "34"


### PR DESCRIPTION
This PR updates the JavaScript misc. data for IE and Edge based upon manual testing. Data is as follows:

javascript.builtins.JSON - 8 (already in data)
javascript.builtins.Map.@@iterator - 12
javascript.builtins.Object - 3
javascript.builtins.Object.defineGetter - 11 (already in data)
javascript.builtins.Object.defineSetter - 11 (already in data)
javascript.builtins.Object.lookupGetter - 11 (already in data)
javascript.builtins.Object.lookupSetter - 11 (already in data)
javascript.builtins.Object.preventExtensions.ES2015_behavior - 11 (already in data)
javascript.builtins.Object.proto - 11 (already in data)
javascript.builtins.Object.prototype - 3
javascript.builtins.Promise - 12
javascript.builtins.Promise.Promise - 12
javascript.builtins.Promise.prototype - 12
javascript.builtins.Proxy.handler.isExtensible - 12
javascript.builtins.Proxy.handler.setPrototypeOf - 12
javascript.builtins.RangeError - 5.5
javascript.builtins.ReferenceError - 5.5
javascript.builtins.Set.@@iterator - 12
javascript.builtins.Symbol.match - false
javascript.builtins.Symbol.replace - false
javascript.builtins.Symbol.search - false
javascript.builtins.Symbol.split - false
javascript.builtins.Symbol.@@toPrimitive - 15
javascript.builtins.SyntaxError - 5.5
javascript.builtins.TypeError - 5.5
javascript.builtins.URIError - 5.5
javascript.builtins.WeakMap.prototype - 11 (already in data)
javascript.builtins.WeakSet.prototype - 12