### PR TITLE
Update IE support for api.PageTransitionEvent.persisted

### DIFF
--- a/api/PageTransitionEvent.json
+++ b/api/PageTransitionEvent.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "12"
           },
           "firefox": {
             "version_added": true
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": null
+            "version_added": true
           },
           "opera": {
             "version_added": true
@@ -67,7 +67,8 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "11",
+              "notes": "The <code>persisted</code> property is known to be buggy in Internet Explorer. It is advised to check if <code>window.performance.navigation.type == 2</code> as well."
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
Supersedes #5077.  It was determined that Internet Explorer's support for this is quite buggy.  This PR adds the version number for this feature, as well as a note describing the buggy nature and how to consistently check it.