### PR TITLE
Fix consistency of WebView data for Clipboard API

### DIFF
--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -38,7 +38,7 @@
             "version_added": true
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "76"
           }
         },
         "status": {


### PR DESCRIPTION
Following up to a recently-merged PR, this fixes the consistency of WebView's data for the Clipboard API.  [ChromeStatus](https://chromestatus.com/feature/5074658793619456) states that the `read` and `write` features were supported since WebView 76, although the API as a whole was indicated as supported in Chrome 66, not WebView (see https://chromestatus.com/feature/5861289330999296).

@jpmedley, I would love to have your input on this one!