### PR TITLE
change experimental flag paint-order

### DIFF
--- a/css/properties/paint-order.json
+++ b/css/properties/paint-order.json
@@ -43,7 +43,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
The `paint-order` property is in everything but IE and spec is in CR https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/paint-order
