### PR TITLE
Update Edge data for api.Element.scrollIntoView

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -6511,7 +6511,7 @@
             "edge": [
               {
                 "version_added": "18",
-                "notes": "No support for <code>smooth</code> behavior."
+                "notes": "The only parameter supported is <code>alignToTop</code>."
               },
               {
                 "version_added": "12",
@@ -6574,7 +6574,7 @@
                 "notes": "The <code>block</code> and <code>inline</code> options support the values <code>start</code>, <code>center</code>, <code>end</code>, <code>nearest</code>."
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "36",


### PR DESCRIPTION
Supersedes #4866.  This applies the Edge data after requested changes have been made.  Opera changes were omitted as they are inconsistent with Chrome's data.