### PR TITLE
additional options for topSites.get added in Firefox 69

### DIFF
--- a/webextensions/api/topSites.json
+++ b/webextensions/api/topSites.json
@@ -85,6 +85,42 @@
                   "version_added": false
                 }
               }
+            },
+            "includePinned": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "69"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
+            "includeSearchShortcuts": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "69"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
topSites.get got additional options in Firefox 69 according to https://blog.mozilla.org/addons/2019/08/05/extensions-in-firefox-69/