### PR TITLE
Update publishing docs and release notes script

### DIFF
--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -8,12 +8,12 @@ Any owner can complete the following steps to publish a new version, but please 
 
 To create and publish a new version of `mdn-browser-compat-data`:
 
-1. Figure out the new version number by looking at [past releases](https://github.com/mdn/browser-compat-data/releases). The project is in alpha, so we're using only patch versions. Lets assume the next version should be `0.0.43`.
-2. On your updated and clean master branch, run `npm version patch -m "43rd alpha version"`. Locally, this updates `package.json`, creates a new commit, and creates a new release tag (see also the docs for [npm version](https://docs.npmjs.com/cli/version)).
+1. Figure out the new version number by looking at [past releases](https://github.com/mdn/browser-compat-data/releases). If the release is a non-breaking and data-only update, we're using patch versions. Lets assume that's the case and the next version should be `1.0.3`.
+2. On your updated and clean master branch, run `npm version patch -m "Patch release containing data or non-breaking updates only"`. Locally, this updates `package.json`, creates a new commit, and creates a new release tag (see also the docs for [npm version](https://docs.npmjs.com/cli/version)).
 3. Push the commit to `master`: `git push origin master`.
 4. Check if the commit passes fine on [Travis CI](https://travis-ci.org/mdn/browser-compat-data).
-5. If Travis is alright, push the git tag as well: `git push origin v0.0.43`.
+5. If Travis is alright, push the git tag as well: `git push origin v1.0.3`.
 This step will trigger Travis to publish to npm automatically (see our [.travis.yml file](https://github.com/mdn/browser-compat-data/blob/master/.travis.yml)).
-6. Check [Travis CI](https://travis-ci.org/mdn/browser-compat-data) again for the v0.0.43 build and also check [mdn-browser-compat-data on npm](https://www.npmjs.com/package/mdn-browser-compat-data) to see if `0.0.43` shows up correctly once Travis has finished its work.
-7. Notify the [#mdndev](irc://irc.mozilla.org/mdndev) IRC channel on irc.mozilla.org about the new release.
-8. Create a new [release on GitHub](https://github.com/mdn/browser-compat-data/releases) by running `npm run release-notes -- v0.0.43`).
+6. Check [Travis CI](https://travis-ci.org/mdn/browser-compat-data) again for the v1.0.3 build and also check [mdn-browser-compat-data on npm](https://www.npmjs.com/package/mdn-browser-compat-data) to see if `1.0.3` shows up correctly once Travis has finished its work.
+7. Notify the #mdn-dev IRC channel on Mozilla Slack about the new release.
+8. Create a new [release on GitHub](https://github.com/mdn/browser-compat-data/releases) by running `npm run release-notes -- v1.0.3`).

--- a/scripts/release-notes.js
+++ b/scripts/release-notes.js
@@ -114,7 +114,7 @@ const makeURL = (version, body) => {
   // Adhering to RFC 3986 makes the full link clickable in Terminal.app
   const encodedBody = encodeURIComponent(body).replace(/[!'()*]/g, c => `%${c.charCodeAt(0).toString(16)}`);
 
-  return `${baseURL}?title=${version}&tag=${version}&prerelease=true&body=${encodedBody}`;
+  return `${baseURL}?title=${version}&tag=${version}&body=${encodedBody}`;
 };
 
 const main = async () => {
@@ -133,8 +133,8 @@ const main = async () => {
 - ${changeMessage}
 
 **Statistics**
-- ${features} total features
 - ${releaseContributors} contributors have changed ${changed} files with ${insertions} additions and ${deletions} deletions in ${commits} commits (https://github.com/mdn/browser-compat-data/compare/${previousVersion}...${version})
+- ${features} total features
 - ${totalContributors} total contributors
 - ${stars} total stargazers`;
 


### PR DESCRIPTION
This PR updates the publishing docs now that we've released 1.0.0.

It also tweaks the release notes script to no longer have "pre releases" checked and sorts the statistics section so that changes in the release itself are presented first and then overall repo stats are mentioned.