### PR TITLE
Add WebExt Privacy Services supported by Chrome

### DIFF
--- a/webextensions/api/privacy.json
+++ b/webextensions/api/privacy.json
@@ -68,7 +68,75 @@
           }
         },
         "services": {
-          "passwordSavingEnabled": {
+          "autofillAddressEnabled": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "70"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "autofillCreditCardEnabled": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "70"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "autofillEnabled": {
+            "__compat": {
+              "status": {
+                "deprecated": true,
+                "experimental": false,
+                "standard_track": false
+              },
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "alternateErrorPagesEnabled": {
             "__compat": {
               "support": {
                 "chrome": {
@@ -78,10 +146,136 @@
                   "version_added": false
                 },
                 "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "passwordSavingEnabled": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "38"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
                   "version_added": "56"
                 },
                 "firefox_android": {
                   "version_added": "56"
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "safeBrowsingEnabled": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "safeBrowsingExtendedReportingEnabled": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "42"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "searchSuggestEnabled": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "spellingServiceEnabled": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "translationServiceEnabled": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
                 },
                 "opera": {
                   "version_added": true


### PR DESCRIPTION
Complete the support table for the WebExtension API `privacy.services`, with all services supported by Chrome, based on their official documentation.

Based on:
- https://developer.chrome.com/extensions/privacy
- https://dxr.mozilla.org/mozilla-central/source/toolkit/components/extensions/parent/ext-privacy.js

A checklist to help your pull request get merged faster:
- [X] Summarize your changes
- [X] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [X] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
