### PR TITLE
Remove html.elements.track.cuechange_event

### DIFF
--- a/html/elements/track.json
+++ b/html/elements/track.json
@@ -77,55 +77,6 @@
             "deprecated": false
           }
         },
-        "cuechange_event": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTrackElement/cuechange_event",
-            "description": "<code>cuechange</code> event",
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": "68"
-              },
-              "firefox_android": {
-                "version_added": "68"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": true
-              },
-              "safari_ios": {
-                "version_added": true
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "default": {
           "__compat": {
             "support": {


### PR DESCRIPTION
## Summary

This data is stored as `api.HTMLTrackElement.cuechange_event`.

This was found while working on #5201.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
