### PR TITLE
Update information about SameSite property.

### DIFF
--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -149,10 +149,12 @@
             "description": "<code>SameSite</code>",
             "support": {
               "chrome": {
-                "version_added": "51"
+                "version_added": "51",
+                "notes": "Starting in Chrome 80, the default was changed to <code>Lax</code> and cookies with <code>SameSite</code> equal to <code>None</code> require a secure context."
               },
               "chrome_android": {
-                "version_added": "51"
+                "version_added": "51",
+                "notes": "Starting in Chrome 80, the default was changed to <code>Lax</code> and cookies with <code>SameSite</code> equal to <code>None</code> require a secure context."
               },
               "edge": {
                 "version_added": "16"
@@ -182,7 +184,8 @@
                 "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": "51"
+                "version_added": "51",
+                "notes": "Starting in Chrome 80, the default was changed to <code>Lax</code> and cookies with <code>SameSite</code> equal to <code>None</code> require a secure context."
               }
             },
             "status": {


### PR DESCRIPTION
SameSite defaults to `Lax`:
https://storage.googleapis.com/chromium-find-releases-static/2fb.html#2fbb8e5c2bce66bede14cbfe9c6b427b835f67d9

SameSite requires a secure context:
https://storage.googleapis.com/chromium-find-releases-static/2fb.html#2fbb8e5c2bce66bede14cbfe9c6b427b835f67d9