### PR TITLE
Update spec URLs for flatMap and flat methods

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -504,7 +504,7 @@
         "flat": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/flat",
-            "spec_url": "https://tc39.es/proposal-flatMap/#sec-Array.prototype.flat",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.flat",
             "support": {
               "chrome": {
                 "version_added": "69"
@@ -556,7 +556,7 @@
         "flatMap": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap",
-            "spec_url": "https://tc39.es/proposal-flatMap/#sec-Array.prototype.flatMap",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.flatmap",
             "support": {
               "chrome": {
                 "version_added": "69"


### PR DESCRIPTION
Array.prototype.flatMap and Array.prototype.flat are now in the ECMAScript spec (they were previously in a draft proposal). So this change updates their associated spec URLs.