### PR TITLE
fix: Mark removed `moz`‑prefixed features as deprecated

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -4196,7 +4196,7 @@
           "status": {
             "experimental": false,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -1178,7 +1178,7 @@
             "status": {
               "experimental": false,
               "standard_track": false,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },

--- a/css/properties/-moz-border-bottom-colors.json
+++ b/css/properties/-moz-border-bottom-colors.json
@@ -55,7 +55,7 @@
           "status": {
             "experimental": false,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/css/properties/-moz-border-left-colors.json
+++ b/css/properties/-moz-border-left-colors.json
@@ -55,7 +55,7 @@
           "status": {
             "experimental": false,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/css/properties/-moz-border-right-colors.json
+++ b/css/properties/-moz-border-right-colors.json
@@ -55,7 +55,7 @@
           "status": {
             "experimental": false,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/css/properties/-moz-border-top-colors.json
+++ b/css/properties/-moz-border-top-colors.json
@@ -55,7 +55,7 @@
           "status": {
             "experimental": false,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
I realised I forgot to do this just after #5090 was merged.