### PR TITLE
Update Chromium versions for JavaScript statements

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -125,10 +125,10 @@
           "spec_url": "https://tc39.es/ecma262/#sec-block",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -158,10 +158,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -177,10 +177,10 @@
           "spec_url": "https://tc39.es/ecma262/#sec-break-statement",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -210,10 +210,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -344,10 +344,10 @@
           "spec_url": "https://tc39.es/ecma262/#sec-continue-statement",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -377,10 +377,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -396,10 +396,10 @@
           "spec_url": "https://tc39.es/ecma262/#sec-debugger-statement",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "5"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -429,10 +429,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -453,10 +453,10 @@
             ],
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -486,10 +486,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -598,10 +598,10 @@
           "spec_url": "https://tc39.es/ecma262/#sec-do-while-statement",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -631,10 +631,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -651,10 +651,10 @@
           "spec_url": "https://tc39.es/ecma262/#sec-empty-statement",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "3"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -684,10 +684,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -790,10 +790,10 @@
           "spec_url": "https://tc39.es/ecma262/#sec-for-statement",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -823,10 +823,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -962,10 +962,10 @@
           "spec_url": "https://tc39.es/ecma262/#sec-for-in-and-for-of-statements",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "49"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "49"
             },
             "edge": {
               "version_added": "12"
@@ -983,10 +983,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "36"
             },
             "safari": {
               "version_added": true
@@ -995,10 +995,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "49"
             }
           },
           "status": {
@@ -1171,10 +1171,10 @@
           "spec_url": "https://tc39.es/ecma262/#sec-function-definitions",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1204,10 +1204,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1387,10 +1387,10 @@
             "description": "Not constructable with <code>new</code> (ES2016)",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "50"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "50"
               },
               "edge": {
                 "version_added": "13"
@@ -1408,10 +1408,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "37"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "37"
               },
               "safari": {
                 "version_added": "10"
@@ -1420,10 +1420,10 @@
                 "version_added": "10"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "50"
               }
             },
             "status": {
@@ -1438,10 +1438,10 @@
             "description": "Trailing comma in parameters",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "58"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "58"
               },
               "edge": {
                 "version_added": "14"
@@ -1459,10 +1459,10 @@
                 "version_added": "8.0.0"
               },
               "opera": {
-                "version_added": true
+                "version_added": "45"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "43"
               },
               "safari": {
                 "version_added": null
@@ -1471,10 +1471,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "7.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "58"
               }
             },
             "status": {
@@ -1492,10 +1492,10 @@
           "spec_url": "https://tc39.es/ecma262/#sec-if-statement",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1525,10 +1525,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1823,10 +1823,10 @@
           "spec_url": "https://tc39.es/ecma262/#sec-labelled-statements",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1856,10 +1856,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1993,10 +1993,10 @@
           "spec_url": "https://tc39.es/ecma262/#sec-return-statement",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2026,10 +2026,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -2045,10 +2045,10 @@
           "spec_url": "https://tc39.es/ecma262/#sec-switch-statement",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2078,10 +2078,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -2097,10 +2097,10 @@
           "spec_url": "https://tc39.es/ecma262/#sec-throw-statement",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2130,10 +2130,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -2150,10 +2150,10 @@
           "spec_url": "https://tc39.es/ecma262/#sec-try-statement",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2183,10 +2183,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -2306,10 +2306,10 @@
           "spec_url": "https://tc39.es/ecma262/#sec-variable-statement",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2339,10 +2339,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -2358,10 +2358,10 @@
           "spec_url": "https://tc39.es/ecma262/#sec-while-statement",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2391,10 +2391,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -2410,10 +2410,10 @@
           "spec_url": "https://tc39.es/ecma262/#sec-with-statement",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2443,10 +2443,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates the Chromium versions for various JavaScript statements based upon manual testing.  Data is as follows:

javascript.statements.block - 1
javascript.statements.break - 1
javascript.statements.continue - 1
javascript.statements.debugger - 5
javascript.statements.default.switch - 1
javascript.statements.do_while - 1
javascript.statements.empty - 3
javascript.statements.for - 1
javascript.statements.for_in - 49
javascript.statements.function - 1
javascript.statements.generator_function.not_constructable_with_new - 50
javascript.statements.generator_function.trailing_comma_in_parameters - 58
javascript.statements.if_else - 1
javascript.statements.label - 1
javascript.statements.return - 1
javascript.statements.switch - 1
javascript.statements.throw - 1
javascript.statements.try_catch - 1
javascript.statements.var - 1
javascript.statements.while - 1
javascript.statements.with - 1