### PR TITLE
IE8 does not fully support according to the proposal for Array.prototype.splice

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -1822,9 +1822,15 @@
               "firefox_android": {
                 "version_added": "4"
               },
-              "ie": {
-                "version_added": "5.5"
-              },
+              "ie": [
+                {
+                  "version_added": "5.5"
+                },
+                {
+                  "version_added": "8",
+                  "notes": "From Internet Explorer 5.5 through 8, all elements of the array will not be deleted if <code>deleteCount</code> is omitted. This behavior was fixed in Internet Explorer 9."
+                }
+              ],
               "nodejs": {
                 "version_added": true
               },

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -1822,15 +1822,10 @@
               "firefox_android": {
                 "version_added": "4"
               },
-              "ie": [
-                {
-                  "version_added": "5.5"
-                },
-                {
-                  "version_added": "8",
-                  "notes": "From Internet Explorer 5.5 through 8, all elements of the array will not be deleted if <code>deleteCount</code> is omitted. This behavior was fixed in Internet Explorer 9."
-                }
-              ],
+              "ie": {
+                "version_added": "5.5",
+                "notes": "From Internet Explorer 5.5 through 8, all elements of the array will not be deleted if <code>deleteCount</code> is omitted. This behavior was fixed in Internet Explorer 9."
+              },
               "nodejs": {
                 "version_added": true
               },


### PR DESCRIPTION
According to #4996, hope to add a note for `Array.prototype.splice` to mention that IE8 has not fully support this method when the second parameter is omitted.