### PR TITLE
Update DOMMatrix[ReadOnly] Chromium compatibility

### DIFF
--- a/api/DOMMatrix.json
+++ b/api/DOMMatrix.json
@@ -4,12 +4,34 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrix",
         "support": {
-          "chrome": {
-            "version_added": "61"
-          },
-          "chrome_android": {
-            "version_added": "61"
-          },
+          "chrome": [
+            {
+              "version_added": "61"
+            },
+            {
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--enable-blink-features=GeometryInterfaces"
+                }
+              ]
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "61"
+            },
+            {
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--enable-blink-features=GeometryInterfaces"
+                }
+              ]
+            }
+          ],
           "edge": {
             "version_added": false
           },
@@ -22,12 +44,34 @@
           "ie": {
             "version_added": false
           },
-          "opera": {
-            "version_added": "48"
-          },
-          "opera_android": {
-            "version_added": "45"
-          },
+          "opera": [
+            {
+              "version_added": "48"
+            },
+            {
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--enable-blink-features=GeometryInterfaces"
+                }
+              ]
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": "48"
+            },
+            {
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--enable-blink-features=GeometryInterfaces"
+                }
+              ]
+            }
+          ],
           "safari": {
             "version_added": "11"
           },
@@ -50,10 +94,10 @@
           "description": "<code>DOMMatrix()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "45"
             },
             "chrome_android": {
-              "version_added": "61"
+              "version_added": "45"
             },
             "edge": {
               "version_added": false
@@ -68,10 +112,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "48"
+              "version_added": "32"
             },
             "opera_android": {
-              "version_added": "45"
+              "version_added": "32"
             },
             "safari": {
               "version_added": "11"
@@ -95,10 +139,10 @@
           "description": "Available in workers",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "57"
             },
             "chrome_android": {
-              "version_added": "61"
+              "version_added": "57"
             },
             "edge": {
               "version_added": false
@@ -113,10 +157,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "48"
+              "version_added": "44"
             },
             "opera_android": {
-              "version_added": "45"
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"

--- a/api/DOMMatrixReadOnly.json
+++ b/api/DOMMatrixReadOnly.json
@@ -4,12 +4,34 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly",
         "support": {
-          "chrome": {
-            "version_added": "45"
-          },
-          "chrome_android": {
-            "version_added": "45"
-          },
+          "chrome": [
+            {
+              "version_added": "61"
+            },
+            {
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--enable-blink-features=GeometryInterfaces"
+                }
+              ]
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "61"
+            },
+            {
+              "version_added": "45",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--enable-blink-features=GeometryInterfaces"
+                }
+              ]
+            }
+          ],
           "edge": {
             "version_added": false
           },
@@ -22,20 +44,42 @@
           "ie": {
             "version_added": false
           },
-          "opera": {
-            "version_added": "32"
-          },
-          "opera_android": {
-            "version_added": "45"
-          },
+          "opera": [
+            {
+              "version_added": "48"
+            },
+            {
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--enable-blink-features=GeometryInterfaces"
+                }
+              ]
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": "48"
+            },
+            {
+              "version_added": "32",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--enable-blink-features=GeometryInterfaces"
+                }
+              ]
+            }
+          ],
           "safari": {
             "version_added": "11"
           },
           "safari_ios": {
-            "version_added": "11.3"
+            "version_added": "11"
           },
           "webview_android": {
-            "version_added": "45"
+            "version_added": "61"
           }
         },
         "status": {


### PR DESCRIPTION
This PR intends to fix some inconsistencies within the `DOMMatrix` and `DOMMatrixReadOnly` data for Chromium.  As I found in #3743, both APIs were implemented in Chrome 45, however in Chrome 60, it's reported as undefined.  And I found out why:

DOMMatrix and DOMMatrixReadOnly were implemented in [Chrome 45](https://storage.googleapis.com/chromium-find-releases-static/588.html#5889261bab473ef399160e39c6b48d5eb21b4499) behind a flag (`--enable-blink-features=GeometryInterfaces`).  The flag was then enabled by default in [Chrome 61](https://storage.googleapis.com/chromium-find-releases-static/065.html#06592e080fd1cf4a188265ed4f9bcf826952671a).

DOMMatrix was available to workers in [Chrome 57](https://storage.googleapis.com/chromium-find-releases-static/0b4.html#0b469432cc5bd5db8422ce5a8100f8fcae148a2c).