### PR TITLE
'TextEncoder' is not defined in Edge

### DIFF
--- a/api/TextEncoder.json
+++ b/api/TextEncoder.json
@@ -11,7 +11,7 @@
             "version_added": "38"
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": [
             {
@@ -79,7 +79,7 @@
               "version_added": "38"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {
@@ -161,7 +161,7 @@
               "version_added": "38"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {
@@ -269,7 +269,7 @@
               "version_added": "38"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": [
               {
@@ -329,7 +329,7 @@
               "version_added": "38"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "20"


### PR DESCRIPTION
The compatibility table for `TextEncoder` [on MDN](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder) is not complete. 

I have tried using `TextEncoder` in `Microsoft Edge 44.18362.387.0` and got the following errors:

```
SCRIPT5022: 'TextEncoder' is not defined
ReferenceError: 'TextEncoder' is not defined
```
