### PR TITLE
Remove mdn_urls to missing pages: CSSMathNegate

### DIFF
--- a/api/CSSMathNegate.json
+++ b/api/CSSMathNegate.json
@@ -2,7 +2,6 @@
   "api": {
     "CSSMathNegate": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMathNegate",
         "support": {
           "chrome": {
             "version_added": "66"
@@ -49,7 +48,6 @@
       },
       "CSSMathNegate": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMathNegate/CSSMathNegate",
           "description": "<code>CSSMathNegate()</code> constructor",
           "support": {
             "chrome": {
@@ -98,7 +96,6 @@
       },
       "values": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMathNegate/value",
           "support": {
             "chrome": {
               "version_added": "66"


### PR DESCRIPTION
## Summary

This removes links to nonexistent pages in api/CSSMathNegate.json, including one url that draft linter from #5201 fails on.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
