### PR TITLE
Update Chromium versions for various JavaScript builtins

### DIFF
--- a/javascript/builtins/Boolean.json
+++ b/javascript/builtins/Boolean.json
@@ -58,10 +58,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-boolean.prototype",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -91,10 +91,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -161,10 +161,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-boolean.prototype.tostring",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -194,10 +194,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -213,10 +213,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-boolean.prototype.valueof",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -246,10 +246,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {

--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -784,10 +784,10 @@
             "description": "<code>DataView()</code> without <code>new</code> throws",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "11"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "13"
@@ -808,7 +808,7 @@
                 "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
                 "version_added": null
@@ -817,10 +817,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -108,10 +108,10 @@
               "description": "<code>caseFirst</code> option",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "24"
                 },
                 "chrome_android": {
-                  "version_added": true
+                  "version_added": "25"
                 },
                 "edge": {
                   "version_added": false
@@ -126,7 +126,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "opera": {
                   "version_added": true
@@ -135,16 +135,16 @@
                   "version_added": true
                 },
                 "safari": {
-                  "version_added": "11"
-                },
-                "safari_ios": {
-                  "version_added": "11"
-                },
-                "samsunginternet_android": {
                   "version_added": true
                 },
+                "safari_ios": {
+                  "version_added": true
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.5"
+                },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "≤37"
                 }
               },
               "status": {

--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -94,7 +94,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -144,7 +144,7 @@
                   "version_added": "1.5"
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "≤37"
                 }
               },
               "status": {

--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -10,7 +10,7 @@
               "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "26"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -61,7 +61,7 @@
                 "version_added": "24"
               },
               "chrome_android": {
-                "version_added": "26"
+                "version_added": "25"
               },
               "edge": {
                 "version_added": "12"
@@ -126,7 +126,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": true
+                  "version_added": null
                 },
                 "opera": {
                   "version_added": true
@@ -144,7 +144,7 @@
                   "version_added": "1.5"
                 },
                 "webview_android": {
-                  "version_added": "≤37"
+                  "version_added": false
                 }
               },
               "status": {

--- a/javascript/builtins/JSON.json
+++ b/javascript/builtins/JSON.json
@@ -7,10 +7,10 @@
           "spec_url": "https://tc39.es/ecma262/#sec-json-object",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "3"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -31,7 +31,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "4"
@@ -40,10 +40,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -110,10 +110,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-json.parse",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "3"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -134,7 +134,7 @@
                 "version_added": "10.5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "11"
               },
               "safari": {
                 "version_added": "4"
@@ -143,10 +143,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -162,10 +162,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-json.stringify",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "3"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -186,7 +186,7 @@
                 "version_added": "10.5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "11"
               },
               "safari": {
                 "version_added": "4"
@@ -195,10 +195,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -545,10 +545,10 @@
             "description": "<code>new Map(null)</code>",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "38"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "12"
@@ -577,10 +577,10 @@
                 }
               ],
               "opera": {
-                "version_added": true
+                "version_added": "25"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "25"
               },
               "safari": {
                 "version_added": "9"
@@ -589,10 +589,10 @@
                 "version_added": "9"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "38"
               }
             },
             "status": {
@@ -607,10 +607,10 @@
             "description": "<code>Map()</code> without <code>new</code> throws",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "38"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "12"
@@ -628,10 +628,10 @@
                 "version_added": "0.12"
               },
               "opera": {
-                "version_added": true
+                "version_added": "25"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "25"
               },
               "safari": {
                 "version_added": "9"
@@ -640,10 +640,10 @@
                 "version_added": "9"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "38"
               }
             },
             "status": {
@@ -871,10 +871,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-map.prototype-@@iterator",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "43"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "43"
               },
               "edge": {
                 "version_added": "12"
@@ -920,10 +920,10 @@
                 "version_added": "0.12"
               },
               "opera": {
-                "version_added": true
+                "version_added": "30"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "30"
               },
               "safari": {
                 "version_added": true
@@ -932,10 +932,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "43"
               }
             },
             "status": {

--- a/javascript/builtins/Set.json
+++ b/javascript/builtins/Set.json
@@ -547,10 +547,10 @@
             "description": "<code>new Set(null)</code>",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "38"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "12"
@@ -579,10 +579,10 @@
                 }
               ],
               "opera": {
-                "version_added": true
+                "version_added": "25"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "25"
               },
               "safari": {
                 "version_added": "9"
@@ -591,10 +591,10 @@
                 "version_added": "9"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "38"
               }
             },
             "status": {
@@ -609,10 +609,10 @@
             "description": "<code>Set()</code> without <code>new</code> throws",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "38"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "12"
@@ -630,10 +630,10 @@
                 "version_added": "0.12"
               },
               "opera": {
-                "version_added": true
+                "version_added": "25"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "25"
               },
               "safari": {
                 "version_added": "9"
@@ -642,10 +642,10 @@
                 "version_added": "9"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "38"
               }
             },
             "status": {
@@ -767,10 +767,10 @@
             "spec_url": "https://tc39.es/ecma262/#sec-set.prototype-@@iterator",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "43"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "43"
               },
               "edge": {
                 "version_added": "12"
@@ -816,10 +816,10 @@
                 "version_added": "0.12"
               },
               "opera": {
-                "version_added": true
+                "version_added": "30"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "30"
               },
               "safari": {
                 "version_added": true
@@ -828,10 +828,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "43"
               }
             },
             "status": {

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -504,10 +504,10 @@
             "description": "<code>new WeakMap(null)</code>",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "36"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "36"
               },
               "edge": {
                 "version_added": "12"
@@ -536,10 +536,10 @@
                 }
               ],
               "opera": {
-                "version_added": true
+                "version_added": "23"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "23"
               },
               "safari": {
                 "version_added": "8"
@@ -548,10 +548,10 @@
                 "version_added": "8"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "37"
               }
             },
             "status": {
@@ -566,10 +566,10 @@
             "description": "<code>WeakMap()</code> without <code>new</code> throws",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "36"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "36"
               },
               "edge": {
                 "version_added": "12"
@@ -587,10 +587,10 @@
                 "version_added": "0.12"
               },
               "opera": {
-                "version_added": true
+                "version_added": "23"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "23"
               },
               "safari": {
                 "version_added": "9"
@@ -599,10 +599,10 @@
                 "version_added": "9"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "37"
               }
             },
             "status": {

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -539,7 +539,7 @@
                 "version_added": "23"
               },
               "opera_android": {
-                "version_added": "23"
+                "version_added": "24"
               },
               "safari": {
                 "version_added": "8"
@@ -590,7 +590,7 @@
                 "version_added": "23"
               },
               "opera_android": {
-                "version_added": "23"
+                "version_added": "24"
               },
               "safari": {
                 "version_added": "9"

--- a/javascript/builtins/WeakSet.json
+++ b/javascript/builtins/WeakSet.json
@@ -398,7 +398,7 @@
                 "version_added": "23"
               },
               "opera_android": {
-                "version_added": "23"
+                "version_added": "24"
               },
               "safari": {
                 "version_added": "9"

--- a/javascript/builtins/WeakSet.json
+++ b/javascript/builtins/WeakSet.json
@@ -374,10 +374,10 @@
             "description": "<code>new WeakSet(null)</code>",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "36"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "36"
               },
               "edge": {
                 "version_added": "12"
@@ -395,10 +395,10 @@
                 "version_added": "0.12"
               },
               "opera": {
-                "version_added": true
+                "version_added": "23"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "23"
               },
               "safari": {
                 "version_added": "9"
@@ -407,10 +407,10 @@
                 "version_added": "9"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "37"
               }
             },
             "status": {


### PR DESCRIPTION
This PR updates the Chromium versions for miscellaneous JavaScript builtins based upon manual testing.  Data is as follows:

javascript.builtins.Boolean.prototype - 1
javascript.builtins.Boolean.toString - 1
javascript.builtins.Boolean.valueOf - 1
javascript.builtins.DataView.new_required - 11
javascript.builtins.Intl.Collator.caseFirst - 24
javascript.builtins.JSON - 3
javascript.builtins.JSON.parse - 3
javascript.builtins.JSON.stringify - 3
javascript.builtins.Map.map_null - 38
javascript.builtins.Map.map_without_new_throws - 38
javascript.builtins.Map.@@iterator - 43
javascript.builtins.Set.set_null - 38
javascript.builtins.Set.set_without_new_throws - 38
javascript.builtins.Set.@@iterator - 43
javascript.builtins.WeakMap.weakmap_null - 36
javascript.builtins.WeakMap.weakmap_without_new_throws - 36
javascript.builtins.WeakSet.weakset_null - 36