### PR TITLE
Use existing dataObject variable for feature sorting check

### DIFF
--- a/test/linter/test-style.js
+++ b/test/linter/test-style.js
@@ -61,7 +61,7 @@ function processData(filename, logger) {
   let dataObject = JSON.parse(actual);
   let expected = JSON.stringify(dataObject, null, 2);
   let expectedBrowserSorting = JSON.stringify(dataObject, orderSupportBlock, 2);
-  let expectedFeatureSorting = JSON.stringify(JSON.parse(actual), orderFeatures, 2);
+  let expectedFeatureSorting = JSON.stringify(dataObject, orderFeatures, 2);
 
   // prevent false positives from git.core.autocrlf on Windows
   if (IS_WINDOWS) {


### PR DESCRIPTION
This PR updates the `expectedFeatureSorting` assignment to use the existing `dataObject` variable, rather than creating the same data without the variable.