### PR TITLE
Fix engine version for Samsung Internet 1.0

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -6,8 +6,8 @@
         "1.0": {
           "release_date": "2013-04-27",
           "status": "retired",
-          "engine": "Blink",
-          "engine_version": "18"
+          "engine": "WebKit",
+          "engine_version": "535.19"
         },
         "1.5": {
           "release_date": "2013-09-25",


### PR DESCRIPTION
Blink 18 doesn't actually exist.  This PR adds the proper WebKit version to Samsung Internet 1.0 in the browser data.