### PR TITLE
Add `allow` attribute implementation bug for Firefox

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -112,10 +112,12 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1572461'>bug 1572461</a>."
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1572461'>bug 1572461</a>."
               },
               "ie": {
                 "version_added": false

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -116,8 +116,7 @@
                 "notes": "See <a href='https://bugzil.la/1572461'>bug 1572461</a>."
               },
               "firefox_android": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1572461'>bug 1572461</a>."
+                "version_added": false
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
Add the `allow` attribute for `<iframe>` implementation bug for Firefox, see https://bugzil.la/1572461.

I'm assuming Firefox for Android as well. Let me know if that is incorrect of me.