### PR TITLE
requestFullscreen() added safari_ios note

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -5962,7 +5962,7 @@
             "safari_ios": {
               "version_added": true,
               "prefix": "webkit",
-              "notes": "Only available on iPad, not on iPhone."
+              "notes": "Only available on iPad, not on iPhone. Shows an overlay button which can not be disabled."
             },
             "samsunginternet_android": {
               "version_added": true,


### PR DESCRIPTION
Added "Shows an overlay button which can not be disabled." to `requestFullscreen()` API.

Source: own experiments 

https://developer.apple.com/videos/play/wwdc2018/234/ at 33:35 min

ref https://github.com/Fyrd/caniuse/pull/4839