### PR TITLE
Prevent non-real values for Chrome in javascript/*

### DIFF
--- a/test/linter/test-real-values.js
+++ b/test/linter/test-real-values.js
@@ -33,7 +33,7 @@ const blockList = {
   html: [],
   http: [],
   svg: [],
-  javascript: ['edge', 'firefox', 'firefox_android', 'ie'],
+  javascript: ['chrome', 'edge', 'firefox', 'firefox_android', 'ie'],
   mathml: blockMany,
   webdriver: blockMany,
   webextensions: [],


### PR DESCRIPTION
Whoo, we finally did it!  This PR locks Chrome into using only real values for JavaScript data, so we will not regress.  This closes #4947.