### PR TITLE
Add Opera prefers-color-scheme support

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1202,10 +1202,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "62"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "54"
               },
               "safari": {
                 "version_added": "12.1"


### PR DESCRIPTION
This PR adds support for prefers-color-scheme in Opera

Opera (Desktop):
- https://blogs.opera.com/desktop/changelog-for-61/#b3298.3

Opera for Android:
- https://blogs.opera.com/mobile/2019/10/ofa-54-new-colors-ui-design-bitcoin/

