### PR TITLE
Add Edge to topSites.get option data

### DIFF
--- a/webextensions/api/topSites.json
+++ b/webextensions/api/topSites.json
@@ -92,6 +92,9 @@
                   "chrome": {
                     "version_added": false
                   },
+                  "edge": {
+                    "version_added": false
+                  },
                   "firefox": {
                     "version_added": "69"
                   },
@@ -108,6 +111,9 @@
               "__compat": {
                 "support": {
                   "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
                     "version_added": false
                   },
                   "firefox": {


### PR DESCRIPTION
Master fails right now due to https://github.com/mdn/browser-compat-data/pull/5271 which did not add Edge (and travis not catching it due to us introducing prettier and not throwing the correct error).