### PR TITLE
updating data for -moz-inline-grid and -moz-inline-stack display values

### DIFF
--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -1356,7 +1356,7 @@
         },
         "xul_grid_values": {
           "__compat": {
-            "description": "<code>-moz-grid</code>, <code>-moz-inline-grid</code>, <code>-moz-grid-group</code> and <code>-moz-grid-line</code>",
+            "description": "<code>-moz-grid</code>, <code>-moz-grid-group</code>, and <code>-moz-grid-line</code>",
             "support": {
               "chrome": {
                 "version_added": false
@@ -1375,6 +1375,83 @@
                 },
                 {
                   "version_added": "62",
+                  "flags": [
+                    {
+                      "name": "layout.css.xul-display-values.content.enabled",
+                      "type": "preference",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "4",
+                  "version_removed": "62",
+                  "notes": "This is still available to Firefox UI code."
+                },
+                {
+                  "version_added": "62",
+                  "flags": [
+                    {
+                      "name": "layout.css.xul-display-values.content.enabled",
+                      "type": "preference",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "xul_inline_grid_stack": {
+          "__compat": {
+            "description": "<code>-moz-inline-grid</code> and <code>-moz-inline-stack</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "1",
+                  "version_removed": "62",
+                  "notes": "Available to Firefox UI code."
+                },
+                {
+                  "version_added": "62",
+                  "version_removed": "70",
                   "flags": [
                     {
                       "name": "layout.css.xul-display-values.content.enabled",
@@ -1506,9 +1583,9 @@
             }
           }
         },
-        "xul_stack_values": {
+        "xul_stack_value": {
           "__compat": {
-            "description": "<code>-moz-stack</code> and <code>-moz-inline-stack</code>",
+            "description": "<code>-moz-stack</code>",
             "support": {
               "chrome": {
                 "version_added": false


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1574994

Basically, the `display` values `-moz-inline-grid` and `-moz-inline-stack` have been completely removed from the platform in Fx70, so I've moved them out into a separate data point and attempted to communicate this. Let me know how well I did ;-)