### PR TITLE
Delete incorrect reference

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -9955,7 +9955,6 @@
       },
       "wasDiscarded": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/width",
           "support": {
             "chrome": {
               "version_added": "68"


### PR DESCRIPTION
Document.wasDiscarded has a reference to the Document.width property page. I can't find any documentation that's actually about wasDiscarded.
