### PR TITLE
Add the `loading` attribute for <img> and <iframe>

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -431,6 +431,65 @@
             }
           }
         },
+        "loading": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "76"
+              },
+              "chrome_android": {
+                "version_added": "76"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": [
+                  "See <a href='https://bugzil.la/1542784'>bug 1542784</a>"
+                ]
+              },
+              "firefox_android": {
+                "version_added": false,
+                "notes": [
+                  "See <a href='https://bugzil.la/1542784'>bug 1542784</a>"
+                ]
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "63"
+              },
+              "opera_android": {
+                "version_added": "54"
+              },
+              "safari": {
+                "version_added": false,
+                "notes": [
+                  "See <a href='https://webkit.org/b/196698'>bug 196698</a>"
+                ]
+              },
+              "safari_ios": {
+                "version_added": false,
+                "notes": [
+                  "See <a href='https://webkit.org/b/196698'>bug 196698</a>"
+                ]
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "longdesc": {
           "__compat": {
             "support": {

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -444,16 +444,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false,
-                "notes": [
-                  "See <a href='https://bugzil.la/1542784'>bug 1542784</a>"
-                ]
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": false,
-                "notes": [
-                  "See <a href='https://bugzil.la/1542784'>bug 1542784</a>"
-                ]
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -489,6 +489,65 @@
             }
           }
         },
+        "loading": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "76"
+              },
+              "chrome_android": {
+                "version_added": "76"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": [
+                  "See <a href='https://bugzil.la/1542784'>bug 1542784</a>"
+                ]
+              },
+              "firefox_android": {
+                "version_added": false,
+                "notes": [
+                  "See <a href='https://bugzil.la/1542784'>bug 1542784</a>"
+                ]
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "63"
+              },
+              "opera_android": {
+                "version_added": "54"
+              },
+              "safari": {
+                "version_added": false,
+                "notes": [
+                  "See <a href='https://webkit.org/b/196698'>bug 196698</a>"
+                ]
+              },
+              "safari_ios": {
+                "version_added": false,
+                "notes": [
+                  "See <a href='https://webkit.org/b/196698'>bug 196698</a>"
+                ]
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "longdesc": {
           "__compat": {
             "support": {


### PR DESCRIPTION
The experimental `loading` attribute, used to lazy-load (or force eager loading of) `<img>` and `<iframe>`.

Enabled by default in Chrome 76:  
https://chromestatus.com/feature/5645767347798016

Bugzilla bug: https://bugzil.la/1542784 (seemingly only for `<img>`, thus only added the bug to `img.json`)
Webkit bug: https://webkit.org/b/196698

I'd be greatful if anyone can help me determine/confirm that the Webkit bug applies to both Safari and Safari iOS, as well as the Bugzilla bug applying to both Firefox and Firefox for Android.

<!--
The spec is still being fleshed out, I expect changes, but will be trying to follow implementations and update accordingly.
-->

<!--
The [spec](https://github.com/whatwg/html/pull/3752) for lazy-loading is still being fleshed out, however Chrome has seemingly implemented the `loading` attribute for both `<img>` and `<iframe>`.

The `<iframe>` part was recently [removed](https://github.com/whatwg/html/pull/3752#issuecomment-547595061)  from the spec PR to be "tackled separately", and while I don't have permission to view the Chrome bug, the headline indicates support for `<iframe>`, as well as the blog post https://web.dev/native-lazy-loading/.
-->

<!-- `auto` value removed: https://github.com/whatwg/html/pull/3752#issuecomment-555328635 -->