### PR TITLE
adding compat data for strict mime types on worker and shared worker …

### DIFF
--- a/api/SharedWorker.json
+++ b/api/SharedWorker.json
@@ -99,6 +99,54 @@
             "deprecated": false
           }
         },
+        "mime_checks": {
+          "__compat": {
+            "description": "Strict MIME type checks for shared worker scripts",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "70"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "name_option": {
           "__compat": {
             "description": "<code>name</code> option",

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -95,6 +95,54 @@
             "deprecated": false
           }
         },
+        "mime_checks": {
+          "__compat": {
+            "description": "Strict MIME type checks for worker scripts",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "70"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "name": {
           "__compat": {
             "description": "Constructor <code>name</code> option",


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1523706

I put Firefox in as v70, but didn't find much else in the way of info on support in other browsers. I wasn't really sure how to test it, TBH.