### PR TITLE
Update XR interface to spec

### DIFF
--- a/api/XR.json
+++ b/api/XR.json
@@ -96,6 +96,55 @@
           }
         }
       },
+      "isSessionSupported": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XR/isSessionSupported",
+          "description": "<code>isSessionSupported()</code>",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "ondevicechange": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XR/ondevicechange",
@@ -148,55 +197,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XR/requestSession",
           "description": "<code>requestSession()</code>",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": false,
-            "deprecated": false
-          }
-        }
-      },
-      "supportsSession": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XR/supportsSession",
-          "description": "<code>supportsSession()</code>",
           "support": {
             "chrome": {
               "version_added": false


### PR DESCRIPTION
This brings the BCD database entry for the `XR` interface
up to spec by updating the name of the `sessionSupported()`
method to `isSessionSupported()`. Sorted it into the right order
in the file.

Source:
* Latest specification: https://immersive-web.github.io/webxr/#xr-interface