### PR TITLE
Fix IE11 compat data for css transform

### DIFF
--- a/css/properties/transform.json
+++ b/css/properties/transform.json
@@ -78,7 +78,6 @@
                 "notes": "Internet Explorer does not support the global values <code>initial</code> and <code>unset</code>."
               },
               {
-                "prefix": "-webkit-",
                 "version_added": "11"
               },
               {


### PR DESCRIPTION
This is a fix for the [browser compatibility docs of the transform CSS property](https://developer.mozilla.org/en-US/docs/Web/CSS/transform#Browser_compatibility).

Reason:
[IE11 supports `transform` without any vendor prefix.](https://developer.microsoft.com/en-us/microsoft-edge/platform/status/transforms/?q=transform%20category%3Acss)

> Unprefixed version: IE 10+, Microsoft Edge build 10240+

Tests:
 - Linter results were ok
 - Manually tested it with IE11 (v11.418.18362.0, Update 11.0.155) on Windows 10 1903

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
