### PR TITLE
Mention Chrome's navigator.clipboard.{read,write} version_added.

### DIFF
--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -52,10 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Clipboard/read",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "76"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "76"
             },
             "edge": {
               "version_added": false
@@ -166,10 +166,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Clipboard/write",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "76"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "76"
             },
             "edge": {
               "version_added": false

--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -86,7 +86,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "63"
             },
             "opera_android": {
               "version_added": false
@@ -101,7 +101,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "76"
             }
           },
           "status": {
@@ -200,7 +200,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "63"
             },
             "opera_android": {
               "version_added": false
@@ -215,7 +215,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "76"
             }
           },
           "status": {


### PR DESCRIPTION
Chrome added navigator.clipboard.{read,write} in M76, so mention it here.
Source:
- https://crbug.com/150835
- https://developers.google.com/web/updates/2019/07/image-support-for-async-clipboard

A checklist to help your pull request get merged faster:
- [ ] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
