### PR TITLE
Update IE/Edge compatibility of JavaScript statements

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -68,7 +68,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": true
+              "version_added": "15"
             },
             "firefox": {
               "version_added": "52"
@@ -131,7 +131,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -140,7 +140,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "11"
             },
             "nodejs": {
               "version_added": true
@@ -183,7 +183,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -192,7 +192,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "nodejs": {
               "version_added": true
@@ -237,7 +237,7 @@
               "notes": "From Chrome 42 to 48 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
             },
             "edge": {
-              "version_added": true
+              "version_added": "13"
             },
             "firefox": {
               "version_added": "45"
@@ -290,7 +290,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "36",
@@ -350,7 +350,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -359,7 +359,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "nodejs": {
               "version_added": true
@@ -402,7 +402,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -411,7 +411,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "nodejs": {
               "version_added": true
@@ -459,7 +459,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"
@@ -468,7 +468,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "4"
               },
               "nodejs": {
                 "version_added": true
@@ -604,7 +604,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -613,7 +613,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "4"
             },
             "nodejs": {
               "version_added": true
@@ -657,7 +657,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -666,7 +666,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "nodejs": {
               "version_added": true
@@ -796,7 +796,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -805,7 +805,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "nodejs": {
               "version_added": true
@@ -968,7 +968,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -1073,7 +1073,7 @@
                 "version_added": "63"
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "57"
@@ -1124,7 +1124,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "53"
@@ -1177,7 +1177,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -1186,7 +1186,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "nodejs": {
               "version_added": true
@@ -1227,7 +1227,7 @@
                 "version_added": "58"
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "52"
@@ -1236,7 +1236,7 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": null
+                "version_added": "5.5"
               },
               "nodejs": {
                 "version_added": "8.0.0"
@@ -1393,7 +1393,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": "13"
               },
               "firefox": {
                 "version_added": "43"
@@ -1444,7 +1444,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": null
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "52"
@@ -1498,7 +1498,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -1507,7 +1507,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "nodejs": {
               "version_added": true
@@ -1729,7 +1729,7 @@
               "version_added": "64"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "62"
@@ -1778,7 +1778,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -1787,7 +1787,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "nodejs": {
               "version_added": true
@@ -1948,7 +1948,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -1957,7 +1957,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "nodejs": {
               "version_added": true
@@ -2000,7 +2000,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -2009,7 +2009,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "nodejs": {
               "version_added": true
@@ -2052,7 +2052,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -2061,7 +2061,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5"
             },
             "nodejs": {
               "version_added": true
@@ -2105,7 +2105,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -2114,7 +2114,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "nodejs": {
               "version_added": true
@@ -2261,7 +2261,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -2270,7 +2270,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "nodejs": {
               "version_added": true
@@ -2313,7 +2313,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -2322,7 +2322,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "nodejs": {
               "version_added": true
@@ -2365,7 +2365,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -2374,7 +2374,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "nodejs": {
               "version_added": true

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1227,7 +1227,7 @@
                 "version_added": "58"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "52"
@@ -1236,7 +1236,7 @@
                 "version_added": "52"
               },
               "ie": {
-                "version_added": "5.5"
+                "version_added": false
               },
               "nodejs": {
                 "version_added": "8.0.0"


### PR DESCRIPTION
This updates the IE and Edge compatibility of various JavaScript statements, based upon manual testing.  The data is as follows:

javascript.statements.async_function - 15
javascript.statements.block - 11
javascript.statements.break - 3
javascript.statements.class - 13
javascript.statements.const - 11 (already in data)
javascript.statements.continue - 3
javascript.statements.debugger - 4
javascript.statements.default.switch - 4
javascript.statements.do_while - 4
javascript.statements.empty - 3
javascript.statements.for - 3
javascript.statements.for_in - 6 (already in data)
javascript.statements.for_of.async_iterators - 12
javascript.statements.for_of.closing_iterators - 14
javascript.statements.function - 3
javascript.statements.function.trailing_comma_in_parameters - 14
javascript.statements.generator_function.not_constructable_with_new - 13
javascript.statements.generator_function.trailing_comma_in_parameters - 14
javascript.statements.if_else - 3
javascript.statements.import_meta - false
javascript.statements.label - 4
javascript.statements.return - 3
javascript.statements.switch - 4
javascript.statements.throw - 5
javascript.statements.try_catch - 5
javascript.statements.var - 3
javascript.statements.while - 3
javascript.statements.with - 3