### PR TITLE
Feature Policy update: battery, webauthn, publickey-credentials, xr-spatial-tracking, and vr

### DIFF
--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -303,7 +303,8 @@
                 "notes": "Will be implemented, see <a href='https://crbug.com/1007264'>bug 1007264</a>."
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "Will be implemented, see <a href='https://crbug.com/1007264'>bug 1007264</a>."
               },
               "edge": {
                 "version_added": false

--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -1741,10 +1741,12 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/vr",
             "support": {
               "chrome": {
-                "version_added": "62"
+                "version_added": "62",
+                "notes": "WebVR API was never enabled by default in any production builds and was replaced by WebXR Device API."
               },
               "chrome_android": {
-                "version_added": "62"
+                "version_added": "62",
+                "notes": "WebVR API was never enabled by default in any production builds and was replaced by WebXR Device API."
               },
               "edge": {
                 "version_added": false
@@ -1759,10 +1761,12 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "49"
+                "version_added": "49",
+                "notes": "WebVR API was never enabled by default in any production builds and was replaced by WebXR Device API."
               },
               "opera_android": {
-                "version_added": "46"
+                "version_added": "46",
+                "notes": "WebVR API was never enabled by default in any production builds and was replaced by WebXR Device API."
               },
               "safari": {
                 "version_added": false
@@ -1771,10 +1775,60 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": "8.0"
+                "version_added": "8.0",
+                "notes": "WebVR API was never enabled by default in any production builds and was replaced by WebXR Device API."
               },
               "webview_android": {
-                "version_added": "62"
+                "version_added": "62",
+                "notes": "WebVR API was never enabled by default in any production builds and was replaced by WebXR Device API."
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "xr-spatial-tracking": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/xr-spatial-tracking",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
               }
             },
             "status": {

--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -1329,6 +1329,55 @@
             }
           }
         },
+        "publickey-credentials": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/publickey-credentials",
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/993007'>bug </a>."
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "speaker": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/speaker",
@@ -1726,54 +1775,6 @@
               },
               "webview_android": {
                 "version_added": "62"
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "webauthn": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/webauthn",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
               }
             },
             "status": {

--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -294,6 +294,55 @@
             }
           }
         },
+        "battery": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/battery",
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "notes": "Will be implemented, see <a href='https://crbug.com/1007264'>bug 1007264</a>."
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "camera": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/camera",


### PR DESCRIPTION
## Summary
Chrome team introduced Feature Policy directive `battery` that controls Battery Status API. This directive is already on standards track, has Web Platform Tests, and Chrome team is implementing it. Firefox and Safari do not plan to implement this feature because Safari never supported Battery Status API and Firefox restricted it to privileged contexts.

`webauthn` directive was renamed `publickey-credentials`.

Related issue: #5095

## Data
### `battery`
 - [Chromium bug](https://crbug.com/1007264)
 - [MDN article on Feature-Policy: battery](https://wiki.developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy/battery)
 - [Battery Status API Feature Policy integration](https://w3c.github.io/battery/#feature-policy-integration)
 - [List of standard features](https://github.com/w3c/webappsec-feature-policy/blob/master/features.md#standardized-features) with `battery` identifier

### `webauthn` becomes `publickey-credentials`
 - [Web Authentication API Feature Policy integration](https://w3c.github.io/webauthn/#sctn-feature-policy)
 - [Chrome bug](https://bugs.chromium.org/p/chromium/issues/detail?id=993007)
 - [List of standard features](https://github.com/w3c/webappsec-feature-policy/blob/master/features.md#standardized-features) with `publickey-credentials` identifier

#### Related issues
[`webauthn` MDN article slug update](https://github.com/mdn/sprints/issues/2441) (fixed)

### `vr` deprecation and introduction of `xr-spatial-tracking`
Since WebVR API was deprecated and eventually will be removed, it makes sense to mark `vr` feature deprecated.
Also, I added `xr-spatial-tracking` feature because it is already standardized and Chromium team works on the implementation. FYI, Chrome 80 Canary already reports it in `document.featurePolicy.features()`.

Related issue: #5094

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
