### PR TITLE
Fix compat data for Document.fullscreen for Chrome

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -4447,11 +4447,9 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/fullscreen",
           "support": {
             "chrome": {
-              "alternative_name": "webkitIsFullScreen",
               "version_added": false
             },
             "chrome_android": {
-              "alternative_name": "webkitIsFullScreen",
               "version_added": false
             },
             "edge": {

--- a/api/Document.json
+++ b/api/Document.json
@@ -4451,7 +4451,7 @@
                 "version_added": "71"
               },
               {
-                "version_added": "15"
+                "version_added": "15",
                 "alternative_name": "webkitIsFullscreen"
               }
             ],
@@ -4460,7 +4460,7 @@
                 "version_added": "71"
               },
               {
-                "version_added": "18"
+                "version_added": "18",
                 "alternative_name": "webkitIsFullscreen"
               }
             ],
@@ -4517,7 +4517,7 @@
                 "version_added": "58"
               },
               {
-                "version_added": "15"
+                "version_added": "15",
                 "alternative_name": "webkitIsFullscreen"
               }
             ],
@@ -4526,7 +4526,7 @@
                 "version_added": "50"
               },
               {
-                "version_added": "14"
+                "version_added": "14",
                 "alternative_name": "webkitIsFullscreen"
               }
             ],
@@ -4542,7 +4542,7 @@
                 "version_added": "10.0"
               },
               {
-                "version_added": "1.0"
+                "version_added": "1.0",
                 "alternative_name": "webkitIsFullscreen"
               }
             ],
@@ -4551,7 +4551,7 @@
                 "version_added": "71"
               },
               {
-                "version_added": "≤37"
+                "version_added": "≤37",
                 "alternative_name": "webkitIsFullscreen"
               }
             ]

--- a/api/Document.json
+++ b/api/Document.json
@@ -4446,12 +4446,24 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/fullscreen",
           "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "15"
+                "alternative_name": "webkitIsFullscreen"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "18"
+                "alternative_name": "webkitIsFullscreen"
+              }
+            ],
             "edge": {
               "version_added": null
             },
@@ -4500,12 +4512,24 @@
             "ie": {
               "version_added": null
             },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "58"
+              },
+              {
+                "version_added": "15"
+                "alternative_name": "webkitIsFullscreen"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "version_added": "14"
+                "alternative_name": "webkitIsFullscreen"
+              }
+            ],
             "safari": {
               "alternative_name": "webkitIsFullScreen",
               "version_added": true
@@ -4513,9 +4537,24 @@
             "safari_ios": {
               "version_added": null
             },
-            "webview_android": {
-              "version_added": false
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "10.0"
+              },
+              {
+                "version_added": "1.0"
+                "alternative_name": "webkitIsFullscreen"
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "≤37"
+                "alternative_name": "webkitIsFullscreen"
+              }
+            ]
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
While reviewing the Samsung Internet mirroring PRs, I found that Chrome had some weird data regarding Document.fullscreen.  The feature was set to `false` in #3291, but yet it had an alternative name property on it...obviously, this can't be right; how can it have an alternate name if there's no support in the first place?