### PR TITLE
remove experimental flag on marker

### DIFF
--- a/css/selectors/marker.json
+++ b/css/selectors/marker.json
@@ -56,7 +56,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
Firefox has implemented, and Chrome has it behind a flag in Chrome 80, spec stable.

https://developer.mozilla.org/en-US/docs/Web/CSS/::marker
