### PR TITLE
Add the `unsafe-hashes` source expression for CSP

### DIFF
--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -1678,6 +1678,55 @@
               }
             }
           },
+          "unsafe-hashes": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe-hashes",
+              "support": {
+                "chrome": {
+                  "version_added": "69"
+                },
+                "chrome_android": {
+                  "version_added": "69"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false,
+                  "notes": "See <a href='https://bugzil.la/1343950'>bug 1343950</a>."
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "56"
+                },
+                "opera_android": {
+                  "version_added": "48"
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": "69"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "upgrade-insecure-requests": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/upgrade-insecure-requests",
@@ -1816,55 +1865,6 @@
                 "webview_android": {
                   "version_added": "59",
                   "notes": "Chrome 59 and higher skips the deprecated <code>child-src</code> directive."
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "unsafe-hashes": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe-hashes",
-              "support": {
-                "chrome": {
-                  "version_added": "69"
-                },
-                "chrome_android": {
-                  "version_added": "69"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/1343950'>bug 1343950</a>."
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "56"
-                },
-                "opera_android": {
-                  "version_added": "48"
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "samsunginternet_android": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": "69"
                 }
               },
               "status": {

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -1824,6 +1824,55 @@
                 "deprecated": false
               }
             }
+          },
+          "unsafe-hashes": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe-hashes",
+              "support": {
+                "chrome": {
+                  "version_added": "69"
+                },
+                "chrome_android": {
+                  "version_added": "69"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false,
+                  "notes": "See <a href='https://bugzil.la/1343950'>bug 1343950</a>."
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "56"
+                },
+                "opera_android": {
+                  "version_added": "48"
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": "69"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
`'unsafe-hashes'` (initially named `unsafe-hashed-attributes`):
- https://w3c.github.io/webappsec-csp/#unsafe-hashes-usage
- https://wiki.developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe-hashes

Chrome status:
https://chromestatus.com/features/5867082285580288
Bugzilla:
https://bugzil.la/1343950

