### PR TITLE
Update jsonDiff() function in linter utils to use yellow/green colors

### DIFF
--- a/test/linter/test-style.js
+++ b/test/linter/test-style.js
@@ -73,17 +73,17 @@ function processData(filename, logger) {
 
   if (actual !== expected) {
     hasErrors = true;
-    logger.error(chalk`{red Error on {bold line ${jsonDiff(actual, expected)}}}`);
+    logger.error(chalk`{red Error on ${jsonDiff(actual, expected)}}`);
   }
 
   if (expected !== expectedBrowserSorting) {
     hasErrors = true;
-    logger.error(chalk`{red Browser sorting error on {bold line ${jsonDiff(expected, expectedBrowserSorting)}}}\n{blue     Tip: Run {bold npm run fix} to fix sorting automatically}`);
+    logger.error(chalk`{red Browser sorting error on ${jsonDiff(expected, expectedBrowserSorting)}}\n{blue     Tip: Run {bold npm run fix} to fix sorting automatically}`);
   }
 
   if (actual !== expectedFeatureSorting) {
     hasErrors = true;
-    logger.error(chalk`{red Feature sorting error on {bold line ${jsonDiff(expected, expectedFeatureSorting)}}}\n{blue     Tip: Run {bold npm run fix} to fix sorting automatically}`);
+    logger.error(chalk`{red Feature sorting error on ${jsonDiff(expected, expectedFeatureSorting)}}\n{blue     Tip: Run {bold npm run fix} to fix sorting automatically}`);
   }
 
   let constructorMatch = actual.match(String.raw`"<code>([^)]*?)</code> constructor"`)

--- a/test/utils.js
+++ b/test/utils.js
@@ -106,7 +106,7 @@ function jsonDiff(actual, expected) {
 
   for (var i = 0; i < actualLines.length; i++) {
     if (actualLines[i] !== expectedLines[i]) {
-      return chalk`#${i + 1}
+      return chalk`{bold line #${i + 1}}
     {yellow Actual:   {bold ${escapeInvisibles(actualLines[i])}}}
     {green Expected: {bold ${escapeInvisibles(expectedLines[i])}}}`;
     }

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,5 +1,6 @@
 'use strict';
 const { platform } = require('os');
+const chalk = require('chalk');
 
 /**
  * @typedef {object} Logger
@@ -105,9 +106,9 @@ function jsonDiff(actual, expected) {
 
   for (var i = 0; i < actualLines.length; i++) {
     if (actualLines[i] !== expectedLines[i]) {
-      return `#${i + 1}
-    Actual:   ${escapeInvisibles(actualLines[i])}
-    Expected: ${escapeInvisibles(expectedLines[i])}`;
+      return chalk`#${i + 1}
+    Actual:   {yellow ${escapeInvisibles(actualLines[i])}}
+    Expected: {green ${escapeInvisibles(expectedLines[i])}}`;
     }
   }
 }

--- a/test/utils.js
+++ b/test/utils.js
@@ -107,8 +107,8 @@ function jsonDiff(actual, expected) {
   for (var i = 0; i < actualLines.length; i++) {
     if (actualLines[i] !== expectedLines[i]) {
       return chalk`#${i + 1}
-    Actual:   {yellow ${escapeInvisibles(actualLines[i])}}
-    Expected: {green ${escapeInvisibles(expectedLines[i])}}`;
+    {yellow Actual:   {bold ${escapeInvisibles(actualLines[i])}}}
+    {green Expected: {bold ${escapeInvisibles(expectedLines[i])}}}`;
     }
   }
 }


### PR DESCRIPTION
Since we're using yellow and green to represent actual and expected values respectively throughout our linter output, I feel that `jsonDiff()` should follow along, maintaining consistent coloring.  This PR updates the function to use said colors, as well as a little extra update to put the word "line" inside of the function (it's never used without it).