### PR TITLE
Disallow null/true for Edge & IE in javascript/ folder

### DIFF
--- a/test/linter/test-real-values.js
+++ b/test/linter/test-real-values.js
@@ -32,7 +32,7 @@ const blockList = {
   html: [],
   http: [],
   svg: [],
-  javascript: ['firefox', 'firefox_android'],
+  javascript: ['edge', 'firefox', 'firefox_android', 'ie'],
   mathml: blockMany,
   webdriver: blockMany.concat(['samsunginternet_android']),
   webextensions: [],


### PR DESCRIPTION
Thanks to @vinyldarkscratch for getting version numbers for Edge in IE in the whole `javascript/` folder. :1st_place_medal: 