### PR TITLE
Long Task API support in Firefox

### DIFF
--- a/api/PerformanceLongTaskTiming.json
+++ b/api/PerformanceLongTaskTiming.json
@@ -16,11 +16,11 @@
           },
           "firefox": {
             "version_added": false,
-            "notes": "See <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1348405'>bug 1348405</a>."
+            "notes": "See <a href='https://bugzil.la/1348405'>bug 1348405</a>."
           },
           "firefox_android": {
             "version_added": false,
-            "notes": "See <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1348405'>bug 1348405</a>."
+            "notes": "See <a href='https://bugzil.la/1348405'>bug 1348405</a>."
           },
           "ie": {
             "version_added": null

--- a/api/PerformanceLongTaskTiming.json
+++ b/api/PerformanceLongTaskTiming.json
@@ -3,6 +3,7 @@
     "PerformanceLongTaskTiming": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceLongTaskTiming",
+        "spec_url": "https://w3c.github.io/longtasks/#sec-PerformanceLongTaskTiming",
         "support": {
           "chrome": {
             "version_added": "58"
@@ -14,10 +15,12 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": false,
+            "notes": "See <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1348405'>bug 1348405</a>."
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false,
+            "notes": "See <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1348405'>bug 1348405</a>."
           },
           "ie": {
             "version_added": null

--- a/api/TaskAttributionTiming.json
+++ b/api/TaskAttributionTiming.json
@@ -3,6 +3,7 @@
     "TaskAttributionTiming": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/TaskAttributionTiming",
+        "spec_url": "https://w3c.github.io/longtasks/#sec-TaskAttributionTiming",
         "support": {
           "chrome": {
             "version_added": "58"
@@ -14,10 +15,12 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": false,
+            "notes": "See <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1348405'>bug 1348405</a>."
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false,
+            "notes": "See <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1348405'>bug 1348405</a>."
           },
           "ie": {
             "version_added": null

--- a/api/TaskAttributionTiming.json
+++ b/api/TaskAttributionTiming.json
@@ -17,7 +17,6 @@
           "firefox": {
             "version_added": false,
             "notes": "See <a href='https://bugzil.la/1348405'>bug 1348405</a>."
-
           },
           "firefox_android": {
             "version_added": false,

--- a/api/TaskAttributionTiming.json
+++ b/api/TaskAttributionTiming.json
@@ -16,11 +16,12 @@
           },
           "firefox": {
             "version_added": false,
-            "notes": "See <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1348405'>bug 1348405</a>."
+            "notes": "See <a href='https://bugzil.la/1348405'>bug 1348405</a>."
+
           },
           "firefox_android": {
             "version_added": false,
-            "notes": "See <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1348405'>bug 1348405</a>."
+            "notes": "See <a href='https://bugzil.la/1348405'>bug 1348405</a>."
           },
           "ie": {
             "version_added": null


### PR DESCRIPTION
Not supported, per https://bugzilla.mozilla.org/show_bug.cgi?id=1348405.