### PR TITLE
Update javascript optional chaining support

### DIFF
--- a/javascript/operators/optional_chaining.json
+++ b/javascript/operators/optional_chaining.json
@@ -56,10 +56,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false

--- a/javascript/operators/optional_chaining.json
+++ b/javascript/operators/optional_chaining.json
@@ -8,10 +8,24 @@
           "spec_url": "https://tc39.es/proposal-optional-chaining/#top",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": 78,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental JavaScript",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": 78,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental JavaScript",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "edge": {
               "version_added": false
@@ -29,7 +43,14 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": 65,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental JavaScript",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "opera_android": {
               "version_added": false

--- a/javascript/operators/optional_chaining.json
+++ b/javascript/operators/optional_chaining.json
@@ -8,7 +8,7 @@
           "spec_url": "https://tc39.es/proposal-optional-chaining/#top",
           "support": {
             "chrome": {
-              "version_added": 78,
+              "version_added": "78",
               "flags": [
                 {
                   "type": "preference",
@@ -18,7 +18,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": 78,
+              "version_added": "78",
               "flags": [
                 {
                   "type": "preference",
@@ -43,7 +43,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": 65,
+              "version_added": "65",
               "flags": [
                 {
                   "type": "preference",


### PR DESCRIPTION
Chrome is adding support in v78: https://www.chromestatus.com/feature/5748330720133120

Tested working in Chrome 79 for Windows & Android with the `Experimental JavaScript` flag enabled.
Added support in Opera, based on [vinyldarkscratch's comment](https://github.com/mdn/browser-compat-data/pull/4958#pullrequestreview-300992363).

Tested not working in Safari 12.1 & 11.1 and in Safari for IOS 13 Beta & 12.

Both Safari and Firefox are working on it, so this should probably be revisited in a few months:
https://bugs.webkit.org/show_bug.cgi?id=200199
https://bugzilla.mozilla.org/show_bug.cgi?id=1566143
Does it make sense to open an issue, so it will remind us to check back later? Or what is best practice?

Test i used: (change to .html)
[test-optional-chaining.txt](https://github.com/mdn/browser-compat-data/files/3740363/test-optional-chaining.txt)