### PR TITLE
Fx71 MediaRecorder updates

### DIFF
--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -160,7 +160,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": "71"
             },
             "firefox_android": {
               "version_added": null
@@ -1141,7 +1141,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": "71"
             },
             "firefox_android": {
               "version_added": null

--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -372,7 +372,8 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "25",
+              "notes": "Starting with Firefox 71, the behavior of <code>mimeType</code> is more consistent. For example, it now returns the media type even after recording has stopped."
             },
             "firefox_android": {
               "version_added": "25"

--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -717,7 +717,8 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "25",
+              "version_removed": "71"
             },
             "firefox_android": {
               "version_added": "25"
@@ -1172,6 +1173,56 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
+          }
+        }
+      },
+      "warning_event": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaRecorder/warning_event",
+          "description": "<code>warning</code> event",
+          "support": {
+            "chrome": {
+              "version_added": "49"
+            },
+            "chrome_android": {
+              "version_added": "49"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "25",
+              "version_removed": "71"
+            },
+            "firefox_android": {
+              "version_added": "25"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "36"
+            },
+            "opera_android": {
+              "version_added": "36"
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "49"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
Updates to the `MediaRecorder` interface for Firefox 71:

* Note that `mimeType` now behaves more reliably
* `audioBitsPerSecond` implemented
* ` videoBitsPerSecond` implemented

Sources:
* https://bugzilla.mozilla.org/show_bug.cgi?id=1512175
* https://bugzilla.mozilla.org/show_bug.cgi?id=1514158