### PR TITLE
Update list-style-type.json: <string>, add Chrome

### DIFF
--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -4161,10 +4161,10 @@
             "description": "<code>&lt;string&gt;</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "79"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "79"
               },
               "edge": {
                 "version_added": false
@@ -4194,7 +4194,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "79"
               }
             },
             "status": {


### PR DESCRIPTION
Chrome Platform Status: list-style-type: <string>
https://www.chromestatus.com/feature/5893875400966144

Enabled by default in:
Chrome for desktop release 79
Chrome for Android release 79
Android WebView release 79

Tracking Bug:
Chromium Issue 687946: Support string values on list-style-type
https://bugs.chromium.org/p/chromium/issues/detail?id=687946

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
