### PR TITLE
CSS: Update flex-direction compat data

### DIFF
--- a/css/properties/flex-direction.json
+++ b/css/properties/flex-direction.json
@@ -35,7 +35,11 @@
             "firefox": [
               {
                 "version_added": "20",
-                "notes": "Since Firefox 28, multi-line flexbox is supported."
+                "partial_implementation": true,
+                "notes": [
+                  "Since Firefox 28, multi-line flexbox is supported.",
+                  "Does not support overflow when using <code>*-reverse</code>. See <a href='https://bugzil.la/1042151'>bug 1042151</a> for more info."
+                ]
               },
               {
                 "version_added": "18",
@@ -67,7 +71,11 @@
             "firefox_android": [
               {
                 "version_added": "20",
-                "notes": "Since Firefox 28, multi-line flexbox is supported."
+                "partial_implementation": true,
+                "notes": [
+                  "Since Firefox 28, multi-line flexbox is supported.",
+                  "Does not support overflow when using <code>*-reverse</code>. See <a href='https://bugzil.la/1042151'>bug 1042151</a> for more info."
+                ]
               },
               {
                 "version_added": "18",


### PR DESCRIPTION
Due to a bug in firefox I have updated the `flex-direction` css property compatibility data. [bug 1042151](https://bugzilla.mozilla.org/show_bug.cgi?id=1042151)

Example: https://jsfiddle.net/hnaeg0q8/
Open in Chrome and then Firefox to see the issue.