### PR TITLE
IE11 doesn't support PageTransitionEvent.persisted

### DIFF
--- a/api/PageTransitionEvent.json
+++ b/api/PageTransitionEvent.json
@@ -67,7 +67,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
Related StackOverflow question: https://stackoverflow.com/q/17432899/1235394

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
