### PR TITLE
Add yellow and green to "Actual" and "Expected" in linters

### DIFF
--- a/test/linter/test-descriptions.js
+++ b/test/linter/test-descriptions.js
@@ -8,9 +8,9 @@ const chalk = require('chalk');
 function hasValidConstrutorDescription(apiData, apiName, logger) {
   const constructor = apiData[apiName];
   if (constructor && constructor.__compat.description !== `<code>${apiName}()</code> constructor`) {
-      logger.error(chalk`{red Incorrect constructor description for {bold ${apiName}()}
-      Actual: {yellow "${constructor.__compat.description || ""}"}
-      Expected: {green "<code>${apiName}()</code> constructor"}}`);
+      logger.error(chalk`{red Incorrect constructor description for {bold ${apiName}()}}
+      {yellow Actual: {bold "${constructor.__compat.description || ""}"}}
+      {green Expected: {bold "<code>${apiName}()</code> constructor"}}`);
   }
 }
 
@@ -25,9 +25,9 @@ function hasCorrectDOMEventsDescription(apiData, apiName, logger) {
       const event = apiData[methodName];
       const eventName = methodName.replace("_event", "");
       if (event.__compat.description !== `<code>${eventName}</code> event`) {
-        logger.error(chalk`{red Incorrect event description for {bold ${apiName}#${methodName}}
-      Actual: {yellow "${event.__compat.description || ""}"}
-      Expected: {green "<code>${eventName}</code> event"}}`);
+        logger.error(chalk`{red Incorrect event description for {bold ${apiName}#${methodName}}}
+      {yellow Actual: {bold "${event.__compat.description || ""}"}}
+      {green Expected: {bold "<code>${eventName}</code> event"}}`);
       }
     }
   }
@@ -41,9 +41,9 @@ function hasCorrectDOMEventsDescription(apiData, apiName, logger) {
 function hasCorrectSecureContextRequiredDescription(apiData, apiName, logger) {
   const secureContext = apiData.secure_context_required;
   if (secureContext && secureContext.__compat.description !== `Secure context required`) {
-      logger.error(chalk`{red Incorrect secure context required description for {bold ${apiName}()}
-      Actual: {yellow "${secureContext.__compat.description || ""}"}
-      Expected: {green "Secure context required"}}`);
+      logger.error(chalk`{red Incorrect secure context required description for {bold ${apiName}()}}
+      {yellow Actual: {bold "${secureContext.__compat.description || ""}"}}
+      {green Expected: {bold "Secure context required"}}`);
   }
 }
 
@@ -55,9 +55,9 @@ function hasCorrectSecureContextRequiredDescription(apiData, apiName, logger) {
 function hasCorrectWebWorkersDescription(apiData, apiName, logger) {
   const workerSupport = apiData.worker_support;
   if (workerSupport && workerSupport.__compat.description !== `Available in workers`) {
-      logger.error(chalk`{red Incorrect worker support description for {bold ${apiName}()}
-      Actual: {yellow "${workerSupport.__compat.description || ""}"}
-      Expected: {green "Available in workers"}}`);
+      logger.error(chalk`{red Incorrect worker support description for {bold ${apiName}()}}
+      {yellow Actual: {bold "${workerSupport.__compat.description || ""}"}}
+      {green Expected: {bold "Available in workers"}}`);
   }
 }
 

--- a/test/test-compare-features.js
+++ b/test/test-compare-features.js
@@ -29,8 +29,8 @@ const testFeatureOrder = () => {
   if (errors) {
     console.error(chalk`{red compareFeatures() – {bold 1} error:}`);
     console.error(chalk`{red   Actual and expected orders do not match}`);
-    console.error(chalk`{red     Actual: {yellow ${actual}}}`);
-    console.error(chalk`{red     Expected: {green ${expected}}}`);
+    console.error(chalk`{yellow     Actual: {bold ${actual}}}`);
+    console.error(chalk`{green     Expected: {bold ${expected}}}`);
     return true;
   }
   return false;


### PR DESCRIPTION
Based upon a [comment in another PR](https://github.com/mdn/browser-compat-data/pull/4970#issuecomment-541586816), this PR updates all other linter files to include the yellow and green colors on the words "Actual" and "Expected" when they appear.