### PR TITLE
correcting offset properties

### DIFF
--- a/css/properties/offset-path.json
+++ b/css/properties/offset-path.json
@@ -7,8 +7,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "55",
-                "notes": "<code>path()</code> is the only value type supported."
+                "version_added": "55"
               },
               {
                 "alternative_name": "motion-path",
@@ -17,8 +16,7 @@
             ],
             "chrome_android": [
               {
-                "version_added": "55",
-                "notes": "<code>path()</code> is the only value type supported."
+                "version_added": "55"
               },
               {
                 "alternative_name": "motion-path",
@@ -30,7 +28,6 @@
             },
             "firefox": {
               "version_added": "63",
-              "notes": "<code>path()</code> is the only value type supported.",
               "flags": [
                 {
                   "type": "preference",
@@ -41,7 +38,6 @@
             },
             "firefox_android": {
               "version_added": "63",
-              "notes": "<code>path()</code> is the only value type supported.",
               "flags": [
                 {
                   "type": "preference",
@@ -55,8 +51,7 @@
             },
             "opera": [
               {
-                "version_added": "45",
-                "notes": "<code>path()</code> is the only value type supported."
+                "version_added": "45"
               },
               {
                 "alternative_name": "motion-path",
@@ -65,8 +60,7 @@
             ],
             "opera_android": [
               {
-                "version_added": "43",
-                "notes": "<code>path()</code> is the only value type supported."
+                "version_added": "43"
               },
               {
                 "alternative_name": "motion-path",
@@ -84,8 +78,7 @@
             },
             "webview_android": [
               {
-                "version_added": "55",
-                "notes": "<code>path()</code> is the only value type supported."
+                "version_added": "55"
               },
               {
                 "alternative_name": "motion-path",
@@ -161,7 +154,14 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "71"
+                "version_added": "71",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.motion-path.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": {
                 "version_added": false

--- a/css/properties/offset.json
+++ b/css/properties/offset.json
@@ -27,7 +27,14 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "71"
+              "version_added": "71",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.motion-path.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
All of the `offset`/`offset-*` properties are supported in Firefox behind a pref, but some of the data points don't include this information. I've added it here, in places where it is missing.

I also got rid of the weird notes in `offset-path` that said `path()` is the only value type supported. This was weird in the first place, and is also no longer true because `ray()` is now also supported.