### PR TITLE
Revert "moved factory functions under a new header by that name (#4921)"

### DIFF
--- a/api/CSS.json
+++ b/api/CSS.json
@@ -69,6 +69,438 @@
           "deprecated": false
         }
       },
+      "Hz": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/Hz",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "Q": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/Q",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "ch": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/ch",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "cm": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/cm",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "deg": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/deg",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dpcm": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/dpcm",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dpi": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/dpi",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dppx": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/dppx",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "em": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/em",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "escape": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/escape",
@@ -117,9 +549,9 @@
           }
         }
       },
-      "factory": {
+      "ex": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/factory_functions",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/ex",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -163,1638 +595,437 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "Hz": {
-          "__compat": {
-            "description": "Numeric factory functions",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/Hz",
-            "support": {
-              "chrome": {
-                "version_added": "66"
-              },
-              "chrome_android": {
-                "version_added": "66"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "66"
-              }
+        }
+      },
+      "fr": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/fr",
+          "support": {
+            "chrome": {
+              "version_added": "66"
             },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "66"
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "Q": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/Q",
-            "support": {
-              "chrome": {
-                "version_added": "66"
-              },
-              "chrome_android": {
-                "version_added": "66"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "66"
-              }
+        }
+      },
+      "grad": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/grad",
+          "support": {
+            "chrome": {
+              "version_added": "66"
             },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "66"
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "ch": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/ch",
-            "support": {
-              "chrome": {
-                "version_added": "66"
-              },
-              "chrome_android": {
-                "version_added": "66"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "66"
-              }
+        }
+      },
+      "ic": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/ic",
+          "support": {
+            "chrome": {
+              "version_added": false
             },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "cm": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/cm",
-            "support": {
-              "chrome": {
-                "version_added": "66"
-              },
-              "chrome_android": {
-                "version_added": "66"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "66"
-              }
+        }
+      },
+      "in": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/in",
+          "support": {
+            "chrome": {
+              "version_added": "66"
             },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "66"
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "deg": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/deg",
-            "support": {
-              "chrome": {
-                "version_added": "66"
-              },
-              "chrome_android": {
-                "version_added": "66"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "66"
-              }
+        }
+      },
+      "kHz": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/kHz",
+          "support": {
+            "chrome": {
+              "version_added": "66"
             },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "66"
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "dpcm": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/dpcm",
-            "support": {
-              "chrome": {
-                "version_added": "66"
-              },
-              "chrome_android": {
-                "version_added": "66"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "66"
-              }
+        }
+      },
+      "lh": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/lh",
+          "support": {
+            "chrome": {
+              "version_added": false
             },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "dpi": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/dpi",
-            "support": {
-              "chrome": {
-                "version_added": "66"
-              },
-              "chrome_android": {
-                "version_added": "66"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "66"
-              }
+        }
+      },
+      "mm": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/mm",
+          "support": {
+            "chrome": {
+              "version_added": "66"
             },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "66"
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "dppx": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/dppx",
-            "support": {
-              "chrome": {
-                "version_added": "66"
-              },
-              "chrome_android": {
-                "version_added": "66"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "66"
-              }
+        }
+      },
+      "ms": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/ms",
+          "support": {
+            "chrome": {
+              "version_added": "66"
             },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "66"
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
-        },
-        "em": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/em",
-            "support": {
-              "chrome": {
-                "version_added": "66"
-              },
-              "chrome_android": {
-                "version_added": "66"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "66"
-              }
+        }
+      },
+      "number": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/number",
+          "support": {
+            "chrome": {
+              "version_added": "66"
             },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "ex": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/ex",
-            "support": {
-              "chrome": {
-                "version_added": "66"
-              },
-              "chrome_android": {
-                "version_added": "66"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "66"
-              }
+            "chrome_android": {
+              "version_added": "66"
             },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "fr": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/fr",
-            "support": {
-              "chrome": {
-                "version_added": "66"
-              },
-              "chrome_android": {
-                "version_added": "66"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "66"
-              }
+            "edge": {
+              "version_added": false
             },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "grad": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/grad",
-            "support": {
-              "chrome": {
-                "version_added": "66"
-              },
-              "chrome_android": {
-                "version_added": "66"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "66"
-              }
+            "firefox": {
+              "version_added": false
             },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "ic": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/ic",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
+            "firefox_android": {
+              "version_added": false
             },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "in": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/in",
-            "support": {
-              "chrome": {
-                "version_added": "66"
-              },
-              "chrome_android": {
-                "version_added": "66"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "66"
-              }
+            "ie": {
+              "version_added": false
             },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "kHz": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/kHz",
-            "support": {
-              "chrome": {
-                "version_added": "66"
-              },
-              "chrome_android": {
-                "version_added": "66"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "66"
-              }
+            "opera": {
+              "version_added": "53"
             },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "lh": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/lh",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
+            "opera_android": {
+              "version_added": "47"
             },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "mm": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/mm",
-            "support": {
-              "chrome": {
-                "version_added": "66"
-              },
-              "chrome_android": {
-                "version_added": "66"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "66"
-              }
+            "safari": {
+              "version_added": false
             },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "ms": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/ms",
-            "support": {
-              "chrome": {
-                "version_added": "66"
-              },
-              "chrome_android": {
-                "version_added": "66"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "66"
-              }
+            "safari_ios": {
+              "version_added": false
             },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "number": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/number",
-            "support": {
-              "chrome": {
-                "version_added": "66"
-              },
-              "chrome_android": {
-                "version_added": "66"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "66"
-              }
+            "samsunginternet_android": {
+              "version_added": true
             },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+            "webview_android": {
+              "version_added": "66"
             }
-          }
-        },
-        "pc": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/pc",
-            "support": {
-              "chrome": {
-                "version_added": "66"
-              },
-              "chrome_android": {
-                "version_added": "66"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "66"
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "percent": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/percent",
-            "support": {
-              "chrome": {
-                "version_added": "66"
-              },
-              "chrome_android": {
-                "version_added": "66"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "66"
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "pt": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/pt",
-            "support": {
-              "chrome": {
-                "version_added": "66"
-              },
-              "chrome_android": {
-                "version_added": "66"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "66"
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "px": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/px",
-            "support": {
-              "chrome": {
-                "version_added": "66"
-              },
-              "chrome_android": {
-                "version_added": "66"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "66"
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "rad": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/rad",
-            "support": {
-              "chrome": {
-                "version_added": "66"
-              },
-              "chrome_android": {
-                "version_added": "66"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "66"
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "rem": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/rem",
-            "support": {
-              "chrome": {
-                "version_added": "66"
-              },
-              "chrome_android": {
-                "version_added": "66"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "66"
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "rlh": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/rlh",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "s": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/s",
-            "support": {
-              "chrome": {
-                "version_added": "66"
-              },
-              "chrome_android": {
-                "version_added": "66"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "66"
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "turn": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/turn",
-            "support": {
-              "chrome": {
-                "version_added": "66"
-              },
-              "chrome_android": {
-                "version_added": "66"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "66"
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "vb": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/vb",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "vh": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/vh",
-            "support": {
-              "chrome": {
-                "version_added": "66"
-              },
-              "chrome_android": {
-                "version_added": "66"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "66"
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "vi": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/vi",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "vmax": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/vmax",
-            "support": {
-              "chrome": {
-                "version_added": "66"
-              },
-              "chrome_android": {
-                "version_added": "66"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "66"
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "vw": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/vw",
-            "support": {
-              "chrome": {
-                "version_added": "66"
-              },
-              "chrome_android": {
-                "version_added": "66"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "66"
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "wmin": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/wmin",
-            "support": {
-              "chrome": {
-                "version_added": "66"
-              },
-              "chrome_android": {
-                "version_added": "66"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": null
-              },
-              "webview_android": {
-                "version_added": "66"
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
@@ -1846,15 +1077,303 @@
           }
         }
       },
-      "registerProperty": {
+      "pc": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/registerProperty",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/pc",
           "support": {
             "chrome": {
-              "version_added": "78"
+              "version_added": "66"
             },
             "chrome_android": {
-              "version_added": "78"
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "percent": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/percent",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pt": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/pt",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "px": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/px",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "rad": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/rad",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "rem": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/rem",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "rlh": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/rlh",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
             },
             "edge": {
               "version_added": false
@@ -1885,6 +1404,54 @@
             },
             "webview_android": {
               "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "s": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/s",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "66"
             }
           },
           "status": {
@@ -1994,6 +1561,342 @@
           },
           "status": {
             "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "turn": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/turn",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vb": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/vb",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vh": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/vh",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vi": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/vi",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vmax": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/vmax",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vw": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/vw",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "wmin": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/wmin",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "66"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "53"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "66"
+            }
+          },
+          "status": {
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
This reverts commit 9ad6e902477c8a049480e6ee035e9a2d43ada1df.

https://github.com/mdn/browser-compat-data/pull/4921 wasn't reviewed. Backing it out.