### PR TITLE
Fix api.DOMHighResTimestamp.mdn_url

### DIFF
--- a/api/DOMHighResTimestamp.json
+++ b/api/DOMHighResTimestamp.json
@@ -2,7 +2,7 @@
   "api": {
     "DOMHighResTimestamp": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMHighResTimeStamp",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMHighResTimestamp",
         "support": {
           "chrome": {
             "version_added": "6"


### PR DESCRIPTION
## Summary
Fix `api.DOMHighResTimestamp.mdn_url` to match capitalization used everywhere else (in the spec, in MDN content).
This is purely cosmetic change as the server uses case-insensitive paths.

## Related issues
This fixes one url that draft linter from #5201 fails on.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
