### PR TITLE
Safari 13 has been released

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -165,10 +165,6 @@
           "status": "current",
           "engine": "WebKit",
           "engine_version": "608.2.11"
-        },
-        "13.1": {
-          "status": "beta",
-          "engine": "WebKit"
         }
       }
     }

--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -160,7 +160,7 @@
           "engine_version": "607.1.40"
         },
         "13": {
-          "release-date": "2019-09-19",
+          "release_date": "2019-09-19",
           "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_13_release_notes",
           "status": "current",
           "engine": "WebKit",

--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -160,7 +160,13 @@
           "engine_version": "607.1.40"
         },
         "13": {
-          "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_13_beta_release_notes",
+          "release-date": "2019-09-19",
+          "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_13_release_notes",
+          "status": "current",
+          "engine": "WebKit",
+          "engine_version": "608.2.11"
+        },
+        "13.1": {
           "status": "beta",
           "engine": "WebKit"
         }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -186,7 +186,13 @@
           "engine_version": "607.1.40"
         },
         "13": {
-          "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_13_beta_release_notes",
+          "release-date": "2019-09-19",
+          "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_13_release_notes",
+          "status": "current",
+          "engine": "WebKit",
+          "engine_version": "608.2.11"
+        },
+        "13.1": {
           "status": "beta",
           "engine": "WebKit"
         }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -191,10 +191,6 @@
           "status": "current",
           "engine": "WebKit",
           "engine_version": "608.2.11"
-        },
-        "13.1": {
-          "status": "beta",
-          "engine": "WebKit"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -186,7 +186,7 @@
           "engine_version": "607.1.40"
         },
         "13": {
-          "release-date": "2019-09-19",
+          "release_date": "2019-09-19",
           "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_13_release_notes",
           "status": "current",
           "engine": "WebKit",


### PR DESCRIPTION
Safari 13 been officially released as of September 19 (as per https://support.apple.com/en-us/HT210608).  This PR is to update our data accordingly, setting Safari 13 as the current and adding Safari 13.1 as the new beta.