### PR TITLE
Add XRSessionMode type to BCD

### DIFF
--- a/api/XRSessionMode.json
+++ b/api/XRSessionMode.json
@@ -1,0 +1,148 @@
+{
+  "api": {
+    "XRSessionMode": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSessionMode",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "immersive-vr": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSessionMode#immersive-vr",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "inline": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSessionMode#inline",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/XRSessionMode.json
+++ b/api/XRSessionMode.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSessionMode",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "79"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "79"
           },
           "edge": {
             "version_added": false
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "79"
           }
         },
         "status": {
@@ -52,10 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSessionMode#immersive-vr",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "79"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "edge": {
               "version_added": false
@@ -85,7 +85,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "79"
             }
           },
           "status": {
@@ -100,10 +100,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSessionMode#inline",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "79"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "edge": {
               "version_added": false
@@ -133,7 +133,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "79"
             }
           },
           "status": {


### PR DESCRIPTION
Adds a BCD file for the `XRSessionMode` enum. The
values each have a feature entry, with the URLs
pointing to the anchor for each value in the
`XRSessionMode` page (since we don't do subpages for
values of enums).
