### PR TITLE
Remove broken MDN URLs: webextensions.api.events

### DIFF
--- a/webextensions/api/events.json
+++ b/webextensions/api/events.json
@@ -48,7 +48,6 @@
           },
           "addRules": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events/addRules",
               "support": {
                 "chrome": {
                   "version_added": true
@@ -70,7 +69,6 @@
           },
           "getRules": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events/getRules",
               "support": {
                 "chrome": {
                   "version_added": true
@@ -92,7 +90,6 @@
           },
           "hasListener": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events/Event/hasListener",
               "support": {
                 "chrome": {
                   "version_added": true
@@ -114,7 +111,6 @@
           },
           "hasListeners": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events/hasListeners",
               "support": {
                 "chrome": {
                   "version_added": true
@@ -136,7 +132,6 @@
           },
           "removeListener": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events/Event/removeListener",
               "support": {
                 "chrome": {
                   "version_added": true
@@ -158,7 +153,6 @@
           },
           "removeRules": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events/removeRules",
               "support": {
                 "chrome": {
                   "version_added": true


### PR DESCRIPTION
## Summary

These URLs do not exist and they do not follow the MDN URL convention.

These URLs fail during test with linter from #5201, so they block #5273 or require an exception.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ x Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
