### PR TITLE
Add NodeJS v13 to browser data

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -194,7 +194,13 @@
           "release_notes": "https://nodejs.org/en/blog/release/v12.11.0/",
           "engine": "V8",
           "engine_version": "7.7"
-        }
+        },
+        "13.0.0": {
+          "release_date": "2019-10-10",
+          "release_notes": "https://nodejs.org/en/blog/release/v13.0.0/",
+          "engine": "V8",
+          "engine_version": "7.8"
+        }        
       }
     }
   }


### PR DESCRIPTION
Nodejs v13 is now the "current" release.  It has been superseded by v13.0.1 but I followed the existing pattern of ignoring those bug-fix releases.  The full list of releases can be [viewed here](https://nodejs.org/en/download/releases/).