### PR TITLE
CSS: Add notes for safe/unsafe keywords to Chrome

### DIFF
--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -298,19 +298,24 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "webview_android": {
                   "version_added": false,

--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -278,10 +278,12 @@
               "description": "<code>safe</code> and <code>unsafe</code>",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "chrome_android": {
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "edge": {
                   "version_added": false
@@ -311,7 +313,8 @@
                   "version_added": false
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 }
               },
               "status": {

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -272,10 +272,12 @@
               "description": "<code>safe</code> and <code>unsafe</code>",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "chrome_android": {
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "edge": {
                   "version_added": false
@@ -305,7 +307,8 @@
                   "version_added": false
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 }
               },
               "status": {

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -292,19 +292,24 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "safari": {
-                  "version_added": "9"
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "safari_ios": {
-                  "version_added": "9"
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "webview_android": {
                   "version_added": false,

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -313,10 +313,12 @@
               "description": "<code>safe</code> and <code>unsafe</code>",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "chrome_android": {
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "edge": {
                   "version_added": false
@@ -346,7 +348,8 @@
                   "version_added": false
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 }
               },
               "status": {

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -333,19 +333,24 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "webview_android": {
                   "version_added": false,

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -341,19 +341,24 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "safari": {
-                  "version_added": "9"
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "safari_ios": {
-                  "version_added": "9"
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "webview_android": {
                   "version_added": false,

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -321,10 +321,12 @@
               "description": "<code>safe</code> and <code>unsafe</code>",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "chrome_android": {
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 },
                 "edge": {
                   "version_added": false
@@ -354,7 +356,8 @@
                   "version_added": false
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "This value is recognized, but has no effect."
                 }
               },
               "status": {


### PR DESCRIPTION
See https://jsfiddle.net/pgw3t1hq/

Notably, this behaviour breaks feature-detection via `@supports`.