### PR TITLE
Firefox now supports BigInt#toLocaleString per ECMA402

### DIFF
--- a/javascript/builtins/BigInt.json
+++ b/javascript/builtins/BigInt.json
@@ -272,7 +272,7 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": "70"
                 },
                 "firefox_android": {
                   "version_added": false
@@ -322,7 +322,7 @@
                   "version_added": false
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": "70"
                 },
                 "firefox_android": {
                   "version_added": false


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1543677
Updates https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/toLocaleString#Browser_compatibility