### PR TITLE
Update compatibility chart for clipboard api (writeText)

### DIFF
--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -256,7 +256,7 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": null


### PR DESCRIPTION
window.navigator.clipboard.writeText() is not supported in safari browser

A checklist to help your pull request get merged faster:
- [x] Summarize your changes: Updates compatibility chart for clipboard api
- [x] Data: I created a copy to clipboard component using `window.navigator.clipboard.writeText` and tested it on safari it didn't work. I had to fallback to `document.execCommand('copy')`