### PR TITLE
aspect-ratio unit

### DIFF
--- a/css/properties/aspect-ratio.json
+++ b/css/properties/aspect-ratio.json
@@ -7,10 +7,12 @@
           "support": {
             "chrome": {
               "version_added": "79",
+              "partial_implementation": true,
               "notes": "Chrome 79 adds internal support only for mapped values"
             },
             "chrome_android": {
               "version_added": "79",
+              "partial_implementation": true,
               "notes": "Chrome 79 adds internal support only for mapped values"
             },
             "edge": {
@@ -19,11 +21,13 @@
             "firefox": [
               {
                 "version_added": "71",
+                "partial_implementation": true,
                 "notes": "Firefox 71 adds internal support only for mapped values"
               },
               {
                 "version_added": "69",
                 "version_removed": "71",
+                "partial_implementation": true,
                 "notes": "Firefox 69 adds internal support only for mapped values",
                 "flags": [
                   {

--- a/css/properties/aspect-ratio.json
+++ b/css/properties/aspect-ratio.json
@@ -61,6 +61,7 @@
             },
             "webview_android": {
               "version_added": "79",
+              "partial_implementation": true,
               "notes": "Webview 79 adds internal support only for mapped values"
             }
           },

--- a/css/properties/aspect-ratio.json
+++ b/css/properties/aspect-ratio.json
@@ -6,16 +6,19 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/aspect-ratio",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "79",
+              "notes": "Chrome 69 adds internal support only for mapped values"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "79",
+              "notes": "Chrome 79 adds internal support only for mapped values"
             },
             "edge": {
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "71",
+              "notes": "Firefox 71 adds internal support only for mapped values"
             },
             "firefox_android": {
               "version_added": false
@@ -39,7 +42,8 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "79",
+              "notes": "Webview 79 adds internal support only for mapped values"
             }
           },
           "status": {

--- a/css/properties/aspect-ratio.json
+++ b/css/properties/aspect-ratio.json
@@ -1,0 +1,115 @@
+{
+  "css": {
+    "properties": {
+      "aspect-ratio": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/aspect-ratio",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "internal-value": {
+          "__compat": {
+            "description": "Internal mapping of width and height",
+            "support": {
+              "chrome": {
+                "version_added": "79"
+              },
+              "chrome_android": {
+                "version_added": "79"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "71"
+                },
+                {
+                  "version_added": "69",
+                  "version_removed": "71",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.width-and-height-map-to-aspect-ratio.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "79"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/aspect-ratio.json
+++ b/css/properties/aspect-ratio.json
@@ -7,7 +7,7 @@
           "support": {
             "chrome": {
               "version_added": "79",
-              "notes": "Chrome 69 adds internal support only for mapped values"
+              "notes": "Chrome 79 adds internal support only for mapped values"
             },
             "chrome_android": {
               "version_added": "79",
@@ -16,10 +16,24 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "71",
-              "notes": "Firefox 71 adds internal support only for mapped values"
-            },
+            "firefox": [
+              {
+                "version_added": "71",
+                "notes": "Firefox 71 adds internal support only for mapped values"
+              },
+              {
+                "version_added": "69",
+                "version_removed": "71",
+                "notes": "Firefox 69 adds internal support only for mapped values",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.width-and-height-map-to-aspect-ratio.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },


### PR DESCRIPTION
In Firefox 71 (and Chrome 79) there will be an internal mapping of width and height to aspect-ratio.

This property is part of CSS Box Sizing but no-one has yet implemented it as a regular CSS property. In order to be abe to track the mapping I've created the page so this compat data is false for the actual property usage but has a line for this internal mapping.

https://drafts.csswg.org/css-sizing-4/#aspect-ratio
https://chromestatus.com/feature/5695266130755584
https://bugzilla.mozilla.org/show_bug.cgi?id=1585637