### PR TITLE
Updated browser support for the contexmenu event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -1957,16 +1957,16 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
-              "version_added": null
+              "version_added": "10.5"
             },
             "opera_android": {
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "3.0"
             },
             "safari_ios": {
               "version_added": null

--- a/api/Element.json
+++ b/api/Element.json
@@ -1948,7 +1948,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -1966,7 +1966,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "3.0"
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": null


### PR DESCRIPTION
Three different sources indicate that it's supported in IE, Opera, and Safari and two of the sources give browser versions:

http://help.dottoro.com/ljhwjsss.php
https://www.w3schools.com/jsref/event_oncontextmenu.asp
https://huge-dom.vanilla-cms.org/en/browser
