### PR TITLE
remove experimental flag for host

### DIFF
--- a/css/selectors/hostfunction.json
+++ b/css/selectors/hostfunction.json
@@ -73,7 +73,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
The host function is supported in Chrome and Firefox so removing the flag: https://developer.mozilla.org/en-US/docs/Web/CSS/:host()
