### PR TITLE
Fix consistency of api.SharedWorker.SharedWorker.mime_checks

### DIFF
--- a/api/SharedWorker.json
+++ b/api/SharedWorker.json
@@ -128,16 +128,16 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": null
               },
               "webview_android": {
-                "version_added": null
+                "version_added": false
               }
             },
             "status": {


### PR DESCRIPTION
Follow-up to #4982.  This fixes the consistency within the new feature.  Since `api.SharedWorker.SharedWorker` isn't supported in Safari, Safari iOS, or Webview, none of its subfeatures should be.