### PR TITLE
Firefox drops mode attribute; Safari never supported it

### DIFF
--- a/mathml/elements/math.json
+++ b/mathml/elements/math.json
@@ -322,7 +322,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "70"
               },
               "firefox_android": {
                 "version_added": "4"
@@ -337,10 +338,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "5.1"
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": "5.1"
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1573438 and https://bugzilla.mozilla.org/show_bug.cgi?id=1573438#c8 for Safari.