### PR TITLE
Firefox 70 has been released

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -511,23 +511,30 @@
         "69": {
           "release_date": "2019-09-03",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/69",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "69"
         },
         "70": {
           "release_date": "2019-10-22",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/70",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "70"
         },
         "71": {
           "release_date": "2019-12-10",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/71",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "71"
+        },
+        "72": {
+          "release_date": "2020-01-07",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/72",
+          "status": "nightly",
+          "engine": "Gecko",
+          "engine_version": "72"
         }
       }
     }


### PR DESCRIPTION
Title says it all -- this PR sets the data accordingly, and adds additional information regarding the planned Firefox 72.