### PR TITLE
Add IE versions for JavaScript builtins (part 5)

### DIFF
--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -125,7 +125,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -177,7 +177,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -229,7 +229,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -281,7 +281,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -333,7 +333,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "4"
               },
               "nodejs": {
                 "version_added": true
@@ -448,7 +448,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "4"
               },
               "nodejs": {
                 "version_added": true
@@ -563,7 +563,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -615,7 +615,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -667,7 +667,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -719,7 +719,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "4"
               },
               "nodejs": {
                 "version_added": true
@@ -900,7 +900,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -952,7 +952,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -1056,7 +1056,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -1108,7 +1108,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -1163,7 +1163,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "5.5"
               },
               "nodejs": {
                 "version_added": true
@@ -1315,7 +1315,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "4"
               },
               "nodejs": {
                 "version_added": true
@@ -1869,7 +1869,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "4"
               },
               "nodejs": {
                 "version_added": true
@@ -1973,7 +1973,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "4"
               },
               "nodejs": {
                 "version_added": true
@@ -2077,7 +2077,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "4"
               },
               "nodejs": {
                 "version_added": true
@@ -2129,7 +2129,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -2181,7 +2181,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "4"
               },
               "nodejs": {
                 "version_added": true
@@ -2296,7 +2296,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -2348,7 +2348,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -2400,7 +2400,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "4"
               },
               "nodejs": {
                 "version_added": true
@@ -2452,7 +2452,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -2504,7 +2504,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -2766,7 +2766,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -2921,7 +2921,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true

--- a/javascript/builtins/globals.json
+++ b/javascript/builtins/globals.json
@@ -22,7 +22,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "nodejs": {
               "version_added": true
@@ -74,7 +74,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "nodejs": {
               "version_added": true
@@ -126,7 +126,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "nodejs": {
               "version_added": true
@@ -178,7 +178,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "nodejs": {
               "version_added": true
@@ -230,7 +230,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "nodejs": {
               "version_added": true
@@ -334,7 +334,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "nodejs": {
               "version_added": true
@@ -386,7 +386,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "nodejs": {
               "version_added": true
@@ -490,7 +490,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "nodejs": {
               "version_added": true
@@ -542,7 +542,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "nodejs": {
               "version_added": true
@@ -594,7 +594,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "nodejs": {
               "version_added": true
@@ -646,7 +646,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "nodejs": {
               "version_added": true
@@ -698,7 +698,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "nodejs": {
               "version_added": true
@@ -801,7 +801,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "nodejs": {
               "version_added": true
@@ -853,7 +853,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "nodejs": {
               "version_added": true


### PR DESCRIPTION
This PR adds IE versions for various JavaScript builtins based upon manual testing. The data is as follows:

javascript.builtins.String.big - 3
javascript.builtins.String.blink - 3
javascript.builtins.String.bold - 3
javascript.builtins.String.charAt - 3
javascript.builtins.String.charCodeAt - 4
javascript.builtins.String.concat - 4
javascript.builtins.String.fixed - 3
javascript.builtins.String.fontcolor - 3
javascript.builtins.String.fontsize - 3
javascript.builtins.String.fromCharCode - 4
javascript.builtins.String.indexOf - 3
javascript.builtins.String.italics - 3
javascript.builtins.String.length - 3
javascript.builtins.String.link - 3
javascript.builtins.String.localeCompare - 5.5
javascript.builtins.String.match - 4
javascript.builtins.String.replace - 4
javascript.builtins.String.search - 4
javascript.builtins.String.slice - 4
javascript.builtins.String.small - 3
javascript.builtins.String.split - 4
javascript.builtins.String.strike - 3
javascript.builtins.String.sub - 3
javascript.builtins.String.substr - 4
javascript.builtins.String.substring - 3
javascript.builtins.String.sup - 3
javascript.builtins.String.toLowerCase - 3
javascript.builtins.String.toUpperCase - 3
javascript.builtins.Infinity - 4
javascript.builtins.NaN - 4
javascript.builtins.decodeURI - 5.5
javascript.builtins.decodeURIComponent - 5.5
javascript.builtins.encodeURI - 5.5
javascript.builtins.escape - 3
javascript.builtins.eval - 3
javascript.builtins.isFinite - 4
javascript.builtins.isNaN - 3
javascript.builtins.null - 3
javascript.builtins.parseFloat - 3
javascript.builtins.parseInt - 3
javascript.builtins.undefined - 5.5
javascript.builtins.unescape - 3