### PR TITLE
Change Array.prototype & BigInt.prototype MDN URL

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -1294,7 +1294,7 @@
         },
         "prototype": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/prototype",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
             "spec_url": "https://tc39.es/ecma262/#sec-array.prototype",
             "support": {
               "chrome": {

--- a/javascript/builtins/BigInt.json
+++ b/javascript/builtins/BigInt.json
@@ -158,7 +158,7 @@
         },
         "prototype": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt/prototype",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt",
             "spec_url": "https://tc39.es/ecma262/#sec-bigint.prototype",
             "support": {
               "chrome": {


### PR DESCRIPTION
See https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array$compare?to=1589607&from=1589603 and https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt$compare?to=1589609&from=1585550, which removed the https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/prototype and https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/prototype
articles and moved their content into their parent articles.