### PR TITLE
Update DataTransfer.json

### DIFF
--- a/api/DataTransfer.json
+++ b/api/DataTransfer.json
@@ -929,7 +929,11 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10",
+              "notes": [
+                "The property returns a <a href='https://developer.mozilla.org/docs/Web/API/DOMStringList'><code>DOMStringList</code></a>.",
+                "<code>Text</code> is returned instead of <code>text/plain</code>"
+              ]
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
Some info about support of DataTransfer#types in IE 10-IE 11:
I have tested only using IE 11 in compatibility modes.
https://caniuse.com/#feat=dragndrop provides the same data
