### PR TITLE
adding Chrome support for jump

### DIFF
--- a/api/EffectTiming.json
+++ b/api/EffectTiming.json
@@ -243,10 +243,10 @@
             "description": "<code>jump-</code> keywords for <code>steps()</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "77"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "77"
               },
               "edge": {
                 "version_added": null
@@ -276,11 +276,11 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "77"
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/animation-timing-function.json
+++ b/css/properties/animation-timing-function.json
@@ -167,10 +167,10 @@
             "description": "<code>jump-</code> keywords for <code>steps()</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "77"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "77"
               },
               "edge": {
                 "version_added": false
@@ -200,11 +200,11 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "77"
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/transition-timing-function.json
+++ b/css/properties/transition-timing-function.json
@@ -165,10 +165,10 @@
             "description": "<code>jump-</code> keywords for <code>steps()</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "77"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "77"
               },
               "edge": {
                 "version_added": false
@@ -198,11 +198,11 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "77"
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/types/timing-function.json
+++ b/css/types/timing-function.json
@@ -149,10 +149,10 @@
               "description": "<code>jump-</code> keywords for <code>steps()</code>",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "77"
                 },
                 "chrome_android": {
-                  "version_added": false
+                  "version_added": "77"
                 },
                 "edge": {
                   "version_added": false
@@ -182,11 +182,11 @@
                   "version_added": false
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "77"
                 }
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }


### PR DESCRIPTION
As part of my work figuring out what is really experimental in the CSS properties (https://github.com/mdn/sprints/issues/2402), I found that Chrome has shipped support for the jump keywords. This PR adds support and also removes the experimental flag as we have two implementations.

- https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/animation-timing-function 
- https://bugs.chromium.org/p/chromium/issues/detail?id=893397
- https://chromestatus.com/features/5730327525851136

