### PR TITLE
Update ScrollToOptions.json

### DIFF
--- a/api/ScrollToOptions.json
+++ b/api/ScrollToOptions.json
@@ -77,7 +77,7 @@
             },
             "safari": {
               "version_added": true,
-              "notes": “Safari does not have support for the <code>smooth</code> scroll behavior."
+              "notes": "Safari does not have support for the <code>smooth</code> scroll behavior."
             },
             "safari_ios": {
               "version_added": false

--- a/api/ScrollToOptions.json
+++ b/api/ScrollToOptions.json
@@ -124,7 +124,7 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
               "version_added": false
@@ -172,7 +172,7 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
               "version_added": false

--- a/api/ScrollToOptions.json
+++ b/api/ScrollToOptions.json
@@ -29,7 +29,9 @@
             "version_added": "32"
           },
           "safari": {
-            "version_added": false
+            "version_added": true,
+            "partial_implementation": true,
+            "notes": "smmoth scroll option not actually smooth"
           },
           "safari_ios": {
             "version_added": false

--- a/api/ScrollToOptions.json
+++ b/api/ScrollToOptions.json
@@ -29,9 +29,7 @@
             "version_added": "32"
           },
           "safari": {
-            "version_added": true,
-            "partial_implementation": true,
-            "notes": "smooth scroll option does not cause smooth scrolling on Safari."
+            "version_added": false,
           },
           "safari_ios": {
             "version_added": false

--- a/api/ScrollToOptions.json
+++ b/api/ScrollToOptions.json
@@ -30,7 +30,6 @@
           },
           "safari": {
             "version_added": true,
-            "partial_implementation": true,
             "notes": "smmoth scroll option not actually smooth"
           },
           "safari_ios": {

--- a/api/ScrollToOptions.json
+++ b/api/ScrollToOptions.json
@@ -29,7 +29,8 @@
             "version_added": "32"
           },
           "safari": {
-            "version_added": false
+            "version_added": "13",
+            "partial_implementation": true,
           },
           "safari_ios": {
             "version_added": false

--- a/api/ScrollToOptions.json
+++ b/api/ScrollToOptions.json
@@ -29,7 +29,7 @@
             "version_added": "32"
           },
           "safari": {
-            "version_added": false,
+            "version_added": false
           },
           "safari_ios": {
             "version_added": false

--- a/api/ScrollToOptions.json
+++ b/api/ScrollToOptions.json
@@ -29,8 +29,9 @@
             "version_added": "32"
           },
           "safari": {
-            "version_added": "13",
-            "partial_implementation": true
+            "version_added": true,
+            "partial_implementation": true,
+            "notes": "smooth scroll option does not cause smooth scrolling on Safari."
           },
           "safari_ios": {
             "version_added": false
@@ -125,7 +126,7 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": "13"
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false
@@ -173,7 +174,7 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": "13"
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false

--- a/api/ScrollToOptions.json
+++ b/api/ScrollToOptions.json
@@ -30,7 +30,7 @@
           },
           "safari": {
             "version_added": "13",
-            "partial_implementation": true,
+            "partial_implementation": true
           },
           "safari_ios": {
             "version_added": false

--- a/api/ScrollToOptions.json
+++ b/api/ScrollToOptions.json
@@ -77,7 +77,7 @@
             },
             "safari": {
               "version_added": true,
-              "notes": "smooth scroll behavior not actually smooth, but doesn't throw an error to use it"
+              "notes": “Safari does not have support for the <code>smooth</code> scroll behavior."
             },
             "safari_ios": {
               "version_added": false

--- a/api/ScrollToOptions.json
+++ b/api/ScrollToOptions.json
@@ -29,8 +29,7 @@
             "version_added": "32"
           },
           "safari": {
-            "version_added": true,
-            "notes": "smmoth scroll option not actually smooth"
+            "version_added": true
           },
           "safari_ios": {
             "version_added": false
@@ -77,7 +76,8 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": false
+              "version_added": true,
+              "notes": "smooth scroll behavior not actually smooth, but doesn't throw an error to use it"
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
    - Based on a test on my version of Safari Version 13.0.3 (14608.3.10.10.1), ScrollToOptions works partially.
- [x] Data: if you tested something, describe how you tested with details like browser and version
    - Visited and used https://mdn.github.io/dom-examples/scrolltooptions/ in Safari 13 on Mac OS X 10.14.6 (18G103)
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
