### PR TITLE
Fix incorrect status for If-None-Match Header

### DIFF
--- a/http/headers/if-none-match.json
+++ b/http/headers/if-none-match.json
@@ -43,9 +43,9 @@
             }
           },
           "status": {
-            "experimental": true,
-            "standard_track": false,
-            "deprecated": true
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }


### PR DESCRIPTION
Please see corresponding discussion: #4924 

It seems this feature has been incorrectly labeled as experimental, non-standard and deprecated.

This pull-request is ready to merge when it is verified that it has been incorrectly labeled. As of writing this, it has NOT been verified by someone who knows what they're doing.