### PR TITLE
Update Chromium OffscreenCanvas support

### DIFF
--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -42,7 +42,7 @@
             "version_added": "56"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "48"
           },
           "safari": {
             "version_added": false
@@ -178,7 +178,7 @@
               "version_added": "56"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "48"
             },
             "safari": {
               "version_added": false
@@ -242,7 +242,7 @@
               "version_added": "56"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "48"
             },
             "safari": {
               "version_added": false
@@ -369,7 +369,7 @@
                 "version_added": "56"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "48"
               },
               "safari": {
                 "version_added": false
@@ -433,7 +433,7 @@
                 "version_added": "56"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "48"
               },
               "safari": {
                 "version_added": false
@@ -481,7 +481,7 @@
                 "version_added": "56"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "48"
               },
               "safari": {
                 "version_added": false
@@ -546,7 +546,7 @@
               "version_added": "56"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "48"
             },
             "safari": {
               "version_added": false
@@ -610,7 +610,7 @@
               "version_added": "56"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "48"
             },
             "safari": {
               "version_added": false
@@ -674,7 +674,7 @@
               "version_added": "56"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "48"
             },
             "safari": {
               "version_added": false

--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -54,13 +54,7 @@
             "version_added": false
           },
           "webview_android": {
-            "version_added": true,
-            "flags": [
-              {
-                "type": "preference",
-                "name": "Experimental canvas features"
-              }
-            ]
+            "version_added": false
           }
         },
         "status": {
@@ -317,7 +311,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": "76"
+                "version_added": false
               }
             },
             "status": {
@@ -381,7 +375,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": "69"
+                "version_added": false
               }
             },
             "status": {
@@ -445,7 +439,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": "69"
+                "version_added": false
               }
             },
             "status": {
@@ -493,7 +487,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": "69"
+                "version_added": false
               }
             },
             "status": {

--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -268,10 +268,10 @@
             "description": "bitmaprenderer context",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": 76
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": 76
               },
               "edge": {
                 "version_added": null
@@ -302,10 +302,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": 63
               },
               "opera_android": {
-                "version_added": false
+                "version_added": 63
               },
               "safari": {
                 "version_added": false
@@ -317,7 +317,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": 76
               }
             },
             "status": {
@@ -332,10 +332,10 @@
             "description": "WebGL context",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": 69
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": 69
               },
               "edge": {
                 "version_added": null
@@ -366,10 +366,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": 56
               },
               "opera_android": {
-                "version_added": false
+                "version_added": 56
               },
               "safari": {
                 "version_added": false
@@ -381,7 +381,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": 69
               }
             },
             "status": {
@@ -396,10 +396,10 @@
             "description": "webgl2 context",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": 69
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": 69
               },
               "edge": {
                 "version_added": null
@@ -430,10 +430,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": 56
               },
               "opera_android": {
-                "version_added": false
+                "version_added": 56
               },
               "safari": {
                 "version_added": false
@@ -445,7 +445,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": 69
               }
             },
             "status": {
@@ -460,10 +460,10 @@
             "description": "2d context",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": 69
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": 69
               },
               "edge": {
                 "version_added": null
@@ -478,10 +478,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": 56
               },
               "opera_android": {
-                "version_added": false
+                "version_added": 56
               },
               "safari": {
                 "version_added": false
@@ -493,7 +493,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": 69
               }
             },
             "status": {

--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -305,7 +305,7 @@
                 "version_added": "63"
               },
               "opera_android": {
-                "version_added": "63"
+                "version_added": false
               },
               "safari": {
                 "version_added": false
@@ -369,7 +369,7 @@
                 "version_added": "56"
               },
               "opera_android": {
-                "version_added": "56"
+                "version_added": true
               },
               "safari": {
                 "version_added": false
@@ -433,7 +433,7 @@
                 "version_added": "56"
               },
               "opera_android": {
-                "version_added": "56"
+                "version_added": true
               },
               "safari": {
                 "version_added": false
@@ -481,7 +481,7 @@
                 "version_added": "56"
               },
               "opera_android": {
-                "version_added": "56"
+                "version_added": true
               },
               "safari": {
                 "version_added": false

--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -268,10 +268,10 @@
             "description": "bitmaprenderer context",
             "support": {
               "chrome": {
-                "version_added": 76
+                "version_added": "76"
               },
               "chrome_android": {
-                "version_added": 76
+                "version_added": "76"
               },
               "edge": {
                 "version_added": null
@@ -302,10 +302,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": 63
+                "version_added": "63"
               },
               "opera_android": {
-                "version_added": 63
+                "version_added": "63"
               },
               "safari": {
                 "version_added": false
@@ -317,7 +317,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": 76
+                "version_added": "76"
               }
             },
             "status": {
@@ -332,10 +332,10 @@
             "description": "WebGL context",
             "support": {
               "chrome": {
-                "version_added": 69
+                "version_added": "69"
               },
               "chrome_android": {
-                "version_added": 69
+                "version_added": "69"
               },
               "edge": {
                 "version_added": null
@@ -366,10 +366,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": 56
+                "version_added": "56"
               },
               "opera_android": {
-                "version_added": 56
+                "version_added": "56"
               },
               "safari": {
                 "version_added": false
@@ -381,7 +381,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": 69
+                "version_added": "69"
               }
             },
             "status": {
@@ -396,10 +396,10 @@
             "description": "webgl2 context",
             "support": {
               "chrome": {
-                "version_added": 69
+                "version_added": "69"
               },
               "chrome_android": {
-                "version_added": 69
+                "version_added": "69"
               },
               "edge": {
                 "version_added": null
@@ -430,10 +430,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": 56
+                "version_added": "56"
               },
               "opera_android": {
-                "version_added": 56
+                "version_added": "56"
               },
               "safari": {
                 "version_added": false
@@ -445,7 +445,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": 69
+                "version_added": "69"
               }
             },
             "status": {
@@ -460,10 +460,10 @@
             "description": "2d context",
             "support": {
               "chrome": {
-                "version_added": 69
+                "version_added": "69"
               },
               "chrome_android": {
-                "version_added": 69
+                "version_added": "69"
               },
               "edge": {
                 "version_added": null
@@ -478,10 +478,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": 56
+                "version_added": "56"
               },
               "opera_android": {
-                "version_added": 56
+                "version_added": "56"
               },
               "safari": {
                 "version_added": false
@@ -493,7 +493,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": 69
+                "version_added": "69"
               }
             },
             "status": {


### PR DESCRIPTION
I have added the supported parameters to `OffscreenCanvas.prototype.getContext` for chromium based browsers.

For chrome/chrome_android:
The example here uses a 2d-context: https://developers.google.com/web/updates/2018/08/offscreen-canvas
This status page gives 2d-context and webgl-context availability since version 69: https://www.chromestatus.com/feature/5681560598609920
This status page gives bitmap-context availability since version 76: https://www.chromestatus.com/feature/5700221617045504

There is only information on webview_android on the latter page, but I assume version 69 for the other features is correct as well.

Opera 56 uses Chromium 69, so I have added that as well. If I understand the (incomplete) mapping on https://help.opera.com/en/opera-version-history/, opera 63 should be using chromium 76.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
