### PR TITLE
remove experimental flags on fullscreen pseudo

### DIFF
--- a/css/selectors/fullscreen.json
+++ b/css/selectors/fullscreen.json
@@ -118,7 +118,7 @@
             ]
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -165,7 +165,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
The fullscreen pseudo-class has more than two browsers supporting it, so removing the flag: https://developer.mozilla.org/en-US/docs/Web/CSS/:fullscreen
