### PR TITLE
Event.composed is not supported in IE/Edge

### DIFF
--- a/api/Event.json
+++ b/api/Event.json
@@ -243,7 +243,7 @@
               "version_added": "53"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "52"
@@ -252,7 +252,7 @@
               "version_added": "52"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "40"


### PR DESCRIPTION
Hi, I have just checked that `composed` property on IE11 and Edge is not supported.