### PR TITLE
column-span is in Firefox 71

### DIFF
--- a/css/properties/column-span.json
+++ b/css/properties/column-span.json
@@ -32,16 +32,21 @@
                 "version_added": "12"
               }
             ],
-            "firefox": {
-              "version_added": "65",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.column-span.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "65",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.column-span.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": "65",
               "flags": [


### PR DESCRIPTION
The `column-span` property is enabled in Firefox 71. This PR adds that support to the compat data.

https://bugzilla.mozilla.org/show_bug.cgi?id=1426010
