### PR TITLE
Safari ios supports Input type="time"

### DIFF
--- a/html/elements/input/time.json
+++ b/html/elements/input/time.json
@@ -36,7 +36,7 @@
                 "notes": "See <a href='https://webkit.org/b/200416'>bug 200416</a>."
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": true
               },
               "samsunginternet_android": {
                 "version_added": "1.5"


### PR DESCRIPTION
Input type="time" works correctly on iOs 13.1.3 safari (iPhone X)

A checklist to help your pull request get merged faster:
- Changed boolean in safari_ios version_added from false to true
- Browser tests
- iOs 13.1.3 safari (iPhone X)
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- https://github.com/mdn/browser-compat-data/issues/5275
