### PR TITLE
Update Chromium versions for JavaScript Object built-ins

### DIFF
--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -298,13 +298,13 @@
                 "version_added": true
               },
               "safari_ios": {
-                "version_added": "1.0"
+                "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": "1"
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -458,13 +458,13 @@
                 "version_added": true
               },
               "safari_ios": {
-                "version_added": "1.0"
+                "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": "1"
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -7,10 +7,10 @@
           "spec_url": "https://tc39.es/ecma262/#sec-object-objects",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -40,10 +40,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -110,10 +110,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.constructor",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -143,10 +143,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -267,10 +267,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.__defineGetter__",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -298,10 +298,10 @@
                 "version_added": true
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1"
               },
               "webview_android": {
                 "version_added": true
@@ -427,10 +427,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.__defineSetter__",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -458,10 +458,10 @@
                 "version_added": true
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1"
               },
               "webview_android": {
                 "version_added": true
@@ -1021,10 +1021,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.hasownproperty",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1054,10 +1054,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -1229,10 +1229,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.isprototypeof",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1262,10 +1262,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -1386,10 +1386,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.__lookupGetter__",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1419,10 +1419,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -1439,10 +1439,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.__lookupSetter__",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1472,10 +1472,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -1752,10 +1752,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.propertyisenumerable",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1785,10 +1785,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -1805,10 +1805,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-additional-properties-of-the-object.prototype-object",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1838,10 +1838,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -1857,10 +1857,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-object.prototype",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1890,10 +1890,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -2013,10 +2013,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.tolocalestring",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -2046,10 +2046,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -2116,10 +2116,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.tostring",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -2149,10 +2149,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -2273,10 +2273,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.valueof",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -2306,10 +2306,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {


### PR DESCRIPTION
This PR updates the Chrome data for the JavaScript Object built-in.  Data is as follows:

javascript.builtins.Object - 1
javascript.builtins.Object.constructor - 1
javascript.builtins.Object.defineGetter - 1
javascript.builtins.Object.defineSetter - 1
javascript.builtins.Object.hasOwnProperty - 1
javascript.builtins.Object.isPrototypeOf - 1
javascript.builtins.Object.lookupGetter - 1
javascript.builtins.Object.lookupSetter - 1
javascript.builtins.Object.propertyIsEnumerable - 1
javascript.builtins.Object.proto - 1
javascript.builtins.Object.prototype - 1
javascript.builtins.Object.toLocaleString - 1
javascript.builtins.Object.toString - 1
javascript.builtins.Object.valueOf - 1