### PR TITLE
Add IE versions for JavaScript functions/grammar/operators (part 2)

### DIFF
--- a/javascript/operators/bitwise.json
+++ b/javascript/operators/bitwise.json
@@ -23,7 +23,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -75,7 +75,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -127,7 +127,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -179,7 +179,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -231,7 +231,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -283,7 +283,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -335,7 +335,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true

--- a/javascript/operators/comparison.json
+++ b/javascript/operators/comparison.json
@@ -23,7 +23,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -75,7 +75,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -127,7 +127,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "4"
               },
               "nodejs": {
                 "version_added": true
@@ -179,7 +179,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "4"
               },
               "nodejs": {
                 "version_added": true
@@ -231,7 +231,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -283,7 +283,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -335,7 +335,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -387,7 +387,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true

--- a/javascript/operators/conditional.json
+++ b/javascript/operators/conditional.json
@@ -23,7 +23,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "nodejs": {
               "version_added": true

--- a/javascript/operators/delete.json
+++ b/javascript/operators/delete.json
@@ -22,7 +22,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "nodejs": {
               "version_added": true

--- a/javascript/operators/function.json
+++ b/javascript/operators/function.json
@@ -22,7 +22,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "nodejs": {
               "version_added": true

--- a/javascript/operators/grouping.json
+++ b/javascript/operators/grouping.json
@@ -23,7 +23,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "nodejs": {
               "version_added": true

--- a/javascript/operators/in.json
+++ b/javascript/operators/in.json
@@ -22,7 +22,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "nodejs": {
               "version_added": true

--- a/javascript/operators/instanceof.json
+++ b/javascript/operators/instanceof.json
@@ -22,7 +22,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5"
             },
             "nodejs": {
               "version_added": true

--- a/javascript/operators/logical.json
+++ b/javascript/operators/logical.json
@@ -23,7 +23,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -75,7 +75,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true
@@ -127,7 +127,7 @@
                 "version_added": "4"
               },
               "ie": {
-                "version_added": true
+                "version_added": "3"
               },
               "nodejs": {
                 "version_added": true

--- a/javascript/operators/new.json
+++ b/javascript/operators/new.json
@@ -22,7 +22,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "nodejs": {
               "version_added": true

--- a/javascript/operators/property_accessors.json
+++ b/javascript/operators/property_accessors.json
@@ -23,7 +23,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "nodejs": {
               "version_added": true

--- a/javascript/operators/this.json
+++ b/javascript/operators/this.json
@@ -22,7 +22,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "nodejs": {
               "version_added": true

--- a/javascript/operators/typeof.json
+++ b/javascript/operators/typeof.json
@@ -22,7 +22,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "3"
             },
             "nodejs": {
               "version_added": true

--- a/javascript/operators/void.json
+++ b/javascript/operators/void.json
@@ -22,7 +22,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5"
             },
             "nodejs": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for various JavaScript functions, grammar, and operators for Internet Explorer, based upon manual testing. The data is as follows:

javascript.operators.bitwise.and - 3
javascript.operators.bitwise.left_shift - 3
javascript.operators.bitwise.not - 3
javascript.operators.bitwise.or - 3
javascript.operators.bitwise.right_shift - 3
javascript.operators.bitwise.unsigned_right_shift - 3
javascript.operators.bitwise.xor - 3
javascript.operators.comparison.equality - 3
javascript.operators.comparison.inequality - 3
javascript.operators.comparison.identity - 4
javascript.operators.comparison.non_identity - 4
javascript.operators.comparison.greater_than - 3
javascript.operators.comparison.greater_than_or_equal - 3
javascript.operators.comparison.less_than - 3
javascript.operators.comparison.less_than_or_equal - 3
javascript.operators.conditional - 3
javascript.operators.delete - 4
javascript.operators.function - 3
javascript.operators.grouping - 3
javascript.operators.in - 5.5
javascript.operators.instanceof - 5
javascript.operators.logical.and - 3
javascript.operators.logical.or - 3
javascript.operators.logical.not - 3
javascript.operators.new - 3
javascript.operators.property_accessors - 3
javascript.operators.this - 4
javascript.operators.typeof - 3
javascript.operators.void - 5