### PR TITLE
Remove Chrome support from `@property` at-rule

### DIFF
--- a/css/at-rules/property.json
+++ b/css/at-rules/property.json
@@ -7,10 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@property",
           "support": {
             "chrome": {
-              "version_added": "78"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "78"
+              "version_added": false
             },
             "edge": {
               "version_added": false
@@ -25,7 +25,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "65"
+              "version_added": false
             },
             "opera_android": {
               "version_added": false
@@ -40,7 +40,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "78"
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
While Chrome [added support](https://developers.google.com/web/updates/2019/10/nic78#css-prop-val) for `CSS.registerProperty` in 78+, it has not yet introduced support for the companion `@property` at-rule. That is currently [under development](https://chromestatus.com/feature/5193698449031168).

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
