### PR TITLE
update experimental flag transition-property

### DIFF
--- a/css/properties/transition-property.json
+++ b/css/properties/transition-property.json
@@ -202,7 +202,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
The ident value of transition-property seems to have wide support, I see no reason to mark experimental 

https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/transition-property
