### PR TITLE
Update various properties for Chromium data for URL API

### DIFF
--- a/api/URL.json
+++ b/api/URL.json
@@ -479,10 +479,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/origin",
           "support": {
             "chrome": {
-              "version_added": "37"
+              "version_added": "32"
             },
             "chrome_android": {
-              "version_added": "37"
+              "version_added": "32"
             },
             "edge": {
               "version_added": "12"
@@ -529,7 +529,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -544,10 +544,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/password",
           "support": {
             "chrome": {
-              "version_added": "37"
+              "version_added": "32"
             },
             "chrome_android": {
-              "version_added": "37"
+              "version_added": "32"
             },
             "edge": {
               "version_added": "12"
@@ -580,7 +580,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1015,7 +1015,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1030,10 +1030,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/username",
           "support": {
             "chrome": {
-              "version_added": "37"
+              "version_added": "32"
             },
             "chrome_android": {
-              "version_added": "37"
+              "version_added": "32"
             },
             "edge": {
               "version_added": "12"
@@ -1066,7 +1066,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/URL.json
+++ b/api/URL.json
@@ -479,10 +479,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/origin",
           "support": {
             "chrome": {
-              "version_added": "52"
+              "version_added": "37"
             },
             "chrome_android": {
-              "version_added": "52"
+              "version_added": "37"
             },
             "edge": {
               "version_added": "12"
@@ -529,7 +529,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "52"
+              "version_added": "37"
             }
           },
           "status": {
@@ -544,10 +544,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/password",
           "support": {
             "chrome": {
-              "version_added": "52"
+              "version_added": "37"
             },
             "chrome_android": {
-              "version_added": "52"
+              "version_added": "37"
             },
             "edge": {
               "version_added": "12"
@@ -580,7 +580,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "52"
+              "version_added": "37"
             }
           },
           "status": {
@@ -982,10 +982,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/toString",
           "support": {
             "chrome": {
-              "version_added": "52"
+              "version_added": "37"
             },
             "chrome_android": {
-              "version_added": "52"
+              "version_added": "37"
             },
             "edge": {
               "version_added": "17"
@@ -1015,7 +1015,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "52"
+              "version_added": "37"
             }
           },
           "status": {
@@ -1030,10 +1030,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/username",
           "support": {
             "chrome": {
-              "version_added": "52"
+              "version_added": "37"
             },
             "chrome_android": {
-              "version_added": "52"
+              "version_added": "37"
             },
             "edge": {
               "version_added": "12"
@@ -1066,7 +1066,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": "52"
+              "version_added": "37"
             }
           },
           "status": {

--- a/api/URL.json
+++ b/api/URL.json
@@ -982,10 +982,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/toString",
           "support": {
             "chrome": {
-              "version_added": "37"
+              "version_added": "19"
             },
             "chrome_android": {
-              "version_added": "37"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "17"


### PR DESCRIPTION
Tested all four of these features on a stock Android 5 Lollipop
emulator image, in both the Chrome browser and a WebView, both at
version 37.

It's possible these features go back to the introduction of the URL
class itself in Chrome 32, but I don't have a handy way to test
Chrome versions between 30 and 37.

On the other hand the `searchParams` feature is indeed missing,
consistent with the existing data that has it start at Chrome 51.
