### PR TITLE
Add Safari animationend info

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -210,7 +210,7 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
               "version_added": null
@@ -259,7 +259,7 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
               "version_added": null
@@ -308,7 +308,7 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
               "version_added": null


### PR DESCRIPTION
Tested using Browserstack and the Codepen/JSFiddle on this page https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/animationend_event

Tested back to Safari 10. Couldn't get Codepen/JSFiddle working on Safari 9, so couldn't verify if it worked.