### PR TITLE
Fix all old Chrome bug URLs

### DIFF
--- a/api/PerformanceFrameTiming.json
+++ b/api/PerformanceFrameTiming.json
@@ -6,11 +6,11 @@
         "support": {
           "chrome": {
             "version_added": false,
-            "notes": "See <a href='https://code.google.com/p/chromium/issues/detail?id=120796'>Chrome bug 120796</a>"
+            "notes": "See <a href='https://crbug.com/120796'>Chrome bug 120796</a>"
           },
           "chrome_android": {
             "version_added": false,
-            "notes": "See <a href='https://code.google.com/p/chromium/issues/detail?id=120796'>Chrome bug 120796</a>"
+            "notes": "See <a href='https://crbug.com/120796'>Chrome bug 120796</a>"
           },
           "edge": {
             "version_added": null
@@ -39,7 +39,7 @@
           },
           "webview_android": {
             "version_added": false,
-            "notes": "See <a href='https://code.google.com/p/chromium/issues/detail?id=120796'>Chrome bug 120796</a>"
+            "notes": "See <a href='https://crbug.com/120796'>Chrome bug 120796</a>"
           }
         },
         "status": {

--- a/css/properties/-webkit-print-color-adjust.json
+++ b/css/properties/-webkit-print-color-adjust.json
@@ -9,14 +9,14 @@
               "version_added": "17",
               "notes": [
                 "Chrome does not print backgrounds of the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/body'><code>&lt;body&gt;</code></a> element. If this property is set to <code>exact</code> for the <code>&lt;body&gt;</code> element, it will apply only to its descendants.",
-                "Before Chrome 26, if background images are clipped (for example, when using <code>background-image</code> sprites) and <code>-webkit-print-color-adjust</code> is set to <code>exact</code>, then backgrounds will appear distorted when printed. Solid backgrounds and background images that are not clipped (i.e., backgrounds that have narrower and shorter than the element to which they are applied) are printed correctly. See <a href='http://code.google.com/p/chromium/issues/detail?id=131054'>Chromium bug 131054</a>."
+                "Before Chrome 26, if background images are clipped (for example, when using <code>background-image</code> sprites) and <code>-webkit-print-color-adjust</code> is set to <code>exact</code>, then backgrounds will appear distorted when printed. Solid backgrounds and background images that are not clipped (i.e., backgrounds that have narrower and shorter than the element to which they are applied) are printed correctly. See <a href='https://crbug.com/131054'>Chromium bug 131054</a>."
               ]
             },
             "chrome_android": {
               "version_added": "18",
               "notes": [
                 "Chrome does not print backgrounds of the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/body'><code>&lt;body&gt;</code></a> element. If this property is set to <code>exact</code> for the <code>&lt;body&gt;</code> element, it will apply only to its descendants.",
-                "Before Chrome 26, if background images are clipped (for example, when using <code>background-image</code> sprites) and <code>-webkit-print-color-adjust</code> is set to <code>exact</code>, then backgrounds will appear distorted when printed. Solid backgrounds and background images that are not clipped (i.e., backgrounds that have narrower and shorter than the element to which they are applied) are printed correctly. See <a href='http://code.google.com/p/chromium/issues/detail?id=131054'>Chromium bug 131054</a>."
+                "Before Chrome 26, if background images are clipped (for example, when using <code>background-image</code> sprites) and <code>-webkit-print-color-adjust</code> is set to <code>exact</code>, then backgrounds will appear distorted when printed. Solid backgrounds and background images that are not clipped (i.e., backgrounds that have narrower and shorter than the element to which they are applied) are printed correctly. See <a href='https://crbug.com/131054'>Chromium bug 131054</a>."
               ]
             },
             "edge": {
@@ -51,7 +51,7 @@
               "version_added": true,
               "notes": [
                 "Samsung Internet does not print backgrounds of the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/body'><code>&lt;body&gt;</code></a> element. If this property is set to <code>exact</code> for the <code>&lt;body&gt;</code> element, it will apply only to its descendants.",
-                "Before Chrome 26, if background images are clipped (for example, when using <code>background-image</code> sprites) and <code>-webkit-print-color-adjust</code> is set to <code>exact</code>, then backgrounds will appear distorted when printed. Solid backgrounds and background images that are not clipped (i.e., backgrounds that have narrower and shorter than the element to which they are applied) are printed correctly. See <a href='http://code.google.com/p/chromium/issues/detail?id=131054'>Chromium bug 131054</a>."
+                "Before Chrome 26, if background images are clipped (for example, when using <code>background-image</code> sprites) and <code>-webkit-print-color-adjust</code> is set to <code>exact</code>, then backgrounds will appear distorted when printed. Solid backgrounds and background images that are not clipped (i.e., backgrounds that have narrower and shorter than the element to which they are applied) are printed correctly. See <a href='https://crbug.com/131054'>Chromium bug 131054</a>."
               ]
             },
             "webview_android": {

--- a/http/headers/cache-control.json
+++ b/http/headers/cache-control.json
@@ -103,7 +103,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See Chromium <a href='https://code.google.com/p/chromium/issues/detail?id=348877'>bug 348877</a>."
+                "notes": "See Chromium <a href='https://crbug.com/348877'>bug 348877</a>."
               },
               "chrome_android": {
                 "version_added": false


### PR DESCRIPTION
Turns out there's an old version of Chromium bug URLs that come from `code.google.com`.  This PR fixes those URLs up.