### PR TITLE
adding note about Firefox not supporting contain: style

### DIFF
--- a/css/properties/contain.json
+++ b/css/properties/contain.json
@@ -16,7 +16,8 @@
             },
             "firefox": [
               {
-                "version_added": "69"
+                "version_added": "69",
+                "notes": "Firefox does not support the <code>style</code> value."
               },
               {
                 "version_added": "41",
@@ -26,8 +27,7 @@
                     "name": "layout.css.contain.enabled",
                     "value_to_set": "true"
                   }
-                ],
-                "notes": "See <a href='https://bugzil.la/1150081'>bug 1150081</a> for the overall implementation status."
+                ]
               }
             ],
             "firefox_android": {
@@ -39,7 +39,7 @@
                   "value_to_set": "true"
                 }
               ],
-              "notes": "See <a href='https://bugzil.la/1150081'>bug 1150081</a> for the overall implementation status."
+              "notes": "Firefox does not support the <code>style</code> value."
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
As per a conversation with Daniel Hobert on Slack, adding a note to say that Firefox does not support the contain: style value.

I also took the liberty of removing the note about implem,entation status, given that it is now implemented and enabled.