### PR TITLE
Update `Clear-Site-Data` values to include double quotes

### DIFF
--- a/http/headers/clear-site-data.json
+++ b/http/headers/clear-site-data.json
@@ -72,7 +72,7 @@
             "deprecated": false
           }
         },
-        "cache": {
+        "\"cache\"": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Clear-Site-Data",
             "support": {
@@ -144,7 +144,7 @@
             }
           }
         },
-        "cookies": {
+        "\"cookies\"": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Clear-Site-Data",
             "support": {
@@ -216,7 +216,7 @@
             }
           }
         },
-        "executionContexts": {
+        "\"executionContexts\"": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Clear-Site-Data",
             "support": {
@@ -290,7 +290,7 @@
             }
           }
         },
-        "storage": {
+        "\"storage\"": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Clear-Site-Data",
             "support": {

--- a/http/headers/clear-site-data.json
+++ b/http/headers/clear-site-data.json
@@ -72,7 +72,7 @@
             "deprecated": false
           }
         },
-        "\"cache\"": {
+        "&quot;cache&quot;": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Clear-Site-Data",
             "support": {
@@ -144,7 +144,7 @@
             }
           }
         },
-        "\"cookies\"": {
+        "&quot;cookies&quot;": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Clear-Site-Data",
             "support": {
@@ -216,7 +216,7 @@
             }
           }
         },
-        "\"executionContexts\"": {
+        "&quot;executionContexts&quot;": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Clear-Site-Data",
             "support": {
@@ -290,7 +290,7 @@
             }
           }
         },
-        "\"storage\"": {
+        "&quot;storage&quot;": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Clear-Site-Data",
             "support": {


### PR DESCRIPTION
Unlike most HTTP header's values, the [`Clear-Site-Data`](https://w3c.github.io/webappsec-clear-site-data/#header) header values "_MUST comply with the quoted-string grammar_", as defined in https://tools.ietf.org/html/rfc7230#section-3.2.6.

E.g.
```http
Clear-Site-Data: "storage"
```

as opposed to this invalid value:

```http
Clear-Site-Data: storage
```

While I should probably edit to clarify this for developers in https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data at some point, it'd be incorrect not to reflect the actual values (including double-quotes) in the support table as well.

Responding with incorrect (unquoted values) in a response may cause issues such as this: https://github.com/webhintio/webhint.io/issues/855.