### PR TITLE
Update Document.create support (all IE for basic)

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -1599,7 +1599,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "10"
+              "version_added": "5"
             },
             "opera": {
               "version_added": true
@@ -1632,11 +1632,11 @@
                 "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
               },
               "chrome_android": {
-                "version_added": false,
+                "version_added": true,
                 "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "50",
@@ -1647,7 +1647,7 @@
                 "notes": "Firefox accepts a string instead of an object here, but only from version 51 onwards. In version 50, options must be an object."
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": true,
@@ -1658,10 +1658,10 @@
                 "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": true,


### PR DESCRIPTION
Revert IE support for basic Document.create from "10" back to "yes". Follows https://github.com/mdn/browser-compat-data/pull/4392.
Looks like it was changed by mistake (maybe Document.createRange or the "options" row was meant?).
Document.create has been around since at least IE5, possibly longer. I've also confirmed it with the
following test in IE6 on WinXP. <https://codepen.io/Krinkle/full/ExxPQZg>.

Fill in missing support data for the "options" parameter based on <https://codepen.io/Krinkle/full/QWWyQdR>.
Passed in Chrome 77.
Passed in Firefox 63.
Failed in IE6-IE11.
Failed in Edge 15-18.
Failed in Safari 12.1, Safari 10.1.

Remove notes from "Document.create/options" for "chrome_android", because there is no support
indicated, hence the note could not apply. Perhaps it was copied here by mistake.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
