### PR TITLE
CSS clip-path is non-experimental for HTML elements

### DIFF
--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -312,7 +312,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
The usage of `clip-path` on HTML elements is part of a spec in CR and stable, with a reasonable amount of rowser support. Updating the experimental flag.
