### PR TITLE
FeaturePolicy.features is behind a pref as well

### DIFF
--- a/api/FeaturePolicy.json
+++ b/api/FeaturePolicy.json
@@ -376,7 +376,14 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "70"
+              "version_added": "70",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.featurePolicy.webidl.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
As discussed in https://github.com/mdn/sprints/issues/2126 `FeaturePolicy.features` is also still behind a pref.