### PR TITLE
adding compat data for xxx-large keyword

### DIFF
--- a/css/properties/font-size.json
+++ b/css/properties/font-size.json
@@ -50,7 +50,7 @@
         },
         "rem_values": {
           "__compat": {
-            "description": "Rem values",
+            "description": "<code>rem</code> values",
             "support": {
               "chrome": {
                 "version_added": "31"
@@ -95,6 +95,54 @@
               },
               "samsunginternet_android": {
                 "version_added": "4.0"
+              },
+              "webview_android": {
+                "version_added": "4.1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "xxx_large": {
+          "__compat": {
+            "description": "<code>xxx-large</code> keyword",
+            "support": {
+              "chrome": {
+                "version_added": "79"
+              },
+              "chrome_android": {
+                "version_added": "79"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "70"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
               },
               "webview_android": {
                 "version_added": "4.1"

--- a/css/properties/font-size.json
+++ b/css/properties/font-size.json
@@ -145,7 +145,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": "4.1"
+                "version_added": "79"
               }
             },
             "status": {

--- a/css/properties/font-size.json
+++ b/css/properties/font-size.json
@@ -107,7 +107,7 @@
             }
           }
         },
-        "xxx_large": {
+        "xxx-large": {
           "__compat": {
             "description": "<code>xxx-large</code> keyword",
             "support": {


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1553545

* It is on by default in Fx 70.
* It looks to be working in Chrome 79, so I've added that data, but I've put other Chromiums at false as it doesn't looked to have reached them yet.
* It isn't working in Safari.
* IE and existing Edge is of course false.