### PR TITLE
Edge 14 supports trailing comma in functions

### DIFF
--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -956,7 +956,7 @@
                 "version_added": "58"
               },
               "edge": {
-                "version_added": false
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "52"


### PR DESCRIPTION
This fixes #4940.  Data comes from #4899.