### PR TITLE
Don't let Prettier clobber lint exit code

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "scripts": {
     "confluence": "node ./node_modules/mdn-confluence/main/generate.es6.js --output-dir=. --bcd-module=./index.js",
-    "lint": "node test/lint; prettier --check **/*.js **/*.ts",
+    "lint": "node test/lint && prettier --check **/*.js **/*.ts",
     "fix": "node scripts/fix; prettier --write **/*.js **/*.ts",
     "stats": "node scripts/statistics",
     "release-notes": "node scripts/release-notes",


### PR DESCRIPTION
In #5251, we added Prettier's check to the `npm run lint` command. However, if linting fails but Prettier's check succeeds, then all of the `npm run lint` succeeds anyway. This PR makes Prettier's run conditional on the success of the linting script; both checks have to succeed for `npm run lint` to succeed.

Thanks to @bershanskiy for noting the problem in https://github.com/mdn/browser-compat-data/pull/5278#issuecomment-562379440.