### PR TITLE
canPlayType(): Firefox 28 note added

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -424,6 +424,7 @@
       "canPlayType": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/canPlayType",
+          "description": "<code>canPlayType()</code>",
           "support": {
             "chrome": {
               "version_added": true
@@ -435,7 +436,8 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "3.5",
+              "notes": "Prior to Firefox 28, <code>canPlayType()</code> returned <code>probably</code> when asked about WebM audio or video files without the <code>codecs</code> parameter. Since multiple codecs are supported, this is not enough information to determine if a file can be played, so <code>maybe</code> is now correctly returned."
             },
             "firefox_android": {
               "version_added": true


### PR DESCRIPTION
Firefox 28 fixed canPlayType() to no longer say
it "probably" supports video/webm or audio/webm files
if the codecs parameter isn't included in the MIME
type. This is because in a container that supports
more than one codec, you can't determine support
without the codecs parameter included.

Source:
* https://bugzilla.mozilla.org/show_bug.cgi?id=884275