### PR TITLE
updateProperties.muted isn't supported in Firefox for Android

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -3096,7 +3096,7 @@
                     "version_added": "45"
                   },
                   "firefox_android": {
-                    "version_added": "54"
+                    "version_added": false
                   },
                   "opera": {
                     "version_added": "32"


### PR DESCRIPTION
As per [1373035](https://bugzilla.mozilla.org/show_bug.cgi?id=1373035), updated to show updateProperties.muted as not supported in Firefox for Android.


A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
