### PR TITLE
remove experimental flag on part()

### DIFF
--- a/css/selectors/part.json
+++ b/css/selectors/part.json
@@ -48,7 +48,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
Chrome has implemented, Firefox has though it is behind a flag, spec seems stable:

https://developer.mozilla.org/en-US/docs/Web/CSS/::part
