### PR TITLE
Update Clear-Site-Data MDN URLs

### DIFF
--- a/http/headers/clear-site-data.json
+++ b/http/headers/clear-site-data.json
@@ -75,7 +75,7 @@
         "cache": {
           "__compat": {
             "description": "<code>&quot;cache&quot;</code>",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Clear-Site-Data",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Clear-Site-Data#cache",
             "support": {
               "chrome": {
                 "version_added": "61"
@@ -148,7 +148,7 @@
         "cookies": {
           "__compat": {
             "description": "<code>&quot;cookies&quot;</code>",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Clear-Site-Data",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Clear-Site-Data#cookies",
             "support": {
               "chrome": {
                 "version_added": "61"
@@ -221,7 +221,7 @@
         "executionContexts": {
           "__compat": {
             "description": "<code>&quot;executionContexts&quot;</code>",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Clear-Site-Data",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Clear-Site-Data#executionContexts",
             "support": {
               "chrome": {
                 "version_added": false,
@@ -297,7 +297,7 @@
         "storage": {
           "__compat": {
             "description": "<code>&quot;storage&quot;</code>",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Clear-Site-Data",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Clear-Site-Data#storage",
             "support": {
               "chrome": {
                 "version_added": "61"


### PR DESCRIPTION
## Summary

This fixes URLs of values for Clear-Site-Data HTTP header to point to their corresponding sections on the page. MDN articles already contain all necessary `id`s to make these URLs work.

## Related issues
Part of #5201.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
