### PR TITLE
Add mdn_url to numeric separators

### DIFF
--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -431,6 +431,7 @@
       "numeric_separators": {
         "__compat": {
           "description": "Numeric separators (<code>1_000_000_000_000</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Numeric_separators",
           "support": {
             "chrome": {
               "version_added": "75"


### PR DESCRIPTION
I've just documented this: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Numeric_separators