### PR TITLE
adding data for the offset-position property

### DIFF
--- a/css/properties/offset-position.json
+++ b/css/properties/offset-position.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "properties": {
+      "offset-position": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/offset-position",
+          "support": {
+            "chrome": {
+              "version_added": false,
+              "notes": "Enabled by default in Chrome Canary only."
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
As per https://github.com/mdn/sprints/issues/2369.

I did a bunch of testing, and the only place I found the property recognized was the latest Chrome Canary for desktop. And even then it didn't make much sense. So I've put it as false, but with a note about Canary. Does that work for you?