### PR TITLE
privacy.websites compatibility data update

### DIFF
--- a/webextensions/api/privacy.json
+++ b/webextensions/api/privacy.json
@@ -102,11 +102,11 @@
                 },
                 "firefox": {
                   "version_added": "59",
-                  "notes": "The <code>behavior</code> property value &quot;reject_trackers&quot; was introduced in version 64."
+                  "notes": "The <code>behavior</code> property value \"reject_trackers\" was introduced in version 64."
                 },
                 "firefox_android": {
                   "version_added": "59",
-                  "notes": "The <code>behavior</code> property value &quot;reject_trackers&quot; was introduced in version 64."
+                  "notes": "The <code>behavior</code> property value \"reject_trackers\" was introduced in version 64."
                 },
                 "opera": {
                   "version_added": false

--- a/webextensions/api/privacy.json
+++ b/webextensions/api/privacy.json
@@ -101,10 +101,12 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": "59"
+                  "version_added": "59",
+                  "notes": "The <code>behavior</code> property value &quot;reject_trackers&quot; was introduced in version 64."
                 },
                 "firefox_android": {
-                  "version_added": "59"
+                  "version_added": "59",
+                  "notes": "The <code>behavior</code> property value &quot;reject_trackers&quot; was introduced in version 64."
                 },
                 "opera": {
                   "version_added": false


### PR DESCRIPTION
Added a note to say that the 'behavior' property value "reject_trackers" was introduced in version 64. See https://bugzilla.mozilla.org/show_bug.cgi?id=1493057 for details/background.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
