### PR TITLE
Update IE compatibility for History API

### DIFF
--- a/api/History.json
+++ b/api/History.json
@@ -64,7 +64,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": true
@@ -109,7 +109,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": true
@@ -154,7 +154,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": true
@@ -199,7 +199,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": true

--- a/api/History.json
+++ b/api/History.json
@@ -64,7 +64,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": true
@@ -109,7 +109,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": true
@@ -154,7 +154,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": true
@@ -199,7 +199,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
back, forward, go & length are all supported by Internet Explorer

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
   Updated the compatibility data for IE for the back, forward, go & length
- [x] Data: if you tested something, describe how you tested with details like browser and version
   I have tested back, forward, go & length on my machine with IE11 and they all work fine.
