### PR TITLE
Update BigInt spec URLs

### DIFF
--- a/javascript/builtins/BigInt.json
+++ b/javascript/builtins/BigInt.json
@@ -4,7 +4,7 @@
       "BigInt": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt",
-          "spec_url": "https://tc39.es/proposal-bigint/#sec-bigint-objects",
+          "spec_url": "https://tc39.es/ecma262/#sec-bigint-objects",
           "support": {
             "chrome": {
               "version_added": "67"
@@ -55,7 +55,7 @@
         "asIntN": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt/asIntN",
-            "spec_url": "https://tc39.es/proposal-bigint/#sec-bigint.asintn",
+            "spec_url": "https://tc39.es/ecma262/#sec-bigint.asintn",
             "support": {
               "chrome": {
                 "version_added": "67"
@@ -107,7 +107,7 @@
         "asUintN": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt/asUintN",
-            "spec_url": "https://tc39.es/proposal-bigint/#sec-bigint.asuintn",
+            "spec_url": "https://tc39.es/ecma262/#sec-bigint.asuintn",
             "support": {
               "chrome": {
                 "version_added": "67"
@@ -159,7 +159,7 @@
         "prototype": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt/prototype",
-            "spec_url": "https://tc39.es/proposal-bigint/#sec-bigint.prototype",
+            "spec_url": "https://tc39.es/ecma262/#sec-bigint.prototype",
             "support": {
               "chrome": {
                 "version_added": "67"
@@ -363,7 +363,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt/toString",
-            "spec_url": "https://tc39.es/proposal-bigint/#sec-bigint.prototype.tostring",
+            "spec_url": "https://tc39.es/ecma262/#sec-bigint.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": "67"
@@ -415,7 +415,7 @@
         "valueOf": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt/valueOf",
-            "spec_url": "https://tc39.es/proposal-bigint/#sec-bigint.prototype.valueof",
+            "spec_url": "https://tc39.es/ecma262/#sec-bigint.prototype.valueof",
             "support": {
               "chrome": {
                 "version_added": "67"

--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -262,7 +262,7 @@
         "getBigInt64": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getBigInt64",
-            "spec_url": "https://tc39.es/proposal-bigint/#sec-dataview.prototype.getbigint64",
+            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.getbigint64",
             "support": {
               "chrome": {
                 "version_added": "67"
@@ -314,7 +314,7 @@
         "getBigUint64": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getBigUint64",
-            "spec_url": "https://tc39.es/proposal-bigint/#sec-dataview.prototype.getbiguint64",
+            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.getbiguint64",
             "support": {
               "chrome": {
                 "version_added": "67"
@@ -885,7 +885,7 @@
         "setBigInt64": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setBigInt64",
-            "spec_url": "https://tc39.es/proposal-bigint/#sec-dataview.prototype.setbigint64",
+            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.setbigint64",
             "support": {
               "chrome": {
                 "version_added": "67"
@@ -937,7 +937,7 @@
         "setBigUint64": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setBigUint64",
-            "spec_url": "https://tc39.es/proposal-bigint/#sec-dataview.prototype.setbiguint64",
+            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype.setbiguint64",
             "support": {
               "chrome": {
                 "version_added": "67"


### PR DESCRIPTION
BigInt is now in the ECMAScript spec (it were previously in a draft proposal), so this change updates its associated spec URLs.