### PR TITLE
Update Chromium versions for JavaScript functions

### DIFF
--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -7,10 +7,10 @@
           "spec_url": "https://tc39.es/ecma262/#sec-function-objects",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -40,10 +40,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -58,10 +58,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-function.prototype.apply",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -91,10 +91,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -108,10 +108,10 @@
               "description": "ES 5.1: generic array-like object as <code>arguments</code>",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "17"
                 },
                 "chrome_android": {
-                  "version_added": true
+                  "version_added": "18"
                 },
                 "edge": {
                   "version_added": "12"
@@ -126,13 +126,13 @@
                   "version_added": "9"
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "opera": {
                   "version_added": true
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "safari": {
                   "version_added": null
@@ -141,10 +141,10 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
-                  "version_added": true
+                  "version_added": "1.0"
                 },
                 "webview_android": {
-                  "version_added": true
+                  "version_added": "≤37"
                 }
               },
               "status": {
@@ -161,10 +161,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-arguments-object",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -194,10 +194,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -316,10 +316,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-function.prototype.call",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -349,10 +349,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -367,10 +367,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/caller",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -400,10 +400,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -523,10 +523,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-function-instances-length",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -556,10 +556,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -573,10 +573,10 @@
               "description": "Configurable: true",
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": "43"
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": "43"
                 },
                 "edge": {
                   "version_added": "12"
@@ -591,13 +591,13 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "30"
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": "30"
                 },
                 "safari": {
                   "version_added": null
@@ -606,10 +606,10 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "4.0"
                 },
                 "webview_android": {
-                  "version_added": null
+                  "version_added": "43"
                 }
               },
               "status": {
@@ -782,10 +782,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-function-instances-prototype",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -815,10 +815,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -888,10 +888,10 @@
             ],
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -921,10 +921,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {

--- a/javascript/builtins/GeneratorFunction.json
+++ b/javascript/builtins/GeneratorFunction.json
@@ -7,10 +7,10 @@
           "spec_url": "https://tc39.es/ecma262/#sec-generatorfunction-objects",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "39"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "39"
             },
             "edge": {
               "version_added": "13"
@@ -25,13 +25,13 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": null
-            },
-            "opera": {
               "version_added": true
             },
+            "opera": {
+              "version_added": "26"
+            },
             "opera_android": {
-              "version_added": null
+              "version_added": "26"
             },
             "safari": {
               "version_added": null
@@ -40,10 +40,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "39"
             }
           },
           "status": {
@@ -58,10 +58,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-generatorfunction.prototype",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "39"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "39"
               },
               "edge": {
                 "version_added": "13"
@@ -76,13 +76,13 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
-              },
-              "opera": {
                 "version_added": true
               },
+              "opera": {
+                "version_added": "26"
+              },
               "opera_android": {
-                "version_added": null
+                "version_added": "26"
               },
               "safari": {
                 "version_added": null
@@ -91,10 +91,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "39"
               }
             },
             "status": {

--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -6,10 +6,10 @@
         "spec_url": "https://tc39.es/ecma262/#sec-function-definitions",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -39,10 +39,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -57,10 +57,10 @@
           "spec_url": "https://tc39.es/ecma262/#sec-arguments-exotic-objects",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -90,10 +90,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -108,10 +108,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-arguments-exotic-objects",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -141,10 +141,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -212,10 +212,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-arguments-exotic-objects",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -245,10 +245,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {


### PR DESCRIPTION
This PR updates the Chrome data for JavaScript functions and function built-ins.  Data is as follows:

javascript.builtins.Function - 1
javascript.builtins.Function.apply - 1
javascript.builtins.Function.apply.generic_arrays_as_arguments - 17
javascript.builtins.Function.arguments - 1
javascript.builtins.Function.call - 1
javascript.builtins.Function.caller - 1
javascript.builtins.Function.length - 1
javascript.builtins.Function.length.configurable_true - 43
javascript.builtins.Function.prototype - 1
javascript.builtins.Function.toString - 1
javascript.builtins.GeneratorFunction - 39
javascript.builtins.GeneratorFunction.prototype - 39
javascript.functions - 1
javascript.functions.arguments - 1
javascript.functions.arguments.callee - 1
javascript.functions.arguments.length - 1