### PR TITLE
adding Fx support data for mediaSource and mediaElement properties

### DIFF
--- a/api/MediaElementAudioSourceNode.json
+++ b/api/MediaElementAudioSourceNode.json
@@ -113,10 +113,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "70"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/MediaStreamAudioSourceNode.json
+++ b/api/MediaStreamAudioSourceNode.json
@@ -113,7 +113,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "70"
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1350973

This is just adding support data for Firefox desktop (both properties supported as of 70), and updating FxA support to definitely `false`.