### PR TITLE
CSD: "executionContexts" is not supported in Chrome

### DIFF
--- a/http/headers/clear-site-data.json
+++ b/http/headers/clear-site-data.json
@@ -221,10 +221,11 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Clear-Site-Data",
             "support": {
               "chrome": {
-                "version_added": "61"
+                "version_added": false,
+                "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=898503'>bug 898503</a>."
               },
               "chrome_android": {
-                "version_added": "61"
+                "version_added": false
               },
               "edge": {
                 "version_added": null
@@ -265,10 +266,10 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": "48"
+                "version_added": false
               },
               "opera_android": {
-                "version_added": "45"
+                "version_added": false
               },
               "safari": {
                 "version_added": null
@@ -280,7 +281,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": "61"
+                "version_added": false
               }
             },
             "status": {

--- a/http/headers/clear-site-data.json
+++ b/http/headers/clear-site-data.json
@@ -222,7 +222,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=898503'>bug 898503</a>."
+                "notes": "See <a href='https://crbug.com/898503'>bug 898503</a>."
               },
               "chrome_android": {
                 "version_added": false


### PR DESCRIPTION
Per https://bugs.chromium.org/p/chromium/issues/detail?id=898503, the `Clear-Site-Data` data type `"executionContexts"` is not supported in Chrome (Blink I should say?)