### PR TITLE
formatRange updates

### DIFF
--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -684,6 +684,36 @@
                 "chrome_android": {
                   "version_added": "76"
                 },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
                 "webview_android": {
                   "version_added": "76"
                 }

--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -674,6 +674,27 @@
               }
             }
           },
+          "formatRange": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/formatRange",
+              "support": {
+                "chrome": {
+                  "version_added": "76"
+                },
+                "chrome_android": {
+                  "version_added": "76"
+                },
+                "webview_android": {
+                  "version_added": "76"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "resolvedOptions": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/resolvedOptions",

--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -466,6 +466,57 @@
               }
             }
           },
+          "formatRange": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/formatRange",
+              "support": {
+                "chrome": {
+                  "version_added": "76"
+                },
+                "chrome_android": {
+                  "version_added": "76"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": "76"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "formatToParts": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/formatToParts",
@@ -665,57 +716,6 @@
                 },
                 "webview_android": {
                   "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "formatRange": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/formatRange",
-              "support": {
-                "chrome": {
-                  "version_added": "76"
-                },
-                "chrome_android": {
-                  "version_added": "76"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "samsunginternet_android": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": "76"
                 }
               },
               "status": {


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] **Summarize your changes**
Adds compat data for `Intl.DateTimeFormat.prototype.formatRange`, a stage 3 proposal that has landed in Chrome 76.
- [x] **Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)**
[Chrome platform support](https://www.chromestatus.com/features/5077134515109888), no other browsers showing support/intent as of now.

- [x] **Data: if you tested something, describe how you tested with details like browser and version**
`npm run render javascript.builtins.Intl.DateTimeFormat.formatRange` runs outputs correct table.

- [x] **Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)**
Travis checks pass.

- [x] **Link to related issues or pull requests, if any**
Part of work being done by ECMA 402 to document `formatRange`. Work is being tracked [here](https://github.com/tc39/proposal-intl-DateTimeFormat-formatRange/issues/12).
