### PR TITLE
test(lint): Fix `testLinks(…)` variable assignment typo

### DIFF
--- a/test/lint.js
+++ b/test/lint.js
@@ -85,7 +85,7 @@ function load(...files) {
         try {
           if (file.indexOf('browsers' + path.sep) !== -1) {
             hasSchemaErrors = testSchema(file, './../../schemas/browsers.schema.json');
-            hasStyleErrors = testLinks(file);
+            hasLinkErrors = testLinks(file);
           } else {
             hasSchemaErrors = testSchema(file);
             hasStyleErrors = testStyle(file);


### PR DESCRIPTION
I&nbsp;accidentally made&nbsp;this&nbsp;typo back&nbsp;in&nbsp;#4847.