### PR TITLE
update nextSibling IE compatibiliy

### DIFF
--- a/api/Node.json
+++ b/api/Node.json
@@ -1281,7 +1281,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "8"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
Added IE compatibility for `Node.nextSibling`.

Tested this code in all browsers I could get my hands on (Chrome, Firefox, Safari, IE8,9,10,11, Edge)
https://codepen.io/nikushx/pen/QWWBaMJ?editors=1111

A lot of the community confusion with this node has to do with the fact that it returns `#text` nodes for whitespace between HTML elements which can be very confusing and be mis-interpreted as a poorly implemented property.