### PR TITLE
Update Date.toLocaleString (and related) for Nodejs

### DIFF
--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -2678,7 +2678,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "13"
+                  "version_added": "13.0.0"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2728,7 +2728,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "13"
+                  "version_added": "13.0.0"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2778,7 +2778,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "13"
+                  "version_added": "13.0.0"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2884,7 +2884,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "13"
+                  "version_added": "13.0.0"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2934,7 +2934,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "13"
+                  "version_added": "13.0.0"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2984,7 +2984,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "13"
+                  "version_added": "13.0.0"
                 },
                 "opera": {
                   "version_added": "15"

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -2470,7 +2470,7 @@
                 },
                 "nodejs": {
                   "version_added": "0.12",
-                  "notes": "Prior to Nodejs 13 only the locale data for 'en-us' is available, by default.  When other English locales are specified, the function silently falls back to 'en-us' (so date formats will be incorrect but may appear correct).  When other languages are specified, it throws a RangeError.  In order to make full ICU (locale) data available for versions prior to 13, see docs on '--with-full-icu=' flag and how to provide the data."
+                  "notes": "Prior to NodeJS 13, only the locale data for <code>en-us</code> is available by default.  When other English locales are specified, the function silently falls back to <code>en-us</code>.  When other languages are specified, it throws a <code>RangeError</code>.  In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
                 },
                 "opera": {
                   "version_added": "15"

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -2369,7 +2369,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": null
+                "version_added": true
               },
               "opera": {
                 "version_added": true
@@ -2419,7 +2419,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "13"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2469,7 +2469,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "13"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2519,7 +2519,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "13"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2628,7 +2628,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": null
+                "version_added": true
               },
               "opera": {
                 "version_added": true
@@ -2678,7 +2678,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "13"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2728,7 +2728,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "13"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2778,7 +2778,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "13"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2834,7 +2834,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": null
+                "version_added": true
               },
               "opera": {
                 "version_added": true
@@ -2884,7 +2884,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "13"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2934,7 +2934,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "13"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2984,7 +2984,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "13"
                 },
                 "opera": {
                   "version_added": "15"

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -2419,7 +2419,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "13.0.0"
+                  "version_added": "true"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2469,7 +2469,8 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "13.0.0"
+                  "version_added": "0.12",
+                  "notes": "Prior to Nodejs 13 only the locale data for 'en-us' is available, by default.  When other English locales are specified, the function silently falls back to 'en-us' (so date formats will be incorrect but may appear correct).  When other languages are specified, it throws a RangeError.  In order to make full ICU (locale) data available for versions prior to 13, see docs on '--with-full-icu=' flag and how to provide the data."
                 },
                 "opera": {
                   "version_added": "15"
@@ -2519,7 +2520,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "13.0.0"
+                  "version_added": "true"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2678,7 +2679,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "13.0.0"
+                  "version_added": "true"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2728,7 +2729,8 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "13.0.0"
+                  "version_added": "0.12",
+                  "notes": "Prior to Nodejs 13 only the locale data for 'en-us' is available, by default.  When other English locales are specified, the function silently falls back to 'en-us' (so date formats will be incorrect but may appear correct).  When other languages are specified, it throws a RangeError.  In order to make full ICU (locale) data available for versions prior to 13, see docs on '--with-full-icu=' flag and how to provide the data."
                 },
                 "opera": {
                   "version_added": "15"
@@ -2778,7 +2780,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "13.0.0"
+                  "version_added": "true"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2884,7 +2886,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "13.0.0"
+                  "version_added": "true"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2934,7 +2936,8 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "13.0.0"
+                  "version_added": "0.12",
+                  "notes": "Prior to Nodejs 13 only the locale data for 'en-us' is available, by default.  When other English locales are specified, the function silently falls back to 'en-us'.  When other languages are specified, it throws a RangeError.  In order to make full ICU (locale) data available for versions prior to 13, see docs on '--with-full-icu=' flag and how to provide the data."
                 },
                 "opera": {
                   "version_added": "15"
@@ -2984,7 +2987,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "13.0.0"
+                  "version_added": "true"
                 },
                 "opera": {
                   "version_added": "15"

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -2419,7 +2419,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "13"
+                  "version_added": "13.0.0"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2469,7 +2469,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "13"
+                  "version_added": "13.0.0"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2519,7 +2519,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "13"
+                  "version_added": "13.0.0"
                 },
                 "opera": {
                   "version_added": "15"

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -2730,7 +2730,7 @@
                 },
                 "nodejs": {
                   "version_added": "0.12",
-                  "notes": "Prior to Nodejs 13 only the locale data for 'en-us' is available, by default.  When other English locales are specified, the function silently falls back to 'en-us' (so date formats will be incorrect but may appear correct).  When other languages are specified, it throws a RangeError.  In order to make full ICU (locale) data available for versions prior to 13, see docs on '--with-full-icu=' flag and how to provide the data."
+                  "notes": "Prior to NodeJS 13, only the locale data for <code>en-us</code> is available by default.  When other English locales are specified, the function silently falls back to <code>en-us</code>.  When other languages are specified, it throws a <code>RangeError</code>.  In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
                 },
                 "opera": {
                   "version_added": "15"

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -2419,7 +2419,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "true"
+                  "version_added": true
                 },
                 "opera": {
                   "version_added": "15"
@@ -2520,7 +2520,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "true"
+                  "version_added": true
                 },
                 "opera": {
                   "version_added": "15"
@@ -2679,7 +2679,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "true"
+                  "version_added": true
                 },
                 "opera": {
                   "version_added": "15"
@@ -2780,7 +2780,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "true"
+                  "version_added": true
                 },
                 "opera": {
                   "version_added": "15"
@@ -2886,7 +2886,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "true"
+                  "version_added": true
                 },
                 "opera": {
                   "version_added": "15"
@@ -2987,7 +2987,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": "true"
+                  "version_added": true
                 },
                 "opera": {
                   "version_added": "15"

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -2937,7 +2937,7 @@
                 },
                 "nodejs": {
                   "version_added": "0.12",
-                  "notes": "Prior to Nodejs 13 only the locale data for 'en-us' is available, by default.  When other English locales are specified, the function silently falls back to 'en-us'.  When other languages are specified, it throws a RangeError.  In order to make full ICU (locale) data available for versions prior to 13, see docs on '--with-full-icu=' flag and how to provide the data."
+                  "notes": "Prior to NodeJS 13, only the locale data for <code>en-us</code> is available by default.  When other English locales are specified, the function silently falls back to <code>en-us</code>.  When other languages are specified, it throws a <code>RangeError</code>.  In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
                 },
                 "opera": {
                   "version_added": "15"


### PR DESCRIPTION
Nodejs' support for locale's has been "build" dependent with the canonical build (that distributed from https://nodejs.org/en/download/) not including locale data, so Date.toLocaleString() and related functions ignore their parameters.  I downloaded the default (64-bit) v13.0.1 for Windows from nodejs.org and tested samples of the locale, options, and IANA tz names and found that they worked as expected, where they were ignored on v12.13.  Note that v13 is now the 'current' version.

I will make note of this PR on an appropriate issue of the nodejs repo and invite others to comment here.

[edit: just remembered that I installed v13 using nvm-windows, not by downloading directly from nodejs.org.]