### PR TITLE
Copy false values to subfeatures in long timing APIs

### DIFF
--- a/api/PerformanceLongTaskTiming.json
+++ b/api/PerformanceLongTaskTiming.json
@@ -64,10 +64,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": null

--- a/api/TaskAttributionTiming.json
+++ b/api/TaskAttributionTiming.json
@@ -64,10 +64,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": null
@@ -112,10 +112,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": null
@@ -160,10 +160,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": null
@@ -208,10 +208,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
Since the long timing APIs are not supported in Firefox, this PR carries those values down to its subfeatures, fixing the consistency linter.