### PR TITLE
Safari supports <img decoding>

### DIFF
--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -264,10 +264,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": false
+                "version_added": "11.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "11.3"
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
Safari supports `<img decoding>` since Safari 11.1 in macOS High Sierra and Safari on iOS 11.3. See: https://webkit.org/blog/8216/new-webkit-features-in-safari-11-1/
On this compatibility table, Safari does not support `decoding` attribute and this PR corrects it.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
