### PR TITLE
update status for Screen Orientation API

### DIFF
--- a/api/Screen.json
+++ b/api/Screen.json
@@ -399,7 +399,8 @@
               "version_added": "38"
             },
             "edge": {
-              "version_added": null
+              "version_added": "12",
+              "prefix": "ms"
             },
             "firefox": {
               "version_added": true,
@@ -574,7 +575,8 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": true,
+              "alternative_name": "onmsorientationchange"
             },
             "firefox": {
               "version_added": false
@@ -623,7 +625,9 @@
               "version_added": "39"
             },
             "edge": {
-              "version_added": null
+              "version_added": "12",
+              "prefix": "ms",
+              "notes": "does not return Orientation object but returns orientation type in string."
             },
             "firefox": [
               {
@@ -784,7 +788,8 @@
               "version_added": "38"
             },
             "edge": {
-              "version_added": null
+              "version_added": "12",
+              "prefix": "ms"
             },
             "firefox": {
               "version_added": true,

--- a/api/Screen.json
+++ b/api/Screen.json
@@ -627,7 +627,7 @@
             "edge": {
               "version_added": "12",
               "prefix": "ms",
-              "notes": "does not return Orientation object but returns orientation type in string."
+              "notes": "Edge does not return an <code>Orientation</code> object; instead, it returns the orientation type as a string."
             },
             "firefox": [
               {


### PR DESCRIPTION
It's been supported since IE11 and Edge 12.
https://github.com/MicrosoftEdge/MicrosoftEdge-Documentation/blob/eaaceb22869de04fc91acaa1243e5f944c377e05/EdgeHTML/EdgeHTML.json#L3584-L3601

Screen.msOrientation returns a string instead of the ScreenOrientation object. This is because they refer to the older spec.
https://www.w3.org/TR/2014/WD-screen-orientation-20140220/#widl-Screen-orientation

A checklist to help your pull request get merged faster:
- [ ] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
