### PR TITLE
adding Fx data for AudioContext.getAudioTimestamp

### DIFF
--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -623,7 +623,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "70"
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1324545

Data was there already; this just adds support in Firefox 70.