### PR TITLE
Update display values to non-experimental; remove display: subgrid

### DIFF
--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -1092,7 +1092,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -150,7 +150,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -197,7 +197,7 @@
                 }
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -543,7 +543,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -776,7 +776,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -1095,62 +1095,6 @@
               "experimental": true,
               "standard_track": true,
               "deprecated": false
-            }
-          }
-        },
-        "subgrid": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "qq_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "uc_android": {
-                "version_added": false
-              },
-              "uc_chinese_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": true
             }
           }
         },


### PR DESCRIPTION
There were a whole bunch of values marked experimental, including `grid`, `inline-grid`, `contents` which are not experimental.

I also removed `display: subgrid` I don't think it makes sense to be here. It was never implemented in any browser, and was part of a suggestion in terms of how to create the subgrid feature, which went up against the single-dimensional model agreed on as values for `grid-template-columns` and `grid-template-rows`. I think leaving it here may well just confuse people.
