### PR TITLE
CSS motion path updates

### DIFF
--- a/css/properties/offset-path.json
+++ b/css/properties/offset-path.json
@@ -146,6 +146,54 @@
               "deprecated": false
             }
           }
+        },
+        "ray-support": {
+          "__compat": {
+            "description": "Supports the <code>ray()</code> function as a value",
+            "support": {
+              "chrome": {
+                "version_added": "64"
+              },
+              "chrome_android": {
+                "version_added": "64"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "71"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "51"
+              },
+              "opera_android": {
+                "version_added": "47"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": "64"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/offset.json
+++ b/css/properties/offset.json
@@ -27,7 +27,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "71"
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
Firefox 71 supports the `offset` shorthand: https://bugzilla.mozilla.org/show_bug.cgi?id=1567330

Firefox 71 also supports the `ray()` function for `offset-path`: https://bugzilla.mozilla.org/show_bug.cgi?id=1480665

It appears that Chrome also supports `ray()` from Chrome 64: https://chromestatus.com/feature/5198375053950976 (tracking bug is linked).
