### PR TITLE
Adding subgrid for Firefox 71

### DIFF
--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -477,17 +477,22 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "69",
-              "notes": "Enabled by default in Firefox Nightly.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.grid-template-subgrid-value.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "69",
+                "notes": "Enabled by default in Firefox Nightly.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid-template-subgrid-value.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -476,17 +476,22 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "69",
-                "notes": "Enabled by default in Firefox Nightly.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid-template-subgrid-value.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "71"
+                },
+                {
+                  "version_added": "69",
+                  "notes": "Enabled by default in Firefox Nightly.",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.grid-template-subgrid-value.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": {
                 "version_added": false
               },


### PR DESCRIPTION
The subgrid value of grid-template-rows and grid-template-columns will be in Firefox 71. This PR adds support.

https://bugzilla.mozilla.org/show_bug.cgi?id=1580894

No other browser yet has support for subgrid.
