### PR TITLE
test(lint): Fix JSDoc types

### DIFF
--- a/test/lint.js
+++ b/test/lint.js
@@ -84,7 +84,7 @@ function load(...files) {
         try {
           if (file.indexOf('browsers' + path.sep) !== -1) {
             hasSchemaErrors = testSchema(file, './../../schemas/browsers.schema.json');
-            hasLinkErrors = testLinks(file);
+            hasStyleErrors = testLinks(file);
           } else {
             hasSchemaErrors = testSchema(file);
             hasStyleErrors = testStyle(file);

--- a/test/lint.js
+++ b/test/lint.js
@@ -84,7 +84,7 @@ function load(...files) {
         try {
           if (file.indexOf('browsers' + path.sep) !== -1) {
             hasSchemaErrors = testSchema(file, './../../schemas/browsers.schema.json');
-            hasStyleErrors = testLinks(file);
+            hasLinkErrors = testLinks(file);
           } else {
             hasSchemaErrors = testSchema(file);
             hasStyleErrors = testStyle(file);

--- a/test/linter/test-browsers.js
+++ b/test/linter/test-browsers.js
@@ -4,6 +4,7 @@ const chalk = require('chalk');
 
 /**
  * @typedef {import('../../types').Identifier} Identifier
+ * @typedef {import('../utils').Logger} Logger
  */
 
 /** @type {Record<string, string[]>} */
@@ -46,7 +47,7 @@ const browsers = {
  * @param {string[]} displayBrowsers
  * @param {string[]} requiredBrowsers
  * @param {string} category
- * @param {import('../utils').Logger} logger
+ * @param {Logger} logger
  * @param {string} [path]
  * @returns {boolean}
  */

--- a/test/linter/test-consistency.js
+++ b/test/linter/test-consistency.js
@@ -1,7 +1,30 @@
 'use strict';
-const path = require('path');
+const { inspect } = require('util');
 const compareVersions = require('compare-versions');
-const chalk = require('chalk')
+const chalk = require('chalk');
+
+/**
+ * @typedef {import('../../types').CompatStatement} CompatStatement
+ * @typedef {import('../../types').Identifier} Identifier
+ * @typedef {import('../../types').IdentifierMeta} IdentifierMeta
+ * @typedef {import('../../types').PrimaryIdentifier} PrimaryIdentifier
+ * @typedef {import('../../types').SimpleSupportStatement} SimpleSupportStatement
+ * @typedef {import('../../types').SupportStatement} SupportStatement
+ * @typedef {import('../../types').VersionValue} VersionValue
+ *
+ * @typedef {'unsupported' | 'support_unknown' | 'subfeature_earlier_implementation'} ErrorType
+ *
+ * @typedef {object} ConsistencyError
+ * @property {string} feature
+ * @property {string[]} path
+ * @property {FeatureError[]} errors
+ *
+ * @typedef {object} FeatureError
+ * @property {ErrorType} errortype
+ * @property {string} browser
+ * @property {VersionValue} parent_value
+ * @property {[string, VersionValue][]} subfeatures
+ */
 
 /**
  * Consistency check.
@@ -9,22 +32,22 @@ const chalk = require('chalk')
  * This checker aims at improving data quality
  * by detecting inconsistent information.
  */
- class ConsistencyChecker
- {
+class ConsistencyChecker {
   /**
-   * @param {object} data
-   * @returns {Array<object>}
+   * @param {Identifier} data
+   * @returns {ConsistencyError[]}
    */
   check(data) {
     return this.checkSubfeatures(data);
   }
 
   /**
-   * @param {object} data
-   * @param {array} path
-   * @returns {Array<object>}
+   * @param {Identifier} data
+   * @param {string[]} [path]
+   * @returns {ConsistencyError[]}
    */
   checkSubfeatures(data, path = []) {
+    /** @type {ConsistencyError[]} */
     let allErrors = [];
 
     // Check this feature.
@@ -55,10 +78,11 @@ const chalk = require('chalk')
   }
 
   /**
-   * @param {object} data
-   * @returns {Array<object>}
+   * @param {PrimaryIdentifier & Required<IdentifierMeta>} data
+   * @returns {FeatureError[]}
    */
   checkFeature(data) {
+    /** @type {FeatureError[]} */
     let errors = [];
 
     const subfeatures = Object.keys(data).filter(key => this.isFeature(data[key]));
@@ -66,6 +90,7 @@ const chalk = require('chalk')
     // Test whether sub-features are supported when basic support is not implemented
     // For all unsupported browsers (basic support == false), sub-features should be set to false
     const unsupportedInParent = this.extractUnsupportedBrowsers(data.__compat);
+    /** @type {Partial<Record<string, [string, VersionValue][]>>} */
     var inconsistentSubfeaturesByBrowser = {};
 
     subfeatures.forEach(subfeature => {
@@ -90,14 +115,14 @@ const chalk = require('chalk')
         errortype,
         browser,
         parent_value,
-        subfeatures
+        subfeatures,
       });
     });
 
     // Test whether sub-features are supported when basic support is not implemented
     // For all unsupported browsers (basic support == false), sub-features should be set to false
     const supportUnknownInParent = this.extractSupportUnknownBrowsers(data.__compat);
-    var inconsistentSubfeaturesByBrowser = {};
+    inconsistentSubfeaturesByBrowser = {};
 
     subfeatures.forEach(subfeature => {
       const supportUnknownInChild = this.extractSupportNotTrueBrowsers(data[subfeature].__compat);
@@ -121,7 +146,7 @@ const chalk = require('chalk')
         errortype,
         browser,
         parent_value,
-        subfeatures
+        subfeatures,
       });
     });
 
@@ -131,7 +156,13 @@ const chalk = require('chalk')
 
     subfeatures.forEach(subfeature => {
       supportInParent.forEach(browser => {
-        if (data[subfeature].__compat.support[browser] != undefined && this.isVersionAddedGreater(data[subfeature].__compat.support[browser], data.__compat.support[browser])) {
+        if (
+          data[subfeature].__compat.support[browser] != undefined &&
+          this.isVersionAddedGreater(
+            data[subfeature].__compat.support[browser],
+            data.__compat.support[browser]
+          )
+        ) {
           inconsistentSubfeaturesByBrowser[browser] = inconsistentSubfeaturesByBrowser[browser] || [];
           const subfeature_value = data[subfeature].__compat.support[browser].version_added;
           inconsistentSubfeaturesByBrowser[browser].push([subfeature, subfeature_value]);
@@ -149,7 +180,7 @@ const chalk = require('chalk')
         errortype,
         browser,
         parent_value,
-        subfeatures
+        subfeatures,
       });
     });
 
@@ -157,58 +188,87 @@ const chalk = require('chalk')
   }
 
   /**
-   * @param {object} data
-   * @returns {boolean}
+   * @param {Identifier} data
+   * @returns {data is Required<IdentifierMeta>}
    */
   isFeature(data) {
     return '__compat' in data;
   }
 
   /**
-   * @param {object} compatData
+   * @param {CompatStatement} compatData
    * @returns {Array<string>}
    */
   extractUnsupportedBrowsers(compatData) {
-    return this.extractBrowsers(compatData, data => data.version_added === false || typeof data.version_removed !== 'undefined' && data.version_removed !== false);
+    return this.extractBrowsers(
+      compatData,
+      data =>
+        data.version_added === false ||
+        (typeof data.version_removed !== 'undefined' &&
+          data.version_removed !== false),
+    );
   }
 
   /**
-   * @param {object} compatData
+   * @param {CompatStatement} compatData
    * @returns {Array<string>}
    */
   extractSupportUnknownBrowsers(compatData) {
-    return this.extractBrowsers(compatData, data => data.version_added === null);
+    return this.extractBrowsers(
+      compatData,
+      data => data.version_added === null,
+    );
   }
 
   /**
-   * @param {object} compatData
+   * @param {CompatStatement} compatData
    * @returns {Array<string>}
    */
   extractSupportNotTrueBrowsers(compatData) {
-    return this.extractBrowsers(compatData, data => (data.version_added === false || data.version_added === null) || typeof data.version_removed !== 'undefined' && data.version_removed !== false);
+    return this.extractBrowsers(
+      compatData,
+      data =>
+        data.version_added === false ||
+        data.version_added === null ||
+        (typeof data.version_removed !== 'undefined' &&
+          data.version_removed !== false),
+    );
   }
   /**
-   * @param {object} compatData
+   * @param {CompatStatement} compatData
    * @returns {Array<string>}
    */
   extractSupportedBrowsersWithVersion(compatData) {
-    return this.extractBrowsers(compatData, data => typeof(data.version_added) === 'string');
+    return this.extractBrowsers(
+      compatData,
+      data => typeof data.version_added === 'string',
+    );
   }
 
-  /*
-   * @param {object} compatData
-   * @returns {string}
+  /**
+   * @param {SupportStatement} compatData
+   * @returns {string | null}
    */
   getVersionAdded(compatData) {
-    var version_added = null;
+    /** @type {string | null} */
+    let version_added = null;
 
-    if (typeof(compatData.version_added) === 'string')
+    if (typeof compatData.version_added === 'string')
       return compatData.version_added;
 
-    if (compatData.constructor === Array) {
-      for (var i = compatData.length - 1; i >= 0; i--) {
-        var va = compatData[i].version_added;
-        if (typeof(va) === 'string' && (version_added == null || (typeof(version_added) === 'string' && compareVersions.compare(version_added.replace("≤", ""), va.replace("≤", ""), ">")))) {
+    if (Array.isArray(compatData)) {
+      for (let i = compatData.length - 1; i >= 0; i--) {
+        const va = compatData[i].version_added;
+        if (
+          typeof va === 'string' &&
+          (version_added == null ||
+            (typeof version_added === 'string' &&
+              compareVersions.compare(
+                version_added.replace('≤', ''),
+                va.replace('≤', ''),
+                '>'
+              )))
+        ) {
           version_added = va;
         }
       }
@@ -217,20 +277,23 @@ const chalk = require('chalk')
     return version_added;
   }
 
-  /*
-   * @param {string} a
-   * @param {string} b
+  /**
+   * @param {SupportStatement} a
+   * @param {SupportStatement} b
    * @returns {boolean}
    */
   isVersionAddedGreater(a, b) {
     var a_version_added = this.getVersionAdded(a);
     var b_version_added = this.getVersionAdded(b);
 
-    if (typeof(a_version_added) === 'string' && typeof(b_version_added) === 'string') {
-      if (a_version_added.startsWith("≤") || b_version_added.startsWith("≤")) {
+    if (
+      typeof a_version_added === 'string' &&
+      typeof b_version_added === 'string'
+    ) {
+      if (a_version_added.startsWith('≤') || b_version_added.startsWith('≤')) {
         return false;
       }
-      return compareVersions.compare(a_version_added, b_version_added, "<");
+      return compareVersions.compare(a_version_added, b_version_added, '<');
     }
 
     return false;
@@ -238,12 +301,11 @@ const chalk = require('chalk')
 
   /**
    *
-   * @param {object} compatData
-   * @param {callback} callback
-   * @returns {boolean}
+   * @param {CompatStatement} compatData
+   * @param {(browserData: SimpleSupportStatement) => boolean} callback
+   * @returns {string[]}
    */
-  extractBrowsers(compatData, callback)
-  {
+  extractBrowsers(compatData, callback) {
     return Object.keys(compatData.support).filter(browser => {
       const browserData = compatData.support[browser];
 
@@ -256,9 +318,13 @@ const chalk = require('chalk')
       }
     });
   }
- }
+}
 
+/**
+ * @param {string} filename
+ */
 function testConsistency(filename) {
+  /** @type {Identifier} */
   let data = require(filename);
 
   const checker = new ConsistencyChecker();
@@ -269,19 +335,25 @@ function testConsistency(filename) {
     errors.forEach(({ feature, path, errors }) =>  {
       console.error(chalk`{red   → {bold ${errors.length}} × {bold ${feature}} [${path.join('.')}]: }`);
       errors.forEach(({ errortype, browser, parent_value, subfeatures }) => {
-        if (errortype == "unsupported") {
-          console.error(chalk`{red     → No support in {bold ${browser}}, but support is declared in the following sub-feature(s):}`);
-        } else if (errortype == "support_unknown") {
-          console.error(chalk`{red     → Unknown support in parent for {bold ${browser}}, but support is declared in the following sub-feature(s):}`);
-        } else if (errortype == "subfeature_earlier_implementation") {
-          console.error(chalk`{red     → Basic support in {bold ${browser}} was declared implemented in a later version ({bold ${parent_value}}) than the following sub-feature(s):}`);
+        switch (errortype) {
+          case 'unsupported':
+            console.error(chalk`{red     → No support in {bold ${browser}}, but support is declared in the following sub-feature(s):}`);
+            break;
+          case 'support_unknown':
+            console.error(chalk`{red     → Unknown support in parent for {bold ${browser}}, but support is declared in the following sub-feature(s):}`);
+            break;
+          case 'subfeature_earlier_implementation':
+            console.error(chalk`{red     → Basic support in {bold ${browser}} was declared implemented in a later version ({bold ${parent_value}}) than the following sub-feature(s):}`);
+            break;
+          default:
+            throw new TypeError('Unknown error type: ' + inspect(errortype));
         }
 
         subfeatures.forEach(subfeature => {
-          console.error(chalk`{red       → {bold ${path.join('.')}.${subfeature[0]}}: ${subfeature[1] || "[Array]"}}`);
+          console.error(chalk`{red       → {bold ${path.join('.')}.${subfeature[0]}}: ${subfeature[1] || '[Array]'}}`);
         });
       });
-    })
+    });
     return true;
   }
   return false;

--- a/test/linter/test-consistency.js
+++ b/test/linter/test-consistency.js
@@ -234,7 +234,7 @@ class ConsistencyChecker {
     if (compatData.constructor === Array) {
       for (var i = compatData.length - 1; i >= 0; i--) {
         var va = compatData[i].version_added;
-        if (typeof(va) === 'string' && (version_added == null || (typeof(version_added) === 'string' && compareVersions.compare(version_added.replace('≤', ''), va.replace('≤', ''), '>')))) {
+        if (typeof(va) === 'string' && (version_added == null || (typeof(version_added) === 'string' && compareVersions.compare(version_added.replace("≤", ""), va.replace("≤", ""), ">")))) {
           version_added = va;
         }
       }
@@ -253,10 +253,10 @@ class ConsistencyChecker {
     var b_version_added = this.getVersionAdded(b);
 
     if (typeof(a_version_added) === 'string' && typeof(b_version_added) === 'string') {
-      if (a_version_added.startsWith('≤') || b_version_added.startsWith('≤')) {
+      if (a_version_added.startsWith("≤") || b_version_added.startsWith("≤")) {
         return false;
       }
-      return compareVersions.compare(a_version_added, b_version_added, '<');
+      return compareVersions.compare(a_version_added, b_version_added, "<");
     }
 
     return false;
@@ -299,16 +299,16 @@ function testConsistency(filename) {
     errors.forEach(({ feature, path, errors }) =>  {
       console.error(chalk`{red   → {bold ${errors.length}} × {bold ${feature}} [${path.join('.')}]: }`);
       errors.forEach(({ errortype, browser, parent_value, subfeatures }) => {
-        if (errortype == 'unsupported') {
+        if (errortype == "unsupported") {
           console.error(chalk`{red     → No support in {bold ${browser}}, but support is declared in the following sub-feature(s):}`);
-        } else if (errortype == 'support_unknown') {
+        } else if (errortype == "support_unknown") {
           console.error(chalk`{red     → Unknown support in parent for {bold ${browser}}, but support is declared in the following sub-feature(s):}`);
-        } else if (errortype == 'subfeature_earlier_implementation') {
+        } else if (errortype == "subfeature_earlier_implementation") {
           console.error(chalk`{red     → Basic support in {bold ${browser}} was declared implemented in a later version ({bold ${parent_value}}) than the following sub-feature(s):}`);
         }
 
         subfeatures.forEach(subfeature => {
-          console.error(chalk`{red       → {bold ${path.join('.')}.${subfeature[0]}}: ${subfeature[1] || '[Array]'}}`);
+          console.error(chalk`{red       → {bold ${path.join('.')}.${subfeature[0]}}: ${subfeature[1] || "[Array]"}}`);
         });
       });
     });

--- a/test/linter/test-consistency.js
+++ b/test/linter/test-consistency.js
@@ -1,7 +1,7 @@
 'use strict';
 const path = require('path');
 const compareVersions = require('compare-versions');
-const chalk = require('chalk');
+const chalk = require('chalk')
 
 /**
  * @typedef {import('../../types').CompatStatement} CompatStatement
@@ -32,7 +32,8 @@ const chalk = require('chalk');
  * This checker aims at improving data quality
  * by detecting inconsistent information.
  */
-class ConsistencyChecker {
+ class ConsistencyChecker
+ {
   /**
    * @param {Identifier} data
    * @return {ConsistencyError[]}
@@ -282,7 +283,7 @@ class ConsistencyChecker {
       }
     });
   }
-}
+ }
 
 /**
  * @param {string} filename
@@ -311,7 +312,7 @@ function testConsistency(filename) {
           console.error(chalk`{red       → {bold ${path.join('.')}.${subfeature[0]}}: ${subfeature[1] || "[Array]"}}`);
         });
       });
-    });
+    })
     return true;
   }
   return false;

--- a/test/linter/test-descriptions.js
+++ b/test/linter/test-descriptions.js
@@ -1,9 +1,14 @@
 const chalk = require('chalk');
 
 /**
+ * @typedef {import('../../types').Identifier} Identifier
+ * @typedef {import('../utils').Logger} Logger
+ */
+
+/**
  * @param {Identifier} apiData
  * @param {String} apiName
- * @param {import('../utils').Logger} logger
+ * @param {Logger} logger
  */
 function hasValidConstrutorDescription(apiData, apiName, logger) {
   const constructor = apiData[apiName];
@@ -17,7 +22,7 @@ function hasValidConstrutorDescription(apiData, apiName, logger) {
 /**
  * @param {Identifier} apiData
  * @param {String} apiName
- * @param {import('../utils').Logger} logger
+ * @param {Logger} logger
  */
 function hasCorrectDOMEventsDescription(apiData, apiName, logger) {
   for (const methodName in apiData) {
@@ -36,7 +41,7 @@ function hasCorrectDOMEventsDescription(apiData, apiName, logger) {
 /**
  * @param {Identifier} apiData
  * @param {String} apiName
- * @param {import('../utils').Logger} logger
+ * @param {Logger} logger
  */
 function hasCorrectSecureContextRequiredDescription(apiData, apiName, logger) {
   const secureContext = apiData.secure_context_required;
@@ -50,7 +55,7 @@ function hasCorrectSecureContextRequiredDescription(apiData, apiName, logger) {
 /**
  * @param {Identifier} apiData
  * @param {String} apiName
- * @param {import('../utils').Logger} logger
+ * @param {Logger} logger
  */
 function hasCorrectWebWorkersDescription(apiData, apiName, logger) {
   const workerSupport = apiData.worker_support;

--- a/test/linter/test-links.js
+++ b/test/linter/test-links.js
@@ -4,8 +4,12 @@ const chalk = require('chalk');
 const { IS_WINDOWS, indexToPos } = require('../utils.js');
 
 /**
+ * @typedef {import('../utils').Logger} Logger
+ */
+
+/**
  * @param {string} filename
- * @param {import('../utils').Logger} logger
+ * @param {Logger} logger
  */
 function processData(filename, logger) {
   let hasErrors = false;

--- a/test/linter/test-prefix.js
+++ b/test/linter/test-prefix.js
@@ -2,6 +2,17 @@
 const path = require('path');
 const chalk = require('chalk');
 
+/**
+ * @typedef {import('../../types').Identifier} Identifier
+ */
+
+/**
+ * @param {Identifier} data
+ * @param {string} category
+ * @param {string[]} errors
+ * @param {string} prefix
+ * @param {string} [path]
+ */
 function checkPrefix(data, category, errors, prefix, path="") {
   for (const key in data) {
     if (key === "prefix" && typeof(data[key]) === "string") {
@@ -25,6 +36,11 @@ function checkPrefix(data, category, errors, prefix, path="") {
   return errors;
 }
 
+/**
+ * @param {Identifier} data
+ * @param {string} category
+ * @return {string[]}
+ */
 function processData(data, category) {
   let errors = [];
   let prefixes = [];
@@ -42,6 +58,9 @@ function processData(data, category) {
   return errors;
 }
 
+/**
+ * @param {string} filename
+ */
 function testPrefix(filename) {
   const relativePath = path.relative(path.resolve(__dirname, '..', '..'), filename);
   const category = relativePath.includes(path.sep) && relativePath.split(path.sep)[0];

--- a/test/linter/test-real-values.js
+++ b/test/linter/test-real-values.js
@@ -7,6 +7,7 @@ const chalk = require('chalk');
  * @typedef {import('../../types').SimpleSupportStatement} SimpleSupportStatement
  * @typedef {import('../../types').SupportBlock} SupportBlock
  * @typedef {import('../../types').VersionValue} VersionValue
+ * @typedef {import('../utils').Logger} Logger
  */
 
 /** @type {string[]} */
@@ -45,7 +46,7 @@ const blockList = {
  * @param {SupportBlock} supportData
  * @param {string[]} blockList
  * @param {string} relPath
- * @param {import('../utils').Logger} logger
+ * @param {Logger} logger
  */
 function checkRealValues(supportData, blockList, relPath, logger) {
   let hasErrors = false;


### PR DESCRIPTION
The&nbsp;**JSDoc**&nbsp;type&nbsp;annotations were&nbsp;either&nbsp;incomplete or&nbsp;flat&nbsp;out&nbsp;incorrect in&nbsp;many&nbsp;places, especially&nbsp;in&nbsp;the&nbsp;consistency&nbsp;checker.

---

review?(@Elchi3, @vinyldarkscratch)
