### PR TITLE
Update max.json

### DIFF
--- a/css/types/max.json
+++ b/css/types/max.json
@@ -7,10 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/max",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "79"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "edge": {
               "version_added": false
@@ -40,7 +40,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "79"
             }
           },
           "status": {


### PR DESCRIPTION
Update `max()` compatibility table
Data: https://chromestatus.com/features/5714277878988800

All chromium based browsers will support this from v79
