### PR TITLE
Microsoft Edge added upgrade-insecure-requests in version 17.

### DIFF
--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -1689,8 +1689,7 @@
                   "version_added": "43"
                 },
                 "edge": {
-                  "version_added": false,
-                  "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/cspupgradeinsecurerequestsdirective'>Under consideration</a> for future release."
+                  "version_added": "17"
                 },
                 "firefox": {
                   "version_added": "42"


### PR DESCRIPTION
Per Microsoft docs at: https://developer.microsoft.com/en-us/microsoft-edge/platform/status/cspupgradeinsecurerequestsdirective/

Refs #2561
