### PR TITLE
marker in Chrome

### DIFF
--- a/css/selectors/marker.json
+++ b/css/selectors/marker.json
@@ -7,10 +7,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::marker",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "80",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              ]
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "80",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              ]
             },
             "edge": {
               "version_added": false


### PR DESCRIPTION
`::marker` is now behind a flag in Chrome https://twitter.com/regocas/status/1193933099274559488?s=20

This PR adds that support.
