### PR TITLE
Mirror Chrome -> Chrome Android for javascript/*

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -61,7 +61,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -113,7 +113,7 @@
                 "version_added": "45"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "45"
               },
               "edge": {
                 "version_added": "12"
@@ -165,7 +165,7 @@
                 "version_added": "38"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "12"
@@ -269,7 +269,7 @@
                 "version_added": "45"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "45"
               },
               "edge": {
                 "version_added": "12"
@@ -384,7 +384,7 @@
                 "version_added": "45"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "45"
               },
               "edge": {
                 "version_added": "12"
@@ -447,7 +447,7 @@
                 "version_added": "45"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "45"
               },
               "edge": {
                 "version_added": "12"
@@ -666,7 +666,7 @@
                 "version_added": "45"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "45"
               },
               "edge": {
                 "version_added": "12"
@@ -718,7 +718,7 @@
                 "version_added": "47"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "47"
               },
               "edge": {
                 "version_added": "14"
@@ -833,7 +833,7 @@
                 "version_added": "5"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -885,7 +885,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -937,7 +937,7 @@
                 "version_added": "38"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "12"
@@ -1249,7 +1249,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1353,7 +1353,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1509,7 +1509,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1561,7 +1561,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1613,7 +1613,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1717,7 +1717,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1814,7 +1814,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -2179,7 +2179,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -2299,7 +2299,7 @@
                 "version_added": "38"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "12"

--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -10,7 +10,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -61,7 +61,7 @@
                 "version_added": "7"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -216,7 +216,7 @@
                 "version_added": "7"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"

--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -10,7 +10,7 @@
               "version_added": "9"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -61,7 +61,7 @@
                 "version_added": "9"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -164,7 +164,7 @@
                 "version_added": "9"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -216,7 +216,7 @@
                 "version_added": "9"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -372,7 +372,7 @@
                 "version_added": "9"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -424,7 +424,7 @@
                 "version_added": "9"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -476,7 +476,7 @@
                 "version_added": "9"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -528,7 +528,7 @@
                 "version_added": "9"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -580,7 +580,7 @@
                 "version_added": "9"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -632,7 +632,7 @@
                 "version_added": "9"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -684,7 +684,7 @@
                 "version_added": "9"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -736,7 +736,7 @@
                 "version_added": "9"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -839,7 +839,7 @@
                 "version_added": "9"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -995,7 +995,7 @@
                 "version_added": "9"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1047,7 +1047,7 @@
                 "version_added": "9"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1099,7 +1099,7 @@
                 "version_added": "9"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1151,7 +1151,7 @@
                 "version_added": "9"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1203,7 +1203,7 @@
                 "version_added": "9"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1255,7 +1255,7 @@
                 "version_added": "9"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1307,7 +1307,7 @@
                 "version_added": "9"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1359,7 +1359,7 @@
                 "version_added": "9"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -1102,7 +1102,7 @@
                 "version_added": "5"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"

--- a/javascript/builtins/Float32Array.json
+++ b/javascript/builtins/Float32Array.json
@@ -10,7 +10,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/javascript/builtins/Float64Array.json
+++ b/javascript/builtins/Float64Array.json
@@ -10,7 +10,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -629,7 +629,7 @@
                 "version_added": "15"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "14"

--- a/javascript/builtins/Generator.json
+++ b/javascript/builtins/Generator.json
@@ -10,7 +10,7 @@
               "version_added": "39"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "39"
             },
             "edge": {
               "version_added": "13"
@@ -72,7 +72,7 @@
                 "version_added": "39"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "39"
               },
               "edge": {
                 "version_added": "13"
@@ -176,7 +176,7 @@
                 "version_added": "39"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "39"
               },
               "edge": {
                 "version_added": "13"

--- a/javascript/builtins/Int16Array.json
+++ b/javascript/builtins/Int16Array.json
@@ -10,7 +10,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/javascript/builtins/Int32Array.json
+++ b/javascript/builtins/Int32Array.json
@@ -10,7 +10,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/javascript/builtins/Int8Array.json
+++ b/javascript/builtins/Int8Array.json
@@ -10,7 +10,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -886,7 +886,7 @@
                     "version_added": "35"
                   },
                   "chrome_android": {
-                    "version_added": true
+                    "version_added": "35"
                   },
                   "edge": {
                     "version_added": "14"

--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -531,7 +531,7 @@
                 "version_added": "38"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "12"
@@ -635,7 +635,7 @@
                 "version_added": "38"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "12"
@@ -791,7 +791,7 @@
                 "version_added": "38"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "12"
@@ -843,7 +843,7 @@
                 "version_added": "38"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "12"
@@ -947,7 +947,7 @@
                 "version_added": "38"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "12"
@@ -1051,7 +1051,7 @@
                 "version_added": "38"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "12"
@@ -1155,7 +1155,7 @@
                 "version_added": "38"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "12"
@@ -1259,7 +1259,7 @@
                 "version_added": "38"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "12"
@@ -1311,7 +1311,7 @@
                 "version_added": "38"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "12"
@@ -1363,7 +1363,7 @@
                 "version_added": "28"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "28"
               },
               "edge": {
                 "version_added": "12"
@@ -1467,7 +1467,7 @@
                 "version_added": "38"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "12"
@@ -1519,7 +1519,7 @@
                 "version_added": "38"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "12"
@@ -1571,7 +1571,7 @@
                 "version_added": "38"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "12"
@@ -1883,7 +1883,7 @@
                 "version_added": "38"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "12"
@@ -1987,7 +1987,7 @@
                 "version_added": "38"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "12"
@@ -2143,7 +2143,7 @@
                 "version_added": "38"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "12"
@@ -2195,7 +2195,7 @@
                 "version_added": "38"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "12"

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -113,7 +113,7 @@
                 "version_added": "34"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "34"
               },
               "edge": {
                 "version_added": "12"
@@ -217,7 +217,7 @@
                 "version_added": "34"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "34"
               },
               "edge": {
                 "version_added": "12"
@@ -477,7 +477,7 @@
                 "version_added": "19"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "25"
               },
               "edge": {
                 "version_added": "12"
@@ -581,7 +581,7 @@
                 "version_added": "25"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "25"
               },
               "edge": {
                 "version_added": "12"

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -217,7 +217,7 @@
                 "version_added": "5"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -323,7 +323,7 @@
                 "version_added": "5"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -375,7 +375,7 @@
                 "version_added": "5"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -597,7 +597,7 @@
                 "version_added": "6"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -753,7 +753,7 @@
                 "version_added": "5"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -868,7 +868,7 @@
                 "version_added": "5"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -972,7 +972,7 @@
                 "version_added": "5"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1076,7 +1076,7 @@
                 "version_added": "30"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "30"
               },
               "edge": {
                 "version_added": "12"
@@ -1128,7 +1128,7 @@
                 "version_added": "6"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1180,7 +1180,7 @@
                 "version_added": "6"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1284,7 +1284,7 @@
                 "version_added": "6"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1336,7 +1336,7 @@
                 "version_added": "5"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1652,7 +1652,7 @@
                 "version_added": "6"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1702,7 +1702,7 @@
                   "version_added": "44"
                 },
                 "chrome_android": {
-                  "version_added": true
+                  "version_added": "44"
                 },
                 "edge": {
                   "version_added": "12"
@@ -1912,7 +1912,7 @@
                 "version_added": "6"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1964,7 +1964,7 @@
                 "version_added": "34"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "34"
               },
               "edge": {
                 "version_added": "12"

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -373,7 +373,7 @@
                 "version_added": "41"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "41"
               },
               "edge": {
                 "version_added": "12"
@@ -759,7 +759,7 @@
                 "version_added": "41"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "41"
               },
               "edge": {
                 "version_added": "12"
@@ -822,7 +822,7 @@
                 "version_added": "41"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "41"
               },
               "edge": {
                 "version_added": "12"

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -10,7 +10,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -61,7 +61,7 @@
                 "version_added": "7"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -113,7 +113,7 @@
                 "version_added": "7"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "14"
@@ -165,7 +165,7 @@
                 "version_added": "7"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "14"
@@ -217,7 +217,7 @@
                 "version_added": "7"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "14"
@@ -372,7 +372,7 @@
                 "version_added": "45"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "45"
               },
               "edge": {
                 "version_added": "14"
@@ -424,7 +424,7 @@
                 "version_added": "45"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "45"
               },
               "edge": {
                 "version_added": "14"
@@ -476,7 +476,7 @@
                 "version_added": "45"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "45"
               },
               "edge": {
                 "version_added": "14"
@@ -528,7 +528,7 @@
                 "version_added": "45"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "45"
               },
               "edge": {
                 "version_added": "14"
@@ -1176,7 +1176,7 @@
                 "version_added": "7"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "14"
@@ -1335,7 +1335,7 @@
                 "version_added": "7"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1541,7 +1541,7 @@
                 "version_added": "7"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1749,7 +1749,7 @@
                 "version_added": "7"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "14"
@@ -1957,7 +1957,7 @@
                 "version_added": "7"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "14"

--- a/javascript/builtins/Uint16Array.json
+++ b/javascript/builtins/Uint16Array.json
@@ -10,7 +10,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/javascript/builtins/Uint32Array.json
+++ b/javascript/builtins/Uint32Array.json
@@ -10,7 +10,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -10,7 +10,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/javascript/builtins/Uint8ClampedArray.json
+++ b/javascript/builtins/Uint8ClampedArray.json
@@ -10,7 +10,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"

--- a/javascript/builtins/globals.json
+++ b/javascript/builtins/globals.json
@@ -736,7 +736,7 @@
                 "version_added": "23"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "25"
               },
               "edge": {
                 "version_added": "12"

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -87,7 +87,8 @@
               "notes": "From Chrome 42 to 48 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "49",
+              "notes": "From Chrome 42 to 48 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
             },
             "edge": {
               "version_added": "13"
@@ -161,7 +162,8 @@
               "notes": "From Chrome 42 to 48 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "49",
+              "notes": "From Chrome 42 to 48 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
             },
             "edge": {
               "version_added": "13"
@@ -341,7 +343,8 @@
               "notes": "From Chrome 42 to 48 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "49",
+              "notes": "From Chrome 42 to 48 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
             },
             "edge": {
               "version_added": "13"

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -288,7 +288,7 @@
               "version_added": "21"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -1019,7 +1019,7 @@
               "version_added": "38"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "38"
             },
             "edge": {
               "version_added": "12"
@@ -1122,7 +1122,7 @@
                 "version_added": "51"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "51"
               },
               "edge": {
                 "version_added": "14"
@@ -1340,7 +1340,7 @@
                 "version_added": "49"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "49"
               },
               "edge": {
                 "version_added": "13"


### PR DESCRIPTION
This PR mirrors Chrome over to Chrome Android for all JavaScript data by using the mirror script introduced in #4729.  (Essentially this is a test run of the mirroring script to help eliminate bugs.)