### PR TITLE
Update private_class_fields: Edge 76 supports private class fields

### DIFF
--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -240,7 +240,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": false
+              "version_added": "76"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
Set edges earliest supported version of private class fields to 76.
Since Edge switches to chromium, it supports private class fields like chrome does.

Here is the chromium tracking bug (was released with chromium 74): https://bugs.chromium.org/p/v8/issues/detail?id=5368

Tested on Edge 76 with the following code:
```js
class TestClass{
  #testProberty=5;
}
new TestClass();
```

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
