### PR TITLE
Adding compatibility data for allowHttpErrors

### DIFF
--- a/webextensions/api/downloads.json
+++ b/webextensions/api/downloads.json
@@ -710,6 +710,27 @@
               }
             }
           },
+          "allowHttpErrors": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "71"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
           "body": {
             "__compat": {
               "support": {


### PR DESCRIPTION
Adding compatibility data for allowHttpErrors as an option property for downloads.download() as per [downloads API: Allow extensions a way to download ignoring HTTP errors](https://bugzilla.mozilla.org/show_bug.cgi?id=1578955)

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
