### PR TITLE
IE + Edge have no support for inputmode

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -986,7 +986,7 @@
               "version_added": "66"
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": false

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -995,7 +995,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "53"


### PR DESCRIPTION
I researched this topic a lot for my article on CSS Tricks. https://css-tricks.com/everything-you-ever-wanted-to-know-about-inputmode/ and helped update the compatibility table at caniuse.com
I tested using this site: https://inputmodes.com/

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
