### PR TITLE
Update support data for StaticRange() constructor

### DIFF
--- a/api/StaticRange.json
+++ b/api/StaticRange.json
@@ -66,7 +66,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/StaticRange.json
+++ b/api/StaticRange.json
@@ -54,10 +54,10 @@
           "description": "<code>StaticRange()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
               "version_added": null
@@ -87,7 +87,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {

--- a/api/StaticRange.json
+++ b/api/StaticRange.json
@@ -78,10 +78,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "13.1"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/StaticRange.json
+++ b/api/StaticRange.json
@@ -78,7 +78,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "13.1"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false

--- a/api/StaticRange.json
+++ b/api/StaticRange.json
@@ -84,7 +84,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/StaticRange.json
+++ b/api/StaticRange.json
@@ -54,19 +54,19 @@
           "description": "<code>StaticRange()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "60"
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": "60"
+              "version_added": null
             },
             "edge": {
-              "version_added": "18"
+              "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": true
             },
             "ie": {
               "version_added": false
@@ -78,16 +78,16 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
               "version_added": true
             },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
             "webview_android": {
-              "version_added": "60"
+              "version_added": null
             }
           },
           "status": {

--- a/api/StaticRange.json
+++ b/api/StaticRange.json
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "47"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "44"
+              "version_added": false
             },
             "safari": {
               "version_added": true

--- a/api/StaticRange.json
+++ b/api/StaticRange.json
@@ -63,7 +63,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "71"
             },
             "firefox_android": {
               "version_added": false

--- a/api/StaticRange.json
+++ b/api/StaticRange.json
@@ -81,7 +81,7 @@
               "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": "13.1"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/StaticRange.json
+++ b/api/StaticRange.json
@@ -60,7 +60,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": true


### PR DESCRIPTION
Test results for the StaticRange() constructor are here:

https://wpt.fyi/results/dom/ranges/StaticRange-constructor.html

Those results indicate Firefox and Safari have support, but Chrome and Edge don’t.