### PR TITLE
Notes about named capturing groups

### DIFF
--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -1299,23 +1299,34 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/match",
             "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.match",
             "support": {
-              "chrome": {
-                "version_added": "1"
-              },
+              "chrome": [
+                {
+                  "version_added": "1",
+                  "version_removed": "64",
+                  "notes": "No support for named capturing groups."
+                },
+                {
+                  "version_added": "64"
+                }
+              ],
               "chrome_android": {
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": "12",
+                "notes": "No support for named capturing groups."
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "notes": "No support for named capturing groups."
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": "4",
+                "notes": "No support for named capturing groups."
               },
               "ie": {
-                "version_added": "4"
+                "version_added": "4",
+                "notes": "No support for named capturing groups."
               },
               "nodejs": {
                 "version_added": true

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -1301,17 +1301,24 @@
             "support": {
               "chrome": [
                 {
+                  "version_added": "64"
+                },
+                {
                   "version_added": "1",
                   "version_removed": "64",
                   "notes": "No support for named capturing groups."
-                },
-                {
-                  "version_added": "64"
                 }
               ],
-              "chrome_android": {
-                "version_added": "18"
-              },
+              "chrome_android": [
+                {
+                  "version_added": "64"
+                },
+                {
+                  "version_added": "18",
+                  "version_removed": "64",
+                  "notes": "No support for named capturing groups."
+                }
+              ],
               "edge": {
                 "version_added": "12",
                 "notes": "No support for named capturing groups."
@@ -1328,27 +1335,62 @@
                 "version_added": "4",
                 "notes": "No support for named capturing groups."
               },
-              "nodejs": {
-                "version_added": true
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
+              "nodejs": [
+                {
+                  "version_added": "10.0.0"
+                },
+                {
+                  "version_added": "1",
+                  "version_removed": "10.0.0",
+                  "notes": "No support for named capturing groups."
+                }
+              ],
+              "opera": [
+                {
+                  "version_added": "51"
+                },
+                {
+                  "version_added": "1",
+                  "version_removed": "51",
+                  "notes": "No support for named capturing groups."
+                }
+              ],
+              "opera_android": [
+                {
+                  "version_added": "47"
+                },
+                {
+                  "version_added": "1",
+                  "version_removed": "47",
+                  "notes": "No support for named capturing groups."
+                }
+              ],
               "safari": {
                 "version_added": true
               },
               "safari_ios": {
                 "version_added": true
               },
-              "samsunginternet_android": {
-                "version_added": "1.0"
-              },
-              "webview_android": {
-                "version_added": "1"
-              }
+              "samsunginternet_android": [
+                {
+                  "version_added": "9"
+                },
+                {
+                  "version_added": "1.0",
+                  "version_removed": "9",
+                  "notes": "No support for named capturing groups."
+                }
+              ],
+              "webview_android": [
+                {
+                  "version_added": "64"
+                },
+                {
+                  "version_added": "1",
+                  "version_removed": "64",
+                  "notes": "No support for named capturing groups."
+                }
+              ]
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -1350,7 +1350,7 @@
                   "version_added": "51"
                 },
                 {
-                  "version_added": "15",
+                  "version_added": true,
                   "version_removed": "51",
                   "notes": "No support for named capturing groups."
                 }

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -1340,7 +1340,7 @@
                   "version_added": "10.0.0"
                 },
                 {
-                  "version_added": "1",
+                  "version_added": "0.1.100",
                   "version_removed": "10.0.0",
                   "notes": "No support for named capturing groups."
                 }
@@ -1350,7 +1350,7 @@
                   "version_added": "51"
                 },
                 {
-                  "version_added": "1",
+                  "version_added": "15",
                   "version_removed": "51",
                   "notes": "No support for named capturing groups."
                 }
@@ -1360,7 +1360,7 @@
                   "version_added": "47"
                 },
                 {
-                  "version_added": "1",
+                  "version_added": true,
                   "version_removed": "47",
                   "notes": "No support for named capturing groups."
                 }
@@ -1373,11 +1373,11 @@
               },
               "samsunginternet_android": [
                 {
-                  "version_added": "9"
+                  "version_added": "9.0"
                 },
                 {
                   "version_added": "1.0",
-                  "version_removed": "9",
+                  "version_removed": "9.0",
                   "notes": "No support for named capturing groups."
                 }
               ],


### PR DESCRIPTION
Not all browsers support these, and the ones that do haven't done so forever.

**Data from:**

* Chrome: https://github.com/tc39/proposal-regexp-named-groups ("V8, shipping in Chrome 64"), https://bugs.chromium.org/p/v8/issues/detail?id=5437
* Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1362154
* Edge: manual testing (see spoiler below)

<details>
<summary>Edge manual testing</summary>
<img src="https://user-images.githubusercontent.com/2552726/69498634-dd36ad80-0ee1-11ea-8146-90261b922493.png">

</details>

