### PR TITLE
Add Node.js support for dynamic import, export, and export default

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -569,7 +569,7 @@
                     "type": "runtime_flag"
                   }
                 ],
-                "notes": "Module file names must end with <code>.mjs</code>, not </code>.js</code>."
+                "notes": "Module file names must end with <code>.mjs</code>, not </code>.js</code>. See Node's <a href='https://nodejs.org/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
               },
               "opera": {
                 "version_added": "47"
@@ -770,7 +770,7 @@
                   "type": "runtime_flag"
                 }
               ],
-              "notes": "Module file names must end with <code>.mjs</code>, not </code>.js</code>."
+              "notes": "Module file names must end with <code>.mjs</code>, not </code>.js</code>. See Node's <a href='https://nodejs.org/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
             },
             "opera": {
               "version_added": "47"
@@ -1621,7 +1621,7 @@
                   "type": "runtime_flag"
                 }
               ],
-              "notes": "Module file names must end with <code>.mjs</code>, not </code>.js</code>."
+              "notes": "Module file names must end with <code>.mjs</code>, not </code>.js</code>. See Node's <a href='https://nodejs.org/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
             },
             "opera": {
               "version_added": "47"
@@ -1705,7 +1705,7 @@
                     "type": "runtime_flag"
                   }
                 ],
-                "notes": "Module file names must end with <code>.mjs</code>, not </code>.js</code>."
+                "notes": "Module file names must end with <code>.mjs</code>, not </code>.js</code>. See Node's <a href='https://nodejs.org/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
               },
               "opera": {
                 "version_added": "50"

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -569,7 +569,7 @@
                     "type": "runtime_flag"
                   }
                 ],
-                "notes": "files must have suffix .mjs, not .js"
+                "notes": "Module file names must end with <code>.mjs</code>, not </code>.js</code>."
               },
               "opera": {
                 "version_added": "47"
@@ -770,7 +770,7 @@
                   "type": "runtime_flag"
                 }
               ],
-              "notes": "files must have suffix .mjs, not .js"
+              "notes": "Module file names must end with <code>.mjs</code>, not </code>.js</code>."
             },
             "opera": {
               "version_added": "47"
@@ -1621,7 +1621,7 @@
                   "type": "runtime_flag"
                 }
               ],
-              "notes": "files must have suffix .mjs, not .js"
+              "notes": "Module file names must end with <code>.mjs</code>, not </code>.js</code>."
             },
             "opera": {
               "version_added": "47"
@@ -1705,7 +1705,7 @@
                     "type": "runtime_flag"
                   }
                 ],
-                "notes": "files must have suffix .mjs, not .js"
+                "notes": "Module file names must end with <code>.mjs</code>, not </code>.js</code>."
               },
               "opera": {
                 "version_added": "50"

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -562,7 +562,14 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "8.5.0",
+                "flags": [
+                  {
+                    "name": "--experimental-modules",
+                    "type": "runtime_flag"
+                  }
+                ],
+                "notes": "files must have suffix .mjs, not .js"
               },
               "opera": {
                 "version_added": "47"
@@ -756,7 +763,14 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": null
+              "version_added": "8.5.0",
+              "flags": [
+                {
+                  "name": "--experimental-modules",
+                  "type": "runtime_flag"
+                }
+              ],
+              "notes": "files must have suffix .mjs, not .js"
             },
             "opera": {
               "version_added": "47"
@@ -1684,7 +1698,14 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "12.0.0",
+                "flags": [
+                  {
+                    "name": "--experimental-modules",
+                    "type": "runtime_flag"
+                  }
+                ],
+                "notes": "files must have suffix .mjs, not .js"
               },
               "opera": {
                 "version_added": "50"


### PR DESCRIPTION
Add Node.js support for the dynamic `import`, `export`, and `export default` statements.

[Source for `export` and `default export`](https://nodejs.org/docs/latest-v8.x/api/esm.html)
[Source for dynamic `import`](https://nodejs.org/docs/latest-v12.x/api/esm.html)

**Edit**
[Better source for `export`](https://github.com/nodejs/node/blob/v8.5.0/doc/api/esm.md) (documentation file didn't exist in [8.4.0](https://github.com/nodejs/node/tree/v8.4.0/doc/api))
[Better source for dynamic `import`](https://github.com/nodejs/node/blob/v12.0.0/doc/api/esm.md) (wasn't mentioned in [11.5.0](https://github.com/nodejs/node/blob/v11.15.0/doc/api/esm.md))