### PR TITLE
CacheStorage: Window only available in Chrome over HTTPS.

### DIFF
--- a/api/CacheStorage.json
+++ b/api/CacheStorage.json
@@ -7,7 +7,7 @@
           "chrome": {
             "version_added": "40",
             "notes": [
-              "Accessible from <code>Window</code> from version 43, but <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1026063">only over HTTPS</a>.",
+              "Accessible from <code>Window</code> from version 43, but <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=1026063'>only over HTTPS</a>.",
               "Accessible from <code>WorkerGlobalScope</code> from version 43."
             ]
           },

--- a/api/CacheStorage.json
+++ b/api/CacheStorage.json
@@ -38,7 +38,7 @@
             "version_added": "27"
           },
           "safari": {
-            "version_added": "11.1"
+            "version_added": "11.1",
             "notes": "<code>window.caches</code> is only available over HTTPS."
           },
           "safari_ios": {

--- a/api/CacheStorage.json
+++ b/api/CacheStorage.json
@@ -7,7 +7,7 @@
           "chrome": {
             "version_added": "40",
             "notes": [
-              "Accessible from <code>Window</code> from version 43.",
+              "Accessible from <code>Window</code> from version 43, but <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1026063">only over HTTPS</a>.",
               "Accessible from <code>WorkerGlobalScope</code> from version 43."
             ]
           },
@@ -39,6 +39,7 @@
           },
           "safari": {
             "version_added": "11.1"
+            "notes": "<code>window.caches</code> is only available over HTTPS."
           },
           "safari_ios": {
             "version_added": true


### PR DESCRIPTION
Firefox exposes `window.caches` over HTTP, but Chrome and Safari do not.

This can be verified in the latest version of those browsers by typing `window.caches` in the console, both on a site that has an SSL certificate installed, and then on one that doesn't.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
