### PR TITLE
Add restartIce()

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -3693,6 +3693,55 @@
           }
         }
       },
+      "restartIce": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/restartIce",
+          "description": "<code>restartIce()</code> method",
+          "support": {
+            "chrome": {
+              "version_added": "76"
+            },
+            "chrome_android": {
+              "version_added": "76"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "70"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "76"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "sctp": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/sctp",

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -3699,10 +3699,10 @@
           "description": "<code>restartIce()</code> method",
           "support": {
             "chrome": {
-              "version_added": "76"
+              "version_added": "77"
             },
             "chrome_android": {
-              "version_added": "76"
+              "version_added": "77"
             },
             "edge": {
               "version_added": false
@@ -3732,7 +3732,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "76"
+              "version_added": "77"
             }
           },
           "status": {


### PR DESCRIPTION
Updated RTCPeerConnection.json to add version info for restartIce().

Chrome info comes from:
* https://bugs.chromium.org/p/chromium/issues/detail?id=980881

Firefox from:
* https://bugzilla.mozilla.org/show_bug.cgi?id=1551316

Spec link: https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-restartice