### PR TITLE
Fix userScripts API compat data and add manifest compat data

### DIFF
--- a/webextensions/api/userScripts.json
+++ b/webextensions/api/userScripts.json
@@ -70,9 +70,9 @@
             }
           }
         },
-        "register": {
+        "onBeforeScript": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/register",
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/onBeforeScript",
             "support": {
               "chrome": {
                 "version_added": false
@@ -104,9 +104,9 @@
             }
           }
         },
-        "onBeforeScript": {
+        "register": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/onBeforeScript",
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/register",
             "support": {
               "chrome": {
                 "version_added": false

--- a/webextensions/api/userScripts.json
+++ b/webextensions/api/userScripts.json
@@ -34,11 +34,45 @@
                 "version_added": false
               }
             }
+          },
+          "unregister": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/RegisteredUserScript/unregister",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": [
+                  {
+                    "version_added": "68"
+                  },
+                  {
+                    "version_added": "66",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "extensions.webextensions.userScripts.enabled",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  }
+                ],
+                "firefox_android": {
+                  "version_added": "68"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
           }
         },
-        "unregister": {
+        "register": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/RegisteredUserScript/unregister",
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/register",
             "support": {
               "chrome": {
                 "version_added": false
@@ -69,72 +103,38 @@
               }
             }
           }
-        }
-      },
-      "register": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/register",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": [
-              {
+        },
+        "onBeforeScript": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/onBeforeScript",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": [
+                {
+                  "version_added": "68"
+                },
+                {
+                  "version_added": "66",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "extensions.webextensions.userScripts.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": {
                 "version_added": "68"
               },
-              {
-                "version_added": "66",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "extensions.webextensions.userScripts.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+              "opera": {
+                "version_added": false
               }
-            ],
-            "firefox_android": {
-              "version_added": "68"
-            },
-            "opera": {
-              "version_added": false
-            }
-          }
-        }
-      },
-      "onBeforeScript": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/onBeforeScript",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": [
-              {
-                "version_added": "68"
-              },
-              {
-                "version_added": "66",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "extensions.webextensions.userScripts.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": {
-              "version_added": "68"
-            },
-            "opera": {
-              "version_added": false
             }
           }
         }

--- a/webextensions/manifest/user_scripts.json
+++ b/webextensions/manifest/user_scripts.json
@@ -1,0 +1,49 @@
+{
+  "webextensions": {
+    "manifest": {
+      "user_scripts": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/user_scripts",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "68"
+            },
+            "firefox_android": {
+              "version_added": "68"
+            },
+            "opera": {
+              "version_added": false
+            }
+          }
+        },
+        "api_script": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "68"
+              },
+              "firefox_android": {
+                "version_added": "68"
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The grouping of the userScript APIs was all wrong, essentially most things were one layer too far up. This moves everything to the place it belongs.

Further, the manifest properties have not had compat data, this rectifies that miss. I'm not sure if that data should also get the flag info.