### PR TITLE
Add final Edge/IE data for JavaScript

### DIFF
--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -682,7 +682,7 @@
                   "version_added": "43"
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": "14"
                 },
                 "firefox": {
                   "version_added": "38"

--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -2298,7 +2298,7 @@
                   "version_added": "63"
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": "18"
                 },
                 "firefox": {
                   "version_added": "58"

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -1149,7 +1149,7 @@
                 "version_added": "47"
               },
               "edge": {
-                "version_added": null
+                "version_added": "15"
               },
               "firefox": {
                 "version_added": "44"

--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -174,7 +174,7 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": true,
+                "version_added": "3",
                 "version_removed": "9"
               },
               "nodejs": {
@@ -1090,7 +1090,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "2"


### PR DESCRIPTION
This PR adds the final data points for Edge and Internet Explorer.  `javascript.builtins.Function.name.configurable_true` was determined from manual testing, the other data points were supposed to be added in other PRs but were somehow missed.

- javascript.functions.arguments.caller (#4918)
- javascript.builtins.Intl.PluralRules.PluralRules (#4789)
- javascript.builtins.Symbol.@@toPrimitive (#4894)
- javascript.functions.block_level_functions (#4896)
- javascript.functions.set (#4896)

This finishes off the Queen Latifah milestone, closes #4772, and closes #4935.