### PR TITLE
Mirror Chrome Android -> Samsung Internet for svg/*

### DIFF
--- a/svg/elements/altGlyph.json
+++ b/svg/elements/altGlyph.json
@@ -38,7 +38,7 @@
               "version_added": "4"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4"

--- a/svg/elements/animate.json
+++ b/svg/elements/animate.json
@@ -36,7 +36,7 @@
               "version_added": "4"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4"

--- a/svg/elements/cursor.json
+++ b/svg/elements/cursor.json
@@ -36,7 +36,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4"

--- a/svg/elements/defs.json
+++ b/svg/elements/defs.json
@@ -36,7 +36,7 @@
               "version_added": "3.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "3"

--- a/svg/elements/desc.json
+++ b/svg/elements/desc.json
@@ -36,7 +36,7 @@
               "version_added": "3.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "3"

--- a/svg/elements/filter.json
+++ b/svg/elements/filter.json
@@ -36,7 +36,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/svg/elements/font.json
+++ b/svg/elements/font.json
@@ -54,8 +54,8 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "version_removed": true
+              "version_added": "1.0",
+              "version_removed": "3.0"
             },
             "webview_android": {
               "version_added": "3",

--- a/svg/elements/foreignObject.json
+++ b/svg/elements/foreignObject.json
@@ -36,7 +36,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4"
@@ -82,7 +82,7 @@
                 "version_added": "3"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -129,7 +129,7 @@
                 "version_added": "3"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -176,7 +176,7 @@
                 "version_added": "3"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -223,7 +223,7 @@
                 "version_added": "3"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"

--- a/svg/elements/image.json
+++ b/svg/elements/image.json
@@ -36,7 +36,7 @@
               "version_added": "3.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "3"

--- a/svg/elements/linearGradient.json
+++ b/svg/elements/linearGradient.json
@@ -36,7 +36,7 @@
               "version_added": "3.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "3"

--- a/svg/elements/radialGradient.json
+++ b/svg/elements/radialGradient.json
@@ -36,7 +36,7 @@
               "version_added": "3.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "3"

--- a/svg/elements/script.json
+++ b/svg/elements/script.json
@@ -36,7 +36,7 @@
               "version_added": "3.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "3"

--- a/svg/elements/stop.json
+++ b/svg/elements/stop.json
@@ -36,7 +36,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "3"
@@ -82,7 +82,7 @@
                 "version_added": "3"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "3"
@@ -129,7 +129,7 @@
                 "version_added": "3"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "3"
@@ -176,7 +176,7 @@
                 "version_added": "3"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "3"

--- a/svg/elements/style.json
+++ b/svg/elements/style.json
@@ -36,7 +36,7 @@
               "version_added": "3.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "3"

--- a/svg/elements/switch.json
+++ b/svg/elements/switch.json
@@ -36,7 +36,7 @@
               "version_added": "3.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "3"

--- a/svg/elements/symbol.json
+++ b/svg/elements/symbol.json
@@ -36,7 +36,7 @@
               "version_added": "3.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "3"

--- a/svg/elements/textpath.json
+++ b/svg/elements/textpath.json
@@ -88,7 +88,8 @@
                 "notes": "Only accepts references to path elements. Basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": true,
+                "notes": "Only accepts references to path elements. Basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
               },
               "webview_android": {
                 "version_added": true,


### PR DESCRIPTION
This is a follow-up to #5040 that replaces the `true` values in the file with their actual version number.  It also copies over a note in `svg/elements/textpath.json` that was omitted.

(The changes in this PR are a test run for the mirroring script introduced in #4729.)