### PR TITLE
Fix Chromium compatibility data for webkit-prefixed URL API

### DIFF
--- a/api/URL.json
+++ b/api/URL.json
@@ -9,7 +9,7 @@
               "version_added": "32"
             },
             {
-              "version_added": "2",
+              "version_added": "19",
               "prefix": "webkit"
             }
           ],
@@ -18,7 +18,7 @@
               "version_added": "32"
             },
             {
-              "version_added": "18",
+              "version_added": "25",
               "prefix": "webkit"
             }
           ],
@@ -87,9 +87,15 @@
               "prefix": "webkit"
             }
           ],
-          "samsunginternet_android": {
-            "version_added": true
-          },
+          "samsunginternet_android": [
+            {
+              "version_added": "2.0"
+            },
+            {
+              "version_added": "1.5",
+              "prefix": "webkit"
+            }
+          ],
           "webview_android": [
             {
               "version_added": "4.4"

--- a/api/URL.json
+++ b/api/URL.json
@@ -170,10 +170,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/createObjectURL",
           "support": {
             "chrome": {
-              "version_added": "8"
+              "version_added": "19"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -768,10 +768,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/revokeObjectURL",
           "support": {
             "chrome": {
-              "version_added": "8"
+              "version_added": "19"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"


### PR DESCRIPTION
While I was reviewing #5078, I found that the prefixed version of the `URL` API was marked as supported since Chrome 2.  This is invalid; Safari implemented support in version 6, which is far too high of a WebKit version for Chrome 2.  Upon manual testing, I found that implementation was actually in Chrome 19.

This PR updates the data accordingly.