### PR TITLE
Fix Safari plain href attribute support in SVG

### DIFF
--- a/svg/attributes/href.json
+++ b/svg/attributes/href.json
@@ -30,10 +30,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "9"
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": "9"
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/svg/elements/a.json
+++ b/svg/elements/a.json
@@ -123,10 +123,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": "9"
+                "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": "9"
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/svg/elements/cursor.json
+++ b/svg/elements/cursor.json
@@ -76,10 +76,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "9"
+                "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": "9"
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "version_added": null

--- a/svg/elements/feImage.json
+++ b/svg/elements/feImage.json
@@ -76,10 +76,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": "9"
+                "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": "9"
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/svg/elements/pattern.json
+++ b/svg/elements/pattern.json
@@ -123,10 +123,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": "9"
+                "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": "9"
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "version_added": null

--- a/svg/elements/textpath.json
+++ b/svg/elements/textpath.json
@@ -80,11 +80,11 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true,
+                "version_added": "12.1",
                 "notes": "Only accepts references to path elements. Basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
               },
               "safari_ios": {
-                "version_added": true,
+                "version_added": "12.2",
                 "notes": "Only accepts references to path elements. Basic shapes (rect, circle, ellipse, line, polygon, polyline) won't work."
               },
               "samsunginternet_android": {

--- a/svg/elements/use.json
+++ b/svg/elements/use.json
@@ -221,10 +221,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": "9"
+                "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": "9"
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
Commit 871ca5c (Add Safari support for href attribute on select SVG elements (#4644)) introduced wrong compatibility data for this attribute on Safari.

[The patch](https://trac.webkit.org/changeset/234683/webkit) which adds support for plain href attributes in SVG was [applied to WebKit 607.1](https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/Configurations/Version.xcconfig?rev=234683) and [got included in Safari Technology Preview 63](https://webkit.org/blog/8403/release-notes-for-safari-technology-preview-63/).

Based on the WebKit version, the first Safari release to include this fix is [Safari 12.1](https://github.com/mdn/browser-compat-data/blob/v1.0.0/browsers/safari.json#L160)/[iOS 12.2](https://github.com/mdn/browser-compat-data/blob/v1.0.0/browsers/safari_ios.json#L138) (thanks @SelenIT).

[A post on the WebKit blog](https://webkit.org/blog/8718/new-webkit-features-in-safari-12-1/) also confirms that Safari 12.1 includes the changes from Safari Technology Preview 63:

A manual test has been performed on BrowserStack which confirms Safari 12.1 and iOS 12.2 both support the plain href attribute in svg:use elements.

See also #4644

Also a Safari version number is specified for plain href support in textPath.