### PR TITLE
Mirror Chrome Android -> Samsung Internet for xslt/elements/stylesheet

### DIFF
--- a/xslt/elements/stylesheet.json
+++ b/xslt/elements/stylesheet.json
@@ -36,7 +36,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -231,7 +231,7 @@
                 "version_added": "3"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"


### PR DESCRIPTION
This is a follow-up to #5041 that replaces the `true` values in the file with their actual version number.

(The changes in this PR are a test run for the mirroring script introduced in #4729.)