### PR TITLE
adding compat data for formdata events

### DIFF
--- a/api/FormDataEvent.json
+++ b/api/FormDataEvent.json
@@ -98,7 +98,7 @@
       },
       "formData": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FormDataEvent.formData",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FormDataEvent/formData",
           "support": {
             "chrome": {
               "version_added": "77"

--- a/api/FormDataEvent.json
+++ b/api/FormDataEvent.json
@@ -1,0 +1,149 @@
+{
+  "api": {
+    "FormDataEvent": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/FormDataEvent",
+        "support": {
+          "chrome": {
+            "version_added": "77"
+          },
+          "chrome_android": {
+            "version_added": "77"
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "72"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "64"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": "77"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "FormDataEvent": {
+        "__compat": {
+          "description": "<code>FormDataEvent()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FormDataEvent/FormDataEvent",
+          "support": {
+            "chrome": {
+              "version_added": "77"
+            },
+            "chrome_android": {
+              "version_added": "77"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "72"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "64"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "77"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "formData": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FormDataEvent.formData",
+          "support": {
+            "chrome": {
+              "version_added": "77"
+            },
+            "chrome_android": {
+              "version_added": "77"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "72"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "64"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "77"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -1507,6 +1507,54 @@
           }
         }
       },
+      "onformdata": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onformdata",
+          "support": {
+            "chrome": {
+              "version_added": "77"
+            },
+            "chrome_android": {
+              "version_added": "77"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "72"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "64"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "77"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "ongotpointercapture": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/ongotpointercapture",

--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -383,6 +383,55 @@
           }
         }
       },
+      "formdata_event": {
+        "__compat": {
+          "description": "<code>formdata</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFormElement/formdata_event",
+          "support": {
+            "chrome": {
+              "version_added": "77"
+            },
+            "chrome_android": {
+              "version_added": "77"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "72"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "64"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "77"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFormElement/length",


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1594708.

The work was first done in https://github.com/mdn/browser-compat-data/pull/5168, but this weirdly got merged to a different branch on the mdn org.

This PR takes that work,  but it updates the Fx data to 72. I've not bothered to write about 71 and the pref. Do you think that's OK?