### PR TITLE
Fix incorrect status for drag event

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -3014,7 +3014,7 @@
             "firefox": {
               "version_added": "3.5",
               "partial_implementation": true,
-              "notes": "Firefox doesn't set the mouse coordinates during the drag event."
+              "notes": "Firefox doesn't set the mouse coordinates during the drag event.  See <a href='https://bugzil.la/505521'>bug 505521</a>."
             },
             "firefox_android": {
               "version_added": false

--- a/api/Document.json
+++ b/api/Document.json
@@ -3065,7 +3065,11 @@
             },
             "firefox": {
               "version_added": "3.5",
-              "notes": "In Firefox, <code>dragend</code> is not dispatched if the source node is moved or removed during the drag (e.g. on <code>drop</code> or <code>dragover</code>). See <a href='https://bugzil.la/460801'>bug 460801</a> for details."
+              "partial_implementation": true,
+              "notes": [
+                "In Firefox, <code>dragend</code> is not dispatched if the source node is moved or removed during the drag (e.g. on <code>drop</code> or <code>dragover</code>). See <a href='https://bugzil.la/460801'>bug 460801</a> for details.", 
+                "Firefox doesn't set the mouse coordinates during the drag event.  See <a href='https://bugzil.la/505521'>bug 505521</a>."
+              ]
             },
             "firefox_android": {
               "version_added": false

--- a/api/Document.json
+++ b/api/Document.json
@@ -3067,8 +3067,8 @@
               "version_added": "3.5",
               "partial_implementation": true,
               "notes": [
-                "In Firefox, <code>dragend</code> is not dispatched if the source node is moved or removed during the drag (e.g. on <code>drop</code> or <code>dragover</code>). See <a href='https://bugzil.la/460801'>bug 460801</a> for details.", 
-                "Firefox doesn't set the mouse coordinates during the drag event.  See <a href='https://bugzil.la/505521'>bug 505521</a>."
+                "Firefox doesn't set the mouse coordinates during the drag event.  See <a href='https://bugzil.la/505521'>bug 505521</a>.",
+                "In Firefox, <code>dragend</code> is not dispatched if the source node is moved or removed during the drag (e.g. on <code>drop</code> or <code>dragover</code>). See <a href='https://bugzil.la/460801'>bug 460801</a> for details."
               ]
             },
             "firefox_android": {

--- a/api/Document.json
+++ b/api/Document.json
@@ -3012,7 +3012,9 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "3.5",
+              "partial_implementation": true,
+              "notes": "Firefox doesn't set the mouse coordinates during the drag event."
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
As outlined in this 10 year old Firefox bug, Firefox is the only browser with a lacking `drag` event implementation https://bugzilla.mozilla.org/show_bug.cgi?id=505521
Therefore, it should be marked as a partial implementation.