### PR TITLE
Track support for input "type" and "disabled" in Samsung Internet browser

### DIFF
--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -352,6 +352,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1121,6 +1124,9 @@
             },
             "safari_ios": {
               "version_added": "1"
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": "1"


### PR DESCRIPTION
Tests: https://codepen.io/CaelanBorowiec/pen/wvwVOqR
Tested version: Samsung Internet 10.1.01.3