### PR TITLE
Add IE versions for JavaScript functions/grammar/operators (part 1)

### DIFF
--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -437,7 +437,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": null
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "46"
@@ -446,7 +446,7 @@
               "version_added": "46"
             },
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "nodejs": {
               "version_added": null

--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -500,7 +500,7 @@
               "version_added": "25"
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "nodejs": {
               "version_added": true

--- a/javascript/operators/arithmetic.json
+++ b/javascript/operators/arithmetic.json
@@ -23,7 +23,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -75,7 +75,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -127,7 +127,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -242,7 +242,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -294,7 +294,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -346,7 +346,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -398,7 +398,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -450,7 +450,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -502,7 +502,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true

--- a/javascript/operators/assignment.json
+++ b/javascript/operators/assignment.json
@@ -23,7 +23,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -75,7 +75,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -127,7 +127,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -179,7 +179,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -231,7 +231,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -346,7 +346,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -398,7 +398,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -450,7 +450,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -502,7 +502,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -554,7 +554,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -606,7 +606,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -658,7 +658,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true

--- a/javascript/operators/await.json
+++ b/javascript/operators/await.json
@@ -22,7 +22,7 @@
               "version_added": "52"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "nodejs": [
               {


### PR DESCRIPTION
This PR adds real values for various JavaScript functions, grammar, and operators for Internet Explorer, based upon manual testing.  The data is as follows:

javascript.functions.arguments.caller - 3
javascript.functions.block_level_functions - 11
javascript.grammar.octal_numeric_literals - false
javascript.operators.arithmetic.addition - 3
javascript.operators.arithmetic.decrement - 3
javascript.operators.arithmetic.division - 3
javascript.operators.arithmetic.increment - 3
javascript.operators.arithmetic.multiplication - 3
javascript.operators.arithmetic.remainder - 3
javascript.operators.arithmetic.subtraction - 3
javascript.operators.arithmetic.unary_negation - 3
javascript.operators.arithmetic.unary_plus - 3
javascript.operators.assignment.addition - 3
javascript.operators.assignment.bitwise_and - 3
javascript.operators.assignment.bitwise_or - 3
javascript.operators.assignment.bitwise_xor - 3
javascript.operators.assignment.division - 3
javascript.operators.assignment.left_shift - 3
javascript.operators.assignment.multiplication - 3
javascript.operators.assignment.remainder - 3
javascript.operators.assignment.right_shift - 3
javascript.operators.assignment.simple - 3
javascript.operators.assignment.subtraction - 3
javascript.operators.assignment.unsigned_right_shift - 3
javascript.operators.await - false