### PR TITLE
updating Fx Navigator.vibrate() notes; no longer allowed in 3rd party iframes

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2165,7 +2165,8 @@
                 "version_added": "16",
                 "notes": [
                   "Until Firefox 26 included, when the vibration pattern was too long or any of its elements too large, Firefox threw an exception instead of returning <code>false</code> (<a href='https://bugzil.la/884935'>bug 884935</a>).",
-                  "From Firefox 32 onwards, when the vibration pattern is too long or any of its elements too large, it returns <code>true</code> but truncates the pattern (<a href='https://bugzil.la/1014581'>bug 1014581</a>)."
+                  "From Firefox 32 onwards, when the vibration pattern is too long or any of its elements too large, it returns <code>true</code> but truncates the pattern (<a href='https://bugzil.la/1014581'>bug 1014581</a>).",
+                  "Beginning in Firefox 72, this is not supported in cross-origin iframes."
                 ]
               },
               {


### PR DESCRIPTION
… iframes

As per https://bugzilla.mozilla.org/show_bug.cgi?id=1591113

But read https://www.fxsitecompat.dev/en-CA/docs/2019/vibration-api-can-no-longer-be-used-from-cross-origin-iframe/ — this explains more clearly what this is about

Ayway, I've just added the note to Fx destop for now. Once Fenix is released, we will also update the data for FxA.