### PR TITLE
Add <string> support for Chrome.

### DIFF
--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -96,7 +96,56 @@
             }
           }
         },
-        "url": {
+        "string": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/string",
+            "description": "<code>&lt;string&gt;</code>",
+            "support": {
+              "chrome": {
+                "version_added": "79"
+              },
+              "chrome_android": {
+                "version_added": "79"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": "79"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "url (copy)": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/url",
             "description": "<code>url()</code>",

--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -145,7 +145,7 @@
             }
           }
         },
-        "url (copy)": {
+        "url": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/url",
             "description": "<code>url()</code>",


### PR DESCRIPTION
Content deserves more attention than I can give it right now. At can at least fix this because it just landed: https://bugs.chromium.org/p/chromium/issues/detail?id=860016