### PR TITLE
removing experimental flags for CSS types

### DIFF
--- a/css/types/length-percentage.json
+++ b/css/types/length-percentage.json
@@ -91,7 +91,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -91,7 +91,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/types/max.json
+++ b/css/types/max.json
@@ -44,7 +44,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/types/min.json
+++ b/css/types/min.json
@@ -44,7 +44,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
A few CSS types which no longer need to be flagged as experimental. The `Q` value for `length` and `length-percentage` as the spec is CR and there are multiple implementations.

The `min()` and `max()` types as there are 2 implementations.

