### PR TITLE
all lowercase alias has been removed

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -2229,6 +2229,7 @@
                       },
                       {
                         "version_added": "61",
+                        "version_removed": "71",
                         "alternative_name": "isarticle"
                       }
                     ],


### PR DESCRIPTION
According to the [Add-ons in Firefox 71 blog post](https://blog.mozilla.org/addons/2019/11/12/extensions-in-firefox-71/), the all lower-case alias for `isArticle` was removed.
