### PR TITLE
adding AudioContext outputLatency and baseLatency Fx support

### DIFF
--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -253,7 +253,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "70"
             },
             "firefox_android": {
               "version_added": false
@@ -671,7 +671,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "70"
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1324552

To be clear, I've just added data to say that support was added in Fx 70 for `baseLatency` and `outputLatency`. I've not researched any other browser support updates for these properties.