### PR TITLE
Set Chromium versions for JavaScript RegExp builtins

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -7,10 +7,10 @@
           "spec_url": "https://tc39.es/ecma262/#sec-regexp-regular-expression-objects",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -40,10 +40,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -58,10 +58,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-regexp.prototype.compile",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -91,10 +91,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -172,10 +172,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-regexp.prototype.exec",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -205,10 +205,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -224,10 +224,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-get-regexp.prototype.flags",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "49"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "49"
               },
               "edge": {
                 "version_added": false
@@ -245,10 +245,10 @@
                 "version_added": "6.0.0"
               },
               "opera": {
-                "version_added": true
+                "version_added": "39"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "41"
               },
               "safari": {
                 "version_added": true
@@ -257,10 +257,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "49"
               }
             },
             "status": {
@@ -276,10 +276,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-get-regexp.prototype.global",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -309,10 +309,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -326,10 +326,10 @@
               "description": "Prototype accessor property (ES2015)",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "48"
                 },
                 "chrome_android": {
-                  "version_added": true
+                  "version_added": "48"
                 },
                 "edge": {
                   "version_added": "12"
@@ -347,10 +347,10 @@
                   "version_added": true
                 },
                 "opera": {
-                  "version_added": true
+                  "version_added": "35"
                 },
                 "opera_android": {
-                  "version_added": true
+                  "version_added": "35"
                 },
                 "safari": {
                   "version_added": true
@@ -359,10 +359,10 @@
                   "version_added": true
                 },
                 "samsunginternet_android": {
-                  "version_added": true
+                  "version_added": "5.0"
                 },
                 "webview_android": {
-                  "version_added": true
+                  "version_added": "48"
                 }
               },
               "status": {
@@ -379,10 +379,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-get-regexp.prototype.ignorecase",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -412,10 +412,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -429,10 +429,10 @@
               "description": "Prototype accessor property (ES2015)",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "48"
                 },
                 "chrome_android": {
-                  "version_added": true
+                  "version_added": "48"
                 },
                 "edge": {
                   "version_added": "12"
@@ -450,10 +450,10 @@
                   "version_added": true
                 },
                 "opera": {
-                  "version_added": true
+                  "version_added": "35"
                 },
                 "opera_android": {
-                  "version_added": true
+                  "version_added": "35"
                 },
                 "safari": {
                   "version_added": true
@@ -462,10 +462,10 @@
                   "version_added": true
                 },
                 "samsunginternet_android": {
-                  "version_added": true
+                  "version_added": "5.0"
                 },
                 "webview_android": {
-                  "version_added": true
+                  "version_added": "48"
                 }
               },
               "status": {
@@ -482,10 +482,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/input",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -515,10 +515,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -534,10 +534,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-properties-of-regexp-instances",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -567,10 +567,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -586,10 +586,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastMatch",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -619,10 +619,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -638,10 +638,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastParen",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -671,10 +671,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -690,10 +690,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/leftContext",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -723,10 +723,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -795,10 +795,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-get-regexp.prototype.multiline",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -828,10 +828,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -845,10 +845,10 @@
               "description": "Prototype accessor property (ES2015)",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "48"
                 },
                 "chrome_android": {
-                  "version_added": true
+                  "version_added": "48"
                 },
                 "edge": {
                   "version_added": "12"
@@ -866,10 +866,10 @@
                   "version_added": true
                 },
                 "opera": {
-                  "version_added": true
+                  "version_added": "35"
                 },
                 "opera_android": {
-                  "version_added": true
+                  "version_added": "35"
                 },
                 "safari": {
                   "version_added": true
@@ -878,10 +878,10 @@
                   "version_added": true
                 },
                 "samsunginternet_android": {
-                  "version_added": true
+                  "version_added": "5.0"
                 },
                 "webview_android": {
-                  "version_added": true
+                  "version_added": "48"
                 }
               },
               "status": {
@@ -898,10 +898,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/n",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -931,10 +931,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -1074,10 +1074,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-regexp.prototype",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1107,10 +1107,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -1126,10 +1126,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/rightContext",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1159,10 +1159,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -1178,10 +1178,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-get-regexp.prototype.source",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1211,10 +1211,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -1228,10 +1228,10 @@
               "description": "\"(?:)\" for empty regexps",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "73"
                 },
                 "chrome_android": {
-                  "version_added": true
+                  "version_added": "73"
                 },
                 "edge": {
                   "version_added": "12"
@@ -1249,10 +1249,10 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": true
+                  "version_added": "60"
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": "52"
                 },
                 "safari": {
                   "version_added": true
@@ -1261,10 +1261,10 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
-                  "version_added": true
+                  "version_added": false
                 },
                 "webview_android": {
-                  "version_added": true
+                  "version_added": "73"
                 }
               },
               "status": {
@@ -1330,10 +1330,10 @@
               "description": "Prototype accessor property (ES2015)",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "48"
                 },
                 "chrome_android": {
-                  "version_added": true
+                  "version_added": "48"
                 },
                 "edge": {
                   "version_added": "12"
@@ -1351,10 +1351,10 @@
                   "version_added": true
                 },
                 "opera": {
-                  "version_added": true
+                  "version_added": "35"
                 },
                 "opera_android": {
-                  "version_added": true
+                  "version_added": "35"
                 },
                 "safari": {
                   "version_added": true
@@ -1363,10 +1363,10 @@
                   "version_added": true
                 },
                 "samsunginternet_android": {
-                  "version_added": true
+                  "version_added": "5.0"
                 },
                 "webview_android": {
-                  "version_added": true
+                  "version_added": "48"
                 }
               },
               "status": {
@@ -1433,10 +1433,10 @@
               "description": "Anchored sticky flag behavior per ES2015",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "49"
                 },
                 "chrome_android": {
-                  "version_added": true
+                  "version_added": "49"
                 },
                 "edge": {
                   "version_added": "13"
@@ -1454,10 +1454,10 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": true
+                  "version_added": "36"
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": "36"
                 },
                 "safari": {
                   "version_added": true
@@ -1466,10 +1466,10 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
-                  "version_added": true
+                  "version_added": "5.0"
                 },
                 "webview_android": {
-                  "version_added": true
+                  "version_added": "49"
                 }
               },
               "status": {
@@ -1484,10 +1484,10 @@
               "description": "Prototype accessor property (ES2015)",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "49"
                 },
                 "chrome_android": {
-                  "version_added": true
+                  "version_added": "49"
                 },
                 "edge": {
                   "version_added": "13"
@@ -1505,10 +1505,10 @@
                   "version_added": true
                 },
                 "opera": {
-                  "version_added": true
+                  "version_added": "36"
                 },
                 "opera_android": {
-                  "version_added": true
+                  "version_added": "36"
                 },
                 "safari": {
                   "version_added": true
@@ -1517,10 +1517,10 @@
                   "version_added": true
                 },
                 "samsunginternet_android": {
-                  "version_added": true
+                  "version_added": "5.0"
                 },
                 "webview_android": {
-                  "version_added": true
+                  "version_added": "49"
                 }
               },
               "status": {
@@ -1537,10 +1537,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-regexp.prototype.test",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1570,10 +1570,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -1640,10 +1640,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-regexp.prototype.tostring",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1673,10 +1673,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -1690,10 +1690,10 @@
               "description": "Escaping",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "73"
                 },
                 "chrome_android": {
-                  "version_added": true
+                  "version_added": "73"
                 },
                 "edge": {
                   "version_added": "12"
@@ -1711,10 +1711,10 @@
                   "version_added": true
                 },
                 "opera": {
-                  "version_added": true
+                  "version_added": "60"
                 },
                 "opera_android": {
-                  "version_added": true
+                  "version_added": "52"
                 },
                 "safari": {
                   "version_added": true
@@ -1723,10 +1723,10 @@
                   "version_added": true
                 },
                 "samsunginternet_android": {
-                  "version_added": true
+                  "version_added": false
                 },
                 "webview_android": {
-                  "version_added": true
+                  "version_added": "73"
                 }
               },
               "status": {
@@ -1796,10 +1796,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-regexp.prototype-@@match",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "50"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "50"
               },
               "edge": {
                 "version_added": "13"
@@ -1817,10 +1817,10 @@
                 "version_added": "6.0.0"
               },
               "opera": {
-                "version_added": true
+                "version_added": "37"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "37"
               },
               "safari": {
                 "version_added": true
@@ -1829,10 +1829,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "50"
               }
             },
             "status": {
@@ -1872,7 +1872,7 @@
                 "version_added": "60"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "52"
               },
               "safari": {
                 "version_added": false
@@ -1881,7 +1881,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "73"
@@ -1900,10 +1900,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-regexp.prototype-@@replace",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "50"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "50"
               },
               "edge": {
                 "version_added": false
@@ -1921,10 +1921,10 @@
                 "version_added": "6.0.0"
               },
               "opera": {
-                "version_added": true
+                "version_added": "37"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "37"
               },
               "safari": {
                 "version_added": true
@@ -1933,10 +1933,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "50"
               }
             },
             "status": {
@@ -1952,10 +1952,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-regexp.prototype-@@search",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "49"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "49"
               },
               "edge": {
                 "version_added": "13"
@@ -1973,10 +1973,10 @@
                 "version_added": "6.0.0"
               },
               "opera": {
-                "version_added": true
+                "version_added": "36"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "36"
               },
               "safari": {
                 "version_added": true
@@ -1985,10 +1985,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "49"
               }
             },
             "status": {
@@ -2004,10 +2004,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-get-regexp-@@species",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "49"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "49"
               },
               "edge": {
                 "version_added": "13"
@@ -2036,10 +2036,10 @@
                 }
               ],
               "opera": {
-                "version_added": true
+                "version_added": "36"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "36"
               },
               "safari": {
                 "version_added": true
@@ -2048,10 +2048,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "49"
               }
             },
             "status": {
@@ -2067,10 +2067,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-regexp.prototype-@@split",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "50"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "50"
               },
               "edge": {
                 "version_added": false
@@ -2088,10 +2088,10 @@
                 "version_added": "6.0.0"
               },
               "opera": {
-                "version_added": true
+                "version_added": "37"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "37"
               },
               "safari": {
                 "version_added": true
@@ -2100,10 +2100,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "50"
               }
             },
             "status": {


### PR DESCRIPTION
This PR sets the Chromium versions for the JavaScript RegExp builtin data based upon manual testing.  Data is as follows:

javascript.builtins.RegExp - 1
javascript.builtins.RegExp.compile - 1
javascript.builtins.RegExp.exec - 1
javascript.builtins.RegExp.flags - 49
javascript.builtins.RegExp.global - 1
javascript.builtins.RegExp.global.prototype_accessor - 48
javascript.builtins.RegExp.ignoreCase - 1
javascript.builtins.RegExp.ignoreCase.prototype_accessor - 48
javascript.builtins.RegExp.input - 1
javascript.builtins.RegExp.lastIndex - 1
javascript.builtins.RegExp.lastMatch - 1
javascript.builtins.RegExp.lastParen - 1
javascript.builtins.RegExp.leftContext - 1
javascript.builtins.RegExp.multiline - 1
javascript.builtins.RegExp.multiline.prototype_accessor - 48
javascript.builtins.RegExp.n - 1
javascript.builtins.RegExp.prototype - 1
javascript.builtins.RegExp.rightContext - 1
javascript.builtins.RegExp.source - 1
javascript.builtins.RegExp.source.empty_regex_string - 73
javascript.builtins.RegExp.source.prototype_accessor - 48
javascript.builtins.RegExp.sticky.anchored_sticky_flag - 49
javascript.builtins.RegExp.sticky.prototype_accessor - 49
javascript.builtins.RegExp.test - 1
javascript.builtins.RegExp.toString - 1
javascript.builtins.RegExp.toString.escaping - 73
javascript.builtins.RegExp.@@match - 50
javascript.builtins.RegExp.@@replace - 50
javascript.builtins.RegExp.@@search - 49
javascript.builtins.RegExp.@@species - 49
javascript.builtins.RegExp.@@split - 50