### PR TITLE
set filter to not be experimental

### DIFF
--- a/css/properties/filter.json
+++ b/css/properties/filter.json
@@ -143,7 +143,7 @@
             ]
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
The `filter` property has wide support at this point, and the spec appears stable.
