### PR TITLE
Add Chromium version for Document.createElementNS options

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -1761,6 +1761,10 @@
               "safari_ios": {
                 "version_added": null
               },
+              "samsunginternet_android": {
+                "version_added": "6.0",
+                "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
+              },
               "webview_android": {
                 "version_added": "56",
                 "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."

--- a/api/Document.json
+++ b/api/Document.json
@@ -1730,7 +1730,7 @@
                 "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
               },
               "chrome_android": {
-                "version_added": false,
+                "version_added": true,
                 "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
               },
               "edge": {

--- a/api/Document.json
+++ b/api/Document.json
@@ -1726,11 +1726,11 @@
             "description": "<code>options</code> parameter",
             "support": {
               "chrome": {
-                "version_added": true,
+                "version_added": "56",
                 "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
               },
               "chrome_android": {
-                "version_added": true,
+                "version_added": "56",
                 "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
               },
               "edge": {
@@ -1748,11 +1748,11 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": true,
+                "version_added": "43",
                 "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
               },
               "opera_android": {
-                "version_added": true,
+                "version_added": "43",
                 "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
               },
               "safari": {
@@ -1762,7 +1762,7 @@
                 "version_added": null
               },
               "webview_android": {
-                "version_added": true,
+                "version_added": "56",
                 "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
               }
             },


### PR DESCRIPTION
I think that Chrome Android was falsely set to...well, `false` for this feature.  Since Opera Android and WebView Android have support (not to mention Chrome/Opera Desktop), it doesn't make much sense that Chrome Android would be `false`.