### PR TITLE
Issue #4967 IE11 supports GlobalEventHandlers.onerror

### DIFF
--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -1431,7 +1431,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": null


### PR DESCRIPTION
Issue #4967

I tested this manually on IE11 (11.356.18362.0).  This is the code used to test:

```
window.addEventListener('error', function (errorEvent) {
    console.log(errorEvent);
});
window.onerror = function (msg, url, line, col, err) {
    console.log(msg);
    console.log(url);
    console.log(line);
    console.log(col);
    console.log(err);
};

setTimeout(function () {
    throw new Error('hi');
});
```

This is the output:

![image](https://user-images.githubusercontent.com/51773923/66690821-d44e8d00-ec4f-11e9-8281-800b6aeaf974.png)
![image](https://user-images.githubusercontent.com/51773923/66690781-981b2c80-ec4f-11e9-8f2e-35d77bd8ffe4.png)

You can see both methods of monitoring onerror receive all arguments.

I also tested this:
```
<img src="imagenotfound.gif" onerror="this.onerror=null;this.src='imagefound.gif';console.log('hit onerror');" />
```

Here is the output:

![image](https://user-images.githubusercontent.com/51773923/66690943-900fbc80-ec50-11e9-9427-7da775b151fb.png)

You can see the console.log output and that both images were requested.


A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
