### PR TITLE
Fix file globbing for Prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
   },
   "scripts": {
     "confluence": "node ./node_modules/mdn-confluence/main/generate.es6.js --output-dir=. --bcd-module=./index.js",
-    "lint": "node test/lint && prettier --check **/*.js **/*.ts",
-    "fix": "node scripts/fix; prettier --write **/*.js **/*.ts",
+    "lint": "node test/lint && prettier --check '**/*.js' '**/*.ts'",
+    "fix": "node scripts/fix; prettier --write '**/*.js' '**/*.ts'",
     "stats": "node scripts/statistics",
     "release-notes": "node scripts/release-notes",
     "show-errors": "npm test 1> /dev/null",


### PR DESCRIPTION
Title says it all; Prettier's file globbing needed to be wrapped in quotes to function properly.  This PR depends on #5301 to be merged first.