### PR TITLE
update experimental flag writing-mode

### DIFF
--- a/css/properties/writing-mode.json
+++ b/css/properties/writing-mode.json
@@ -222,7 +222,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
While Firefox is the only implementation at present I don't see any reason to have the sideways values of writing-mode marked experimental. Spec is in CR:

https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/writing-mode
