### PR TITLE
Update support for feature-policies in Chrome

### DIFF
--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -582,7 +582,7 @@
                 "version_added": "49"
               },
               "opera_android": {
-                "version_added": "49"
+                "version_added": "46"
               },
               "safari": {
                 "version_added": false

--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -423,7 +423,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/document-domain",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "77"
               },
               "chrome_android": {
                 "version_added": false
@@ -547,10 +547,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/fullscreen",
             "support": {
               "chrome": {
-                "version_added": "60"
+                "version_added": "62"
               },
               "chrome_android": {
-                "version_added": "60"
+                "version_added": "62"
               },
               "edge": {
                 "version_added": false

--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -455,7 +455,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": 64
               },
               "opera_android": {
                 "version_added": false
@@ -579,10 +579,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "47"
+                "version_added": "49"
               },
               "opera_android": {
-                "version_added": "44"
+                "version_added": "49"
               },
               "safari": {
                 "version_added": false
@@ -594,7 +594,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": "60"
+                "version_added": "62"
               }
             },
             "status": {

--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -455,7 +455,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": 64
+                "version_added": "64"
               },
               "opera_android": {
                 "version_added": false


### PR DESCRIPTION
- Add feature `document-domain` for Chrome for desktop impl. in v77 (https://www.chromestatus.com/feature/5341992867332096)
- Change support for the feature `fullscreen` for Chrome from v60 to v62 (https://www.chromestatus.com/feature/5094837900541952).