### PR TITLE
Update Window.json

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -2993,7 +2993,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera": {
               "version_added": true

--- a/api/Window.json
+++ b/api/Window.json
@@ -2993,7 +2993,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": true
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
Window.history property exists in all versions of Internet Explorer

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
Window.history property exists in all versions of Internet Explorer
- [x] Data: if you tested something, describe how you tested with details like browser and version
Verified the presence of property in IE6, IE7, IE8, IE9, IE10, IE11

URL: https://developer.mozilla.org/en-US/docs/Web/API/Window/history