### PR TITLE
Update support data for Document() constructor

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -56,16 +56,16 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": null
+              "version_added": true
             },
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": "47"
@@ -74,10 +74,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": "60"

--- a/api/Document.json
+++ b/api/Document.json
@@ -65,7 +65,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": "47"


### PR DESCRIPTION
All browser engines support the Document() constructor. See test results:

https://wpt.fyi/results/dom/nodes/Document-constructor.html