### PR TITLE
[Firefox] Bug 1571487: Implement `MathMLElement`

### DIFF
--- a/api/MathMLElement.json
+++ b/api/MathMLElement.json
@@ -1,0 +1,52 @@
+{
+  "api": {
+    "MathMLElement": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/MathMLElement",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "71"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
See [bug 1571487](https://bugzilla.mozilla.org/show_bug.cgi?id=1571487) and https://github.com/mathml-refresh/mathml/issues/83 for details.

---

review?(@vinyldarkscratch)
