### PR TITLE
Set Chromium versions for JavaScript String builtins

### DIFF
--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -7,10 +7,10 @@
           "spec_url": "https://tc39.es/ecma262/#sec-string-objects",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -40,10 +40,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -57,10 +57,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/anchor",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -91,10 +91,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -110,10 +110,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.big",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -143,10 +143,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -162,10 +162,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.blink",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -195,10 +195,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -214,10 +214,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.bold",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -247,10 +247,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -266,10 +266,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.charat",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -299,10 +299,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -318,10 +318,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.charcodeat",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -351,10 +351,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -433,10 +433,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.concat",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -466,10 +466,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -548,10 +548,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.fixed",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -581,10 +581,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -600,10 +600,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.fontcolor",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -633,10 +633,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -652,10 +652,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.fontsize",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -685,10 +685,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -704,10 +704,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.fromcharcodes",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -737,10 +737,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -885,10 +885,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.indexof",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -918,10 +918,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -937,10 +937,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.italics",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -970,10 +970,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -989,10 +989,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.lastindexof",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1022,10 +1022,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -1041,10 +1041,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-properties-of-string-instances-length",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1074,10 +1074,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -1093,10 +1093,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.link",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1126,10 +1126,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -1148,10 +1148,10 @@
             ],
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1181,10 +1181,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -1300,10 +1300,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.match",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1333,10 +1333,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -1634,10 +1634,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1667,10 +1667,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -1854,10 +1854,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.replace",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1887,10 +1887,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -1958,10 +1958,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.search",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1991,10 +1991,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -2062,10 +2062,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.slice",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -2095,10 +2095,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -2114,10 +2114,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.small",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -2147,10 +2147,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -2166,10 +2166,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.split",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -2199,10 +2199,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -2281,10 +2281,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.strike",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -2314,10 +2314,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -2333,10 +2333,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.sub",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -2366,10 +2366,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -2385,10 +2385,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.substr",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -2418,10 +2418,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -2437,10 +2437,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.substring",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -2470,10 +2470,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -2489,10 +2489,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.sup",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -2522,10 +2522,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -2544,10 +2544,10 @@
             ],
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -2577,10 +2577,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -2593,10 +2593,10 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": "58"
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": "58"
                 },
                 "edge": {
                   "version_added": "12"
@@ -2614,10 +2614,10 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "45"
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": "43"
                 },
                 "safari": {
                   "version_added": null
@@ -2626,10 +2626,10 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "7.0"
                 },
                 "webview_android": {
-                  "version_added": null
+                  "version_added": "58"
                 }
               },
               "status": {
@@ -2649,10 +2649,10 @@
             ],
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -2682,10 +2682,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -2698,10 +2698,10 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": "58"
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": "58"
                 },
                 "edge": {
                   "version_added": "12"
@@ -2719,10 +2719,10 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "45"
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": "42"
                 },
                 "safari": {
                   "version_added": null
@@ -2731,10 +2731,10 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "7.0"
                 },
                 "webview_android": {
-                  "version_added": null
+                  "version_added": "58"
                 }
               },
               "status": {
@@ -2751,10 +2751,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.tolowercase",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -2784,10 +2784,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -2854,10 +2854,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.tostring",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -2887,10 +2887,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -2906,10 +2906,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.touppercase",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -2939,10 +2939,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -2958,10 +2958,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.trim",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "4"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -2982,7 +2982,7 @@
                 "version_added": "10.5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "11"
               },
               "safari": {
                 "version_added": "5"
@@ -2991,10 +2991,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -3014,7 +3014,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "4",
                   "alternative_name": "trimRight"
                 }
               ],
@@ -3023,7 +3023,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "18",
                   "alternative_name": "trimRight"
                 }
               ],
@@ -3061,12 +3061,24 @@
                   "alternative_name": "trimRight"
                 }
               ],
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
+              "opera": [
+                {
+                  "version_added": "53"
+                },
+                {
+                  "version_added": true,
+                  "alternative_name": "trimRight"
+                }
+              ],
+              "opera_android": [
+                {
+                  "version_added": "47"
+                },
+                {
+                  "version_added": true,
+                  "alternative_name": "trimRight"
+                }
+              ],
               "safari": {
                 "version_added": "12"
               },
@@ -3075,10 +3087,10 @@
               },
               "samsunginternet_android": [
                 {
-                  "version_added": true
+                  "version_added": "9.0"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "1.0",
                   "alternative_name": "trimRight"
                 }
               ],
@@ -3087,7 +3099,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "≤37",
                   "alternative_name": "trimRight"
                 }
               ]
@@ -3109,7 +3121,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "4",
                   "alternative_name": "trimLeft"
                 }
               ],
@@ -3118,7 +3130,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "18",
                   "alternative_name": "trimLeft"
                 }
               ],
@@ -3156,12 +3168,24 @@
                   "alternative_name": "trimLeft"
                 }
               ],
-              "opera": {
-                "version_added": "53"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
+              "opera": [
+                {
+                  "version_added": "53"
+                },
+                {
+                  "version_added": true,
+                  "alternative_name": "trimLeft"
+                }
+              ],
+              "opera_android": [
+                {
+                  "version_added": "47"
+                },
+                {
+                  "version_added": true,
+                  "alternative_name": "trimLeft"
+                }
+              ],
               "safari": {
                 "version_added": "12"
               },
@@ -3170,10 +3194,10 @@
               },
               "samsunginternet_android": [
                 {
-                  "version_added": true
+                  "version_added": "9.0"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "1.0",
                   "alternative_name": "trimLeft"
                 }
               ],
@@ -3182,7 +3206,7 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": true,
+                  "version_added": "≤37",
                   "alternative_name": "trimLeft"
                 }
               ]
@@ -3199,10 +3223,10 @@
             "description": "Unicode code point escapes \\u{xxxxxx}",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -3232,10 +3256,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -3251,10 +3275,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.valueof",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -3284,10 +3308,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -3303,10 +3327,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype-@@iterator",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "38"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "12"
@@ -3352,10 +3376,10 @@
                 "version_added": "0.12"
               },
               "opera": {
-                "version_added": false
+                "version_added": "25"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "25"
               },
               "safari": {
                 "version_added": false
@@ -3364,10 +3388,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "3.0"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "38"
               }
             },
             "status": {


### PR DESCRIPTION
This PR adds Chromium versions for the JavaScript String builtin data based upon manual testing.  Data is as follows:

javascript.builtins.String - 1
javascript.builtins.String.anchor - 1
javascript.builtins.String.big - 1
javascript.builtins.String.blink - 1
javascript.builtins.String.bold - 1
javascript.builtins.String.charAt - 1
javascript.builtins.String.charCodeAt - 1
javascript.builtins.String.concat - 1
javascript.builtins.String.fixed - 1
javascript.builtins.String.fontcolor - 1
javascript.builtins.String.fontsize - 1
javascript.builtins.String.fromCharCode - 1
javascript.builtins.String.indexOf - 1
javascript.builtins.String.italics - 1
javascript.builtins.String.lastIndexOf - 1
javascript.builtins.String.length - 1
javascript.builtins.String.link - 1
javascript.builtins.String.localeCompare - 1
javascript.builtins.String.match - 1
javascript.builtins.String.prototype - 1
javascript.builtins.String.replace - 1
javascript.builtins.String.search - 1
javascript.builtins.String.slice - 1
javascript.builtins.String.small - 1
javascript.builtins.String.split - 1
javascript.builtins.String.strike - 1
javascript.builtins.String.sub - 1
javascript.builtins.String.substr - 1
javascript.builtins.String.substring - 1
javascript.builtins.String.sup - 1
javascript.builtins.String.toLocaleLowerCase - 1
javascript.builtins.String.toLocaleLowerCase.locale - 58
javascript.builtins.String.toLocaleUpperCase - 1
javascript.builtins.String.toLocaleUpperCase.locale - 58
javascript.builtins.String.toLowerCase - 1
javascript.builtins.String.toString - 1
javascript.builtins.String.toUpperCase - 1
javascript.builtins.String.trim - 4
javascript.builtins.String.trimEnd (as trimRight) - 4
javascript.builtins.String.trimStart (as trimLeft) - 4
javascript.builtins.String.unicode_code_point_escapes - 1
javascript.builtins.String.valueOf - 1
javascript.builtins.String.@@iterator - 38