### PR TITLE
Update Samsung Internet Data, Updating folder browsers/

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -140,6 +140,18 @@
           "status": "current",
           "engine": "Blink",
           "engine_version": "67"
+        },
+        "10.0": {
+          "release_date": "2019-08-22",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "71"
+        },
+        "10.2": {
+          "release_date": "2019-10-09",
+          "status": "beta",
+          "engine": "Blink",
+          "engine_version": "71"
         }
       }
     }


### PR DESCRIPTION
This is to add Samsung Internet version 10.0 and 10.2 to the browsers json as part of #5028.