### PR TITLE
Add IE versions for JavaScript builtins (part 4)

### DIFF
--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -125,7 +125,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "4"
               },
               "nodejs": {
                 "version_added": true
@@ -1036,7 +1036,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "5.5"
               },
               "nodejs": {
                 "version_added": true
@@ -1244,7 +1244,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "9"
               },
               "nodejs": {
                 "version_added": true
@@ -1767,7 +1767,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "5.5"
               },
               "nodejs": {
                 "version_added": true
@@ -2028,7 +2028,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "5.5"
               },
               "nodejs": {
                 "version_added": true
@@ -2131,7 +2131,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -2288,7 +2288,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "4"
               },
               "nodejs": {
                 "version_added": true

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -1558,7 +1558,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": "4.4"
+                "version_added": "4"
               },
               "nodejs": {
                 "version_added": true

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -73,7 +73,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "4"
               },
               "nodejs": {
                 "version_added": true
@@ -187,7 +187,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "4"
               },
               "nodejs": {
                 "version_added": true
@@ -297,7 +297,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "5.5"
               },
               "nodejs": {
                 "version_added": true
@@ -400,7 +400,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "5.5"
               },
               "nodejs": {
                 "version_added": true
@@ -503,7 +503,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "5.5"
               },
               "nodejs": {
                 "version_added": true
@@ -555,7 +555,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "5.5"
               },
               "nodejs": {
                 "version_added": true
@@ -607,7 +607,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "5.5"
               },
               "nodejs": {
                 "version_added": true
@@ -659,7 +659,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "5.5"
               },
               "nodejs": {
                 "version_added": true
@@ -711,7 +711,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "5.5"
               },
               "nodejs": {
                 "version_added": true
@@ -816,7 +816,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "5.5"
               },
               "nodejs": {
                 "version_added": true
@@ -1147,7 +1147,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "5.5"
               },
               "nodejs": {
                 "version_added": true
@@ -1558,7 +1558,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "4.4"
               },
               "nodejs": {
                 "version_added": true


### PR DESCRIPTION
This PR adds IE versions for various JavaScript builtins based upon manual testing. The data is as follows:

javascript.builtins.Object.constructor - 4
javascript.builtins.Object.hasOwnProperty - 5.5
javascript.builtins.Object.isPrototypeOf - 9
javascript.builtins.Object.propertyIsEnumerable - 5.5
javascript.builtins.Object.toLocaleString - 5.5
javascript.builtins.Object.toString - 3
javascript.builtins.Object.valueOf - 4
javascript.builtins.RegExp.compile - 4
javascript.builtins.RegExp.exec - 4
javascript.builtins.RegExp.global - 5.5
javascript.builtins.RegExp.ignoreCase - 5.5
javascript.builtins.RegExp.input - 5.5
javascript.builtins.RegExp.lastIndex - 5.5
javascript.builtins.RegExp.lastMatch - 5.5
javascript.builtins.RegExp.lastParen - 5.5
javascript.builtins.RegExp.leftContext - 5.5
javascript.builtins.RegExp.multiline - 5.5
javascript.builtins.RegExp.rightContext - 5.5
javascript.builtins.RegExp.test - 4