### PR TITLE
Add Samsung Internet compatibility for HTMLSelectElement.checkValidity()

### DIFF
--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -306,6 +306,9 @@
             },
             "webview_android": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
             }
           },
           "status": {


### PR DESCRIPTION
Tested and verified that checkValidity() works in Samsung's Internet browser.
Test: https://codepen.io/CaelanBorowiec/pen/NWKQEpo 
Browser version tested: 10.1.00.27
