### PR TITLE
Mirror IE -> Edge for http/

### DIFF
--- a/http/headers/accept-encoding.json
+++ b/http/headers/accept-encoding.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/accept-language.json
+++ b/http/headers/accept-language.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/accept-ranges.json
+++ b/http/headers/accept-ranges.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/accept.json
+++ b/http/headers/accept.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true,

--- a/http/headers/age.json
+++ b/http/headers/age.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/cache-control.json
+++ b/http/headers/cache-control.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/connection.json
+++ b/http/headers/connection.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/content-disposition.json
+++ b/http/headers/content-disposition.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/content-encoding.json
+++ b/http/headers/content-encoding.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/content-language.json
+++ b/http/headers/content-language.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/content-length.json
+++ b/http/headers/content-length.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/content-location.json
+++ b/http/headers/content-location.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/content-range.json
+++ b/http/headers/content-range.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/content-type.json
+++ b/http/headers/content-type.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/cookie.json
+++ b/http/headers/cookie.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/date.json
+++ b/http/headers/date.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/digest.json
+++ b/http/headers/digest.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/dnt.json
+++ b/http/headers/dnt.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "4"

--- a/http/headers/etag.json
+++ b/http/headers/etag.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/expires.json
+++ b/http/headers/expires.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/from.json
+++ b/http/headers/from.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/host.json
+++ b/http/headers/host.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/if-match.json
+++ b/http/headers/if-match.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/if-modified-since.json
+++ b/http/headers/if-modified-since.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/if-none-match.json
+++ b/http/headers/if-none-match.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/if-range.json
+++ b/http/headers/if-range.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/if-unmodified-since.json
+++ b/http/headers/if-unmodified-since.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/keep-alive.json
+++ b/http/headers/keep-alive.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/last-modified.json
+++ b/http/headers/last-modified.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/location.json
+++ b/http/headers/location.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/origin.json
+++ b/http/headers/origin.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true,
+              "version_added": "12",
               "notes": "Not sent with <code>POST</code> requests, see <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/10482384/'>bug 10482384</a>."
             },
             "firefox": [

--- a/http/headers/pragma.json
+++ b/http/headers/pragma.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/range.json
+++ b/http/headers/range.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/referer.json
+++ b/http/headers/referer.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/server.json
+++ b/http/headers/server.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -59,7 +59,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "3"

--- a/http/headers/te.json
+++ b/http/headers/te.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/trailer.json
+++ b/http/headers/trailer.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/transfer-encoding.json
+++ b/http/headers/transfer-encoding.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/user-agent.json
+++ b/http/headers/user-agent.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/vary.json
+++ b/http/headers/vary.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/via.json
+++ b/http/headers/via.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/want-digest.json
+++ b/http/headers/want-digest.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/warning.json
+++ b/http/headers/warning.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/headers/x-content-type-options.json
+++ b/http/headers/x-content-type-options.json
@@ -26,7 +26,7 @@
               }
             ],
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "50"

--- a/http/headers/x-frame-options.json
+++ b/http/headers/x-frame-options.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.6.9"
@@ -59,7 +59,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": true
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "18",
@@ -110,7 +110,7 @@
                 "notes": "Starting in Chrome 61, this applies to all of a frame's ancestors."
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": true,

--- a/http/methods.json
+++ b/http/methods.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -60,7 +60,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -108,7 +108,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -156,7 +156,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -204,7 +204,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -252,7 +252,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -300,7 +300,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true

--- a/http/status.json
+++ b/http/status.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -60,7 +60,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -108,7 +108,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -156,7 +156,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -204,7 +204,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -252,7 +252,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -300,7 +300,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -348,7 +348,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -396,7 +396,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -444,7 +444,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -492,7 +492,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -541,7 +541,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -589,7 +589,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -637,7 +637,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -685,7 +685,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -733,7 +733,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -781,7 +781,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -829,7 +829,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -877,7 +877,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -925,7 +925,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -973,7 +973,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -1069,7 +1069,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -1117,7 +1117,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -1165,7 +1165,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -1213,7 +1213,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -1261,7 +1261,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -1309,7 +1309,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true


### PR DESCRIPTION
This PR is somewhat of a test of the mirroring script, as well as preparation for the Edge migration coming up in the near future.  This PR sets "12" for any feature implemented in Internet Explorer, as well as copies notes when applicable.  This PR applies to the `http/` folder specifically.