### PR TITLE
IDBTransaction.commit() not available in Fx 71 afterall

### DIFF
--- a/api/IDBTransaction.json
+++ b/api/IDBTransaction.json
@@ -222,7 +222,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "71"
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1497007#c35, `IDBTransaction.commit()` is not available in 71, so reverting this change.