### PR TITLE
CacheStorage API requires secure context in Chrome/Safari/Firefox

### DIFF
--- a/api/CacheStorage.json
+++ b/api/CacheStorage.json
@@ -321,6 +321,51 @@
             "deprecated": false
           }
         }
+      },
+      "secure_context_required": {
+        "__compat": {
+          "description": "Secure context required",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true
+            },
+            "opera_android": {
+              "version_added": true
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/CacheStorage.json
+++ b/api/CacheStorage.json
@@ -327,10 +327,10 @@
           "description": "Secure context required",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "65"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "65"
             },
             "edge": {
               "version_added": null
@@ -345,10 +345,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "52"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "47"
             },
             "safari": {
               "version_added": true
@@ -357,7 +357,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "65"
             }
           },
           "status": {

--- a/api/CacheStorage.json
+++ b/api/CacheStorage.json
@@ -336,10 +336,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "44"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "44"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Continuation off of #5169 due to lack of response from the original author.