### PR TITLE
Update blockMany to include all browsers displayed on MDN

### DIFF
--- a/test/linter/test-real-values.js
+++ b/test/linter/test-real-values.js
@@ -21,6 +21,7 @@ const blockMany = [
   'opera_android',
   'safari',
   'safari_ios',
+  'samsunginternet_android',
   'webview_android'
 ];
 
@@ -34,7 +35,7 @@ const blockList = {
   svg: [],
   javascript: ['edge', 'firefox', 'firefox_android', 'ie'],
   mathml: blockMany,
-  webdriver: blockMany.concat(['samsunginternet_android']),
+  webdriver: blockMany,
   webextensions: [],
   xpath: [],
   xslt: []


### PR DESCRIPTION
Samsung has provided data for mathml, so I'd like to have `blockMany` contain all browsers displayed on MDN (except nodejs, which will have to add to the `javascript` blockList once it is complete).