### PR TITLE
Refactor scripts: prefer const and let

### DIFF
--- a/scripts/render.js
+++ b/scripts/render.js
@@ -9,15 +9,15 @@ Run as `npm run render $query $depth $aggregateMode`
 
 const bcd = require('..');
 
-const query = process.argv[2];
-const depth = process.argv[3] || 1;
-const aggregateMode = process.argv[4] || false;
+var query = process.argv[2];
+var depth = process.argv[3] || 1;
+var aggregateMode = process.argv[4] || false;
 
-let output = '';
+var output = '';
 
-const s_no_data_found = `No compatibility data found. Please contribute data for "${query}" (depth: ${depth}) to the <a href="https://github.com/mdn/browser-compat-data">MDN compatibility data repository</a>.`;
-const s_firefox_android = 'Firefox for Android';
-const s_chrome_android = 'Chrome for Android';
+var s_no_data_found = `No compatibility data found. Please contribute data for "${query}" (depth: ${depth}) to the <a href="https://github.com/mdn/browser-compat-data">MDN compatibility data repository</a>.`;
+var s_firefox_android = 'Firefox for Android';
+var s_chrome_android = 'Chrome for Android';
 
 const browsers = {
   "desktop": {
@@ -44,7 +44,7 @@ const browsers = {
   }
 };
 
-const notesArray = [];
+var notesArray = [];
 
 /*
 Write the table header.
@@ -52,19 +52,19 @@ Write the table header.
 `browserPlatformType` is either "mobile", "desktop" or "webextensions"
 */
 function writeTableHead(browserPlatformType) {
-  const browserNameKeys = Object.keys(browsers[browserPlatformType]);
+  let browserNameKeys = Object.keys(browsers[browserPlatformType]);
   let output = '';
   if (browserPlatformType === 'webextensions') {
     output = '<table class="webext-summary-compat-table"><thead><tr><th style="width: 40%"></th>'
-    const browserColumnWidth = 60/browserNameKeys.length;
-    for (const browserNameKey of browserNameKeys) {
+    let browserColumnWidth = 60/browserNameKeys.length;
+    for (let browserNameKey of browserNameKeys) {
       output += `<th style="width:${browserColumnWidth}%">${browsers[browserPlatformType][browserNameKey]}</th>`;
     }
     output += "<tr></thead>";
   } else {
     output = `<div id="compat-${browserPlatformType}"><table class="compat-table"><thead><tr>`;
     output +=  '<th>Feature</th>';
-    for (const browserNameKey of browserNameKeys) {
+    for (let browserNameKey of browserNameKeys) {
       output += `<th>${browsers[browserPlatformType][browserNameKey]}</th>`;
     }
     output += '</tr></thead>';
@@ -109,23 +109,23 @@ function getSupportClass(supportInfo) {
   } else if (supportInfo) { // there is just one support statement
     checkSupport(supportInfo.version_added, supportInfo.version_removed);
   } else { // this browser has no info, it's unknown
-    return 'unknown-support';
-  }
+  return 'unknown-support';
+}
 
-  function checkSupport(added, removed) {
-    if (added === null) {
-      cssClass = 'unknown-support';
-    } else if (added) {
-      cssClass = 'full-support';
-      if (removed) {
-        cssClass = 'no-support';
-      }
-    } else {
+function checkSupport(added, removed) {
+  if (added === null) {
+    cssClass = 'unknown-support';
+  } else if (added) {
+    cssClass = 'full-support';
+    if (removed) {
       cssClass = 'no-support';
     }
+  } else {
+    cssClass = 'no-support';
   }
+}
 
-  return cssClass;
+return cssClass;
 }
 
 /*
@@ -161,7 +161,7 @@ function writeFlagsNote(supportData, browserId) {
     flagTextStart = ' this';
   }
 
-  const flagText = `${flagTextStart} feature is behind the <code>${supportData.flag.name}</code>`;
+  let flagText = `${flagTextStart} feature is behind the <code>${supportData.flag.name}</code>`;
 
   // value_to_set is optional
   let valueToSet = '';
@@ -237,27 +237,27 @@ function writeSupportInfo(supportData, browserId, compatNotes) {
     // Generate notes, if any
     if (supportData.notes) {
       if (Array.isArray(supportData.notes)) {
-        for (const note of supportData.notes) {
-          const noteIndex = compatNotes.indexOf(note);
+        for (let note of supportData.notes) {
+          let noteIndex = compatNotes.indexOf(note);
           noteAnchors.push(`<sup><a href="#compatNote_${noteIndex+1}">${noteIndex+1}</a></sup>`);
         }
       } else {
-        const noteIndex = compatNotes.indexOf(supportData.notes);
+        let noteIndex = compatNotes.indexOf(supportData.notes);
         noteAnchors.push(`<sup><a href="#compatNote_${noteIndex+1}">${noteIndex+1}</a></sup>`);
       }
     }
 
     // there is a flag and it needs a note, too
     if (supportData.flag) {
-      const flagNote = writeFlagsNote(supportData, browserId);
-      const noteIndex = compatNotes.indexOf(flagNote);
+      let flagNote = writeFlagsNote(supportData, browserId);
+      let noteIndex = compatNotes.indexOf(flagNote);
       noteAnchors.push(`<sup><a href="#compatNote_${noteIndex+1}">${noteIndex+1}</a></sup>`);
     }
 
     // add a link to the alternative name note, if there is one
     if (supportData.alternative_name) {
-      const altNameNote = writeAlternativeNameNote(supportData.alternative_name);
-      const noteIndex = compatNotes.indexOf(altNameNote);
+      let altNameNote = writeAlternativeNameNote(supportData.alternative_name);
+      let noteIndex = compatNotes.indexOf(altNameNote);
       noteAnchors.push(`<sup><a href="#compatNote_${noteIndex+1}">${noteIndex+1}</a></sup>`);
     }
 
@@ -280,9 +280,9 @@ function collectCompatNotes() {
   function pushNotes(supportEntry, browserName) {
     // collect notes
     if (supportEntry.hasOwnProperty('notes')) {
-      const notes = supportEntry['notes'];
+      let notes = supportEntry['notes'];
       if (Array.isArray(notes)) {
-        for (const note of notes) {
+        for (let note of notes) {
           if (notesArray.indexOf(note) === -1) {
             notesArray.push(note);
           }
@@ -295,24 +295,24 @@ function collectCompatNotes() {
     }
     // collect flags
     if (supportEntry.hasOwnProperty('flag')) {
-      const flagNote = writeFlagsNote(supportEntry, browserName);
+      let flagNote = writeFlagsNote(supportEntry, browserName);
       if (notesArray.indexOf(flagNote) === -1) {
         notesArray.push(flagNote);
       }
     }
     // collect alternative names
     if (supportEntry.hasOwnProperty('alternative_name')) {
-      const altNameNote = writeAlternativeNameNote(supportEntry.alternative_name);
+      let altNameNote = writeAlternativeNameNote(supportEntry.alternative_name);
       if (notesArray.indexOf(altNameNote) === -1) {
         notesArray.push(altNameNote);
       }
     }
   }
-  for (const row of features) {
-    const support = Object.keys(row).map((k) => row[k])[0].support;
-    for (const browserName of Object.keys(support)) {
+  for (let row of features) {
+    let support = Object.keys(row).map((k) => row[k])[0].support;
+    for (let browserName of Object.keys(support)) {
       if (Array.isArray(support[browserName])) {
-        for (const entry of support[browserName]) {
+        for (let entry of support[browserName]) {
           pushNotes(entry, browserName);
         }
       } else {
@@ -332,36 +332,36 @@ an identifier for the row,  like "Basic support".
 function writeSupportCells(supportData, compatNotes, browserPlatformType) {
   let output = '';
 
-  for (const browserNameKey of Object.keys(browsers[browserPlatformType])) {
-    const support = supportData[browserNameKey];
+  for (let browserNameKey of Object.keys(browsers[browserPlatformType])) {
+    let support = supportData[browserNameKey];
     let supportInfo = '';
     // if supportData is an array, there are multiple support statements
     if (Array.isArray(support)) {
-      for (const entry of support) {
+      for (let entry of support) {
         supportInfo += `<p>${writeSupportInfo(entry, browserNameKey, compatNotes)}</p>`;
       }
     } else if (support) { // there is just one support statement
       supportInfo = writeSupportInfo(support, browserNameKey, compatNotes);
     } else { // this browser has no info, it's unknown
-      supportInfo = writeSupportInfo(null);
-    }
-    output += `<td class="${getSupportClass(supportData[browserNameKey])}">${supportInfo}</td>`;
+    supportInfo = writeSupportInfo(null);
   }
-  return output;
+  output += `<td class="${getSupportClass(supportData[browserNameKey])}">${supportInfo}</td>`;
+}
+return output;
 }
 
 /*
 Write compat table
 */
 function writeTable(browserPlatformType) {
-  const compatNotes = collectCompatNotes();
+  let compatNotes = collectCompatNotes();
   let output = writeTableHead(browserPlatformType);
   output += '<tbody>';
-  for (const row of features) {
-    const feature = Object.keys(row).map((k) => row[k])[0];
+  for (let row of features) {
+    let feature = Object.keys(row).map((k) => row[k])[0];
     let desc = '';
     if (feature.description) {
-      const label = Object.keys(row)[0];
+      let label = Object.keys(row)[0];
       // Basic support or unnested features need no prefixing
       if (label.indexOf('.') === -1) {
         desc += feature.description;
@@ -387,9 +387,9 @@ Write each compat note, with an `id` so it will be linked from the table.
 */
 function writeNotes() {
   let output = '';
-  const compatNotes = collectCompatNotes();
-  for (const note of compatNotes) {
-    const noteIndex = compatNotes.indexOf(note);
+  let compatNotes = collectCompatNotes();
+  for (let note of compatNotes) {
+    let noteIndex = compatNotes.indexOf(note);
     output += `<p id=compatNote_${noteIndex+1}>${noteIndex+1}. ${note}</p>`;
   }
   return output;
@@ -411,20 +411,20 @@ Flatten them into a features array
 function traverseFeatures(obj, depth, identifier) {
   depth--;
   if (depth >= 0) {
-    for (const i in obj) {
+    for (let i in obj) {
       if (!!obj[i] && typeof(obj[i])=="object" && i !== '__compat') {
         if (obj[i].__compat) {
 
-          const featureNames = Object.keys(obj[i]);
+          let featureNames = Object.keys(obj[i]);
           if (featureNames.length > 1) {
             // there are sub features below this node,
             // so we need to identify partial support for the main feature
-            for (const subfeatureName of featureNames) {
+            for (let subfeatureName of featureNames) {
               // if this is actually a subfeature (i.e. it is not a __compat object)
               // and the subfeature has a __compat object
               if ((subfeatureName !== '__compat') && (obj[i][subfeatureName].__compat)) {
-                const browserNames = Object.keys(obj[i].__compat.support);
-                for (const browser of browserNames) {
+                let browserNames = Object.keys(obj[i].__compat.support);
+                for (let browser of browserNames) {
                   if (obj[i].__compat.support[browser].version_added !=
                       obj[i][subfeatureName].__compat.support[browser].version_added ||
                       obj[i][subfeatureName].__compat.support[browser].notes) {
@@ -443,10 +443,10 @@ function traverseFeatures(obj, depth, identifier) {
   }
 }
 
-const compatData = getData(query, bcd);
-const features = [];
-const identifier = query.split(".").pop();
-const isWebExtensions = query.split(".")[0] === "webextensions";
+var compatData = getData(query, bcd);
+var features = [];
+var identifier = query.split(".").pop();
+var isWebExtensions = query.split(".")[0] === "webextensions";
 
 if (!compatData) {
   output = s_no_data_found;

--- a/scripts/render.js
+++ b/scripts/render.js
@@ -9,15 +9,15 @@ Run as `npm run render $query $depth $aggregateMode`
 
 const bcd = require('..');
 
-var query = process.argv[2];
-var depth = process.argv[3] || 1;
-var aggregateMode = process.argv[4] || false;
+const query = process.argv[2];
+const depth = process.argv[3] || 1;
+const aggregateMode = process.argv[4] || false;
 
-var output = '';
+let output = '';
 
-var s_no_data_found = `No compatibility data found. Please contribute data for "${query}" (depth: ${depth}) to the <a href="https://github.com/mdn/browser-compat-data">MDN compatibility data repository</a>.`;
-var s_firefox_android = 'Firefox for Android';
-var s_chrome_android = 'Chrome for Android';
+const s_no_data_found = `No compatibility data found. Please contribute data for "${query}" (depth: ${depth}) to the <a href="https://github.com/mdn/browser-compat-data">MDN compatibility data repository</a>.`;
+const s_firefox_android = 'Firefox for Android';
+const s_chrome_android = 'Chrome for Android';
 
 const browsers = {
   "desktop": {
@@ -44,7 +44,7 @@ const browsers = {
   }
 };
 
-var notesArray = [];
+const notesArray = [];
 
 /*
 Write the table header.
@@ -52,19 +52,19 @@ Write the table header.
 `browserPlatformType` is either "mobile", "desktop" or "webextensions"
 */
 function writeTableHead(browserPlatformType) {
-  let browserNameKeys = Object.keys(browsers[browserPlatformType]);
+  const browserNameKeys = Object.keys(browsers[browserPlatformType]);
   let output = '';
   if (browserPlatformType === 'webextensions') {
     output = '<table class="webext-summary-compat-table"><thead><tr><th style="width: 40%"></th>'
-    let browserColumnWidth = 60/browserNameKeys.length;
-    for (let browserNameKey of browserNameKeys) {
+    const browserColumnWidth = 60/browserNameKeys.length;
+    for (const browserNameKey of browserNameKeys) {
       output += `<th style="width:${browserColumnWidth}%">${browsers[browserPlatformType][browserNameKey]}</th>`;
     }
     output += "<tr></thead>";
   } else {
     output = `<div id="compat-${browserPlatformType}"><table class="compat-table"><thead><tr>`;
     output +=  '<th>Feature</th>';
-    for (let browserNameKey of browserNameKeys) {
+    for (const browserNameKey of browserNameKeys) {
       output += `<th>${browsers[browserPlatformType][browserNameKey]}</th>`;
     }
     output += '</tr></thead>';
@@ -109,23 +109,23 @@ function getSupportClass(supportInfo) {
   } else if (supportInfo) { // there is just one support statement
     checkSupport(supportInfo.version_added, supportInfo.version_removed);
   } else { // this browser has no info, it's unknown
-  return 'unknown-support';
-}
+    return 'unknown-support';
+  }
 
-function checkSupport(added, removed) {
-  if (added === null) {
-    cssClass = 'unknown-support';
-  } else if (added) {
-    cssClass = 'full-support';
-    if (removed) {
+  function checkSupport(added, removed) {
+    if (added === null) {
+      cssClass = 'unknown-support';
+    } else if (added) {
+      cssClass = 'full-support';
+      if (removed) {
+        cssClass = 'no-support';
+      }
+    } else {
       cssClass = 'no-support';
     }
-  } else {
-    cssClass = 'no-support';
   }
-}
 
-return cssClass;
+  return cssClass;
 }
 
 /*
@@ -161,7 +161,7 @@ function writeFlagsNote(supportData, browserId) {
     flagTextStart = ' this';
   }
 
-  let flagText = `${flagTextStart} feature is behind the <code>${supportData.flag.name}</code>`;
+  const flagText = `${flagTextStart} feature is behind the <code>${supportData.flag.name}</code>`;
 
   // value_to_set is optional
   let valueToSet = '';
@@ -237,27 +237,27 @@ function writeSupportInfo(supportData, browserId, compatNotes) {
     // Generate notes, if any
     if (supportData.notes) {
       if (Array.isArray(supportData.notes)) {
-        for (let note of supportData.notes) {
-          let noteIndex = compatNotes.indexOf(note);
+        for (const note of supportData.notes) {
+          const noteIndex = compatNotes.indexOf(note);
           noteAnchors.push(`<sup><a href="#compatNote_${noteIndex+1}">${noteIndex+1}</a></sup>`);
         }
       } else {
-        let noteIndex = compatNotes.indexOf(supportData.notes);
+        const noteIndex = compatNotes.indexOf(supportData.notes);
         noteAnchors.push(`<sup><a href="#compatNote_${noteIndex+1}">${noteIndex+1}</a></sup>`);
       }
     }
 
     // there is a flag and it needs a note, too
     if (supportData.flag) {
-      let flagNote = writeFlagsNote(supportData, browserId);
-      let noteIndex = compatNotes.indexOf(flagNote);
+      const flagNote = writeFlagsNote(supportData, browserId);
+      const noteIndex = compatNotes.indexOf(flagNote);
       noteAnchors.push(`<sup><a href="#compatNote_${noteIndex+1}">${noteIndex+1}</a></sup>`);
     }
 
     // add a link to the alternative name note, if there is one
     if (supportData.alternative_name) {
-      let altNameNote = writeAlternativeNameNote(supportData.alternative_name);
-      let noteIndex = compatNotes.indexOf(altNameNote);
+      const altNameNote = writeAlternativeNameNote(supportData.alternative_name);
+      const noteIndex = compatNotes.indexOf(altNameNote);
       noteAnchors.push(`<sup><a href="#compatNote_${noteIndex+1}">${noteIndex+1}</a></sup>`);
     }
 
@@ -280,9 +280,9 @@ function collectCompatNotes() {
   function pushNotes(supportEntry, browserName) {
     // collect notes
     if (supportEntry.hasOwnProperty('notes')) {
-      let notes = supportEntry['notes'];
+      const notes = supportEntry['notes'];
       if (Array.isArray(notes)) {
-        for (let note of notes) {
+        for (const note of notes) {
           if (notesArray.indexOf(note) === -1) {
             notesArray.push(note);
           }
@@ -295,24 +295,24 @@ function collectCompatNotes() {
     }
     // collect flags
     if (supportEntry.hasOwnProperty('flag')) {
-      let flagNote = writeFlagsNote(supportEntry, browserName);
+      const flagNote = writeFlagsNote(supportEntry, browserName);
       if (notesArray.indexOf(flagNote) === -1) {
         notesArray.push(flagNote);
       }
     }
     // collect alternative names
     if (supportEntry.hasOwnProperty('alternative_name')) {
-      let altNameNote = writeAlternativeNameNote(supportEntry.alternative_name);
+      const altNameNote = writeAlternativeNameNote(supportEntry.alternative_name);
       if (notesArray.indexOf(altNameNote) === -1) {
         notesArray.push(altNameNote);
       }
     }
   }
-  for (let row of features) {
-    let support = Object.keys(row).map((k) => row[k])[0].support;
-    for (let browserName of Object.keys(support)) {
+  for (const row of features) {
+    const support = Object.keys(row).map((k) => row[k])[0].support;
+    for (const browserName of Object.keys(support)) {
       if (Array.isArray(support[browserName])) {
-        for (let entry of support[browserName]) {
+        for (const entry of support[browserName]) {
           pushNotes(entry, browserName);
         }
       } else {
@@ -332,36 +332,36 @@ an identifier for the row,  like "Basic support".
 function writeSupportCells(supportData, compatNotes, browserPlatformType) {
   let output = '';
 
-  for (let browserNameKey of Object.keys(browsers[browserPlatformType])) {
-    let support = supportData[browserNameKey];
+  for (const browserNameKey of Object.keys(browsers[browserPlatformType])) {
+    const support = supportData[browserNameKey];
     let supportInfo = '';
     // if supportData is an array, there are multiple support statements
     if (Array.isArray(support)) {
-      for (let entry of support) {
+      for (const entry of support) {
         supportInfo += `<p>${writeSupportInfo(entry, browserNameKey, compatNotes)}</p>`;
       }
     } else if (support) { // there is just one support statement
       supportInfo = writeSupportInfo(support, browserNameKey, compatNotes);
     } else { // this browser has no info, it's unknown
-    supportInfo = writeSupportInfo(null);
+      supportInfo = writeSupportInfo(null);
+    }
+    output += `<td class="${getSupportClass(supportData[browserNameKey])}">${supportInfo}</td>`;
   }
-  output += `<td class="${getSupportClass(supportData[browserNameKey])}">${supportInfo}</td>`;
-}
-return output;
+  return output;
 }
 
 /*
 Write compat table
 */
 function writeTable(browserPlatformType) {
-  let compatNotes = collectCompatNotes();
+  const compatNotes = collectCompatNotes();
   let output = writeTableHead(browserPlatformType);
   output += '<tbody>';
-  for (let row of features) {
-    let feature = Object.keys(row).map((k) => row[k])[0];
+  for (const row of features) {
+    const feature = Object.keys(row).map((k) => row[k])[0];
     let desc = '';
     if (feature.description) {
-      let label = Object.keys(row)[0];
+      const label = Object.keys(row)[0];
       // Basic support or unnested features need no prefixing
       if (label.indexOf('.') === -1) {
         desc += feature.description;
@@ -387,9 +387,9 @@ Write each compat note, with an `id` so it will be linked from the table.
 */
 function writeNotes() {
   let output = '';
-  let compatNotes = collectCompatNotes();
-  for (let note of compatNotes) {
-    let noteIndex = compatNotes.indexOf(note);
+  const compatNotes = collectCompatNotes();
+  for (const note of compatNotes) {
+    const noteIndex = compatNotes.indexOf(note);
     output += `<p id=compatNote_${noteIndex+1}>${noteIndex+1}. ${note}</p>`;
   }
   return output;
@@ -411,20 +411,20 @@ Flatten them into a features array
 function traverseFeatures(obj, depth, identifier) {
   depth--;
   if (depth >= 0) {
-    for (let i in obj) {
+    for (const i in obj) {
       if (!!obj[i] && typeof(obj[i])=="object" && i !== '__compat') {
         if (obj[i].__compat) {
 
-          let featureNames = Object.keys(obj[i]);
+          const featureNames = Object.keys(obj[i]);
           if (featureNames.length > 1) {
             // there are sub features below this node,
             // so we need to identify partial support for the main feature
-            for (let subfeatureName of featureNames) {
+            for (const subfeatureName of featureNames) {
               // if this is actually a subfeature (i.e. it is not a __compat object)
               // and the subfeature has a __compat object
               if ((subfeatureName !== '__compat') && (obj[i][subfeatureName].__compat)) {
-                let browserNames = Object.keys(obj[i].__compat.support);
-                for (let browser of browserNames) {
+                const browserNames = Object.keys(obj[i].__compat.support);
+                for (const browser of browserNames) {
                   if (obj[i].__compat.support[browser].version_added !=
                       obj[i][subfeatureName].__compat.support[browser].version_added ||
                       obj[i][subfeatureName].__compat.support[browser].notes) {
@@ -443,10 +443,10 @@ function traverseFeatures(obj, depth, identifier) {
   }
 }
 
-var compatData = getData(query, bcd);
-var features = [];
-var identifier = query.split(".").pop();
-var isWebExtensions = query.split(".")[0] === "webextensions";
+const compatData = getData(query, bcd);
+const features = [];
+const identifier = query.split(".").pop();
+const isWebExtensions = query.split(".")[0] === "webextensions";
 
 if (!compatData) {
   output = s_no_data_found;

--- a/scripts/statistics.js
+++ b/scripts/statistics.js
@@ -12,7 +12,7 @@ const bcd = require('..');
 
 const browsers = ['chrome', 'chrome_android', 'edge', 'firefox', 'ie', 'safari', 'safari_ios', 'webview_android'];
 /** @type {{total: VersionStats; [browser: string]: VersionStats}} */
-const stats = { total: { all: 0, true: 0, null: 0, range: 0, real: 0 } };
+let stats = { total: { all: 0, true: 0, null: 0, range: 0, real: 0 } };
 browsers.forEach(browser => {
   stats[browser] = { all: 0, true: 0, null: 0, range: 0, real: 0 }
 });

--- a/scripts/statistics.js
+++ b/scripts/statistics.js
@@ -12,7 +12,7 @@ const bcd = require('..');
 
 const browsers = ['chrome', 'chrome_android', 'edge', 'firefox', 'ie', 'safari', 'safari_ios', 'webview_android'];
 /** @type {{total: VersionStats; [browser: string]: VersionStats}} */
-let stats = { total: { all: 0, true: 0, null: 0, range: 0, real: 0 } };
+const stats = { total: { all: 0, true: 0, null: 0, range: 0, real: 0 } };
 browsers.forEach(browser => {
   stats[browser] = { all: 0, true: 0, null: 0, range: 0, real: 0 }
 });
@@ -69,7 +69,7 @@ const processData = (data) => {
 };
 
 const iterateData = (data) => {
-  for (let key in data) {
+  for (const key in data) {
     if (key === '__compat') {
       processData(data[key]);
     } else {
@@ -81,7 +81,7 @@ const iterateData = (data) => {
 if (process.argv[2]) {
   iterateData(bcd[process.argv[2]]);
 } else {
-  for (let data in bcd) {
+  for (const data in bcd) {
     if (!(data === 'browsers' || data === 'webextensions')) {
       iterateData(bcd[data]);
     }

--- a/scripts/traverse.js
+++ b/scripts/traverse.js
@@ -19,15 +19,15 @@ const { argv } = require('yargs').command('$0 <browser> [folder] [value]', 'Test
 function traverseFeatures(obj, depth, identifier) {
   depth--;
   if (depth >= 0) {
-    for (let i in obj) {
+    for (const i in obj) {
       if (!!obj[i] && typeof(obj[i]) == "object" && i !== '__compat') {
         if (obj[i].__compat) {
-          let comp = obj[i].__compat.support;
+          const comp = obj[i].__compat.support;
           let browser = comp[argv.browser];
           if (!Array.isArray(browser)) {
             browser = [browser];
           }
-          for (let range in browser) {
+          for (const range in browser) {
             if (browser[range] === undefined) {
               if (values.includes("null")) features.push(`${identifier}${i}`);
             }
@@ -46,11 +46,11 @@ function traverseFeatures(obj, depth, identifier) {
   }
 }
 
-let features = [];
-let folders = Array.isArray(argv.folder) ? argv.folder : argv.folder.split(",");
-let values = Array.isArray(argv.value) ? argv.value : argv.value.toString().split(",");
+const features = [];
+const folders = Array.isArray(argv.folder) ? argv.folder : argv.folder.split(",");
+const values = Array.isArray(argv.value) ? argv.value : argv.value.toString().split(",");
 
-for (let folder in folders) traverseFeatures(bcd[folders[folder]], 100, `${folders[folder]}.`);
+for (const folder in folders) traverseFeatures(bcd[folders[folder]], 100, `${folders[folder]}.`);
 
 console.log(features.join("\n"));
 console.log(features.length);

--- a/scripts/traverse.js
+++ b/scripts/traverse.js
@@ -46,7 +46,7 @@ function traverseFeatures(obj, depth, identifier) {
   }
 }
 
-const features = [];
+let features = [];
 const folders = Array.isArray(argv.folder) ? argv.folder : argv.folder.split(",");
 const values = Array.isArray(argv.value) ? argv.value : argv.value.toString().split(",");
 

--- a/test/linter/test-browsers.js
+++ b/test/linter/test-browsers.js
@@ -68,7 +68,7 @@ function processData(data, displayBrowsers, requiredBrowsers, category, logger, 
     }
 
     for (const [browser, supportStatement] of Object.entries(support)) {
-      let statementList = Array.isArray(supportStatement) ? supportStatement : [supportStatement];
+      const statementList = Array.isArray(supportStatement) ? supportStatement : [supportStatement];
       function hasVersionAddedOnly(statement) {
         const keys = Object.keys(statement);
         return keys.length === 1 && keys[0] === 'version_added';

--- a/test/linter/test-descriptions.js
+++ b/test/linter/test-descriptions.js
@@ -20,7 +20,7 @@ function hasValidConstrutorDescription(apiData, apiName, logger) {
  * @param {import('../utils').Logger} logger
  */
 function hasCorrectDOMEventsDescription(apiData, apiName, logger) {
-  for (let methodName in apiData) {
+  for (const methodName in apiData) {
     if (methodName.endsWith("_event")) {
       const event = apiData[methodName];
       const eventName = methodName.replace("_event", "");
@@ -79,7 +79,7 @@ function testDescriptions(filename) {
   };
 
   if (data.api) {
-    for (let apiName in data.api) {
+    for (const apiName in data.api) {
       const apiData = data.api[apiName];
       hasValidConstrutorDescription(apiData, apiName, logger);
       hasCorrectDOMEventsDescription(apiData, apiName, logger);

--- a/test/linter/test-links.js
+++ b/test/linter/test-links.js
@@ -12,7 +12,7 @@ function processData(filename, logger) {
 
   let actual = fs.readFileSync(filename, 'utf-8').trim();
   /** @type {import('../../types').CompatData} */
-  let dataObject = JSON.parse(actual);
+  const dataObject = JSON.parse(actual);
   let expected = JSON.stringify(dataObject, null, 2);
 
   // prevent false positives from git.core.autocrlf on Windows
@@ -91,7 +91,8 @@ function processData(filename, logger) {
     String.raw`\b(https?)://((?:[a-z][a-z0-9-]*\.)*)developer.mozilla.org/(.*?)(?=["'\s])`,
     match => {
       const [url, protocol, subdomain, path] = match;
-      let [, locale, expectedPath] = /^(?:(\w\w(?:-\w\w)?)\/)?(.*)$/.exec(path);
+      const [, locale, expectedPath_] = /^(?:(\w\w(?:-\w\w)?)\/)?(.*)$/.exec(path);
+      let expectedPath = expectedPath_
 
       if (!expectedPath.startsWith('docs/')) {
         // Convert legacy zone URLs (see https://bugzil.la/1462475):

--- a/test/linter/test-prefix.js
+++ b/test/linter/test-prefix.js
@@ -26,7 +26,7 @@ function checkPrefix(data, category, errors, prefix, path="") {
 }
 
 function processData(data, category) {
-  const errors = [];
+  let errors = [];
   let prefixes = [];
 
   if (category === "api") {

--- a/test/linter/test-prefix.js
+++ b/test/linter/test-prefix.js
@@ -3,11 +3,11 @@ const path = require('path');
 const chalk = require('chalk');
 
 function checkPrefix(data, category, errors, prefix, path="") {
-  for (var key in data) {
+  for (const key in data) {
     if (key === "prefix" && typeof(data[key]) === "string") {
       if (data[key].includes(prefix)) {
-        var error = chalk`{red {bold ${prefix}} prefix is wrong for key: {bold ${path}}}`;
-        var rules = [
+        const error = chalk`{red {bold ${prefix}} prefix is wrong for key: {bold ${path}}}`;
+        const rules = [
           category == "api" && !data[key].startsWith(prefix),
           category == "css" && !data[key].startsWith(`-${prefix}`)
         ];
@@ -17,7 +17,7 @@ function checkPrefix(data, category, errors, prefix, path="") {
       }
     } else {
       if (typeof data[key] === "object") {
-        var curr_path = (path.length > 0) ? `${path}.${key}` : key;
+        const curr_path = (path.length > 0) ? `${path}.${key}` : key;
         checkPrefix(data[key], category, errors, prefix, curr_path);
       }
     }
@@ -26,8 +26,8 @@ function checkPrefix(data, category, errors, prefix, path="") {
 }
 
 function processData(data, category) {
-  var errors = [];
-  var prefixes = [];
+  const errors = [];
+  let prefixes = [];
 
   if (category === "api") {
     prefixes = ["moz", "Moz", "webkit", "WebKit", "webKit", "ms", "MS"];
@@ -36,7 +36,7 @@ function processData(data, category) {
     prefixes = ["webkit", "moz", "ms"];
   }
 
-  for (let prefix of prefixes) {
+  for (const prefix of prefixes) {
     checkPrefix(data, category, errors, prefix);
   }
   return errors;
@@ -46,7 +46,7 @@ function testPrefix(filename) {
   const relativePath = path.relative(path.resolve(__dirname, '..', '..'), filename);
   const category = relativePath.includes(path.sep) && relativePath.split(path.sep)[0];
   const data = require(filename);
-  var errors = processData(data, category);
+  const errors = processData(data, category);
 
   if (errors.length) {
     console.error(chalk`{red   Prefix – {bold ${errors.length}} ${errors.length === 1 ? 'error' : 'errors'}:}`);

--- a/test/linter/test-style.js
+++ b/test/linter/test-style.js
@@ -58,10 +58,10 @@ function processData(filename, logger) {
 
   let actual = fs.readFileSync(filename, 'utf-8').trim();
   /** @type {import('../../types').CompatData} */
-  let dataObject = JSON.parse(actual);
+  const dataObject = JSON.parse(actual);
   let expected = JSON.stringify(dataObject, null, 2);
   let expectedBrowserSorting = JSON.stringify(dataObject, orderSupportBlock, 2);
-  let expectedFeatureSorting = JSON.stringify(JSON.parse(actual), orderFeatures, 2);
+  let expectedFeatureSorting = JSON.stringify(dataObject, orderFeatures, 2);
 
   // prevent false positives from git.core.autocrlf on Windows
   if (IS_WINDOWS) {
@@ -86,22 +86,22 @@ function processData(filename, logger) {
     logger.error(chalk`{red Feature sorting error on {bold line ${jsonDiff(expected, expectedFeatureSorting)}}}\n{blue     Tip: Run {bold npm run fix} to fix sorting automatically}`);
   }
 
-  let constructorMatch = actual.match(String.raw`"<code>([^)]*?)</code> constructor"`)
+  const constructorMatch = actual.match(String.raw`"<code>([^)]*?)</code> constructor"`)
   if (constructorMatch) {
     hasErrors = true;
     logger.error(chalk`{red ${indexToPos(actual, constructorMatch.index)} – Use parentheses in constructor description ({yellow ${constructorMatch[1]}} → {green ${constructorMatch[1]}{bold ()}}).}`);
   }
 
-  let hrefDoubleQuoteIndex = actual.indexOf('href=\\"');
+  const hrefDoubleQuoteIndex = actual.indexOf('href=\\"');
   if (hrefDoubleQuoteIndex >= 0) {
     hasErrors = true;
     logger.error(chalk`{red ${indexToPos(actual, hrefDoubleQuoteIndex)} - Found {yellow \\"}, but expected {green \'} for <a href>.}`);
   }
 
   const regexp = new RegExp(String.raw`<a href='([^'>]+)'>((?:.(?!</a>))*.)</a>`, 'g');
-  let match = regexp.exec(actual);
+  const match = regexp.exec(actual);
   if (match) {
-    var a_url = url.parse(match[1]);
+    const a_url = url.parse(match[1]);
     if (a_url.hostname === null) {
       hasErrors = true;
       logger.error(chalk`{red ${indexToPos(actual, constructorMatch.index)} - Include hostname in URL ({yellow ${match[1]}} → {green {bold https://developer.mozilla.org/}${match[1]}}).}`);

--- a/test/test-compare-features.js
+++ b/test/test-compare-features.js
@@ -14,12 +14,12 @@ const compareFeatures = require('../scripts/compare-features');
   * @returns {boolean} If the sorter isn't functioning properly
   */
 const testFeatureOrder = () => {
-  let input = ['foobar', 'Foo', '__compat', 'toString', 'secure_context_required', 'protocol-r30', '$0', 'Bar', '_updated_spec', '43', '--variable', 'ZOO_Pals', '2-factor-auth'];
-  let actual = input.sort(compareFeatures);
-  let expected = ["__compat", "Bar", "Foo", "ZOO_Pals", "foobar", "protocol-r30", "secure_context_required", "toString", "_updated_spec", "--variable", "$0", "2-factor-auth", "43"];
+  const input = ['foobar', 'Foo', '__compat', 'toString', 'secure_context_required', 'protocol-r30', '$0', 'Bar', '_updated_spec', '43', '--variable', 'ZOO_Pals', '2-factor-auth'];
+  const actual = input.sort(compareFeatures);
+  const expected = ["__compat", "Bar", "Foo", "ZOO_Pals", "foobar", "protocol-r30", "secure_context_required", "toString", "_updated_spec", "--variable", "$0", "2-factor-auth", "43"];
 
-  var errors = false;
-  for (var i = actual.length; i--;) {
+  let errors = false;
+  for (let i = actual.length; i--;) {
     if (actual[i] !== expected[i]) {
       errors = true;
       break;

--- a/test/utils.js
+++ b/test/utils.js
@@ -60,7 +60,7 @@ function indexToPosRaw(str, index) {
   }
 
   for (let i = 0; i < index; i++) {
-    let char = str[i];
+    const char = str[i];
     switch (char) {
       case '\n':
         if (prevChar === '\r') break;
@@ -100,10 +100,10 @@ function indexToPos(str, index) {
  * @return {string}
  */
 function jsonDiff(actual, expected) {
-  var actualLines = actual.split(/\n/);
-  var expectedLines = expected.split(/\n/);
+  const actualLines = actual.split(/\n/);
+  const expectedLines = expected.split(/\n/);
 
-  for (var i = 0; i < actualLines.length; i++) {
+  for (let i = 0; i < actualLines.length; i++) {
     if (actualLines[i] !== expectedLines[i]) {
       return `#${i + 1}
     Actual:   ${escapeInvisibles(actualLines[i])}


### PR DESCRIPTION
## Summary
Fixes #4973. Uses `const` and `let` wherever possible, entirely removing `var`.

## Tests performed
I ran the scripts after these edits to to ensure they still produce the expected result.

```
npm run lint
npm run stats
npm run render api.Window (and similar)
```

### `traverse` tests
```
npm run traverse chrome_android
npm run traverse edge
npm run traverse firefox
npm run traverse nodejs
npm run traverse opera
npm run traverse safari_ios
npm run traverse samsunginternet_android
npm run traverse uc_chinese_android
npm run traverse chrome
npm run traverse firefox_android
npm run traverse ie
npm run traverse opera_android
npm run traverse qq_android
npm run traverse safari
npm run traverse uc_android
npm run traverse webview_android
```

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
