### PR TITLE
Add IE versions for JavaScript builtins (part 1)

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -22,7 +22,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "nodejs": {
               "version_added": true
@@ -1053,7 +1053,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "4"
               },
               "nodejs": {
                 "version_added": true
@@ -1313,7 +1313,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "4"
               },
               "nodejs": {
                 "version_added": true
@@ -1625,7 +1625,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "4"
               },
               "nodejs": {
                 "version_added": true
@@ -1878,7 +1878,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "5.5"
               },
               "nodejs": {
                 "version_added": true
@@ -2083,7 +2083,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "4"
               },
               "nodejs": {
                 "version_added": true
@@ -2387,7 +2387,7 @@
                 "version_added": "48"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "nodejs": [
                 {
@@ -2450,7 +2450,7 @@
                 "version_added": "48"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "nodejs": {
                 "version_added": "0.12"

--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -386,7 +386,7 @@
                 "version_added": "48"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "nodejs": [
                 {

--- a/javascript/builtins/Boolean.json
+++ b/javascript/builtins/Boolean.json
@@ -22,7 +22,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "nodejs": {
               "version_added": true
@@ -73,7 +73,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -176,7 +176,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -228,7 +228,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "4"
               },
               "nodejs": {
                 "version_added": true

--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -123,7 +123,7 @@
                   "version_added": "55"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "nodejs": {
                   "version_added": null
@@ -1422,7 +1422,7 @@
                 "version_added": "55"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "nodejs": {
                 "version_added": null


### PR DESCRIPTION
This PR adds IE versions for various JavaScript builtins based upon manual testing.  The data is as follows:

javascript.builtins.Array - 4
javascript.builtins.Array.length - 4
javascript.builtins.Array.prototype - 4
javascript.builtins.Array.slice - 4
javascript.builtins.Array.toLocaleString - 5.5
javascript.builtins.Array.toString - 4
javascript.builtins.Array.@@species - false
javascript.builtins.Array.@@unscopables - false
javascript.builtins.ArrayBuffer.@@species - false
javascript.builtins.Boolean - 3
javascript.builtins.Boolean.prototype - 3
javascript.builtins.Boolean.toString - 3
javascript.builtins.Boolean.valueOf - 4
javascript.builtins.DataView.buffer.sharedarraybuffer_support - false
javascript.builtins.DataView.sharedarraybuffer_support - false