### PR TITLE
Drop the mdn_url for document.wasDiscarded

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -9955,7 +9955,6 @@
       },
       "wasDiscarded": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document",
           "support": {
             "chrome": {
               "version_added": "68"


### PR DESCRIPTION
document.wasDiscarded  isn’t yet actually documented in any MDN article.

cc @jpmedley @bershanskiy 