### PR TITLE
Chrome/Firefox now support nullish coalescing operator

### DIFF
--- a/javascript/operators/nullish_coalescing.json
+++ b/javascript/operators/nullish_coalescing.json
@@ -8,16 +8,16 @@
           "spec_url": "https://tc39.es/proposal-nullish-coalescing/#top",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "80"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "80"
             },
             "edge": {
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "72"
             },
             "firefox_android": {
               "version_added": false
@@ -44,11 +44,11 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "80"
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
Firefox 72
- https://groups.google.com/forum/#!topic/mozilla.dev.platform/RB8wtfcFEdo
- https://bugzilla.mozilla.org/show_bug.cgi?id=1566141

Chrome 80:
- https://www.chromestatus.com/feature/5663559390330880
