### PR TITLE
Implicit rollback on setRemoteDescription()

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -3960,6 +3960,7 @@
       "setRemoteDescription": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/setRemoteDescription",
+          "description": "<code>setRemoteDescription()</code>",
           "support": {
             "chrome": [
               {
@@ -4034,6 +4035,54 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "implicit_rollback": {
+          "__compat": {
+            "description": "Implicit rollback",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "70"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },


### PR DESCRIPTION
Added a new subfeature to setRemoteDescription() to
cover support for implicit rollback being triggered
by an incoming offer when one isn't expected.

Sources:
* Chrome status: https://chromestatus.com/features/5079977739419648
* MDN bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1567951
* Spec: https://w3c.github.io/webrtc-pc/#dom-peerconnection-setremotedescription

Did not find this issue in Edge tracking, nor in
Safari release notes through current tech preview.
