### PR TITLE
Update data for api.Navigator.connection for Firefox

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -436,7 +436,14 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.netinfo.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": "14",


### PR DESCRIPTION
Supersedes #5093.  Firefox for desktop supports `navigator.connection` behind a flag, which is disabled by default.