### PR TITLE
Update IE/Edge compatibility of JavaScript functions

### DIFF
--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -12,7 +12,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "1"
@@ -21,7 +21,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "3"
           },
           "nodejs": {
             "version_added": true
@@ -63,7 +63,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -72,7 +72,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "nodejs": {
               "version_added": true
@@ -114,7 +114,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -218,7 +218,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -227,7 +227,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "4"
               },
               "nodejs": {
                 "version_added": true
@@ -273,7 +273,7 @@
                 "version_added": "52"
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "46"
@@ -327,7 +327,7 @@
               "version_added": "45"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "22",
@@ -385,7 +385,7 @@
                 "version_added": "58"
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "52"
@@ -540,7 +540,7 @@
                 "version_added": "49"
               },
               "edge": {
-                "version_added": null
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "41"
@@ -644,7 +644,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "2"
@@ -694,7 +694,7 @@
                 "version_added": "46"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "34"
@@ -748,7 +748,7 @@
               "version_added": "39"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "34"
@@ -798,7 +798,7 @@
                 "version_added": "63"
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "55"
@@ -860,7 +860,7 @@
                 "version_added": "55"
               },
               "edge": {
-                "version_added": null
+                "version_added": "15"
               },
               "firefox": {
                 "version_added": "52"
@@ -922,7 +922,7 @@
                 "version_added": "42"
               },
               "edge": {
-                "version_added": null
+                "version_added": "13"
               },
               "firefox": {
                 "version_added": "43"
@@ -1140,7 +1140,7 @@
                 "version_added": "46"
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "34"


### PR DESCRIPTION
This PR adds version numbers for IE and Edge for various JavaScript functions data points, determined via manual testing.  Data is as follows:

javascript.functions - 3
javascript.functions.arguments - 3
javascript.functions.arguments.callee - 6 (already in data)
javascript.functions.arguments.length - 4
javascript.functions.arguments.@@iterator - 12
javascript.functions.arrow_functions - 12
javascript.functions.arrow_functions.trailing_comma - 12
javascript.functions.block_level_functions - 11
javascript.functions.default_parameters.destructured_parameter_with_default_value_assignment - 14
javascript.functions.get - 9 (already in data)
javascript.functions.get.computed_property_names - 12
javascript.functions.method_definitions - 12
javascript.functions.method_definitions.async_generator_methods - false
javascript.functions.method_definitions.async_methods - 15
javascript.functions.method_definitions.generator_methods_not_constructable - 13
javascript.functions.set - 9 (already in data)
javascript.functions.set.computed_property_names - 12