### PR TITLE
removing proprietary moz members from DataTransfer

### DIFF
--- a/api/DataTransfer.json
+++ b/api/DataTransfer.json
@@ -438,7 +438,8 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "71"
             },
             "firefox_android": {
               "version_added": null
@@ -534,7 +535,8 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "71"
             },
             "firefox_android": {
               "version_added": null
@@ -582,7 +584,8 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "71"
             },
             "firefox_android": {
               "version_added": null
@@ -630,7 +633,8 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "71"
             },
             "firefox_android": {
               "version_added": null
@@ -726,7 +730,8 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "71"
             },
             "firefox_android": {
               "version_added": null


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1345192.

The following 5 members were removed from `DataTransfer` in Fx 71:

    DataTransfer.mozItemCount
    DataTransfer.mozClearDataAt()
    DataTransfer.mozGetDataAt()
    DataTransfer.mozSetDataAt()
    DataTransfer.mozTypesAt()
