### PR TITLE
add safari support for unicode property escape

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -1055,10 +1055,10 @@
                 "version_added": "47"
               },
               "safari": {
-                "version_added": null
+                "version_added": "11.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "11.3"
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any

Added Safari support data for unicode property escape.

This feature has been supported since [Safari Technology Preview 42](https://webkit.org/blog/8001/release-notes-for-safari-technology-preview-42/), the Webkit version 605. Later it is included in Safari 11.1 and Safari iOS 11.3 according to the [Safari version history](https://en.wikipedia.org/wiki/Safari_version_history).