### PR TITLE
Add missing Audio() constructor; fix moz* versions

### DIFF
--- a/api/HTMLAudioElement.json
+++ b/api/HTMLAudioElement.json
@@ -47,9 +47,59 @@
           "deprecated": false
         }
       },
+      "Audio": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAudioElement/Audio",
+          "description": "<code>Audio()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": true
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "mozCurrentSampleOffset": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAudioElement/mozCurrentSampleOffset",
+          "description": "<code>mozCurrentSampleOffset()</code>",
           "support": {
             "chrome": {
               "version_added": false
@@ -61,10 +111,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "4",
+              "version_removed": "31"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "31"
             },
             "ie": {
               "version_added": false
@@ -98,6 +150,7 @@
       "mozSetup": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAudioElement/mozSetup",
+          "description": "<code>mozSetup()</code>",
           "support": {
             "chrome": {
               "version_added": false
@@ -109,10 +162,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "4",
+              "version_removed": "31"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "31"
             },
             "ie": {
               "version_added": false
@@ -146,6 +201,7 @@
       "mozWriteAudio": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAudioElement/mozWriteAudio",
+          "description": "<code>mozWriteAudio()</code>",
           "support": {
             "chrome": {
               "version_added": false

--- a/api/HTMLAudioElement.json
+++ b/api/HTMLAudioElement.json
@@ -59,7 +59,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5"
@@ -68,7 +68,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "9"
+              "version_added": "10"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This update adds the missing `Audio()` constructor
to `HTMLAudioElement`. It also corrects version
information for the Mozilla-specific methods; they
were all removed way back in Firefox 31. Other minor
version tweaks have been made as well.

Sources:
* Removal of moz* methods: https://bugzilla.mozilla.org/show_bug.cgi?id=927245
