### PR TITLE
Add Opera Android version for Intl.RelativeTimeFormat

### DIFF
--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -2573,7 +2573,7 @@
                 "version_added": "58"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "50"
               },
               "safari": {
                 "version_added": false
@@ -2625,7 +2625,7 @@
                   "version_added": "58"
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": "50"
                 },
                 "safari": {
                   "version_added": false
@@ -2677,7 +2677,7 @@
                   "version_added": "58"
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": "50"
                 },
                 "safari": {
                   "version_added": false
@@ -2729,7 +2729,7 @@
                   "version_added": "58"
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": "50"
                 },
                 "safari": {
                   "version_added": false
@@ -2781,7 +2781,7 @@
                   "version_added": "58"
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": "50"
                 },
                 "safari": {
                   "version_added": false
@@ -2833,7 +2833,7 @@
                   "version_added": "58"
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": "50"
                 },
                 "safari": {
                   "version_added": false
@@ -2935,7 +2935,7 @@
                   "version_added": "58"
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": "50"
                 },
                 "safari": {
                   "version_added": false


### PR DESCRIPTION
This PR adds the Opera Android version numbers for `Intl.RelativeTimeFormat` based upon Chrome Android.  This also eliminates a linter issue with version inconsistencies ("child has support but not parent").