### PR TITLE
change experimental flag on text-decoration props

### DIFF
--- a/css/properties/text-decoration-skip-ink.json
+++ b/css/properties/text-decoration-skip-ink.json
@@ -43,7 +43,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/text-decoration-thickness.json
+++ b/css/properties/text-decoration-thickness.json
@@ -56,7 +56,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
The `text-decoration-skip-ink` and `text-decoration-thickness` properties each have two implementations, updating to remove experimental flag.

- https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-skip-ink
- https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness
