### PR TITLE
feat(css): Add the CSS4 behaviour of `:empty`

### DIFF
--- a/css/selectors/blank.json
+++ b/css/selectors/blank.json
@@ -16,7 +16,8 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1197736'>bug 1197736</a>."
             },
             "firefox_android": {
               "version_added": false

--- a/css/selectors/empty.json
+++ b/css/selectors/empty.json
@@ -48,6 +48,55 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "matches_whitespace": {
+          "__compat": {
+            "description": "Matches elements with whitespace",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1106296'>bug 1106296</a>."
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
This adds the **“matches elements with whitespace”** behaviour [from CSS4 to `:empty`](https://drafts.csswg.org/selectors-4/#the-empty-pseudo).