### PR TITLE
Add Chromium (+ some Safari) versions for Array JavaScript data

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -7,10 +7,10 @@
           "spec_url": "https://tc39.es/ecma262/#sec-array-objects",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -40,10 +40,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -214,10 +214,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.every",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -247,10 +247,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -329,10 +329,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.filter",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -362,10 +362,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -611,10 +611,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.foreach",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -644,10 +644,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -778,10 +778,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.indexof",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -811,10 +811,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -986,10 +986,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.lastindexof",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1019,10 +1019,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -1038,10 +1038,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-properties-of-array-instances-length",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1071,10 +1071,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -1090,10 +1090,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.map",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1123,10 +1123,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -1298,10 +1298,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-array.prototype",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1331,10 +1331,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -1402,10 +1402,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.reduce",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "3"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1429,16 +1429,16 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": "4"
+                "version_added": "4.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "4"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -1454,10 +1454,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.reduceright",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "3"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1481,16 +1481,16 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": "4"
+                "version_added": "4.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "4"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -1662,10 +1662,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.some",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1695,10 +1695,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -1863,10 +1863,10 @@
             ],
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1896,10 +1896,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -2068,10 +2068,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.tostring",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -2101,10 +2101,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -110,10 +110,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-arraybuffer.isview",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "32"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "32"
               },
               "edge": {
                 "version_added": "12"
@@ -143,10 +143,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -161,10 +161,10 @@
             "description": "<code>ArrayBuffer()</code> without <code>new</code> throws",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "7"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "14"
@@ -185,19 +185,19 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -265,10 +265,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-arraybuffer.prototype.slice",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "17"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -300,10 +300,10 @@
                 "version_added": "6"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/javascript/builtins/Float32Array.json
+++ b/javascript/builtins/Float32Array.json
@@ -57,10 +57,10 @@
             "description": "Constructor without arguments",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "7"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -78,22 +78,22 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -159,10 +159,10 @@
             "description": "<code>Float32Array()</code> without <code>new</code> throws",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "7"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "14"
@@ -183,19 +183,19 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/javascript/builtins/Float64Array.json
+++ b/javascript/builtins/Float64Array.json
@@ -57,10 +57,10 @@
             "description": "Constructor without arguments",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "7"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -78,22 +78,22 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "\u226437"
               }
             },
             "status": {
@@ -159,10 +159,10 @@
             "description": "<code>Float64Array()</code> without <code>new</code> throws",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "7"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "14"
@@ -183,19 +183,19 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "\u226437"
               }
             },
             "status": {

--- a/javascript/builtins/Float64Array.json
+++ b/javascript/builtins/Float64Array.json
@@ -93,7 +93,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "\u226437"
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -195,7 +195,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "\u226437"
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/javascript/builtins/Int16Array.json
+++ b/javascript/builtins/Int16Array.json
@@ -57,10 +57,10 @@
             "description": "Constructor without arguments",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "7"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -78,22 +78,22 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "\u226437"
               }
             },
             "status": {
@@ -159,10 +159,10 @@
             "description": "<code>Int16Array()</code> without <code>new</code> throws",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "7"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "14"
@@ -183,19 +183,19 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "\u226437"
               }
             },
             "status": {

--- a/javascript/builtins/Int16Array.json
+++ b/javascript/builtins/Int16Array.json
@@ -93,7 +93,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "\u226437"
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -195,7 +195,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "\u226437"
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/javascript/builtins/Int32Array.json
+++ b/javascript/builtins/Int32Array.json
@@ -93,7 +93,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "\u226437"
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -195,7 +195,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "\u226437"
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/javascript/builtins/Int32Array.json
+++ b/javascript/builtins/Int32Array.json
@@ -57,10 +57,10 @@
             "description": "Constructor without arguments",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "7"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -78,22 +78,22 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "\u226437"
               }
             },
             "status": {
@@ -159,10 +159,10 @@
             "description": "<code>Int32Array()</code> without <code>new</code> throws",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "7"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "14"
@@ -183,19 +183,19 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "\u226437"
               }
             },
             "status": {

--- a/javascript/builtins/Int8Array.json
+++ b/javascript/builtins/Int8Array.json
@@ -57,10 +57,10 @@
             "description": "Constructor without arguments",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "7"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -78,22 +78,22 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "\u226437"
               }
             },
             "status": {
@@ -159,10 +159,10 @@
             "description": "<code>Int8Array()</code> without <code>new</code> throws",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "7"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "14"
@@ -183,19 +183,19 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "\u226437"
               }
             },
             "status": {

--- a/javascript/builtins/Int8Array.json
+++ b/javascript/builtins/Int8Array.json
@@ -93,7 +93,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "\u226437"
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -195,7 +195,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "\u226437"
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -265,10 +265,10 @@
             "description": "Constructor without arguments",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "7"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -286,22 +286,22 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -577,10 +577,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.find",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "45"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "45"
               },
               "edge": {
                 "version_added": "14"
@@ -598,10 +598,10 @@
                 "version_added": "4.0.0"
               },
               "opera": {
-                "version_added": false
+                "version_added": "32"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "32"
               },
               "safari": {
                 "version_added": false
@@ -610,10 +610,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "45"
               }
             },
             "status": {
@@ -629,10 +629,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.findindex",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "45"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "45"
               },
               "edge": {
                 "version_added": "14"
@@ -650,10 +650,10 @@
                 "version_added": "4.0.0"
               },
               "opera": {
-                "version_added": false
+                "version_added": "32"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "32"
               },
               "safari": {
                 "version_added": false
@@ -662,10 +662,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "45"
               }
             },
             "status": {
@@ -681,10 +681,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.foreach",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "45"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "45"
               },
               "edge": {
                 "version_added": "14"
@@ -702,10 +702,10 @@
                 "version_added": "4.0.0"
               },
               "opera": {
-                "version_added": true
+                "version_added": "32"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "32"
               },
               "safari": {
                 "version_added": "10"
@@ -714,10 +714,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "45"
               }
             },
             "status": {
@@ -847,11 +847,11 @@
             "description": "Indexed properties not consulting prototype",
             "support": {
               "chrome": {
-                "version_added": true,
+                "version_added": "7",
                 "notes": "Negative integers are not considered as indexed properties and therefore return the value of the prototype property."
               },
               "chrome_android": {
-                "version_added": true,
+                "version_added": "18",
                 "notes": "Negative integers are not considered as indexed properties and therefore return the value of the prototype property."
               },
               "edge": {
@@ -877,19 +877,23 @@
                 "notes": "Negative integers are not considered as indexed properties and therefore return the value of the prototype property."
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true,
+                "notes": "Negative integers are not considered as indexed properties and therefore return the value of the prototype property."
               },
               "safari": {
-                "version_added": null
+                "version_added": "5.1",
+                "notes": "Negative integers are not considered as indexed properties and therefore return the value of the prototype property."
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "5",
+                "notes": "Negative integers are not considered as indexed properties and therefore return the value of the prototype property."
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0",
+                "notes": "Negative integers are not considered as indexed properties and therefore return the value of the prototype property."
               },
               "webview_android": {
-                "version_added": true,
+                "version_added": "≤37",
                 "notes": "Negative integers are not considered as indexed properties and therefore return the value of the prototype property."
               }
             },
@@ -1011,10 +1015,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.join",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "45"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "45"
               },
               "edge": {
                 "version_added": "14"
@@ -1032,10 +1036,10 @@
                 "version_added": "4.0.0"
               },
               "opera": {
-                "version_added": false
+                "version_added": "32"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "32"
               },
               "safari": {
                 "version_added": false
@@ -1044,10 +1048,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "45"
               }
             },
             "status": {
@@ -1063,10 +1067,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.keys",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "38"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "14"
@@ -1084,10 +1088,10 @@
                 "version_added": "0.12"
               },
               "opera": {
-                "version_added": false
+                "version_added": "25"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "25"
               },
               "safari": {
                 "version_added": "10"
@@ -1096,10 +1100,10 @@
                 "version_added": "10"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "38"
               }
             },
             "status": {
@@ -1115,10 +1119,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.lastindexof",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "45"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "45"
               },
               "edge": {
                 "version_added": "14"
@@ -1138,10 +1142,10 @@
                 "version_added": "4.0.0"
               },
               "opera": {
-                "version_added": true
+                "version_added": "32"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "32"
               },
               "safari": {
                 "version_added": "10"
@@ -1150,10 +1154,10 @@
                 "version_added": "10"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "45"
               }
             },
             "status": {
@@ -1221,10 +1225,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.map",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "45"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "45"
               },
               "edge": {
                 "version_added": "14"
@@ -1242,10 +1246,10 @@
                 "version_added": "4.0.0"
               },
               "opera": {
-                "version_added": false
+                "version_added": "32"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "32"
               },
               "safari": {
                 "version_added": false
@@ -1254,10 +1258,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "45"
               }
             },
             "status": {
@@ -1379,10 +1383,10 @@
             "description": "Named properties",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "7"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1403,19 +1407,19 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -1430,10 +1434,10 @@
             "description": "<code>TypedArray()</code> without <code>new</code> throws",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "7"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "14"
@@ -1451,22 +1455,22 @@
                 "version_added": "0.12"
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -1898,10 +1902,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.sort",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "45"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "45"
               },
               "edge": {
                 "version_added": "14"
@@ -1919,10 +1923,10 @@
                 "version_added": "4.0.0"
               },
               "opera": {
-                "version_added": true
+                "version_added": "32"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "32"
               },
               "safari": {
                 "version_added": null
@@ -1931,10 +1935,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "45"
               }
             },
             "status": {
@@ -2002,10 +2006,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.tolocalestring",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "7"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -2029,16 +2033,16 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -2054,10 +2058,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.tostring",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "7"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -2081,16 +2085,16 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -2106,10 +2110,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.values",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "38"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "14"
@@ -2127,10 +2131,10 @@
                 "version_added": "0.12"
               },
               "opera": {
-                "version_added": "26"
+                "version_added": "25"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "25"
               },
               "safari": {
                 "version_added": "10"
@@ -2139,10 +2143,10 @@
                 "version_added": "10"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "38"
               }
             },
             "status": {
@@ -2158,10 +2162,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype-@@iterator",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "38"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "12"
@@ -2207,10 +2211,10 @@
                 "version_added": "0.12"
               },
               "opera": {
-                "version_added": true
+                "version_added": "25"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "25"
               },
               "safari": {
                 "version_added": true
@@ -2219,10 +2223,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "38"
               }
             },
             "status": {
@@ -2238,10 +2242,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-get-%typedarray%-@@species",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "51"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "51"
               },
               "edge": {
                 "version_added": "13"
@@ -2270,10 +2274,10 @@
                 }
               ],
               "opera": {
-                "version_added": true
+                "version_added": "38"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "41"
               },
               "safari": {
                 "version_added": null
@@ -2282,10 +2286,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "51"
               }
             },
             "status": {

--- a/javascript/builtins/Uint16Array.json
+++ b/javascript/builtins/Uint16Array.json
@@ -57,10 +57,10 @@
             "description": "Constructor without arguments",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "7"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -78,22 +78,22 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "\u226437"
               }
             },
             "status": {
@@ -159,10 +159,10 @@
             "description": "<code>Uint16Array()</code> without <code>new</code> throws",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "7"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "14"
@@ -183,19 +183,19 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "\u226437"
               }
             },
             "status": {

--- a/javascript/builtins/Uint16Array.json
+++ b/javascript/builtins/Uint16Array.json
@@ -93,7 +93,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "\u226437"
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -195,7 +195,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "\u226437"
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/javascript/builtins/Uint32Array.json
+++ b/javascript/builtins/Uint32Array.json
@@ -57,10 +57,10 @@
             "description": "Constructor without arguments",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "7"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -78,22 +78,22 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "\u226437"
               }
             },
             "status": {
@@ -159,10 +159,10 @@
             "description": "<code>Uint32Array()</code> without <code>new</code> throws",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "7"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "14"
@@ -183,19 +183,19 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "\u226437"
               }
             },
             "status": {

--- a/javascript/builtins/Uint32Array.json
+++ b/javascript/builtins/Uint32Array.json
@@ -93,7 +93,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "\u226437"
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -195,7 +195,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "\u226437"
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -57,10 +57,10 @@
             "description": "Constructor without arguments",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "7"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -78,22 +78,22 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "\u226437"
               }
             },
             "status": {
@@ -159,10 +159,10 @@
             "description": "<code>Uint8Array()</code> without <code>new</code> throws",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "7"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "14"
@@ -183,19 +183,19 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "\u226437"
               }
             },
             "status": {

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -93,7 +93,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "\u226437"
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -195,7 +195,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "\u226437"
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/javascript/builtins/Uint8ClampedArray.json
+++ b/javascript/builtins/Uint8ClampedArray.json
@@ -57,10 +57,10 @@
             "description": "Constructor without arguments",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "7"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -78,22 +78,22 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "\u226437"
               }
             },
             "status": {
@@ -159,10 +159,10 @@
             "description": "<code>Uint8ClampedArray()</code> without <code>new</code> throws",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "7"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "14"
@@ -183,19 +183,19 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "\u226437"
               }
             },
             "status": {

--- a/javascript/builtins/Uint8ClampedArray.json
+++ b/javascript/builtins/Uint8ClampedArray.json
@@ -93,7 +93,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "\u226437"
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -195,7 +195,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "\u226437"
+                "version_added": "≤37"
               }
             },
             "status": {


### PR DESCRIPTION
This PR adds Chromium data (and a little Safari data) for Array builtins JavaScript data, based upon manual testing in both SauceLabs and downloaded old Chromium builds.  The data is as follows:

javascript.builtins.Array - 1
javascript.builtins.Array.every - 1
javascript.builtins.Array.filter - 1
javascript.builtins.Array.forEach - 1
javascript.builtins.Array.indexOf - 1
javascript.builtins.Array.lastIndexOf - 1
javascript.builtins.Array.length - 1
javascript.builtins.Array.map - 1
javascript.builtins.Array.prototype - 1
javascript.builtins.Array.reduce - 3 (Safari 4.1)
javascript.builtins.Array.reduceRight - 3 (Safari 4.1)
javascript.builtins.Array.some - 1
javascript.builtins.Array.toLocaleString - 1
javascript.builtins.Array.toString - 1

javascript.builtins.ArrayBuffer.isView - 32
javascript.builtins.ArrayBuffer.new_required - 7 (Safari 5.1)
javascript.builtins.ArrayBuffer.slice - 17 (Safari 6)

javascript.builtins.TypedArray.find - 45
javascript.builtins.TypedArray.findIndex - 45
javascript.builtins.TypedArray.forEach - 45
javascript.builtins.TypedArray.join - 45
javascript.builtins.TypedArray.keys - 38
javascript.builtins.TypedArray.lastIndexOf - 45
javascript.builtins.TypedArray.map - 45
javascript.builtins.TypedArray.sort - 45
javascript.builtins.TypedArray.toLocaleString - 7 (Safari 5.1)
javascript.builtins.TypedArray.toString - 7 (Safari 5.1)
javascript.builtins.TypedArray.values - 38
javascript.builtins.TypedArray.@@iterator - 38
javascript.builtins.TypedArray.@@species - 51
javascript.builtins.TypedArray.index_properties_not_consulting_prototype - 7 (Safari 5.1)
javascript.builtins.TypedArray.named_properties - 7 (Safari 5.1)

javascript.builtins.TypedArray.constructor_without_arguments - 7 (Safari 5.1)
javascript.builtins.Float32Array.constructor_without_arguments - 7 (Safari 5.1)
javascript.builtins.Float64Array.constructor_without_arguments - 7 (Safari 5.1)
javascript.builtins.Int16Array.constructor_without_arguments - 7 (Safari 5.1)
javascript.builtins.Int32Array.constructor_without_arguments - 7 (Safari 5.1)
javascript.builtins.Int8Array.constructor_without_arguments - 7 (Safari 5.1)
javascript.builtins.Uint16Array.constructor_without_arguments - 7 (Safari 5.1)
javascript.builtins.Uint32Array.constructor_without_arguments - 7 (Safari 5.1)
javascript.builtins.Uint8Array.constructor_without_arguments - 7 (Safari 5.1)
javascript.builtins.Uint8ClampedArray.constructor_without_arguments - 7 (Safari 5.1)

javascript.builtins.TypedArray.new_required - 7 (Safari 5.1)
javascript.builtins.Float32Array.new_required - 7 (Safari 5.1)
javascript.builtins.Float64Array.new_required - 7 (Safari 5.1)
javascript.builtins.Int16Array.new_required - 7 (Safari 5.1)
javascript.builtins.Int32Array.new_required - 7 (Safari 5.1)
javascript.builtins.Int8Array.new_required - 7 (Safari 5.1)
javascript.builtins.Uint16Array.new_required - 7 (Safari 5.1)
javascript.builtins.Uint32Array.new_required - 7 (Safari 5.1)
javascript.builtins.Uint8Array.new_required - 7 (Safari 5.1)
javascript.builtins.Uint8ClampedArray.new_required - 7 (Safari 5.1)