### PR TITLE
[Firefox] Bug 1591968: Remove `window.mozPaintCount`

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -4165,10 +4165,11 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "4",
+              "version_removed": "72"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "4"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
See&nbsp;[bug&nbsp;1591968](https://bugzilla.mozilla.org/show_bug.cgi?id=1591968) for&nbsp;details.