### PR TITLE
Mirror Chrome Android 76/77 -> Opera Android 54/55

### DIFF
--- a/api/Blob.json
+++ b/api/Blob.json
@@ -125,7 +125,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": false
@@ -294,7 +294,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": false
@@ -343,7 +343,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": false

--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -89,7 +89,7 @@
               "version_added": "63"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": false
@@ -203,7 +203,7 @@
               "version_added": "63"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": false

--- a/api/EffectTiming.json
+++ b/api/EffectTiming.json
@@ -217,7 +217,7 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": false

--- a/api/EffectTiming.json
+++ b/api/EffectTiming.json
@@ -264,7 +264,7 @@
                 "version_added": false
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "55"
               },
               "safari": {
                 "version_added": false

--- a/api/FormDataEvent.json
+++ b/api/FormDataEvent.json
@@ -26,7 +26,7 @@
             "version_added": "64"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "55"
           },
           "safari": {
             "version_added": false
@@ -74,7 +74,7 @@
               "version_added": "64"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "55"
             },
             "safari": {
               "version_added": false
@@ -122,7 +122,7 @@
               "version_added": "64"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "55"
             },
             "safari": {
               "version_added": false

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -1533,7 +1533,7 @@
               "version_added": "64"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "55"
             },
             "safari": {
               "version_added": false

--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -410,7 +410,7 @@
               "version_added": "64"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "55"
             },
             "safari": {
               "version_added": false

--- a/api/IDBTransaction.json
+++ b/api/IDBTransaction.json
@@ -234,7 +234,7 @@
               "version_added": "63"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": false

--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -299,7 +299,7 @@
                 "version_added": "63"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "54"
               },
               "safari": {
                 "version_added": false

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -3720,7 +3720,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "55"
             },
             "safari": {
               "version_added": false
@@ -3770,7 +3770,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": false

--- a/api/RTCSctpTransport.json
+++ b/api/RTCSctpTransport.json
@@ -28,7 +28,7 @@
             "version_added": false
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "54"
           },
           "safari": {
             "version_added": false
@@ -77,7 +77,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": false
@@ -127,7 +127,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": false
@@ -177,7 +177,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": false
@@ -227,7 +227,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": false
@@ -277,7 +277,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": false

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1205,7 +1205,7 @@
                 "version_added": false
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "54"
               },
               "safari": {
                 "version_added": "12.1"

--- a/css/properties/animation-timing-function.json
+++ b/css/properties/animation-timing-function.json
@@ -188,7 +188,7 @@
                 "version_added": false
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "55"
               },
               "safari": {
                 "version_added": false

--- a/css/properties/backdrop-filter.json
+++ b/css/properties/backdrop-filter.json
@@ -62,9 +62,20 @@
                 }
               ]
             },
-            "opera_android": {
-              "version_added": null
-            },
+            "opera_android": [
+              {
+                "version_added": "54"
+              },
+              {
+                "version_added": "34",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Enable Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
             "safari": {
               "prefix": "-webkit-",
               "version_added": "9"

--- a/css/properties/transition-timing-function.json
+++ b/css/properties/transition-timing-function.json
@@ -186,7 +186,7 @@
                 "version_added": false
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "55"
               },
               "safari": {
                 "version_added": false

--- a/css/properties/white-space.json
+++ b/css/properties/white-space.json
@@ -27,7 +27,7 @@
               "version_added": "4"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/properties/white-space.json
+++ b/css/properties/white-space.json
@@ -74,7 +74,7 @@
                 "version_added": "62"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "54"
               },
               "safari": {
                 "version_added": false

--- a/css/types/timing-function.json
+++ b/css/types/timing-function.json
@@ -170,7 +170,7 @@
                   "version_added": false
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "55"
                 },
                 "safari": {
                   "version_added": false

--- a/javascript/builtins/BigInt.json
+++ b/javascript/builtins/BigInt.json
@@ -287,7 +287,7 @@
                   "version_added": false
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "54"
                 },
                 "safari": {
                   "version_added": false
@@ -337,7 +337,7 @@
                   "version_added": false
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "54"
                 },
                 "safari": {
                   "version_added": false

--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -442,7 +442,7 @@
                   "version_added": "63"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "54"
                 },
                 "safari": {
                   "version_added": null
@@ -545,7 +545,7 @@
                   "version_added": false
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "54"
                 },
                 "safari": {
                   "version_added": false
@@ -596,7 +596,7 @@
                   "version_added": false
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "54"
                 },
                 "safari": {
                   "version_added": false
@@ -1010,7 +1010,7 @@
                   "version_added": "63"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "54"
                 },
                 "safari": {
                   "version_added": null

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -194,7 +194,7 @@
                 "version_added": null
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "54"
               },
               "safari": {
                 "version_added": null


### PR DESCRIPTION
Follow-up to #5281.  This PR mirrors Chrome Android to Opera Android for the new versions added in this PR.