### PR TITLE
Symbol.prototype.description is now in the ES spec

### DIFF
--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -106,7 +106,7 @@
         "description": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/description",
-            "spec_url": "https://tc39.es/proposal-Symbol-description/#sec-symbol.prototype.description",
+            "spec_url": "https://tc39.es/ecma262/#sec-symbol.prototype.description",
             "support": {
               "chrome": {
                 "version_added": "70"


### PR DESCRIPTION
Symbol.prototype.description (previously part of a spec proposal) has now been adopted into the ECMAScript spec; so this change updates the spec URL.