### PR TITLE
Change the release number of optional chaining.

### DIFF
--- a/javascript/operators/optional_chaining.json
+++ b/javascript/operators/optional_chaining.json
@@ -8,7 +8,7 @@
           "spec_url": "https://tc39.es/proposal-optional-chaining/#top",
           "support": {
             "chrome": {
-              "version_added": "78",
+              "version_added": "79",
               "flags": [
                 {
                   "type": "preference",
@@ -18,7 +18,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "78",
+              "version_added": "79",
               "flags": [
                 {
                   "type": "preference",
@@ -78,4 +78,3 @@
     }
   }
 }
-  


### PR DESCRIPTION
This did not actually ship in Chrome 78. It will ship in Chrome 79 as shown here: https://chromiumdash.appspot.com/commit/67180425bcecc021a3aa8df23b44afa531ab6630

It is still behind a flag.