### PR TITLE
groupId added to constraints on Firefox 70

### DIFF
--- a/api/MediaTrackConstraints.json
+++ b/api/MediaTrackConstraints.json
@@ -477,10 +477,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "50"
+              "version_added": "70"
             },
             "firefox_android": {
-              "version_added": "50"
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/MediaTrackSupportedConstraints.json
+++ b/api/MediaTrackSupportedConstraints.json
@@ -477,7 +477,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "70"
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
Firefox 70 now supports groupId on the
`MediaTrackConstraints` and `MediaStreamTrackSupportedConstraints`
dictionaries.

Source
* https://bugzilla.mozilla.org/show_bug.cgi?id=1561254