### PR TITLE
adding compat data for FormDataEvent

### DIFF
--- a/api/FormDataEvent.json
+++ b/api/FormDataEvent.json
@@ -1,0 +1,170 @@
+{
+  "api": {
+    "FormDataEvent": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/FormDataEvent",
+        "support": {
+          "chrome": {
+            "version_added": "77"
+          },
+          "chrome_android": {
+            "version_added": "77"
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "71",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.formdata.event.enabled",
+                "value_to_set": "true"
+              }
+            ]
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "64"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": "77"
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "FormDataEvent": {
+        "__compat": {
+          "description": "<code>FormDataEvent()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FormDataEvent/FormDataEvent",
+          "support": {
+            "chrome": {
+              "version_added": "77"
+            },
+            "chrome_android": {
+              "version_added": "77"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.formdata.event.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "64"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "77"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "formData": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FormDataEvent.formData",
+          "support": {
+            "chrome": {
+              "version_added": "77"
+            },
+            "chrome_android": {
+              "version_added": "77"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.formdata.event.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "64"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "77"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -1507,6 +1507,61 @@
           }
         }
       },
+      "onformdata": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onformdata",
+          "support": {
+            "chrome": {
+              "version_added": "77"
+            },
+            "chrome_android": {
+              "version_added": "77"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.formdata.event.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "64"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "77"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "ongotpointercapture": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/ongotpointercapture",

--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -383,6 +383,62 @@
           }
         }
       },
+      "formdata_event": {
+        "__compat": {
+          "description": "<code>formdata</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFormElement/formdata_event",
+          "support": {
+            "chrome": {
+              "version_added": "77"
+            },
+            "chrome_android": {
+              "version_added": "77"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.formdata.event.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "64"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "77"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFormElement/length",


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1518442

The current state in Fx is behind a pref from 71 onwards.

I got the Chrome data from https://bugzilla.mozilla.org/show_bug.cgi?id=1518442 (and extrapolated the Opera data from that).

Tested manually in Safari — no support