### PR TITLE
Add window.print() support for Internet Explorer

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -6697,7 +6697,7 @@
               "notes": "See <a href='https://bugzil.la/1247609'>bug 1247609</a>."
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": true

--- a/api/Window.json
+++ b/api/Window.json
@@ -6697,7 +6697,7 @@
               "notes": "See <a href='https://bugzil.la/1247609'>bug 1247609</a>."
             },
             "ie": {
-              "version_added": true
+              "version_added": "5"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
Tested in IE11 on Windows 10 1903. Returns immediately and then opens Print dialog.