### PR TITLE
Update Chromium versions for JavaScript Number built-ins

### DIFF
--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -7,10 +7,10 @@
           "spec_url": "https://tc39.es/ecma262/#sec-number-objects",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -40,10 +40,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -58,10 +58,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-number.epsilon",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "34"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "34"
               },
               "edge": {
                 "version_added": "12"
@@ -79,10 +79,10 @@
                 "version_added": "0.12"
               },
               "opera": {
-                "version_added": true
+                "version_added": "21"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "21"
               },
               "safari": {
                 "version_added": "9"
@@ -91,10 +91,10 @@
                 "version_added": "9"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -162,10 +162,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-number.max_value",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -195,10 +195,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -266,10 +266,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-number.min_value",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -299,10 +299,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -318,10 +318,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-number.nan",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -351,10 +351,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -370,10 +370,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-number.negative_infinity",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -403,10 +403,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -422,10 +422,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-number.positive_infinity",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -455,10 +455,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -526,10 +526,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-number.isinteger",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "34"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "34"
               },
               "edge": {
                 "version_added": "12"
@@ -547,10 +547,10 @@
                 "version_added": "0.12"
               },
               "opera": {
-                "version_added": true
+                "version_added": "21"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "21"
               },
               "safari": {
                 "version_added": true
@@ -559,10 +559,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -630,10 +630,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-number.issafeinteger",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "34"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "34"
               },
               "edge": {
                 "version_added": "12"
@@ -651,10 +651,10 @@
                 "version_added": "0.12"
               },
               "opera": {
-                "version_added": true
+                "version_added": "21"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "21"
               },
               "safari": {
                 "version_added": "10"
@@ -663,10 +663,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -682,10 +682,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-number.parsefloat",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "34"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "34"
               },
               "edge": {
                 "version_added": "12"
@@ -703,10 +703,10 @@
                 "version_added": "0.12"
               },
               "opera": {
-                "version_added": true
+                "version_added": "21"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "21"
               },
               "safari": {
                 "version_added": "9"
@@ -715,10 +715,10 @@
                 "version_added": "9"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -734,10 +734,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-number.parseint",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "34"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "34"
               },
               "edge": {
                 "version_added": "12"
@@ -755,10 +755,10 @@
                 "version_added": "0.12"
               },
               "opera": {
-                "version_added": true
+                "version_added": "21"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "21"
               },
               "safari": {
                 "version_added": "9"
@@ -767,10 +767,10 @@
                 "version_added": "9"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -786,10 +786,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-properties-of-the-number-prototype-object",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -819,10 +819,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -838,10 +838,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-number.prototype.toexponential",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -871,10 +871,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -890,10 +890,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-number.prototype.tofixed",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -923,10 +923,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -998,10 +998,10 @@
             ],
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1031,10 +1031,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -1150,10 +1150,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-number.prototype.toprecision",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1183,10 +1183,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -1253,10 +1253,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-number.prototype.tostring",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1286,10 +1286,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -1305,10 +1305,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-number.prototype.valueof",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1338,10 +1338,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {


### PR DESCRIPTION
This PR updates the Chrome data for the JavaScript Number built-ins.  Data is as follows:

javascript.builtins.Number - 1
javascript.builtins.Number.EPSILON - 34
javascript.builtins.Number.MAX_VALUE - 1
javascript.builtins.Number.MIN_VALUE - 1
javascript.builtins.Number.NaN - 1
javascript.builtins.Number.NEGATIVE_INFINITY - 1
javascript.builtins.Number.POSITIVE_INFINITY - 1
javascript.builtins.Number.isInteger - 34
javascript.builtins.Number.isSafeInteger - 34
javascript.builtins.Number.parseFloat - 34
javascript.builtins.Number.parseInt - 34
javascript.builtins.Number.prototype - 1
javascript.builtins.Number.toExponential - 1
javascript.builtins.Number.toFixed - 1
javascript.builtins.Number.toLocaleString - 1
javascript.builtins.Number.toPrecision - 1
javascript.builtins.Number.toString - 1
javascript.builtins.Number.valueOf - 1