### PR TITLE
Remove experimental flag for line-break property

### DIFF
--- a/css/properties/line-break.json
+++ b/css/properties/line-break.json
@@ -94,7 +94,7 @@
             ]
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
line-break is supported in various browsers (thought some prefixed) but I don't see anything to suggest the spec is experimental.
