### PR TITLE
Update min() max() and clamp() data

### DIFF
--- a/css/types/clamp.json
+++ b/css/types/clamp.json
@@ -25,7 +25,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "66"
             },
             "opera_android": {
               "version_added": false

--- a/css/types/clamp.json
+++ b/css/types/clamp.json
@@ -7,10 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/clamp",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "79"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "edge": {
               "version_added": false
@@ -40,7 +40,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "79"
             }
           },
           "status": {

--- a/css/types/max.json
+++ b/css/types/max.json
@@ -25,7 +25,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "66"
             },
             "opera_android": {
               "version_added": false

--- a/css/types/max.json
+++ b/css/types/max.json
@@ -7,10 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/max",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "79"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "edge": {
               "version_added": false
@@ -40,7 +40,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "79"
             }
           },
           "status": {

--- a/css/types/min.json
+++ b/css/types/min.json
@@ -25,7 +25,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "66"
             },
             "opera_android": {
               "version_added": false

--- a/css/types/min.json
+++ b/css/types/min.json
@@ -25,10 +25,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "79"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "79"
+              "version_added": false
             },
             "safari": {
               "version_added": "11.1"

--- a/css/types/min.json
+++ b/css/types/min.json
@@ -7,10 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/min",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "79"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "edge": {
               "version_added": false
@@ -25,10 +25,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "79"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "safari": {
               "version_added": "11.1"
@@ -40,7 +40,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "79"
             }
           },
           "status": {


### PR DESCRIPTION
Update `min()` compatibility table
Update `max()` compatibility table
Update `clamp()` compatibility table
Data: https://chromestatus.com/features/5714277878988800

All chromium based browsers will support this from v79.

