### PR TITLE
Firefox 72 disables Public-Key-Pins header

### DIFF
--- a/http/headers/public-key-pins.json
+++ b/http/headers/public-key-pins.json
@@ -17,12 +17,38 @@
               "version_added": false,
               "notes": "<a href='https://developer.microsoft.com/microsoft-edge/platform/status/publickeypinningextensionforhttp'>Under consideration</a> for future release."
             },
-            "firefox": {
-              "version_added": "35"
-            },
-            "firefox_android": {
-              "version_added": "35"
-            },
+            "firefox": [
+              {
+                "version_added": "35",
+                "version_removed": "72"
+              },
+              {
+                "version_added": "72",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "security.cert_pinning.hpkp.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "35",
+                "version_removed": "72"
+              },
+              {
+                "version_added": "72",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "security.cert_pinning.hpkp.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/http/headers/public-key-pins.json
+++ b/http/headers/public-key-pins.json
@@ -33,22 +33,9 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "35",
-                "version_removed": "72"
-              },
-              {
-                "version_added": "72",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "security.cert_pinning.hpkp.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "35"
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
## Summary
Firefox 72 disabled `Public-Key-Pins` HTTP header, adds a flag to re-enable it.

## Data
1. [HTTP Public Key Pinning is no longer supported [by Firefox 72]](https://www.fxsitecompat.dev/en-CA/docs/2019/http-public-key-pinning-is-no-longer-supported/)
2. [Commit comment](https://hg.mozilla.org/mozilla-central/rev/d791bfa31f08) mentions the flag:
   > ... This patch adds the preference "security.cert_pinning.hpkp.enabled" and sets it to false by default. As such, the platform will no longer process the HPKP header nor
consult any cached HPKP information for certificate pins. Preloaded (statically-compiled) pins are still enabled in Firefox by default. This patch also disables dynamically setting pins via our remote security settings infrastructure, as it uses the same backend and represents similar compatibility risk.

On a side note, I'm pretty sure Opera, Opera for Android, Android webview, and Samsung Internet do not currently support this header either.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
