### PR TITLE
Fix consistency within :visited selector

### DIFF
--- a/css/selectors/visited.json
+++ b/css/selectors/visited.json
@@ -92,7 +92,7 @@
                 "notes": "Chromium has never matched <code>&lt;link&gt;</code> elements with link pseudo-classes."
               },
               "webview_android": {
-                "version_added": "1",
+                "version_added": "4.4",
                 "notes": "Chromium has never matched <code>&lt;link&gt;</code> elements with link pseudo-classes."
               }
             },


### PR DESCRIPTION
This PR fixes a version inconsistency within new data that has been added to the `:visited` CSS selector.