### PR TITLE
Fix call to jsonDiff() in sorting tests

### DIFF
--- a/test/linter/test-style.js
+++ b/test/linter/test-style.js
@@ -81,7 +81,7 @@ function processData(filename, logger) {
     logger.error(chalk`{red Browser sorting error on {bold line ${jsonDiff(actual, expectedBrowserSorting)}}}\n{blue     Tip: Run {bold npm run fix} to fix sorting automatically}`);
   }
 
-  if (actual !== expectedFeatureSorting) {
+  if (expected !== expectedFeatureSorting) {
     hasErrors = true;
     logger.error(chalk`{red Feature sorting error on {bold line ${jsonDiff(actual, expectedFeatureSorting)}}}\n{blue     Tip: Run {bold npm run fix} to fix sorting automatically}`);
   }

--- a/test/linter/test-style.js
+++ b/test/linter/test-style.js
@@ -78,12 +78,12 @@ function processData(filename, logger) {
 
   if (expected !== expectedBrowserSorting) {
     hasErrors = true;
-    logger.error(chalk`{red Browser sorting error on {bold line ${jsonDiff(expected, expectedBrowserSorting)}}}\n{blue     Tip: Run {bold npm run fix} to fix sorting automatically}`);
+    logger.error(chalk`{red Browser sorting error on {bold line ${jsonDiff(actual, expectedBrowserSorting)}}}\n{blue     Tip: Run {bold npm run fix} to fix sorting automatically}`);
   }
 
   if (actual !== expectedFeatureSorting) {
     hasErrors = true;
-    logger.error(chalk`{red Feature sorting error on {bold line ${jsonDiff(expected, expectedFeatureSorting)}}}\n{blue     Tip: Run {bold npm run fix} to fix sorting automatically}`);
+    logger.error(chalk`{red Feature sorting error on {bold line ${jsonDiff(actual, expectedFeatureSorting)}}}\n{blue     Tip: Run {bold npm run fix} to fix sorting automatically}`);
   }
 
   let constructorMatch = actual.match(String.raw`"<code>([^)]*?)</code> constructor"`)


### PR DESCRIPTION
In the browser/feature sorting linters, `jsonDiff()` wanted two variables: `actual` and `expected`.  Apparently...I was passing in `expected` and `expected`, which caused the function to return `undefined` (see [this Travis log](https://travis-ci.org/mdn/browser-compat-data/builds/596936120?utm_source=github_status&utm_medium=notification) for an example).  This PR intends to fix this.