### PR TITLE
adding data for IDBTransaction.commit

### DIFF
--- a/api/IDBTransaction.json
+++ b/api/IDBTransaction.json
@@ -208,6 +208,54 @@
           }
         }
       },
+      "commit": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBTransaction/commit",
+          "support": {
+            "chrome": {
+              "version_added": "76"
+            },
+            "chrome_android": {
+              "version_added": "76"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "63"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": "76"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "complete_event": {
         "__compat": {
           "description": "<code>complete</code> event",


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1497007

Supported in Fx 71.

I got the Chromiums support from https://www.chromestatus.com/features/5375472036741120

Safari and Opera I tested, Samsung I kinda guessed.