### PR TITLE
Update PaymentResponse.retry().

### DIFF
--- a/api/PaymentResponse.json
+++ b/api/PaymentResponse.json
@@ -706,10 +706,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/retry",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "78"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "78"
             },
             "edge": {
               "version_added": null


### PR DESCRIPTION
I'm not sure why this had 69, but it's not true.

https://www.chromestatus.com/feature/6559988684161024