### PR TITLE
Fix JavaScript import statement data for Samsung Internet

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1622,7 +1622,7 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "61"
@@ -1699,7 +1699,7 @@
                 "version_added": "11.1"
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "8.0"
               },
               "webview_android": {
                 "version_added": "63"


### PR DESCRIPTION
Apparently, support for the `import` statement was marked as `false` for Samsung Internet.  However, since it's supported in Chrome and WebView, I highly doubt Samsung Internet doesn't have support.