### PR TITLE
Fix notes for api.Document.characterSet by adding browser name

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -950,7 +950,7 @@
               {
                 "alternative_name": "charset",
                 "version_added": true,
-                "notes": "<code>charset</code> alias was made read-only in Webview 45."
+                "notes": "<code>charset</code> alias was made read-only in WebView 45."
               },
               {
                 "alternative_name": "inputEncoding",

--- a/api/Document.json
+++ b/api/Document.json
@@ -818,7 +818,7 @@
               {
                 "alternative_name": "charset",
                 "version_added": "1",
-                "notes": "<code>charset</code> alias was made read-only in 45."
+                "notes": "<code>charset</code> alias was made read-only in Chrome 45."
               },
               {
                 "alternative_name": "inputEncoding",
@@ -832,7 +832,7 @@
               {
                 "alternative_name": "charset",
                 "version_added": true,
-                "notes": "<code>charset</code> alias was made read-only in 45."
+                "notes": "<code>charset</code> alias was made read-only in Chrome 45."
               },
               {
                 "alternative_name": "inputEncoding",
@@ -950,7 +950,7 @@
               {
                 "alternative_name": "charset",
                 "version_added": true,
-                "notes": "<code>charset</code> alias was made read-only in 45."
+                "notes": "<code>charset</code> alias was made read-only in Webview 45."
               },
               {
                 "alternative_name": "inputEncoding",


### PR DESCRIPTION
We've always added the browser name before a version number in our notes, so this PR fixes an existing note by adding "Chrome" and "Webview" before the browser version number.