### PR TITLE
Add animation event info for IE and Edge

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -439,7 +439,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": null
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -448,7 +448,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": "30"
@@ -488,7 +488,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": null
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "51"
@@ -497,7 +497,7 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": "30"
@@ -537,7 +537,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": null
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "51"
@@ -546,7 +546,7 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": "30"


### PR DESCRIPTION
This PR adds information for the animationend, animationstart, and animationiteration for those browsers. 
We can read the information here https://msdn.microsoft.com/en-us/sync/hh772072(v=vs.100)

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
