### PR TITLE
Add Samsung Internet compatibility for HTMLSelectElement.checkValidity()

### DIFF
--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -306,6 +306,9 @@
             },
             "webview_android": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
             }
           },
           "status": {

--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -304,10 +304,10 @@
             "safari_ios": {
               "version_added": true
             },
-            "webview_android": {
+            "samsunginternet_android": {
               "version_added": true
             },
-            "samsunginternet_android": {
+            "webview_android": {
               "version_added": true
             }
           },


### PR DESCRIPTION
Tested and verified that checkValidity() works in Samsung's Internet browser.
Test: https://codepen.io/CaelanBorowiec/pen/NWKQEpo
Browser version tested: 10.1.00.27

(resubmit of https://github.com/mdn/browser-compat-data/pull/4919 to hopefully fix sort order error in travis)