### PR TITLE
tabHide is a permission, not an API method

### DIFF
--- a/webextensions/api/permissions.json
+++ b/webextensions/api/permissions.json
@@ -179,28 +179,6 @@
               }
             }
           }
-        },
-        "tabHide": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/tabHide",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "61"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              }
-            }
-          }
         }
       }
     }

--- a/webextensions/manifest/permissions.json
+++ b/webextensions/manifest/permissions.json
@@ -749,6 +749,28 @@
             }
           }
         },
+        "tabHide": {
+          "__compat": {
+            "description": "<code>tabHide</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "61"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
         "tabs": {
           "__compat": {
             "description": "<code>tabs</code>",


### PR DESCRIPTION
`tabHide` is a permission that you declare in your manifest and not a method in the `permissions` namespace for WebExtensions. See also original formulation in #2913 which would then lead to https://hg.mozilla.org/mozreview/gecko/rev/1a0a2f439964ea520af160bccd998c19e25c5d99#index_header as the very original source. Further, this is already in the optional_permissions compat data (optional_permissions.json, https://github.com/mdn/browser-compat-data/commit/370be97bf066b9cd8a9977967deb77b6b1ef9eae), but not the required permissions.

As advised in https://github.com/mdn/browser-compat-data/commit/3520d4c925707a99b4adea1e6ae5650f7d5a40de cc @rebloor 
