### PR TITLE
MediaSession (Partial) added to Firefox 71

### DIFF
--- a/api/MediaMetadata.json
+++ b/api/MediaMetadata.json
@@ -14,7 +14,7 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": "71"
           },
           "firefox_android": {
             "version_added": null
@@ -43,7 +43,7 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": false,
+          "standard_track": true,
           "deprecated": false
         }
       },
@@ -62,7 +62,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "71"
             },
             "firefox_android": {
               "version_added": null
@@ -91,7 +91,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -110,7 +110,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "71"
             },
             "firefox_android": {
               "version_added": null
@@ -139,7 +139,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -158,7 +158,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "71"
             },
             "firefox_android": {
               "version_added": null
@@ -187,7 +187,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -206,7 +206,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "71"
             },
             "firefox_android": {
               "version_added": null
@@ -235,7 +235,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -254,7 +254,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "71"
             },
             "firefox_android": {
               "version_added": null
@@ -283,7 +283,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -160,7 +160,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": "71"
             },
             "firefox_android": {
               "version_added": null
@@ -1141,7 +1141,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": "71"
             },
             "firefox_android": {
               "version_added": null

--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -372,7 +372,8 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "25",
+              "notes": "Starting with Firefox 71, the behavior of <code>mimeType</code> is more consistent. For example, it now returns the media type even after recording has stopped."
             },
             "firefox_android": {
               "version_added": "25"

--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -160,7 +160,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "71"
+              "version_added": null
             },
             "firefox_android": {
               "version_added": null
@@ -1140,7 +1140,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "71"
+              "version_added": null
             },
             "firefox_android": {
               "version_added": null

--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -372,8 +372,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "25",
-              "notes": "Starting with Firefox 71, the behavior of <code>mimeType</code> is more consistent. For example, it now returns the media type even after recording has stopped."
+              "version_added": "25"
             },
             "firefox_android": {
               "version_added": "25"

--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -14,7 +14,7 @@
             "version_added": null
           },
           "firefox": {
-            "version_added": null
+            "version_added": "71"
           },
           "firefox_android": {
             "version_added": null
@@ -40,7 +40,7 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": false,
+          "standard_track": true,
           "deprecated": false
         }
       },
@@ -58,7 +58,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "71"
             },
             "firefox_android": {
               "version_added": null
@@ -84,7 +84,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -103,7 +103,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
               "version_added": null
@@ -129,7 +129,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -137,6 +137,7 @@
       "setActionHandler": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSession/setActionHandler",
+          "description": "<code>setActionHandler()</code>",
           "support": {
             "chrome": {
               "version_added": "73"
@@ -148,7 +149,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "71"
             },
             "firefox_android": {
               "version_added": null
@@ -174,7 +175,53 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "setPositionState": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSession/setActionHandler",
+          "description": "<code>setPositionState()</code>",
+          "support": {
+            "chrome": {
+              "version_added": "73"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1379,7 +1379,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "71"
             },
             "firefox_android": {
               "version_added": null


### PR DESCRIPTION
Add to BCD the parts of MediaSession API that Firefox 71 supports:
* `Navigator.mediaSession`
* Added missing `setPositionState()` to the `MediaSession` data
* `MediaSession` (all but two members)
* `MediaMetadata`

Source: https://bugzilla.mozilla.org/show_bug.cgi?id=1580602