### PR TITLE
The proxy permission in the browser extension manifest is supported by Chrome

### DIFF
--- a/webextensions/manifest/permissions.json
+++ b/webextensions/manifest/permissions.json
@@ -644,7 +644,7 @@
             "description": "<code>proxy</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "33"
               },
               "edge": {
                 "version_added": false


### PR DESCRIPTION
[According to the Chrome documentation](https://developer.chrome.com/extensions/proxy) it has been supported since Chrome 33:

<img width="908" alt="image" src="https://user-images.githubusercontent.com/97460/68829388-b9b86b00-0676-11ea-9c20-f94740827ae8.png">
