### PR TITLE
individual transforms

### DIFF
--- a/css/properties/rotate.json
+++ b/css/properties/rotate.json
@@ -16,6 +16,7 @@
             },
             "firefox": {
               "version_added": "60",
+              "notes": "Enabled by default in Firefox Nightly 71.",
               "flags": [
                 {
                   "type": "preference",

--- a/css/properties/scale.json
+++ b/css/properties/scale.json
@@ -16,6 +16,7 @@
             },
             "firefox": {
               "version_added": "60",
+              "notes": "Enabled by default in Firefox Nightly 71.",
               "flags": [
                 {
                   "type": "preference",

--- a/css/properties/translate.json
+++ b/css/properties/translate.json
@@ -16,6 +16,7 @@
             },
             "firefox": {
               "version_added": "60",
+              "notes": "Enabled by default in Firefox Nightly 71.",
               "flags": [
                 {
                   "type": "preference",


### PR DESCRIPTION
the three individual transforms properties have been enabled by default in Nightly 71 so have added a note to say as such.

https://bugzilla.mozilla.org/show_bug.cgi?id=1506939
