### PR TITLE
Standardize styling for linters

### DIFF
--- a/test/linter/test-browsers.js
+++ b/test/linter/test-browsers.js
@@ -57,13 +57,13 @@ function processData(data, displayBrowsers, requiredBrowsers, category, logger, 
 
     const invalidEntries = Object.keys(support).filter(value => !displayBrowsers.includes(value));
     if (invalidEntries.length > 0) {
-      logger.error(chalk`{red {bold ${path}} has the following browsers, which are invalid for {bold ${category}} compat data: {bold ${invalidEntries.join(', ')}}}`);
+      logger.error(chalk`{red → {bold ${path}} has the following browsers, which are invalid for {bold ${category}} compat data: {bold ${invalidEntries.join(', ')}}}`);
       hasErrors = true;
     }
 
     const missingEntries = requiredBrowsers.filter(value => !(value in support));
     if (missingEntries.length > 0) {
-      logger.error(chalk`{red {bold ${path}} is missing the following browsers, which are required for {bold ${category}} compat data: {bold ${missingEntries.join(', ')}}}`);
+      logger.error(chalk`{red → {bold ${path}} is missing the following browsers, which are required for {bold ${category}} compat data: {bold ${missingEntries.join(', ')}}}`);
       hasErrors = true;
     }
 
@@ -77,7 +77,7 @@ function processData(data, displayBrowsers, requiredBrowsers, category, logger, 
       for (const statement of statementList) {
         if (hasVersionAddedOnly(statement)) {
           if (sawVersionAddedOnly) {
-           logger.error(`'${path}' has multiple support statement with only \`version_added\` for ${browser}`);
+           logger.error(chalk`{red → '{bold ${path}}' has multiple support statement with only \`{bold version_added}\` for {bold ${browser}}}`);
             hasErrors = true;
             break;
           } else {

--- a/test/linter/test-browsers.js
+++ b/test/linter/test-browsers.js
@@ -154,7 +154,7 @@ function testBrowsers(filename) {
   if (errors.length) {
     console.error(chalk`{red   Browsers – {bold ${errors.length}} ${errors.length === 1 ? 'error' : 'errors'}:}`);
     for (const error of errors) {
-      console.error(`    ${error}`);
+      console.error(`  ${error}`);
     }
     return true;
   }

--- a/test/linter/test-descriptions.js
+++ b/test/linter/test-descriptions.js
@@ -8,7 +8,7 @@ const chalk = require('chalk');
 function hasValidConstrutorDescription(apiData, apiName, logger) {
   const constructor = apiData[apiName];
   if (constructor && constructor.__compat.description !== `<code>${apiName}()</code> constructor`) {
-      logger.error(chalk`{red → Incorrect constructor description for {bold ${apiName}()}}
+      logger.error(chalk`{red Incorrect constructor description for {bold ${apiName}()}}
       {yellow Actual: {bold "${constructor.__compat.description || ""}"}}
       {green Expected: {bold "<code>${apiName}()</code> constructor"}}`);
   }
@@ -25,7 +25,7 @@ function hasCorrectDOMEventsDescription(apiData, apiName, logger) {
       const event = apiData[methodName];
       const eventName = methodName.replace("_event", "");
       if (event.__compat.description !== `<code>${eventName}</code> event`) {
-        logger.error(chalk`{red → Incorrect event description for {bold ${apiName}#${methodName}}}
+        logger.error(chalk`{red Incorrect event description for {bold ${apiName}#${methodName}}}
       {yellow Actual: {bold "${event.__compat.description || ""}"}}
       {green Expected: {bold "<code>${eventName}</code> event"}}`);
       }
@@ -41,7 +41,7 @@ function hasCorrectDOMEventsDescription(apiData, apiName, logger) {
 function hasCorrectSecureContextRequiredDescription(apiData, apiName, logger) {
   const secureContext = apiData.secure_context_required;
   if (secureContext && secureContext.__compat.description !== `Secure context required`) {
-      logger.error(chalk`{red → Incorrect secure context required description for {bold ${apiName}()}}
+      logger.error(chalk`{red Incorrect secure context required description for {bold ${apiName}()}}
       {yellow Actual: {bold "${secureContext.__compat.description || ""}"}}
       {green Expected: {bold "Secure context required"}}`);
   }
@@ -55,7 +55,7 @@ function hasCorrectSecureContextRequiredDescription(apiData, apiName, logger) {
 function hasCorrectWebWorkersDescription(apiData, apiName, logger) {
   const workerSupport = apiData.worker_support;
   if (workerSupport && workerSupport.__compat.description !== `Available in workers`) {
-      logger.error(chalk`{red → Incorrect worker support description for {bold ${apiName}()}}
+      logger.error(chalk`{red Incorrect worker support description for {bold ${apiName}()}}
       {yellow Actual: {bold "${workerSupport.__compat.description || ""}"}}
       {green Expected: {bold "Available in workers"}}`);
   }

--- a/test/linter/test-descriptions.js
+++ b/test/linter/test-descriptions.js
@@ -8,7 +8,7 @@ const chalk = require('chalk');
 function hasValidConstrutorDescription(apiData, apiName, logger) {
   const constructor = apiData[apiName];
   if (constructor && constructor.__compat.description !== `<code>${apiName}()</code> constructor`) {
-      logger.error(chalk`{red Incorrect constructor description for {bold ${apiName}()}}
+      logger.error(chalk`{red → Incorrect constructor description for {bold ${apiName}()}}
       {yellow Actual: {bold "${constructor.__compat.description || ""}"}}
       {green Expected: {bold "<code>${apiName}()</code> constructor"}}`);
   }
@@ -25,7 +25,7 @@ function hasCorrectDOMEventsDescription(apiData, apiName, logger) {
       const event = apiData[methodName];
       const eventName = methodName.replace("_event", "");
       if (event.__compat.description !== `<code>${eventName}</code> event`) {
-        logger.error(chalk`{red Incorrect event description for {bold ${apiName}#${methodName}}}
+        logger.error(chalk`{red → Incorrect event description for {bold ${apiName}#${methodName}}}
       {yellow Actual: {bold "${event.__compat.description || ""}"}}
       {green Expected: {bold "<code>${eventName}</code> event"}}`);
       }
@@ -41,7 +41,7 @@ function hasCorrectDOMEventsDescription(apiData, apiName, logger) {
 function hasCorrectSecureContextRequiredDescription(apiData, apiName, logger) {
   const secureContext = apiData.secure_context_required;
   if (secureContext && secureContext.__compat.description !== `Secure context required`) {
-      logger.error(chalk`{red Incorrect secure context required description for {bold ${apiName}()}}
+      logger.error(chalk`{red → Incorrect secure context required description for {bold ${apiName}()}}
       {yellow Actual: {bold "${secureContext.__compat.description || ""}"}}
       {green Expected: {bold "Secure context required"}}`);
   }
@@ -55,7 +55,7 @@ function hasCorrectSecureContextRequiredDescription(apiData, apiName, logger) {
 function hasCorrectWebWorkersDescription(apiData, apiName, logger) {
   const workerSupport = apiData.worker_support;
   if (workerSupport && workerSupport.__compat.description !== `Available in workers`) {
-      logger.error(chalk`{red Incorrect worker support description for {bold ${apiName}()}}
+      logger.error(chalk`{red → Incorrect worker support description for {bold ${apiName}()}}
       {yellow Actual: {bold "${workerSupport.__compat.description || ""}"}}
       {green Expected: {bold "Available in workers"}}`);
   }

--- a/test/linter/test-links.js
+++ b/test/linter/test-links.js
@@ -29,7 +29,7 @@ function processData(filename, logger) {
     match => {
       // use https://bugzil.la/1000000 instead
       hasErrors = true;
-      logger.error(chalk`{red ${indexToPos(actual, match.index)} – Use shortenable URL ({yellow ${match[0]}} → {green {bold https://bugzil.la/}${match[1]}}).}`);
+      logger.error(chalk`{red → ${indexToPos(actual, match.index)} – Use shortenable URL ({yellow ${match[0]}} → {green {bold https://bugzil.la/}${match[1]}}).}`);
     }
   );
 
@@ -38,7 +38,7 @@ function processData(filename, logger) {
     match => {
       // use https://crbug.com/100000 instead
       hasErrors = true;
-      logger.error(chalk`{red ${indexToPos(actual, match.index)} – Use shortenable URL ({yellow ${match[0]}} → {green {bold https://crbug.com/}${match[1]}}).}`);
+      logger.error(chalk`{red → ${indexToPos(actual, match.index)} – Use shortenable URL ({yellow ${match[0]}} → {green {bold https://crbug.com/}${match[1]}}).}`);
     }
   );
 
@@ -47,7 +47,7 @@ function processData(filename, logger) {
     match => {
       // use https://webkit.org/b/100000 instead
       hasErrors = true;
-      logger.error(chalk`{red ${indexToPos(actual, match.index)} – Use shortenable URL ({yellow ${match[0]}} → {green {bold https://webkit.org/b/}${match[1]}}).}`);
+      logger.error(chalk`{red → ${indexToPos(actual, match.index)} – Use shortenable URL ({yellow ${match[0]}} → {green {bold https://webkit.org/b/}${match[1]}}).}`);
     }
   );
 
@@ -65,7 +65,7 @@ function processData(filename, logger) {
 
       if (protocol !== 'https') {
         hasErrors = true;
-        logger.error(chalk`{red ${indexToPos(actual, match.index)} – Use HTTPS URL ({yellow http://${domain}/${bugId}} → {green http{bold s}://${domain}/${bugId}}).}`);
+        logger.error(chalk`{red → ${indexToPos(actual, match.index)} – Use HTTPS URL ({yellow http://${domain}/${bugId}} → {green http{bold s}://${domain}/${bugId}}).}`);
       }
 
       if (domain !== 'bugzil.la') {
@@ -74,15 +74,15 @@ function processData(filename, logger) {
 
       if (/^bug $/.test(before)) {
         hasErrors = true;
-        logger.error(chalk`{red ${indexToPos(actual, match.index)} – Move word "bug" into link text ({yellow "${before}<a href='...'>${linkText}</a>"} → {green "<a href='...'>{bold ${before}}${bugId}</a>"}).}`);
+        logger.error(chalk`{red → ${indexToPos(actual, match.index)} – Move word "bug" into link text ({yellow "${before}<a href='...'>${linkText}</a>"} → {green "<a href='...'>{bold ${before}}${bugId}</a>"}).}`);
       } else if (linkText === `Bug ${bugId}`) {
         if (!/(\. |")$/.test(before)) {
           hasErrors = true;
-          logger.error(chalk`{red ${indexToPos(actual, match.index)} – Use lowercase "bug" word within sentence ({yellow "Bug ${bugId}"} → {green "{bold bug} ${bugId}"}).}`);
+          logger.error(chalk`{red → ${indexToPos(actual, match.index)} – Use lowercase "bug" word within sentence ({yellow "Bug ${bugId}"} → {green "{bold bug} ${bugId}"}).}`);
         }
       } else if (linkText !== `bug ${bugId}`) {
         hasErrors = true;
-        logger.error(chalk`{red ${indexToPos(actual, match.index)} – Use standard link text ({yellow "${linkText}"} → {green "bug ${bugId}"}).}`);
+        logger.error(chalk`{red → ${indexToPos(actual, match.index)} – Use standard link text ({yellow "${linkText}"} → {green "bug ${bugId}"}).}`);
       }
     }
   )
@@ -120,21 +120,21 @@ function processData(filename, logger) {
       if (protocol !== 'https') {
         hasErrors = true;
         logger.error(
-          chalk`{red ${pos} – Use HTTPS MDN URL ({yellow ${protocol}://developer.mozilla.org/${path}} → {green https://developer.mozilla.org/${expectedPath}}).}`,
+          chalk`{red → ${pos} – Use HTTPS MDN URL ({yellow ${protocol}://developer.mozilla.org/${path}} → {green https://developer.mozilla.org/${expectedPath}}).}`,
         );
       }
 
       if (subdomain) {
         hasErrors = true;
         logger.error(
-          chalk`{red ${pos} - Use correct MDN domain ({yellow ${protocol}://{red ${subdomain}}developer.mozilla.org/${path}} → {green https://developer.mozilla.org/${expectedPath}})}`,
+          chalk`{red → ${pos} - Use correct MDN domain ({yellow ${protocol}://{red ${subdomain}}developer.mozilla.org/${path}} → {green https://developer.mozilla.org/${expectedPath}})}`,
         );
       }
 
       if (path !== expectedPath) {
         hasErrors = true;
         logger.error(
-          chalk`{red ${pos} – Use ${
+          chalk`{red → ${pos} – Use ${
             locale ? 'non-localized' : 'correct'
           } MDN URL ({yellow ${url}} → {green https://developer.mozilla.org/${expectedPath}}).}`,
         );
@@ -146,7 +146,7 @@ function processData(filename, logger) {
     String.raw`https?://developer.microsoft.com/(\w\w-\w\w)/(.*?)(?=["'\s])`,
     match => {
       hasErrors = true;
-      logger.error(chalk`{red ${indexToPos(actual, match.index)} – Use non-localized Microsoft Developer URL ({yellow ${match[0]}} → {green https://developer.microsoft.com/${match[2]}}).}`);
+      logger.error(chalk`{red → ${indexToPos(actual, match.index)} – Use non-localized Microsoft Developer URL ({yellow ${match[0]}} → {green https://developer.microsoft.com/${match[2]}}).}`);
     }
   );
 

--- a/test/linter/test-links.js
+++ b/test/linter/test-links.js
@@ -186,7 +186,7 @@ function testLinks(filename) {
   if (errors.length) {
     console.error(chalk`{red   Links – {bold ${errors.length}} ${errors.length === 1 ? 'error' : 'errors'}:}`);
     for (const error of errors) {
-      console.error(`    ${error}`);
+      console.error(`  ${error}`);
     }
     return true;
   }

--- a/test/linter/test-prefix.js
+++ b/test/linter/test-prefix.js
@@ -6,7 +6,7 @@ function checkPrefix(data, category, errors, prefix, path="") {
   for (var key in data) {
     if (key === "prefix" && typeof(data[key]) === "string") {
       if (data[key].includes(prefix)) {
-        var error = chalk`{red {bold ${prefix}} prefix is wrong for key: {bold ${path}}}`;
+        var error = chalk`{red → {bold ${prefix}} prefix is wrong for key: {bold ${path}}}`;
         var rules = [
           category == "api" && !data[key].startsWith(prefix),
           category == "css" && !data[key].startsWith(`-${prefix}`)

--- a/test/linter/test-prefix.js
+++ b/test/linter/test-prefix.js
@@ -51,7 +51,7 @@ function testPrefix(filename) {
   if (errors.length) {
     console.error(chalk`{red   Prefix – {bold ${errors.length}} ${errors.length === 1 ? 'error' : 'errors'}:}`);
     for (const error of errors) {
-      console.error(`    ${error}`);
+      console.error(`  ${error}`);
     }
     return true;
   }

--- a/test/linter/test-real-values.js
+++ b/test/linter/test-real-values.js
@@ -59,15 +59,15 @@ function checkRealValues(supportData, blockList, relPath, logger) {
 
     for (const statement of supportStatements) {
       if (statement === undefined) {
-        logger.error(chalk`{red {bold ${browser}} must be defined for {bold ${relPath}}}`);
+        logger.error(chalk`{red → {bold ${browser}} must be defined for {bold ${relPath}}}`);
           hasErrors = true;
       } else {
         if ([true, null].includes(statement.version_added)) {
-          logger.error(chalk`{red {bold ${relPath}} - {bold ${browser}} no longer accepts {bold ${statement.version_added}} as a value}`);
+          logger.error(chalk`{red → {bold ${relPath}} - {bold ${browser}} no longer accepts {bold ${statement.version_added}} as a value}`);
           hasErrors = true;
         }
         if ([true, null].includes(statement.version_removed)) {
-          logger.error(chalk`{red {bold ${relPath}} - {bold ${browser}} no longer accepts} {bold ${statement.version_removed}} as a value}`);
+          logger.error(chalk`{red → {bold ${relPath}} - {bold ${browser}} no longer accepts} {bold ${statement.version_removed}} as a value}`);
           hasErrors = true;
         }
       }

--- a/test/linter/test-real-values.js
+++ b/test/linter/test-real-values.js
@@ -116,7 +116,7 @@ function testRealValues(filename) {
   if (errors.length) {
     console.error(chalk`{red   Real values – {bold ${errors.length}} ${errors.length === 1 ? 'error' : 'errors'}:}`);
     for (const error of errors) {
-      console.error(`    ${error}`);
+      console.error(`  ${error}`);
     }
     return true;
   }

--- a/test/linter/test-schema.js
+++ b/test/linter/test-schema.js
@@ -17,7 +17,7 @@ function testSchema(dataFilename, schemaFilename = './../../schemas/compat-data.
   const valid = ajv.validate(schema, data);
 
   if (!valid) {
-    console.error(chalk`{red   {bold JSON Schema} – {bold ${ajv.errors.length}} ${ajv.errors.length === 1 ? 'error' : 'errors'}:}`);
+    console.error(chalk`{red   JSON Schema – {bold ${ajv.errors.length}} ${ajv.errors.length === 1 ? 'error' : 'errors'}:}`);
     // Output messages by one since better-ajv-errors wrongly joins messages
     // (see https://github.com/atlassian/better-ajv-errors/pull/21)
     ajv.errors.forEach(e => {

--- a/test/linter/test-style.js
+++ b/test/linter/test-style.js
@@ -73,29 +73,29 @@ function processData(filename, logger) {
 
   if (actual !== expected) {
     hasErrors = true;
-    logger.error(chalk`{red Error on ${jsonDiff(actual, expected)}}`);
+    logger.error(chalk`{red → Error on ${jsonDiff(actual, expected)}}`);
   }
 
   if (expected !== expectedBrowserSorting) {
     hasErrors = true;
-    logger.error(chalk`{red Browser sorting error on ${jsonDiff(actual, expectedBrowserSorting)}}\n{blue     Tip: Run {bold npm run fix} to fix sorting automatically}`);
+    logger.error(chalk`{red → Browser sorting error on ${jsonDiff(actual, expectedBrowserSorting)}}\n{blue     Tip: Run {bold npm run fix} to fix sorting automatically}`);
   }
 
   if (expected !== expectedFeatureSorting) {
     hasErrors = true;
-    logger.error(chalk`{red Feature sorting error on ${jsonDiff(actual, expectedFeatureSorting)}}\n{blue     Tip: Run {bold npm run fix} to fix sorting automatically}`);
+    logger.error(chalk`{red → Feature sorting error on ${jsonDiff(actual, expectedFeatureSorting)}}\n{blue     Tip: Run {bold npm run fix} to fix sorting automatically}`);
   }
 
   let constructorMatch = actual.match(String.raw`"<code>([^)]*?)</code> constructor"`)
   if (constructorMatch) {
     hasErrors = true;
-    logger.error(chalk`{red ${indexToPos(actual, constructorMatch.index)} – Use parentheses in constructor description ({yellow ${constructorMatch[1]}} → {green ${constructorMatch[1]}{bold ()}}).}`);
+    logger.error(chalk`{red → ${indexToPos(actual, constructorMatch.index)} – Use parentheses in constructor description ({yellow ${constructorMatch[1]}} → {green ${constructorMatch[1]}{bold ()}}).}`);
   }
 
   let hrefDoubleQuoteIndex = actual.indexOf('href=\\"');
   if (hrefDoubleQuoteIndex >= 0) {
     hasErrors = true;
-    logger.error(chalk`{red ${indexToPos(actual, hrefDoubleQuoteIndex)} - Found {yellow \\"}, but expected {green \'} for <a href>.}`);
+    logger.error(chalk`{red → ${indexToPos(actual, hrefDoubleQuoteIndex)} - Found {yellow \\"}, but expected {green \'} for <a href>.}`);
   }
 
   const regexp = new RegExp(String.raw`<a href='([^'>]+)'>((?:.(?!</a>))*.)</a>`, 'g');
@@ -104,7 +104,7 @@ function processData(filename, logger) {
     var a_url = url.parse(match[1]);
     if (a_url.hostname === null) {
       hasErrors = true;
-      logger.error(chalk`{red ${indexToPos(actual, constructorMatch.index)} - Include hostname in URL ({yellow ${match[1]}} → {green {bold https://developer.mozilla.org/}${match[1]}}).}`);
+      logger.error(chalk`{red → ${indexToPos(actual, constructorMatch.index)} - Include hostname in URL ({yellow ${match[1]}} → {green {bold https://developer.mozilla.org/}${match[1]}}).}`);
     }
   }
 

--- a/test/linter/test-style.js
+++ b/test/linter/test-style.js
@@ -126,7 +126,7 @@ function testStyle(filename) {
   if (errors.length) {
     console.error(chalk`{red   Style – {bold ${errors.length}} ${errors.length === 1 ? 'error' : 'errors'}:}`);
     for (const error of errors) {
-      console.error(`    ${error}`);
+      console.error(`  ${error}`);
     }
     return true;
   }

--- a/test/linter/test-versions.js
+++ b/test/linter/test-versions.js
@@ -60,11 +60,11 @@ function checkVersions(supportData, relPath, logger) {
 
       for (const statement of supportStatements) {
         if (!isValidVersion(browser, statement.version_added)) {
-          logger.error(chalk`{red {bold ${relPath}} - {bold version_added: "${statement.version_added}"} is {bold NOT} a valid version number for {bold ${browser}}\n    Valid {bold ${browser}} versions are: ${validBrowserVersionsString}}`);
+          logger.error(chalk`{red → {bold ${relPath}} - {bold version_added: "${statement.version_added}"} is {bold NOT} a valid version number for {bold ${browser}}\n    Valid {bold ${browser}} versions are: ${validBrowserVersionsString}}`);
           hasErrors = true;
         }
         if (!isValidVersion(browser, statement.version_removed)) {
-          logger.error(chalk`{red {bold ${relPath}} - {bold version_removed: "${statement.version_removed}"} is {bold NOT} a valid version number for {bold ${browser}}\n    Valid {bold ${browser}} versions are: ${validBrowserVersionsString}}`);
+          logger.error(chalk`{red → {bold ${relPath}} - {bold version_removed: "${statement.version_removed}"} is {bold NOT} a valid version number for {bold ${browser}}\n    Valid {bold ${browser}} versions are: ${validBrowserVersionsString}}`);
           hasErrors = true;
         }
         if ('version_removed' in statement && 'version_added' in statement) {
@@ -72,7 +72,7 @@ function checkVersions(supportData, relPath, logger) {
             typeof statement.version_added !== 'string' &&
             statement.version_added !== true
           ) {
-            logger.error(chalk`{red {bold ${relPath}} - {bold version_added: "${statement.version_added}"} is {bold NOT} a valid version number for {bold ${browser}} when {bold version_removed} is present\n    Valid {bold ${browser}} versions are: ${validBrowserVersionsTruthy}}`);
+            logger.error(chalk`{red → {bold ${relPath}} - {bold version_added: "${statement.version_added}"} is {bold NOT} a valid version number for {bold ${browser}} when {bold version_removed} is present\n    Valid {bold ${browser}} versions are: ${validBrowserVersionsTruthy}}`);
             hasErrors = true;
           } else if (typeof statement.version_added === 'string' && typeof statement.version_removed === 'string') {
             if (
@@ -84,7 +84,7 @@ function checkVersions(supportData, relPath, logger) {
                 compareVersions.compare(statement.version_added.replace("≤", ""), statement.version_removed.replace("≤", ""), ">=")
               )
             ) {
-              logger.error(chalk`{red {bold ${relPath}} - {bold version_removed: "${statement.version_removed}"} must be greater than {bold version_added: "${statement.version_added}"}}`);
+              logger.error(chalk`{red → {bold ${relPath}} - {bold version_removed: "${statement.version_removed}"} must be greater than {bold version_added: "${statement.version_added}"}}`);
               hasErrors = true;
             }
           }

--- a/test/linter/test-versions.js
+++ b/test/linter/test-versions.js
@@ -132,7 +132,7 @@ function testVersions(filename) {
   if (errors.length) {
     console.error(chalk`{red   Versions – {bold ${errors.length}} ${errors.length === 1 ? 'error' : 'errors'}:}`);
     for (const error of errors) {
-      console.error(`    ${error}`);
+      console.error(`  ${error}`);
     }
     return true;
   }

--- a/test/test-compare-features.js
+++ b/test/test-compare-features.js
@@ -28,7 +28,7 @@ const testFeatureOrder = () => {
 
   if (errors) {
     console.error(chalk`{red compareFeatures() – {bold 1} error:}`);
-    console.error(chalk`{red   Actual and expected orders do not match}`);
+    console.error(chalk`{red   → Actual and expected orders do not match}`);
     console.error(chalk`{yellow     Actual: {bold ${actual}}}`);
     console.error(chalk`{green     Expected: {bold ${expected}}}`);
     return true;


### PR DESCRIPTION
This PR provides a little standardization of linter styling to maintain consistency across the linter output.  This provides a few updates:

- Adds a "→" for bullet points for each error
- Fixes the use of bold in test-schema.js
- Adds coloring to a statement initially lacking any