### PR TITLE
clip-path: path() in firefox 71

### DIFF
--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -331,16 +331,21 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.clip-path-path.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "71"
+                },
+                {
+                  "version_added": "63",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.clip-path-path.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": {
                 "version_added": "63",
                 "flags": [


### PR DESCRIPTION
The `path()` value of `clip-path` ships in Firefox 71.

https://bugzilla.mozilla.org/show_bug.cgi?id=1488530

The bug mentions support in Safari, and I've researched this but I don't see it working in a release version, using the tests on WPT. On wpt.fyi it is passing in Safari Technology Preview. If I find out more I'll update this.
