### PR TITLE
Add node.js release v12.11.0

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -182,6 +182,12 @@
           "release_notes": "https://nodejs.org/en/blog/release/v12.9.0/",
           "engine": "V8",
           "engine_version": "7.6"
+        },
+        "12.11.0": {
+          "release_date": "2019-09-25",
+          "release_notes": "https://nodejs.org/en/blog/release/v12.11.0/",
+          "engine": "V8",
+          "engine_version": "7.7"
         }
       }
     }


### PR DESCRIPTION
On 2019-09-25 Node.js `v12.11.0` [was released](https://nodejs.org/en/blog/release/v12.11.0/) with V8 version `7.7`.

This V8 version introduces [some changes](https://v8.dev/blog/v8-release-77#javascript-language-features) in `Intl.NumberFormat`:

 - [Units of measurement](https://v8.dev/features/intl-numberformat#units)
 - [Compact, scientific, and engineering notation](https://v8.dev/features/intl-numberformat#notation)
 - [Sign display](https://v8.dev/features/intl-numberformat#sign)

But `Intl.NumberFormat` options are not listed in compat data, so no more changes are necessary.