### PR TITLE
updating geolocation interface names as per new spec

### DIFF
--- a/api/CanvasPattern.json
+++ b/api/CanvasPattern.json
@@ -90,7 +90,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -42,8 +42,8 @@
           }
         },
         "status": {
-          "experimental": true,
-          "standard_track": false,
+          "experimental": false,
+          "standard_track": true,
           "deprecated": false
         }
       },

--- a/api/Console.json
+++ b/api/Console.json
@@ -401,7 +401,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -456,7 +456,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/DataTransferItem.json
+++ b/api/DataTransferItem.json
@@ -282,7 +282,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/Document.json
+++ b/api/Document.json
@@ -861,7 +861,7 @@
               {
                 "alternative_name": "charset",
                 "version_added": "1",
-                "notes": "<code>charset</code> alias was made read-only in 45."
+                "notes": "<code>charset</code> alias was made read-only in Chrome 45."
               },
               {
                 "alternative_name": "inputEncoding",
@@ -875,7 +875,7 @@
               {
                 "alternative_name": "charset",
                 "version_added": true,
-                "notes": "<code>charset</code> alias was made read-only in 45."
+                "notes": "<code>charset</code> alias was made read-only in Chrome 45."
               },
               {
                 "alternative_name": "inputEncoding",
@@ -1007,7 +1007,7 @@
               {
                 "alternative_name": "charset",
                 "version_added": true,
-                "notes": "<code>charset</code> alias was made read-only in 45."
+                "notes": "<code>charset</code> alias was made read-only in WebView 45."
               },
               {
                 "alternative_name": "inputEncoding",

--- a/api/Document.json
+++ b/api/Document.json
@@ -1265,7 +1265,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/Event.json
+++ b/api/Event.json
@@ -1094,8 +1094,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
-            "deprecated": false
+            "standard_track": true,
+            "deprecated": true
           }
         }
       },

--- a/api/File.json
+++ b/api/File.json
@@ -287,7 +287,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/FileSystem.json
+++ b/api/FileSystem.json
@@ -51,8 +51,8 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": false,
-          "deprecated": true
+          "standard_track": true,
+          "deprecated": false
         }
       },
       "name": {
@@ -98,8 +98,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
-            "deprecated": true
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
@@ -146,8 +146,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
-            "deprecated": true
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/api/FileSystemDirectoryEntry.json
+++ b/api/FileSystemDirectoryEntry.json
@@ -48,9 +48,9 @@
           }
         },
         "status": {
-          "experimental": false,
-          "standard_track": false,
-          "deprecated": true
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
         }
       },
       "createReader": {
@@ -96,8 +96,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
-            "deprecated": true
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
@@ -146,8 +146,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
-            "deprecated": true
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
@@ -196,8 +196,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
-            "deprecated": true
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },

--- a/api/FileSystemEntry.json
+++ b/api/FileSystemEntry.json
@@ -48,7 +48,7 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": false,
+          "standard_track": true,
           "deprecated": false
         }
       },
@@ -96,7 +96,7 @@
           "status": {
             "experimental": true,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -143,7 +143,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -191,7 +191,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -240,7 +240,7 @@
           "status": {
             "experimental": true,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -287,7 +287,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -335,7 +335,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -383,7 +383,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -432,7 +432,7 @@
           "status": {
             "experimental": true,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -479,7 +479,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -528,7 +528,7 @@
           "status": {
             "experimental": true,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -576,7 +576,7 @@
           "status": {
             "experimental": true,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/api/FileSystemFileEntry.json
+++ b/api/FileSystemFileEntry.json
@@ -48,7 +48,7 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": false,
+          "standard_track": true,
           "deprecated": false
         }
       },
@@ -147,7 +147,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/FileSystemFlags.json
+++ b/api/FileSystemFlags.json
@@ -47,7 +47,7 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": false,
+          "standard_track": true,
           "deprecated": false
         }
       },
@@ -102,7 +102,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -158,7 +158,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/FontFaceSetLoadEvent.json
+++ b/api/FontFaceSetLoadEvent.json
@@ -91,7 +91,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/GeolocationCoordinates.json
+++ b/api/GeolocationCoordinates.json
@@ -1,29 +1,36 @@
 {
   "api": {
-    "Coordinates": {
+    "GeolocationCoordinates": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/Coordinates",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationCoordinates",
         "support": {
           "chrome": {
-            "version_added": "5"
+            "version_added": "5",
+            "notes": "Interface updated to <code>GeolocationCoordinates</code> in version 79."
           },
           "chrome_android": {
-            "version_added": "18"
+            "version_added": "18",
+            "notes": "Interface updated to <code>GeolocationCoordinates</code> in version 79."
           },
           "edge": {
+            "alternative_name": "Coordinates",
             "version_added": true
           },
           "firefox": {
-            "version_added": "3.5"
+            "version_added": "3.5",
+            "notes": "Interface updated to <code>GeolocationCoordinates</code> in version 72."
           },
           "firefox_android": {
+            "alternative_name": "Coordinates",
             "version_added": "4"
           },
           "ie": {
+            "alternative_name": "Coordinates",
             "version_added": "9"
           },
           "opera": [
             {
+              "alternative_name": "Coordinates",
               "version_added": "16"
             },
             {
@@ -41,16 +48,20 @@
             }
           ],
           "safari": {
+            "alternative_name": "Coordinates",
             "version_added": "5"
           },
           "safari_ios": {
+            "alternative_name": "Coordinates",
             "version_added": "4.2"
           },
           "samsunginternet_android": {
+            "alternative_name": "Coordinates",
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": true,
+            "notes": "Interface updated to <code>GeolocationCoordinates</code> in version 79."
           }
         },
         "status": {
@@ -61,7 +72,7 @@
       },
       "accuracy": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Coordinates/accuracy",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationCoordinates/accuracy",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -121,7 +132,7 @@
       },
       "altitude": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Coordinates/altitude",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationCoordinates/altitude",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -181,7 +192,7 @@
       },
       "altitudeAccuracy": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Coordinates/altitudeAccuracy",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationCoordinates/altitudeAccuracy",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -241,7 +252,7 @@
       },
       "heading": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Coordinates/heading",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationCoordinates/heading",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -301,7 +312,7 @@
       },
       "latitude": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Coordinates/latitude",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationCoordinates/latitude",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -361,7 +372,7 @@
       },
       "longitude": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Coordinates/longitude",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationCoordinates/longitude",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -469,7 +480,7 @@
       },
       "speed": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Coordinates/speed",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationCoordinates/speed",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/api/GeolocationCoordinates.json
+++ b/api/GeolocationCoordinates.json
@@ -4,22 +4,40 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationCoordinates",
         "support": {
-          "chrome": {
-            "version_added": "5",
-            "notes": "Interface updated to <code>GeolocationCoordinates</code> in version 79."
-          },
-          "chrome_android": {
-            "version_added": "18",
-            "notes": "Interface updated to <code>GeolocationCoordinates</code> in version 79."
-          },
+          "chrome": [
+            {
+              "version_added": "79"
+            },
+            {
+              "version_added": "5",
+              "version_removed": "78",
+              "alternative_name": "Coordinates"
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "79"
+            },
+            {
+              "version_added": "18",
+              "version_removed": "78",
+              "alternative_name": "Coordinates"
+            }
+          ],
           "edge": {
             "alternative_name": "Coordinates",
             "version_added": true
           },
-          "firefox": {
-            "version_added": "3.5",
-            "notes": "Interface updated to <code>GeolocationCoordinates</code> in version 72."
-          },
+          "firefox": [
+            {
+              "version_added": "72"
+            },
+            {
+              "version_added": "3.5",
+              "version_removed": "71",
+              "alternative_name": "Coordinates"
+            }
+          ],
           "firefox_android": {
             "alternative_name": "Coordinates",
             "version_added": "4"
@@ -59,10 +77,16 @@
             "alternative_name": "Coordinates",
             "version_added": "1.0"
           },
-          "webview_android": {
-            "version_added": true,
-            "notes": "Interface updated to <code>GeolocationCoordinates</code> in version 79."
-          }
+          "webview_android": [
+            {
+              "version_added": "79"
+            },
+            {
+              "version_added": true,
+              "version_removed": "78",
+              "alternative_name": "Coordinates"
+            }
+          ]
         },
         "status": {
           "experimental": false,

--- a/api/GeolocationPosition.json
+++ b/api/GeolocationPosition.json
@@ -1,44 +1,55 @@
 {
   "api": {
-    "Position": {
+    "GeolocationPosition": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/Position",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationPosition",
         "support": {
           "chrome": {
-            "version_added": "5"
+            "version_added": "5",
+            "notes": "Interface updated to <code>GeolocationPosition</code> in version 79."
           },
           "chrome_android": {
-            "version_added": "18"
+            "version_added": "18",
+            "notes": "Interface updated to <code>GeolocationPosition</code> in version 79."
           },
           "edge": {
+            "alternative_name": "Position",
             "version_added": true
           },
           "firefox": {
-            "version_added": "3.5"
+            "version_added": "3.5",
+            "notes": "Interface updated to <code>GeolocationPosition</code> in version 72."
           },
           "firefox_android": {
+            "alternative_name": "Position",
             "version_added": "4"
           },
           "ie": {
+            "alternative_name": "Position",
             "version_added": "9"
           },
           "opera": {
+            "alternative_name": "Position",
             "version_added": "16"
           },
           "opera_android": {
+            "alternative_name": "Position",
             "version_added": "16"
           },
           "safari": {
+            "alternative_name": "Position",
             "version_added": "5"
           },
           "safari_ios": {
+            "alternative_name": "Position",
             "version_added": true
           },
           "samsunginternet_android": {
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": true,
+            "notes": "Interface updated to <code>GeolocationPosition</code> in version 79."
           }
         },
         "status": {
@@ -49,7 +60,7 @@
       },
       "coords": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Position/coords",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationPosition/coords",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -145,7 +156,7 @@
       },
       "timestamp": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Position/timestamp",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationPosition/timestamp",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/api/GeolocationPosition.json
+++ b/api/GeolocationPosition.json
@@ -4,22 +4,40 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationPosition",
         "support": {
-          "chrome": {
-            "version_added": "5",
-            "notes": "Interface updated to <code>GeolocationPosition</code> in version 79."
-          },
-          "chrome_android": {
-            "version_added": "18",
-            "notes": "Interface updated to <code>GeolocationPosition</code> in version 79."
-          },
+          "chrome": [
+            {
+              "version_added": "79"
+            },
+            {
+              "version_added": "5",
+              "version_removed": "78",
+              "alternative_name": "Position"
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "79"
+            },
+            {
+              "version_added": "18",
+              "version_removed": "78",
+              "alternative_name": "Position"
+            }
+          ],
           "edge": {
             "alternative_name": "Position",
             "version_added": true
           },
-          "firefox": {
-            "version_added": "3.5",
-            "notes": "Interface updated to <code>GeolocationPosition</code> in version 72."
-          },
+          "firefox": [
+            {
+              "version_added": "72"
+            },
+            {
+              "version_added": "3.5",
+              "version_removed": "71",
+              "alternative_name": "Position"
+            }
+          ],
           "firefox_android": {
             "alternative_name": "Position",
             "version_added": "4"
@@ -44,13 +62,16 @@
             "alternative_name": "Position",
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": "1.0"
-          },
-          "webview_android": {
-            "version_added": true,
-            "notes": "Interface updated to <code>GeolocationPosition</code> in version 79."
-          }
+          "webview_android": [
+            {
+              "version_added": "79"
+            },
+            {
+              "version_added": true,
+              "version_removed": "78",
+              "alternative_name": "Position"
+            }
+          ]
         },
         "status": {
           "experimental": false,

--- a/api/GeolocationPositionError.json
+++ b/api/GeolocationPositionError.json
@@ -4,22 +4,40 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationPositionError",
         "support": {
-          "chrome": {
-            "version_added": "5",
-            "notes": "Interface updated to <code>GeolocationPositionError</code> in version 79."
-          },
-          "chrome_android": {
-            "version_added": "18",
-            "notes": "Interface updated to <code>GeolocationPositionError</code> in version 79."
-          },
+          "chrome": [
+            {
+              "version_added": "79"
+            },
+            {
+              "version_added": "5",
+              "version_removed": "78",
+              "alternative_name": "PositionError"
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "79"
+            },
+            {
+              "version_added": "18",
+              "version_removed": "78",
+              "alternative_name": "PositionError"
+            }
+          ],
           "edge": {
             "alternative_name": "PositionError",
             "version_added": true
           },
-          "firefox": {
-            "version_added": "3.5",
-            "notes": "Interface updated to <code>GeolocationPositionError</code> in version 72."
-          },
+          "firefox": [
+            {
+              "version_added": "72"
+            },
+            {
+              "version_added": "3.5",
+              "version_removed": "71",
+              "alternative_name": "PositionError"
+            }
+          ],
           "firefox_android": {
             "alternative_name": "PositionError",
             "version_added": "4"
@@ -44,13 +62,16 @@
             "alternative_name": "PositionError",
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": "1.0"
-          },
-          "webview_android": {
-            "version_added": true,
-            "notes": "Interface updated to <code>GeolocationPositionError</code> in version 79."
-          }
+          "webview_android": [
+            {
+              "version_added": "79"
+            },
+            {
+              "version_added": true,
+              "version_removed": "78",
+              "alternative_name": "PositionError"
+            }
+          ]
         },
         "status": {
           "experimental": false,

--- a/api/GeolocationPositionError.json
+++ b/api/GeolocationPositionError.json
@@ -1,44 +1,55 @@
 {
   "api": {
-    "PositionError": {
+    "GeolocationPositionError": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/PositionError",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationPositionError",
         "support": {
           "chrome": {
-            "version_added": "5"
+            "version_added": "5",
+            "notes": "Interface updated to <code>GeolocationPositionError</code> in version 79."
           },
           "chrome_android": {
-            "version_added": "18"
+            "version_added": "18",
+            "notes": "Interface updated to <code>GeolocationPositionError</code> in version 79."
           },
           "edge": {
+            "alternative_name": "PositionError",
             "version_added": true
           },
           "firefox": {
-            "version_added": "3.5"
+            "version_added": "3.5",
+            "notes": "Interface updated to <code>GeolocationPositionError</code> in version 72."
           },
           "firefox_android": {
+            "alternative_name": "PositionError",
             "version_added": "4"
           },
           "ie": {
+            "alternative_name": "PositionError",
             "version_added": "9"
           },
           "opera": {
+            "alternative_name": "PositionError",
             "version_added": "16"
           },
           "opera_android": {
+            "alternative_name": "PositionError",
             "version_added": "16"
           },
           "safari": {
+            "alternative_name": "PositionError",
             "version_added": "5"
           },
           "safari_ios": {
+            "alternative_name": "PositionError",
             "version_added": true
           },
           "samsunginternet_android": {
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": true,
+            "notes": "Interface updated to <code>GeolocationPositionError</code> in version 79."
           }
         },
         "status": {
@@ -49,7 +60,7 @@
       },
       "code": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PositionError/code",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationPositionError/code",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -97,7 +108,7 @@
       },
       "message": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PositionError/message",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationPositionError/message",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/api/HMDVRDevice.json
+++ b/api/HMDVRDevice.json
@@ -57,7 +57,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "8.0"
           },
           "webview_android": {
             "version_added": false
@@ -126,7 +126,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": false
@@ -196,7 +196,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/HTMLAllCollection.json
+++ b/api/HTMLAllCollection.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -76,6 +79,9 @@
               "version_added": "6"
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -123,6 +129,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
             "webview_android": {
               "version_added": "44"
             }
@@ -166,6 +175,9 @@
               "version_added": "6"
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/HTMLAnchorElement.json
+++ b/api/HTMLAnchorElement.json
@@ -226,7 +226,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -514,7 +514,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"

--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -514,7 +514,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -356,9 +356,15 @@
               "safari_ios": {
                 "version_added": null
               },
-              "samsunginternet_android": {
-                "version_added": null
-              },
+              "samsunginternet_android": [
+                {
+                  "version_added": "2.0"
+                },
+                {
+                  "alternative_name": "experimental-webgl",
+                  "version_added": "1.0"
+                }
+              ],
               "webview_android": [
                 {
                   "version_added": "37"
@@ -805,7 +811,7 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -865,7 +871,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false
@@ -914,7 +920,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -963,7 +969,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -1012,7 +1018,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -879,7 +879,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -92,7 +92,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/HTMLCollection.json
+++ b/api/HTMLCollection.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -76,6 +79,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -123,6 +129,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -166,6 +175,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/HTMLContentElement.json
+++ b/api/HTMLContentElement.json
@@ -51,7 +51,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "3.0"
           },
           "webview_android": {
             "version_added": "37"
@@ -114,7 +114,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -178,7 +178,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/api/HTMLDataElement.json
+++ b/api/HTMLDataElement.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "8.0"
           },
           "webview_android": {
             "version_added": "62"
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "62"

--- a/api/HTMLDataListElement.json
+++ b/api/HTMLDataListElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": false
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -77,6 +80,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/HTMLDocument.json
+++ b/api/HTMLDocument.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": "1.0"
+          },
           "webview_android": {
             "version_added": true
           }
@@ -77,6 +80,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -123,6 +129,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -168,6 +177,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -216,7 +228,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -265,7 +277,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -314,7 +326,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -360,6 +372,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -455,6 +470,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": "4.4"
             }
@@ -505,6 +523,10 @@
               "version_added": true,
               "notes": "Before Safari 6, <code>click</code> is only defined on buttons and inputs."
             },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "notes": "Before Samsung Internet 1.5, <code>click</code> is only defined on buttons and inputs."
+            },
             "webview_android": {
               "version_added": true,
               "notes": "Before Android WebView 4.4, <code>click</code> is only defined on buttons and inputs."
@@ -550,6 +572,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -598,6 +623,10 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "5.0",
+              "version_removed": "8.0"
+            },
             "webview_android": {
               "version_added": "45",
               "version_removed": "61"
@@ -644,6 +673,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": "4.4"
             }
@@ -689,6 +721,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": "4.4"
             }
@@ -733,6 +768,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -781,6 +819,10 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "7.0"
+            },
             "webview_android": {
               "version_added": "4.4",
               "version_removed": "59"
@@ -827,6 +869,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": "4.4"
             }
@@ -870,6 +915,9 @@
               },
               "safari_ios": {
                 "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": "9.0"
               },
               "webview_android": {
                 "version_added": "64"
@@ -916,6 +964,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -964,7 +1015,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "57"
@@ -1009,6 +1060,9 @@
               "version_added": "6"
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -1056,6 +1110,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
             "webview_android": {
               "version_added": "60"
             }
@@ -1102,7 +1159,7 @@
               "version_added": "4"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -1203,7 +1260,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -1249,6 +1306,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -1298,6 +1358,10 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "1.5"
+            },
             "webview_android": {
               "version_added": false
             }
@@ -1345,6 +1409,10 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "1.5"
             },
             "webview_android": {
               "version_added": false
@@ -1394,6 +1462,10 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "1.5"
+            },
             "webview_android": {
               "version_added": false
             }
@@ -1441,6 +1513,10 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "1.5"
             },
             "webview_android": {
               "version_added": false
@@ -1490,6 +1566,10 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "1.5"
+            },
             "webview_android": {
               "version_added": false
             }
@@ -1538,6 +1618,10 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "1.5"
+            },
             "webview_android": {
               "version_added": false
             }
@@ -1582,6 +1666,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -1630,7 +1717,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "57"
@@ -1677,6 +1764,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
             "webview_android": {
               "version_added": "60"
             }
@@ -1721,6 +1811,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "61"
@@ -1767,6 +1860,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            },
             "webview_android": {
               "version_added": "47"
             }
@@ -1811,6 +1907,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "47"
@@ -1857,6 +1956,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            },
             "webview_android": {
               "version_added": "47"
             }
@@ -1901,6 +2003,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "47"
@@ -1947,6 +2052,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            },
             "webview_android": {
               "version_added": "47"
             }
@@ -1991,6 +2099,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "71"
@@ -2037,6 +2148,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
             "webview_android": {
               "version_added": "71"
             }
@@ -2081,6 +2195,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"
@@ -2127,6 +2244,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
             "webview_android": {
               "version_added": "71"
             }
@@ -2171,6 +2291,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -2244,7 +2367,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -2318,7 +2441,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -2392,7 +2515,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -2466,7 +2589,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -2540,7 +2663,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -2614,7 +2737,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -2688,7 +2811,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -2762,7 +2885,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -2809,6 +2932,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
             "webview_android": {
               "version_added": "43"
             }
@@ -2854,6 +2980,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -2909,6 +3038,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": "4.4"
             }
@@ -2953,6 +3085,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -3230,6 +3365,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4"

--- a/api/HTMLEmbedElement.json
+++ b/api/HTMLEmbedElement.json
@@ -38,6 +38,10 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true,
+            "notes": "Starting with Samsung Internet 7.0, this interface can no longer be called as a function."
+          },
           "webview_android": {
             "version_added": true,
             "notes": "Starting with Chrome 58, this interface can no longer be called as a function."

--- a/api/HTMLFieldSetElement.json
+++ b/api/HTMLFieldSetElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -76,6 +79,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -123,6 +129,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -166,6 +175,9 @@
               },
               "safari_ios": {
                 "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": "7.0"
               },
               "webview_android": {
                 "version_added": "57"
@@ -213,6 +225,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -256,6 +271,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -351,6 +369,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -394,6 +415,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -441,6 +465,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -484,6 +511,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/HTMLFormControlsCollection.json
+++ b/api/HTMLFormControlsCollection.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -92,6 +95,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -707,7 +707,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/HTMLFrameElement.json
+++ b/api/HTMLFrameElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -77,6 +80,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -123,6 +129,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -167,6 +176,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -213,6 +225,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -257,6 +272,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -303,6 +321,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -347,6 +368,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -393,6 +417,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -438,6 +465,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -482,6 +512,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/HTMLFrameSetElement.json
+++ b/api/HTMLFrameSetElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -75,6 +78,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -122,6 +128,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -164,6 +173,9 @@
               "version_added": null
             },
             "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
               "version_added": null
             },
             "webview_android": {
@@ -210,6 +222,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -252,6 +267,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/HTMLHeadingElement.json
+++ b/api/HTMLHeadingElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -76,6 +79,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/HTMLHyperlinkElementUtils.json
+++ b/api/HTMLHyperlinkElementUtils.json
@@ -44,6 +44,10 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true,
+            "notes": "Starting in Samsung Internet 6.0, the members of this interface were moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+          },
           "webview_android": {
             "version_added": true,
             "notes": "Starting in Chrome 52, the members of this interface were moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
@@ -92,6 +96,10 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "webview_android": {
               "version_added": true,
@@ -144,6 +152,10 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true,
+              "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+            },
             "webview_android": {
               "version_added": true,
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
@@ -194,6 +206,10 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true,
+              "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+            },
             "webview_android": {
               "version_added": true,
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
@@ -243,6 +259,10 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "webview_android": {
               "version_added": true,
@@ -300,6 +320,10 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true,
+              "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+            },
             "webview_android": {
               "version_added": true,
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
@@ -349,6 +373,10 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "webview_android": {
               "version_added": true,
@@ -406,6 +434,10 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true,
+              "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+            },
             "webview_android": {
               "version_added": true,
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
@@ -456,6 +488,10 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true,
+              "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+            },
             "webview_android": {
               "version_added": true,
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
@@ -505,6 +541,10 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "webview_android": {
               "version_added": true,
@@ -562,6 +602,10 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true,
+              "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
+            },
             "webview_android": {
               "version_added": true,
               "notes": "Starting in Chrome 52, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
@@ -609,6 +653,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "52"
@@ -658,6 +705,10 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "notes": "Starting in Samsung Internet 6.0, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "webview_android": {
               "version_added": true,

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -76,6 +79,9 @@
               "version_added": "6"
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -121,6 +127,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -181,6 +190,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": false
             },
             "webview_android": {
               "prefix": "webkit",
@@ -243,6 +255,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -286,6 +301,9 @@
               "version_added": "10"
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -333,6 +351,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -377,6 +398,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "61"
@@ -537,6 +561,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": "74",
               "notes": "<a href='https://www.chromestatus.com/feature/5190687460950016'>Chrome Platform Status</a> incorrectly describes this variable as <code>document.policy</code>. It was renamed in <a href='https://crbug.com/917057'>bug 917057</a> before being shipped in <a href='https://crbug.com/703703#c22'>bug 703703</a>."
@@ -581,6 +608,9 @@
               "version_added": "6"
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -628,6 +658,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -671,6 +704,9 @@
               "version_added": "6"
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -718,6 +754,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -761,6 +800,9 @@
               "version_added": "6"
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -808,6 +850,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -852,6 +897,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "51"
@@ -903,6 +951,10 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "notes": "Before Samsung Internet 5.0, this property returned the deprecated child <code>DOMSettableTokenList</code> instead of <code>DOMTokenList</code>."
+            },
             "webview_android": {
               "version_added": true,
               "notes": "Before Chrome 50, this property returned the deprecated child <code>DOMSettableTokenList</code> instead of <code>DOMTokenList</code>."
@@ -947,6 +999,9 @@
               "version_added": "6"
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -995,6 +1050,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -1038,6 +1096,9 @@
               "version_added": "6"
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -1084,6 +1145,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1127,6 +1191,9 @@
               "version_added": "6"
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -74,6 +77,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -118,6 +124,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -160,6 +169,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -200,6 +212,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -245,6 +260,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -285,6 +303,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -358,6 +379,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            },
             "webview_android": {
               "version_added": "45"
             }
@@ -401,6 +425,9 @@
             "safari_ios": {
               "version_added": "11.3"
             },
+            "samsunginternet_android": {
+              "version_added": "9.0"
+            },
             "webview_android": {
               "version_added": "64"
             }
@@ -442,6 +469,9 @@
             },
             "safari_ios": {
               "version_added": "11.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -490,6 +520,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -530,6 +563,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -574,6 +610,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -614,6 +653,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -658,6 +700,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -700,6 +745,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -740,6 +788,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -784,6 +835,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -824,6 +878,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -872,6 +929,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -916,6 +976,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "51"
@@ -988,6 +1051,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            },
             "webview_android": {
               "version_added": "45"
             }
@@ -1031,6 +1097,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -1104,6 +1173,9 @@
             "safari_ios": {
               "version_added": "8"
             },
+            "samsunginternet_android": {
+              "version_added": "2.0"
+            },
             "webview_android": {
               "version_added": "37"
             }
@@ -1147,6 +1219,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -1194,6 +1269,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1237,6 +1315,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -1296,6 +1377,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1351,6 +1435,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -75,6 +78,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -121,6 +127,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -163,6 +172,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -211,6 +223,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -253,6 +268,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -299,6 +317,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -341,6 +362,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -387,6 +411,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -429,6 +456,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -475,6 +505,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -517,6 +550,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -612,6 +648,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -655,6 +694,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -700,6 +742,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -743,6 +788,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -788,6 +836,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -830,6 +881,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -877,6 +931,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -921,6 +978,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -963,6 +1023,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -1057,6 +1120,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1102,6 +1168,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1201,6 +1270,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -1312,6 +1384,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1364,6 +1439,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1406,6 +1484,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -1452,6 +1533,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1495,6 +1579,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1540,6 +1627,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": false
             }
@@ -1584,6 +1674,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1626,6 +1719,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/HTMLKeygenElement.json
+++ b/api/HTMLKeygenElement.json
@@ -41,6 +41,10 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": true,
+            "version_removed": "7.0"
+          },
           "webview_android": {
             "version_added": true,
             "version_removed": "57",

--- a/api/HTMLLabelElement.json
+++ b/api/HTMLLabelElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -76,6 +79,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -123,6 +129,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -166,6 +175,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/HTMLLinkElement.json
+++ b/api/HTMLLinkElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -78,6 +81,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            },
             "webview_android": {
               "version_added": "50"
             }
@@ -121,6 +127,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -168,6 +177,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            },
             "webview_android": {
               "version_added": "51"
             }
@@ -211,6 +223,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -257,6 +272,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "54"
@@ -306,6 +324,10 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "notes": "Before Samsung Internet 5.0, this property returned the deprecated child <code>DOMSettableTokenList</code> instead of <code>DOMTokenList</code>."
             },
             "webview_android": {
               "version_added": true,

--- a/api/HTMLMapElement.json
+++ b/api/HTMLMapElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -76,6 +79,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -121,6 +127,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/HTMLMarqueeElement.json
+++ b/api/HTMLMarqueeElement.json
@@ -36,6 +36,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": "1.0"
+          },
           "webview_android": {
             "version_added": "1"
           }
@@ -78,6 +81,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -123,6 +129,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": "1"
             }
@@ -166,6 +175,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -211,6 +223,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": "1"
             }
@@ -253,6 +268,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -299,6 +317,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -342,6 +363,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -387,6 +411,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": "1"
             }
@@ -430,6 +457,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -475,6 +505,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -518,6 +551,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -46,6 +46,15 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": [
+            {
+              "version_added": "4.0"
+            },
+            {
+              "prefix": "webkit",
+              "version_added": "1.0"
+            }
+          ],
           "webview_android": [
             {
               "version_added": "42"
@@ -98,7 +107,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -157,6 +166,15 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": [
+              {
+                "version_added": "4.0"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "3.0"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "42"
@@ -222,6 +240,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -267,6 +288,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
             "webview_android": {
               "version_added": "43"
             }
@@ -311,6 +335,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -359,7 +386,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -408,7 +435,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -455,6 +482,9 @@
               "version_added": "6"
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -504,6 +534,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
             "webview_android": {
               "version_added": "62"
             }
@@ -551,6 +584,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -596,6 +632,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
             "webview_android": {
               "version_added": "43"
             }
@@ -634,6 +673,9 @@
             },
             "safari": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "58"
@@ -687,6 +729,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
             "webview_android": {
               "version_added": "43"
             }
@@ -731,6 +776,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -777,6 +825,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
             "webview_android": {
               "version_added": "43"
             }
@@ -822,6 +873,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
             "webview_android": {
               "version_added": "43"
             }
@@ -860,6 +914,9 @@
             },
             "safari": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -906,6 +963,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            },
             "webview_android": {
               "version_added": "49"
             }
@@ -950,6 +1010,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -998,7 +1061,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -1047,7 +1110,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -1093,6 +1156,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -1141,7 +1207,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -1187,6 +1253,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -1235,7 +1304,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1350,6 +1419,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": "1"
             }
@@ -1397,7 +1469,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -1446,7 +1518,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -1495,7 +1567,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1534,6 +1606,9 @@
               "version_added": true
             },
             "safari": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -1576,6 +1651,9 @@
             },
             "safari": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -1712,6 +1790,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -1787,6 +1868,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -1830,6 +1914,9 @@
               "version_added": false
             },
             "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
               "version_added": false
             },
             "webview_android": {
@@ -1879,6 +1966,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -1922,6 +2012,9 @@
               "version_added": false
             },
             "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
               "version_added": false
             },
             "webview_android": {
@@ -1969,6 +2062,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -2013,6 +2109,9 @@
               "version_added": "6"
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -2088,6 +2187,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -2199,6 +2301,9 @@
             "safari": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
             "webview_android": {
               "version_added": "55"
             }
@@ -2242,6 +2347,9 @@
               "version_added": "6"
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -2291,7 +2399,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -2336,6 +2444,9 @@
               "version_added": "6"
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -2383,6 +2494,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -2426,6 +2540,9 @@
               },
               "safari_ios": {
                 "version_added": "10"
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "50"
@@ -2475,7 +2592,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -2516,6 +2633,9 @@
             "safari": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -2553,6 +2673,9 @@
               "version_added": true
             },
             "safari": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -2602,7 +2725,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -2641,6 +2764,9 @@
               "version_added": true
             },
             "safari": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -2690,6 +2816,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -2737,7 +2866,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -2786,7 +2915,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -2833,6 +2962,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
             "webview_android": {
               "version_added": "43"
             }
@@ -2870,6 +3002,9 @@
               "version_added": true
             },
             "safari": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -2919,7 +3054,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -2964,6 +3099,9 @@
               "version_added": "6"
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -3013,7 +3151,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -3155,6 +3293,10 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": false,
+              "notes": "Not availabe due to <a href='https://crbug.com/648286'>a limitation in Android</a>."
+            },
             "webview_android": {
               "version_added": false,
               "notes": "Not availabe due to <a href='https://crbug.com/648286'>a limitation in Android</a>."
@@ -3191,6 +3333,9 @@
             },
             "safari": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -3235,6 +3380,9 @@
               "version_added": "6"
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -3307,6 +3455,11 @@
             "safari": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "partial_implementation": true,
+              "version_added": "6.0",
+              "notes": "Currently only supports <code>MediaStream</code> objects."
+            },
             "webview_android": {
               "version_added": "52",
               "partial_implementation": true,
@@ -3356,7 +3509,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -3405,7 +3558,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -3484,7 +3637,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -3576,6 +3729,9 @@
               "version_added": "6"
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/HTMLMenuElement.json
+++ b/api/HTMLMenuElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -76,6 +79,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -124,6 +130,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -169,6 +178,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/HTMLMenuItemElement.json
+++ b/api/HTMLMenuItemElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": false
           },
+          "samsunginternet_android": {
+            "version_added": false
+          },
           "webview_android": {
             "version_added": false
           }
@@ -76,6 +79,9 @@
               "version_added": false
             },
             "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
               "version_added": false
             },
             "webview_android": {
@@ -121,6 +127,9 @@
               "version_added": false
             },
             "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
               "version_added": false
             },
             "webview_android": {
@@ -170,6 +179,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -213,6 +225,9 @@
               "version_added": false
             },
             "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
               "version_added": false
             },
             "webview_android": {
@@ -260,6 +275,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -303,6 +321,9 @@
               "version_added": false
             },
             "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
               "version_added": false
             },
             "webview_android": {
@@ -350,6 +371,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -393,6 +417,9 @@
               "version_added": false
             },
             "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
               "version_added": false
             },
             "webview_android": {

--- a/api/HTMLObjectElement.json
+++ b/api/HTMLObjectElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": "1.0"
+          },
           "webview_android": {
             "version_added": "37"
           }
@@ -77,6 +80,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -123,6 +129,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": "37"
             }
@@ -167,6 +176,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -213,6 +225,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            },
             "webview_android": {
               "version_added": "46"
             }
@@ -257,6 +272,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -303,6 +321,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": "37"
             }
@@ -347,6 +368,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -393,6 +417,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": "37"
             }
@@ -437,6 +464,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "53"
@@ -483,6 +513,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": "37"
             }
@@ -527,6 +560,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "46"
@@ -573,6 +609,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            },
             "webview_android": {
               "version_added": "46"
             }
@@ -616,6 +655,9 @@
               "version_added": "6"
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -663,6 +705,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": "37"
             }
@@ -707,6 +752,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "46"
@@ -753,6 +801,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": "37"
             }
@@ -796,6 +847,9 @@
               "version_added": "10"
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -843,6 +897,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -887,6 +944,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -933,6 +993,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": "37"
             }
@@ -976,6 +1039,9 @@
               "version_added": false
             },
             "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
               "version_added": false
             },
             "webview_android": {
@@ -1023,6 +1089,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": "37"
             }
@@ -1067,6 +1136,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "46"
@@ -1113,6 +1185,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            },
             "webview_android": {
               "version_added": "46"
             }
@@ -1157,6 +1232,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "46"
@@ -1203,6 +1281,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": "37"
             }
@@ -1247,6 +1328,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "46"

--- a/api/HTMLObjectElement.json
+++ b/api/HTMLObjectElement.json
@@ -1291,7 +1291,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },

--- a/api/HTMLOutputElement.json
+++ b/api/HTMLOutputElement.json
@@ -230,7 +230,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Before Samsung Internet 5.0, this property returned the deprecated child <code>DOMSettableTokenList</code> instead of <code>DOMTokenList</code>."
             },
             "webview_android": {
               "version_added": true,

--- a/api/HTMLPictureElement.json
+++ b/api/HTMLPictureElement.json
@@ -61,7 +61,7 @@
             "version_added": "9.3"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "3.0"
           },
           "webview_android": {
             "version_added": "38"

--- a/api/HTMLProgressElement.json
+++ b/api/HTMLProgressElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -76,6 +79,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -123,6 +129,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -168,6 +177,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -211,6 +223,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -75,6 +78,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -121,6 +127,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -163,6 +172,9 @@
               "version_added": "4"
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -216,6 +228,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -260,6 +275,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -302,6 +320,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -374,6 +395,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -419,6 +443,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
             "webview_android": {
               "version_added": "70"
             }
@@ -461,6 +488,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -507,6 +537,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -549,6 +582,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -35,6 +35,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": "1.0"
+          },
           "webview_android": {
             "version_added": "1"
           }
@@ -79,6 +82,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -121,6 +127,9 @@
                 "version_added": true
               },
               "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
                 "version_added": true
               },
               "webview_android": {
@@ -169,6 +178,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "9.0"
+            },
             "webview_android": {
               "version_added": "66"
             }
@@ -214,6 +226,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -257,6 +272,9 @@
               "version_added": null
             },
             "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
               "version_added": null
             },
             "webview_android": {
@@ -400,6 +418,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": null
+            },
             "webview_android": {
               "version_added": null
             }
@@ -443,6 +464,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -490,6 +514,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -533,6 +560,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -580,6 +610,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -625,6 +658,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -668,6 +704,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -717,6 +756,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -760,6 +802,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -903,6 +948,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -946,6 +994,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -993,6 +1044,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1038,6 +1092,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1081,6 +1138,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -1129,7 +1189,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -1174,6 +1234,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -1221,6 +1284,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1266,6 +1332,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1309,6 +1378,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/HTMLShadowElement.json
+++ b/api/HTMLShadowElement.json
@@ -51,7 +51,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "3.0"
           },
           "webview_android": {
             "version_added": "37"
@@ -98,7 +98,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/api/HTMLSlotElement.json
+++ b/api/HTMLSlotElement.json
@@ -141,7 +141,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"

--- a/api/HTMLSourceElement.json
+++ b/api/HTMLSourceElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -86,6 +89,9 @@
             "safari": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -129,6 +135,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -194,6 +203,9 @@
             "safari": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -237,6 +249,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -302,6 +317,9 @@
             "safari": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -345,6 +363,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/HTMLTableCellElement.json
+++ b/api/HTMLTableCellElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -76,6 +79,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -123,6 +129,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -166,6 +175,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -213,6 +225,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -256,6 +271,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -303,6 +321,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -346,6 +367,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -393,6 +417,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -436,6 +463,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -483,6 +513,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -526,6 +559,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -573,6 +609,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -616,6 +655,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -663,6 +705,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -706,6 +751,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/HTMLTableColElement.json
+++ b/api/HTMLTableColElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -76,6 +79,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -123,6 +129,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -166,6 +175,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -213,6 +225,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -258,6 +273,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -301,6 +319,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/HTMLTableHeaderCellElement.json
+++ b/api/HTMLTableHeaderCellElement.json
@@ -43,6 +43,10 @@
             "version_added": false,
             "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
           },
+          "samsunginternet_android": {
+            "version_added": false,
+            "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
+          },
           "webview_android": {
             "version_added": false,
             "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
@@ -94,6 +98,10 @@
               "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
             },
             "safari_ios": {
+              "version_added": false,
+              "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
+            },
+            "samsunginternet_android": {
               "version_added": false,
               "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
             },
@@ -152,6 +160,10 @@
               "version_added": false,
               "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
             },
+            "samsunginternet_android": {
+              "version_added": false,
+              "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
+            },
             "webview_android": {
               "version_added": false,
               "notes": "Members of the <code>HTMLTableHeaderCellElement</code> interface now implemented on <code>HTMLTableCellElement</code>."
@@ -196,6 +208,9 @@
               "version_added": false
             },
             "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
               "version_added": false
             },
             "webview_android": {

--- a/api/HTMLTableSectionElement.json
+++ b/api/HTMLTableSectionElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -76,6 +79,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -123,6 +129,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -166,6 +175,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -213,6 +225,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -256,6 +271,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -303,6 +321,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -346,6 +367,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/HTMLTemplateElement.json
+++ b/api/HTMLTemplateElement.json
@@ -35,7 +35,7 @@
             "version_added": "8"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": true
@@ -82,7 +82,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -77,6 +80,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": false
@@ -123,6 +129,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "9.0"
+            },
             "webview_android": {
               "version_added": "66"
             }
@@ -166,6 +175,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -259,6 +271,9 @@
               "version_added": "9"
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/HTMLTimeElement.json
+++ b/api/HTMLTimeElement.json
@@ -46,6 +46,9 @@
           "safari_ios": {
             "version_added": "10"
           },
+          "samsunginternet_android": {
+            "version_added": "8.0"
+          },
           "webview_android": {
             "version_added": "62"
           }
@@ -101,6 +104,9 @@
             },
             "safari_ios": {
               "version_added": "10"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "62"

--- a/api/HTMLTitleElement.json
+++ b/api/HTMLTitleElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -76,6 +79,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/HTMLTrackElement.json
+++ b/api/HTMLTrackElement.json
@@ -62,6 +62,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": "1.5"
+          },
           "webview_android": {
             "version_added": true
           }
@@ -105,6 +108,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -178,6 +184,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -248,6 +257,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -320,6 +332,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -390,6 +405,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -464,6 +482,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -535,6 +556,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -605,6 +629,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true

--- a/api/HTMLUListElement.json
+++ b/api/HTMLUListElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -76,6 +79,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -121,6 +127,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/HashChangeEvent.json
+++ b/api/HashChangeEvent.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": "5"
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/History.json
+++ b/api/History.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -76,6 +79,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -123,6 +129,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -166,6 +175,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -213,6 +225,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -258,6 +273,9 @@
             },
             "safari_ios": {
               "version_added": "4.3"
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -350,6 +368,9 @@
             "safari_ios": {
               "version_added": "4.3"
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -440,6 +461,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            },
             "webview_android": {
               "version_added": false
             }
@@ -483,6 +507,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/IDBCursor.json
+++ b/api/IDBCursor.json
@@ -72,12 +72,12 @@
           },
           "samsunginternet_android": [
             {
-              "version_added": true
+              "version_added": "1.5"
             },
             {
               "version_removed": "7.0",
               "prefix": "webkit",
-              "version_added": true
+              "version_added": "1.5"
             }
           ],
           "webview_android": [
@@ -768,12 +768,12 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "1.5"
               },
               {
                 "version_removed": "7.0",
                 "prefix": "webkit",
-                "version_added": true
+                "version_added": "1.5"
               }
             ],
             "webview_android": [

--- a/api/IDBCursorWithValue.json
+++ b/api/IDBCursorWithValue.json
@@ -58,12 +58,12 @@
           },
           "samsunginternet_android": [
             {
-              "version_added": true
+              "version_added": "1.5"
             },
             {
               "version_removed": "7.0",
               "prefix": "webkit",
-              "version_added": true
+              "version_added": "1.5"
             }
           ],
           "webview_android": [

--- a/api/IDBDatabase.json
+++ b/api/IDBDatabase.json
@@ -58,12 +58,12 @@
           },
           "samsunginternet_android": [
             {
-              "version_added": true
+              "version_added": "1.5"
             },
             {
               "version_removed": "7.0",
               "prefix": "webkit",
-              "version_added": true
+              "version_added": "1.5"
             }
           ],
           "webview_android": [
@@ -134,7 +134,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -197,7 +197,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -246,7 +246,7 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": true
@@ -309,7 +309,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -372,7 +372,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -436,7 +436,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -499,7 +499,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -562,7 +562,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -625,7 +625,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -674,7 +674,7 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": true
@@ -737,7 +737,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -800,7 +800,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -863,7 +863,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -926,7 +926,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -990,7 +990,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -1058,7 +1058,7 @@
               {
                 "version_removed": "7.0",
                 "prefix": "webkit",
-                "version_added": true
+                "version_added": "1.5"
               }
             ],
             "webview_android": [

--- a/api/IDBEnvironment.json
+++ b/api/IDBEnvironment.json
@@ -50,7 +50,7 @@
             "version_added": "8"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": true

--- a/api/IDBFactory.json
+++ b/api/IDBFactory.json
@@ -58,12 +58,12 @@
           },
           "samsunginternet_android": [
             {
-              "version_added": true
+              "version_added": "1.5"
             },
             {
               "version_removed": "7.0",
               "prefix": "webkit",
-              "version_added": true
+              "version_added": "1.5"
             }
           ],
           "webview_android": [
@@ -133,7 +133,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": [
               {
@@ -190,7 +190,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "71"
@@ -253,7 +253,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": [
               {
@@ -323,7 +323,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": [
               {

--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -58,12 +58,12 @@
           },
           "samsunginternet_android": [
             {
-              "version_added": true
+              "version_added": "1.5"
             },
             {
               "version_removed": "7.0",
               "prefix": "webkit",
-              "version_added": true
+              "version_added": "1.5"
             }
           ],
           "webview_android": [
@@ -133,7 +133,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": [
               {
@@ -203,7 +203,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": [
               {
@@ -393,7 +393,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": [
               {
@@ -511,7 +511,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": [
               {
@@ -629,7 +629,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": [
               {
@@ -699,7 +699,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": [
               {
@@ -817,7 +817,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": [
               {
@@ -887,7 +887,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": [
               {
@@ -957,7 +957,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": [
               {
@@ -1027,7 +1027,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": [
               {

--- a/api/IDBObjectStore.json
+++ b/api/IDBObjectStore.json
@@ -58,12 +58,12 @@
           },
           "samsunginternet_android": [
             {
-              "version_added": true
+              "version_added": "1.5"
             },
             {
               "version_removed": "7.0",
               "prefix": "webkit",
-              "version_added": true
+              "version_added": "1.5"
             }
           ],
           "webview_android": [
@@ -141,12 +141,12 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "1.5"
               },
               {
                 "version_removed": "7.0",
                 "prefix": "webkit",
-                "version_added": true
+                "version_added": "1.5"
               }
             ],
             "webview_android": [
@@ -225,12 +225,12 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "1.5"
               },
               {
                 "version_removed": "7.0",
                 "prefix": "webkit",
-                "version_added": true
+                "version_added": "1.5"
               }
             ],
             "webview_android": [
@@ -309,12 +309,12 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "1.5"
               },
               {
                 "version_removed": "7.0",
                 "prefix": "webkit",
-                "version_added": true
+                "version_added": "1.5"
               }
             ],
             "webview_android": [
@@ -393,12 +393,12 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "1.5"
               },
               {
                 "version_removed": "7.0",
                 "prefix": "webkit",
-                "version_added": true
+                "version_added": "1.5"
               }
             ],
             "webview_android": [
@@ -477,12 +477,12 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "1.5"
               },
               {
                 "version_removed": "7.0",
                 "prefix": "webkit",
-                "version_added": true
+                "version_added": "1.5"
               }
             ],
             "webview_android": [
@@ -561,12 +561,12 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "1.5"
               },
               {
                 "version_removed": "7.0",
                 "prefix": "webkit",
-                "version_added": true
+                "version_added": "1.5"
               }
             ],
             "webview_android": [
@@ -645,12 +645,12 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "1.5"
               },
               {
                 "version_removed": "7.0",
                 "prefix": "webkit",
-                "version_added": true
+                "version_added": "1.5"
               }
             ],
             "webview_android": [
@@ -729,12 +729,12 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "1.5"
               },
               {
                 "version_removed": "7.0",
                 "prefix": "webkit",
-                "version_added": true
+                "version_added": "1.5"
               }
             ],
             "webview_android": [
@@ -963,12 +963,12 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "1.5"
               },
               {
                 "version_removed": "7.0",
                 "prefix": "webkit",
-                "version_added": true
+                "version_added": "1.5"
               }
             ],
             "webview_android": [
@@ -1047,12 +1047,12 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "1.5"
               },
               {
                 "version_removed": "7.0",
                 "prefix": "webkit",
-                "version_added": true
+                "version_added": "1.5"
               }
             ],
             "webview_android": [
@@ -1131,12 +1131,12 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "1.5"
               },
               {
                 "version_removed": "7.0",
                 "prefix": "webkit",
-                "version_added": true
+                "version_added": "1.5"
               }
             ],
             "webview_android": [
@@ -1215,12 +1215,12 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "1.5"
               },
               {
                 "version_removed": "7.0",
                 "prefix": "webkit",
-                "version_added": true
+                "version_added": "1.5"
               }
             ],
             "webview_android": [
@@ -1347,12 +1347,12 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "1.5"
               },
               {
                 "version_removed": "7.0",
                 "prefix": "webkit",
-                "version_added": true
+                "version_added": "1.5"
               }
             ],
             "webview_android": [
@@ -1430,12 +1430,12 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "1.5"
               },
               {
                 "version_removed": "7.0",
                 "prefix": "webkit",
-                "version_added": true
+                "version_added": "1.5"
               }
             ],
             "webview_android": [
@@ -1514,12 +1514,12 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "1.5"
               },
               {
                 "version_removed": "7.0",
                 "prefix": "webkit",
-                "version_added": true
+                "version_added": "1.5"
               }
             ],
             "webview_android": [
@@ -1598,12 +1598,12 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "1.5"
               },
               {
                 "version_removed": "7.0",
                 "prefix": "webkit",
-                "version_added": true
+                "version_added": "1.5"
               }
             ],
             "webview_android": [

--- a/api/IDBOpenDBRequest.json
+++ b/api/IDBOpenDBRequest.json
@@ -58,12 +58,12 @@
           },
           "samsunginternet_android": [
             {
-              "version_added": true
+              "version_added": "1.5"
             },
             {
               "version_removed": "7.0",
               "prefix": "webkit",
-              "version_added": true
+              "version_added": "1.5"
             }
           ],
           "webview_android": [
@@ -142,12 +142,12 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "1.5"
               },
               {
                 "version_removed": "7.0",
                 "prefix": "webkit",
-                "version_added": true
+                "version_added": "1.5"
               }
             ],
             "webview_android": [
@@ -226,12 +226,12 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "1.5"
               },
               {
                 "version_removed": "7.0",
                 "prefix": "webkit",
-                "version_added": true
+                "version_added": "1.5"
               }
             ],
             "webview_android": [
@@ -310,12 +310,12 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "1.5"
               },
               {
                 "version_removed": "7.0",
                 "prefix": "webkit",
-                "version_added": true
+                "version_added": "1.5"
               }
             ],
             "webview_android": [
@@ -395,12 +395,12 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "1.5"
               },
               {
                 "version_removed": "7.0",
                 "prefix": "webkit",
-                "version_added": true
+                "version_added": "1.5"
               }
             ],
             "webview_android": [

--- a/api/IDBRequest.json
+++ b/api/IDBRequest.json
@@ -58,12 +58,12 @@
           },
           "samsunginternet_android": [
             {
-              "version_added": true
+              "version_added": "1.5"
             },
             {
               "version_removed": "7.0",
               "prefix": "webkit",
-              "version_added": true
+              "version_added": "1.5"
             }
           ],
           "webview_android": [
@@ -141,12 +141,12 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "1.5"
               },
               {
                 "version_removed": "7.0",
                 "prefix": "webkit",
-                "version_added": true
+                "version_added": "1.5"
               }
             ],
             "webview_android": [

--- a/api/IDBTransaction.json
+++ b/api/IDBTransaction.json
@@ -58,12 +58,12 @@
           },
           "samsunginternet_android": [
             {
-              "version_added": true
+              "version_added": "1.5"
             },
             {
               "version_removed": "7.0",
               "prefix": "webkit",
-              "version_added": true
+              "version_added": "1.5"
             }
           ],
           "webview_android": [
@@ -377,12 +377,12 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "1.5"
               },
               {
                 "version_removed": "7.0",
                 "prefix": "webkit",
-                "version_added": true
+                "version_added": "1.5"
               }
             ],
             "webview_android": [
@@ -461,12 +461,12 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "1.5"
               },
               {
                 "version_removed": "7.0",
                 "prefix": "webkit",
-                "version_added": true
+                "version_added": "1.5"
               }
             ],
             "webview_android": [

--- a/api/IDBVersionChangeEvent.json
+++ b/api/IDBVersionChangeEvent.json
@@ -119,12 +119,12 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "1.5"
               },
               {
                 "version_removed": "7.0",
                 "prefix": "webkit",
-                "version_added": true
+                "version_added": "1.5"
               }
             ],
             "webview_android": [
@@ -203,12 +203,12 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "1.5"
               },
               {
                 "version_removed": "7.0",
                 "prefix": "webkit",
-                "version_added": true
+                "version_added": "1.5"
               }
             ],
             "webview_android": [
@@ -270,7 +270,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/IIRFilterNode.json
+++ b/api/IIRFilterNode.json
@@ -85,7 +85,8 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "6.0",
+              "notes": "Before Samsung Internet 7.0, the default values were not supported."
             },
             "webview_android": {
               "version_added": "55",

--- a/api/IdleDeadline.json
+++ b/api/IdleDeadline.json
@@ -59,7 +59,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": "47"
@@ -130,7 +130,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "47"
@@ -202,7 +202,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "47"

--- a/api/ImageBitmap.json
+++ b/api/ImageBitmap.json
@@ -130,7 +130,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "50"
@@ -178,7 +178,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "50"

--- a/api/ImageBitmapRenderingContext.json
+++ b/api/ImageBitmapRenderingContext.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -96,7 +96,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/ImageBitmapRenderingContext.json
+++ b/api/ImageBitmapRenderingContext.json
@@ -43,7 +43,7 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": false,
+          "standard_track": true,
           "deprecated": false
         }
       },
@@ -104,7 +104,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/ImageCapture.json
+++ b/api/ImageCapture.json
@@ -179,7 +179,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "61"
@@ -306,9 +306,17 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": "7.0"
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "8.0"
+              },
+              {
+                "partial_implementation": true,
+                "version_added": "7.0",
+                "version_removed": "8.0",
+                "notes": "<code>photoSettings</code> argument not supported."
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "60"

--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -275,7 +275,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/InputDeviceCapabilities.json
+++ b/api/InputDeviceCapabilities.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": "47"
@@ -83,7 +83,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "47"
@@ -131,7 +131,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "47"

--- a/api/InputDeviceInfo.json
+++ b/api/InputDeviceInfo.json
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "67"

--- a/api/InputEvent.json
+++ b/api/InputEvent.json
@@ -35,7 +35,7 @@
             "version_added": "10.3"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "8.0"
           },
           "webview_android": {
             "version_added": "60"
@@ -83,7 +83,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"
@@ -179,7 +179,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"
@@ -227,7 +227,7 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"
@@ -275,7 +275,7 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"
@@ -371,7 +371,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -275,7 +275,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -322,7 +322,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "49"
@@ -563,7 +563,7 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -1383,7 +1383,7 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "56"
@@ -1432,7 +1432,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "51"
@@ -1479,7 +1479,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "51"
@@ -1528,7 +1528,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "51"
@@ -1577,7 +1577,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "51"
@@ -1678,7 +1678,8 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.5",
+              "version_removed": "6.0"
             },
             "webview_android": {
               "version_added": true,
@@ -1922,7 +1923,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/LinearAccelerationSensor.json
+++ b/api/LinearAccelerationSensor.json
@@ -29,7 +29,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "10.0"
           },
           "webview_android": {
             "version_added": "69"
@@ -71,7 +71,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "69"
@@ -119,7 +119,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "69"
@@ -167,7 +167,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "69"
@@ -215,7 +215,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "69"

--- a/api/LinkStyle.json
+++ b/api/LinkStyle.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": null
+          },
           "webview_android": {
             "version_added": null
           }
@@ -76,6 +79,9 @@
               "version_added": null
             },
             "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
               "version_added": null
             },
             "webview_android": {

--- a/api/LocalFileSystem.json
+++ b/api/LocalFileSystem.json
@@ -36,6 +36,10 @@
           "safari_ios": {
             "version_added": false
           },
+          "samsunginternet_android": {
+            "prefix": "webkit",
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true,
             "prefix": "webkit"
@@ -81,6 +85,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -125,6 +132,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/LocalFileSystemSync.json
+++ b/api/LocalFileSystemSync.json
@@ -36,6 +36,10 @@
           "safari_ios": {
             "version_added": false
           },
+          "samsunginternet_android": {
+            "prefix": "webkit",
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true,
             "prefix": "webkit"
@@ -81,6 +85,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -125,6 +132,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/LocalMediaStream.json
+++ b/api/LocalMediaStream.json
@@ -36,6 +36,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": null
+          },
           "webview_android": {
             "version_added": null
           }

--- a/api/Location.json
+++ b/api/Location.json
@@ -323,7 +323,7 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -371,7 +371,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -715,7 +715,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "52"
@@ -763,7 +763,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/Lock.json
+++ b/api/Lock.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "10.0"
           },
           "webview_android": {
             "version_added": "69"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "69"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "69"

--- a/api/LockManager.json
+++ b/api/LockManager.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "10.0"
           },
           "webview_android": {
             "version_added": "69"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "69"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "69"

--- a/api/LongRange.json
+++ b/api/LongRange.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/MIDIAccess.json
+++ b/api/MIDIAccess.json
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -130,7 +130,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -179,7 +179,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -227,7 +227,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"

--- a/api/MIDIConnectionEvent.json
+++ b/api/MIDIConnectionEvent.json
@@ -82,6 +82,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
             "webview_android": {
               "version_added": "43"
             }
@@ -126,6 +129,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"

--- a/api/MIDIInput.json
+++ b/api/MIDIInput.json
@@ -82,6 +82,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
             "webview_android": {
               "version_added": false
             }

--- a/api/MIDIMessageEvent.json
+++ b/api/MIDIMessageEvent.json
@@ -82,6 +82,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
             "webview_android": {
               "version_added": false
             }
@@ -126,6 +129,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/MIDIOutput.json
+++ b/api/MIDIOutput.json
@@ -81,6 +81,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
             "webview_android": {
               "version_added": false
             }

--- a/api/MIDIPort.json
+++ b/api/MIDIPort.json
@@ -81,6 +81,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
             "webview_android": {
               "version_added": "43"
             }
@@ -125,6 +128,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -171,6 +177,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
             "webview_android": {
               "version_added": "43"
             }
@@ -215,6 +224,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -261,6 +273,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
             "webview_android": {
               "version_added": "43"
             }
@@ -306,6 +321,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
             "webview_android": {
               "version_added": "43"
             }
@@ -350,6 +368,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -397,6 +418,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
             "webview_android": {
               "version_added": "43"
             }
@@ -442,6 +466,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
             "webview_android": {
               "version_added": "43"
             }
@@ -486,6 +513,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"

--- a/api/Magnetometer.json
+++ b/api/Magnetometer.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "10.0"
           },
           "webview_android": {
             "version_added": "69"
@@ -83,7 +83,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "69"
@@ -131,7 +131,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "69"
@@ -179,7 +179,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "69"
@@ -227,7 +227,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "69"

--- a/api/MediaCapabilities.json
+++ b/api/MediaCapabilities.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": "9.0"
+          },
           "webview_android": {
             "version_added": "66"
           }
@@ -77,6 +80,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -136,6 +142,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/MediaCapabilitiesInfo.json
+++ b/api/MediaCapabilitiesInfo.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -178,7 +178,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/MediaDeviceInfo.json
+++ b/api/MediaDeviceInfo.json
@@ -39,7 +39,8 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "6.0"
+            "version_added": "6.0",
+            "notes": "For earlier versions, this interface is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
           },
           "webview_android": {
             "version_added": "55",
@@ -91,7 +92,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "6.0",
+              "notes": "For earlier versions, this interface is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
             },
             "webview_android": {
               "version_added": "55",
@@ -146,7 +148,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "6.0",
+              "notes": "For earlier versions, this interface is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
             },
             "webview_android": {
               "version_added": "55",
@@ -199,7 +202,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "6.0",
+              "notes": "For earlier versions, this interface is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
             },
             "webview_android": {
               "version_added": "55",
@@ -252,7 +256,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "6.0",
+              "notes": "For earlier versions, this interface is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
             },
             "webview_android": {
               "version_added": "55",

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -35,7 +35,7 @@
             "version_added": "11"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": "47"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -157,7 +157,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "47"
@@ -229,7 +229,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false,
@@ -328,7 +328,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "53"
@@ -444,7 +444,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "53"
@@ -491,7 +491,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true
@@ -554,7 +554,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/MediaElementAudioSourceNode.json
+++ b/api/MediaElementAudioSourceNode.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -85,7 +85,8 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "6.0",
+              "notes": "Before Samsung Internet 7.0, the default values were not supported."
             },
             "webview_android": {
               "version_added": "55",

--- a/api/MediaEncryptedEvent.json
+++ b/api/MediaEncryptedEvent.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "4.0"
           },
           "webview_android": {
             "version_added": "43"
@@ -83,7 +83,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -131,7 +131,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -179,7 +179,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"

--- a/api/MediaMetadata.json
+++ b/api/MediaMetadata.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "7.0"
           },
           "webview_android": {
             "version_added": false
@@ -83,7 +83,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": false
@@ -131,7 +131,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": false
@@ -179,7 +179,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": false
@@ -227,7 +227,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": false
@@ -275,7 +275,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/MediaQueryList.json
+++ b/api/MediaQueryList.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": "5"
           },
+          "samsunginternet_android": {
+            "version_added": "1.0"
+          },
           "webview_android": {
             "version_added": true
           }
@@ -77,6 +80,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -123,6 +129,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            },
             "webview_android": {
               "version_added": "45"
             }
@@ -167,6 +176,9 @@
             },
             "safari_ios": {
               "version_added": "5"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -213,6 +225,9 @@
             "safari_ios": {
               "version_added": "5"
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -257,6 +272,9 @@
             },
             "safari_ios": {
               "version_added": "5"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -303,6 +321,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            },
             "webview_android": {
               "version_added": "45"
             }
@@ -347,6 +368,9 @@
             },
             "safari_ios": {
               "version_added": "5"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -132,7 +132,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "49"
@@ -230,7 +230,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -280,7 +280,8 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "5.0",
+              "version_removed": "7.0"
             },
             "webview_android": {
               "version_added": "49",
@@ -394,7 +395,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "5.0"
             },
             "webview_android": [
               {
@@ -450,7 +451,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -498,7 +499,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -546,7 +547,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -594,7 +595,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -642,7 +643,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -690,7 +691,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -739,7 +740,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -787,7 +788,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -835,7 +836,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -883,7 +884,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -995,7 +996,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "5.0"
             },
             "webview_android": [
               {
@@ -1051,7 +1052,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -1115,7 +1116,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"

--- a/api/MediaRecorderErrorEvent.json
+++ b/api/MediaRecorderErrorEvent.json
@@ -39,7 +39,8 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": false,
+            "notes": "Uses a generic event with an <code>error</code> property."
           },
           "webview_android": {
             "version_added": false
@@ -91,7 +92,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "Uses a generic event with an <code>error</code> property."
             },
             "webview_android": {
               "version_added": false
@@ -143,7 +145,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "Uses a generic event with an <code>error</code> property."
             },
             "webview_android": {
               "version_added": false

--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": "7.0"
+          },
           "webview_android": {
             "version_added": false
           }
@@ -77,6 +80,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": false
@@ -122,6 +128,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": false
@@ -214,6 +223,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/MediaSettingsRange.json
+++ b/api/MediaSettingsRange.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": "7.0"
+          },
           "webview_android": {
             "version_added": "59"
           }
@@ -77,6 +80,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "59"
@@ -123,6 +129,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "7.0"
+            },
             "webview_android": {
               "version_added": "59"
             }
@@ -167,6 +176,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "59"

--- a/api/MediaSource.json
+++ b/api/MediaSource.json
@@ -76,9 +76,16 @@
           "safari_ios": {
             "version_added": false
           },
-          "samsunginternet_android": {
-            "version_added": true
-          },
+          "samsunginternet_android": [
+            {
+              "version_added": "2.0"
+            },
+            {
+              "prefix": "WebKit",
+              "version_added": "1.5",
+              "version_removed": "2.0"
+            }
+          ],
           "webview_android": {
             "version_added": "4.4.3"
           }
@@ -146,7 +153,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -208,7 +215,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -270,7 +277,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -315,7 +322,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "62"
@@ -377,7 +384,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -439,7 +446,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -501,7 +508,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -563,7 +570,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -625,7 +632,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -687,7 +694,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -749,7 +756,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -811,7 +818,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -856,7 +863,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "62"
@@ -918,7 +925,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4.3"

--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": "37"
@@ -131,7 +131,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -180,7 +180,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -228,7 +228,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "37"
@@ -325,7 +325,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -379,7 +379,9 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "6.0",
+              "notes": "Deprecated in Samsung Internet 6.0."
             },
             "webview_android": {
               "version_added": true,
@@ -431,7 +433,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "37"
@@ -479,7 +481,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "37"
@@ -527,7 +529,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -577,7 +579,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "37"
@@ -629,7 +631,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "6.0"
             },
             "webview_android": {
               "version_added": true,
@@ -679,7 +682,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -730,7 +733,9 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "6.0",
+              "notes": "Deprecated in Samsung Internet 5.0."
             },
             "webview_android": {
               "version_added": true,
@@ -780,7 +785,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -828,7 +833,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "37"
@@ -876,7 +881,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -924,7 +929,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "37"
@@ -972,7 +977,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "37"
@@ -1070,7 +1075,8 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true,
+              "version_removed": "5.0"
             },
             "webview_android": {
               "version_added": true,

--- a/api/MediaStreamAudioDestinationNode.json
+++ b/api/MediaStreamAudioDestinationNode.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -85,7 +85,8 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "6.0",
+              "notes": "Before Samsung Internet 7.0, the default values were not supported."
             },
             "webview_android": {
               "version_added": "55",
@@ -134,7 +135,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/MediaStreamAudioSourceNode.json
+++ b/api/MediaStreamAudioSourceNode.json
@@ -85,7 +85,8 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "6.0",
+              "notes": "Before Samsung Internet 7.0, the default values were not supported."
             },
             "webview_android": {
               "version_added": "55",

--- a/api/MediaStreamAudioSourceOptions.json
+++ b/api/MediaStreamAudioSourceOptions.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "6.0"
           },
           "webview_android": {
             "version_added": "55"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"

--- a/api/MediaStreamEvent.json
+++ b/api/MediaStreamEvent.json
@@ -131,7 +131,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -178,7 +178,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"
@@ -323,7 +323,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -419,7 +419,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "61"
@@ -1147,7 +1147,8 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "5.0",
+              "version_removed": "7.0"
             },
             "webview_android": {
               "version_added": "48",
@@ -1196,7 +1197,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "61"

--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -911,7 +911,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/MediaTrackConstraints.json
+++ b/api/MediaTrackConstraints.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": "59"
           }
@@ -77,6 +80,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "59"
@@ -135,6 +141,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -180,6 +189,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "7.0"
+            },
             "webview_android": {
               "version_added": "59"
             }
@@ -224,6 +236,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -272,6 +287,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "7.0"
+            },
             "webview_android": {
               "version_added": "59"
             }
@@ -316,6 +334,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -362,6 +383,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "7.0"
+            },
             "webview_android": {
               "version_added": "59"
             }
@@ -406,6 +430,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "59"
@@ -452,6 +479,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "7.0"
+            },
             "webview_android": {
               "version_added": "59"
             }
@@ -496,6 +526,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "59"
@@ -542,6 +575,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "7.0"
+            },
             "webview_android": {
               "version_added": "59"
             }
@@ -587,6 +623,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "7.0"
+            },
             "webview_android": {
               "version_added": "59"
             }
@@ -631,6 +670,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -689,6 +731,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -733,6 +778,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "59"
@@ -779,6 +827,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "7.0"
+            },
             "webview_android": {
               "version_added": "59"
             }
@@ -824,6 +875,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "7.0"
+            },
             "webview_android": {
               "version_added": "59"
             }
@@ -868,6 +922,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "59"

--- a/api/MediaTrackSettings.json
+++ b/api/MediaTrackSettings.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": "7.0"
+          },
           "webview_android": {
             "version_added": "59"
           }
@@ -77,6 +80,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -137,6 +143,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -181,6 +190,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -227,6 +239,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
             "webview_android": {
               "version_added": "71"
             }
@@ -271,6 +286,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -317,6 +335,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
             "webview_android": {
               "version_added": "71"
             }
@@ -361,6 +382,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -407,6 +431,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -451,6 +478,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -497,6 +527,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -541,6 +574,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -587,6 +623,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -631,6 +670,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "71"
@@ -691,6 +733,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -735,6 +780,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -781,6 +829,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -825,6 +876,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -871,6 +925,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -915,6 +972,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/MediaTrackSupportedConstraints.json
+++ b/api/MediaTrackSupportedConstraints.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": "6.0"
+          },
           "webview_android": {
             "version_added": "52"
           }
@@ -77,6 +80,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "52"
@@ -137,6 +143,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
             "webview_android": {
               "version_added": "69"
             }
@@ -181,6 +190,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "52"
@@ -227,6 +239,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -271,6 +286,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "52"
@@ -317,6 +335,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -361,6 +382,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "52"
@@ -407,6 +431,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
             "webview_android": {
               "version_added": "52"
             }
@@ -451,6 +478,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "52"
@@ -497,6 +527,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
             "webview_android": {
               "version_added": "52"
             }
@@ -541,6 +574,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "52"
@@ -587,6 +623,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
             "webview_android": {
               "version_added": "52"
             }
@@ -631,6 +670,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -691,6 +733,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
             "webview_android": {
               "version_added": "69"
             }
@@ -735,6 +780,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -781,6 +829,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
             "webview_android": {
               "version_added": "52"
             }
@@ -825,6 +876,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "52"
@@ -871,6 +925,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
             "webview_android": {
               "version_added": "52"
             }
@@ -915,6 +972,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "52"

--- a/api/MerchantValidationEvent.json
+++ b/api/MerchantValidationEvent.json
@@ -51,7 +51,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
             "version_added": false
@@ -101,7 +101,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -152,7 +152,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -202,7 +202,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -252,7 +252,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/MessageChannel.json
+++ b/api/MessageChannel.json
@@ -39,7 +39,7 @@
             "version_added": "5.1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": "4.4"
@@ -91,7 +91,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -142,7 +142,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -193,7 +193,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"

--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -83,7 +83,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -322,7 +322,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true
@@ -466,7 +466,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true

--- a/api/MessagePort.json
+++ b/api/MessagePort.json
@@ -39,7 +39,7 @@
             "version_added": "5.1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -89,7 +89,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -143,7 +143,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -195,7 +195,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"
@@ -246,7 +246,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -297,7 +297,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"
@@ -348,7 +348,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -399,7 +399,7 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/Metadata.json
+++ b/api/Metadata.json
@@ -37,7 +37,8 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true,
+            "prefix": "webkit"
           },
           "webview_android": {
             "version_added": false
@@ -84,7 +85,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -132,7 +133,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false

--- a/api/MimeTypeArray.json
+++ b/api/MimeTypeArray.json
@@ -84,7 +84,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0",
+              "notes": "Prior to Samsung Internet 7.0, method parameters were optional"
             },
             "webview_android": {
               "version_added": "59",
@@ -183,7 +184,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0",
+              "notes": "Prior to Samsung Internet 7.0, method parameters were optional"
             },
             "webview_android": {
               "version_added": "59",

--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -83,7 +83,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "47"
@@ -130,7 +130,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "6.0"
               },
               "webview_android": {
                 "version_added": "56"
@@ -186,7 +186,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": false
@@ -338,7 +338,7 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -433,7 +433,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "6.0"
               },
               "webview_android": {
                 "version_added": "56"
@@ -529,7 +529,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "6.0"
               },
               "webview_android": {
                 "version_added": "56"
@@ -626,7 +626,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "47"
@@ -673,7 +673,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": false
@@ -722,7 +722,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -845,9 +845,16 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "4.0"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": true,
+                "version_removed": "4.0"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "37"
@@ -928,9 +935,16 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "4.0"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": true,
+                "version_removed": "4.0"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "37"
@@ -1031,7 +1045,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "6.0"
               },
               "webview_android": {
                 "version_added": "56"
@@ -1127,7 +1141,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "6.0"
               },
               "webview_android": {
                 "version_added": "56"
@@ -1176,7 +1190,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -1223,7 +1237,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "6.0"
               },
               "webview_android": {
                 "version_added": "56"
@@ -1272,7 +1286,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -1319,7 +1333,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "6.0"
               },
               "webview_android": {
                 "version_added": "56"
@@ -1389,7 +1403,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -1532,7 +1546,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "6.0"
               },
               "webview_android": {
                 "version_added": "56"
@@ -1628,7 +1642,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "6.0"
               },
               "webview_android": {
                 "version_added": "56"
@@ -1727,7 +1741,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/MouseWheelEvent.json
+++ b/api/MouseWheelEvent.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -178,7 +178,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/MutationObserver.json
+++ b/api/MutationObserver.json
@@ -62,9 +62,16 @@
               "prefix": "WebKit"
             }
           ],
-          "samsunginternet_android": {
-            "version_added": true
-          },
+          "samsunginternet_android": [
+            {
+              "version_added": "1.5"
+            },
+            {
+              "prefix": "WebKit",
+              "version_added": "1.0",
+              "version_removed": "1.5"
+            }
+          ],
           "webview_android": [
             {
               "version_added": true
@@ -145,9 +152,16 @@
                 "prefix": "WebKit"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "prefix": "WebKit",
+                "version_added": "1.0",
+                "version_removed": "1.5"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": true
@@ -201,7 +215,7 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -249,7 +263,7 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -297,7 +311,7 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/MutationObserverInit.json
+++ b/api/MutationObserverInit.json
@@ -62,9 +62,16 @@
               "version_removed": "7"
             }
           ],
-          "samsunginternet_android": {
-            "version_added": null
-          }
+          "samsunginternet_android": [
+            {
+              "version_added": "1.5"
+            },
+            {
+              "prefix": "webkit",
+              "version_added": "1.0",
+              "version_removed": "1.5"
+            }
+          ]
         },
         "status": {
           "experimental": false,
@@ -134,9 +141,16 @@
                 "version_removed": "7"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.0",
+                "version_removed": "1.5"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -209,9 +223,16 @@
                 "version_removed": "7"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.0",
+                "version_removed": "1.5"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -284,9 +305,16 @@
                 "version_removed": "7"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.0",
+                "version_removed": "1.5"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -359,9 +387,16 @@
                 "version_removed": "7"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.0",
+                "version_removed": "1.5"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -434,9 +469,16 @@
                 "version_removed": "7"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.0",
+                "version_removed": "1.5"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -507,9 +549,16 @@
                 "version_removed": "7"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.0",
+                "version_removed": "1.5"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -580,9 +629,16 @@
                 "version_removed": "7"
               }
             ],
-            "samsunginternet_android": {
-              "version_added": null
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.0",
+                "version_removed": "1.5"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/api/NamedNodeMap.json
+++ b/api/NamedNodeMap.json
@@ -56,6 +56,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -98,6 +101,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -145,6 +151,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -188,6 +197,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -235,6 +247,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -278,6 +293,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -325,6 +343,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -370,6 +391,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -413,6 +437,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/NavigationPreloadManager.json
+++ b/api/NavigationPreloadManager.json
@@ -37,7 +37,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "8.0"
           },
           "webview_android": {
             "version_added": "62"
@@ -86,7 +86,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "62"
@@ -136,7 +136,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "62"
@@ -186,7 +186,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "62"
@@ -236,7 +236,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "62"

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -91,7 +91,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             },
             "webview_android": {
               "version_added": true
@@ -247,7 +248,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -307,7 +308,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -403,7 +404,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -459,7 +460,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "50"
@@ -509,7 +510,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "59"
@@ -557,7 +558,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "51"
@@ -605,7 +606,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "63"
@@ -661,7 +662,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -768,7 +769,7 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "47"
@@ -821,7 +822,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -892,9 +893,15 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "3.0"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.5"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "37"
@@ -974,9 +981,16 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": false
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "6.0"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.5",
+                "notes": "An outdated constraint syntax is still in use, but the syntax described here is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "53"
@@ -1039,7 +1053,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "notes": "Currently supported only by Google Daydream."
             },
             "webview_android": {
               "version_added": true
@@ -1135,7 +1150,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "69"
@@ -1209,7 +1224,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -1257,7 +1272,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -1305,7 +1320,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "51"
@@ -1352,7 +1367,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": "74"
@@ -1401,7 +1416,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": false
@@ -1548,7 +1563,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": false
@@ -1649,7 +1664,8 @@
               "notes": "Always returns <code>20030107</code>."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Always returns <code>20030107</code>."
             },
             "webview_android": {
               "version_added": true
@@ -1747,7 +1763,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -1869,7 +1885,11 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0",
+              "notes": [
+                "The spec requires that the passed <code>supportedConfigurations</code> option contain at least one of <code>audioCapabilities</code> or <code>videoCapabilities</code>, and that said parameters include a codec string.",
+                "The function does not exist in insecure contexts. This was not enforced until Samsung Internet 7.0."
+              ]
             },
             "webview_android": {
               "version_added": "43",
@@ -1925,7 +1945,8 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0",
+              "notes": "Starting in Samsung Internet 7.0, this method cannot send a <code>Blob</code> whose type is not CORS safelisted. This is a temporary change until a mitigation can be found for the security issues that this creates. For more information see <a href='https://crbug.com/720283'>Chrome bug 720283</a>."
             },
             "webview_android": {
               "version_added": "40",
@@ -1986,7 +2007,7 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "40"
@@ -2034,7 +2055,7 @@
               "version_added": "12.2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": false
@@ -2204,7 +2225,11 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0",
+              "notes": [
+                "Beginning in Samsung Internet 6.0, this is not supported in cross-origin iframes.",
+                "Beginning in Samsung Internet 8.0, this method requires a user gesture. Otherwise it returns <code>false</code>."
+              ]
             },
             "webview_android": {
               "version_added": "4.4.3",
@@ -2256,7 +2281,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "63"

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1424,7 +1424,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/NavigatorConcurrentHardware.json
+++ b/api/NavigatorConcurrentHardware.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "3.0"
           },
           "webview_android": {
             "version_added": "37"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/api/NavigatorID.json
+++ b/api/NavigatorID.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -76,6 +79,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -123,6 +129,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -166,6 +175,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -217,6 +229,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -260,6 +275,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -307,6 +325,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -350,6 +371,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/NavigatorLanguage.json
+++ b/api/NavigatorLanguage.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -88,6 +91,10 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true,
+              "notes": "Returns the browser UI language, not the value of the <code>Accept-Language</code> <a href='https://developer.mozilla.org/docs/Web/HTTP/Headers'>HTTP header</a>."
+            },
             "webview_android": {
               "version_added": true,
               "notes": "Returns the browser UI language, not the value of the <code>Accept-Language</code> <a href='https://developer.mozilla.org/docs/Web/HTTP/Headers'>HTTP header</a>."
@@ -139,6 +146,10 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "2.0",
+              "notes": "In Samsung Internet, <code>navigator.language</code> is the language of the browser UI, and is not guaranteed to be equal to <code>navigator.languages[0]</code>."
+            },
             "webview_android": {
               "version_added": "4.4.3",
               "notes": "In Chrome, <code>navigator.language</code> is the language of the browser UI, and is not guaranteed to be equal to <code>navigator.languages[0]</code>."
@@ -184,6 +195,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": null
             },
             "webview_android": {
               "version_added": null

--- a/api/NavigatorOnLine.json
+++ b/api/NavigatorOnLine.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -88,6 +91,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true,
               "notes": "Faulty in a WebView component, see Issue <a href='http://code.google.com/p/android/issues/detail?id=16760'>bug 16760</a>."
@@ -133,6 +139,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": null

--- a/api/NavigatorStorage.json
+++ b/api/NavigatorStorage.json
@@ -53,6 +53,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": null
+          },
           "webview_android": {
             "version_added": null
           }
@@ -114,6 +117,9 @@
               "version_added": null
             },
             "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
               "version_added": null
             },
             "webview_android": {

--- a/api/NetworkInformation.json
+++ b/api/NetworkInformation.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": false
           },
+          "samsunginternet_android": {
+            "version_added": "3.0"
+          },
           "webview_android": {
             "version_added": "50"
           }
@@ -77,6 +80,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "50"
@@ -124,6 +130,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
             "webview_android": {
               "version_added": "50"
             }
@@ -168,6 +177,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "50"
@@ -215,6 +227,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
             "webview_android": {
               "version_added": "50"
             }
@@ -258,6 +273,9 @@
               "version_added": false
             },
             "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
               "version_added": false
             },
             "webview_android": {
@@ -305,6 +323,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
             "webview_android": {
               "version_added": "50"
             }
@@ -349,6 +370,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -396,6 +420,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
             "webview_android": {
               "version_added": "50"
             }
@@ -440,6 +467,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "50"

--- a/api/Node.json
+++ b/api/Node.json
@@ -41,7 +41,8 @@
             "notes": "WebKit and old versions of Blink incorrectly do not make <code>Node</code> inherit from <code>EventTarget</code>."
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": true,
+            "notes": "WebKit and old versions of Blink incorrectly do not make <code>Node</code> inherit from <code>EventTarget</code>."
           },
           "webview_android": {
             "version_added": true,
@@ -86,6 +87,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -277,6 +281,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -345,6 +352,9 @@
               "safari_ios": {
                 "version_added": true
               },
+              "samsunginternet_android": {
+                "version_added": true
+              },
               "webview_android": {
                 "version_added": true
               }
@@ -392,6 +402,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -436,6 +449,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -531,6 +547,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -575,6 +594,9 @@
             },
             "safari_ios": {
               "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "54"
@@ -623,6 +645,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -667,6 +692,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -713,6 +741,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -757,6 +788,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -851,6 +885,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -894,6 +931,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -953,6 +993,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -999,6 +1042,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -1100,7 +1146,9 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "5.0",
+              "notes": "This API was moved to the <code>Element</code> and <code>Attr</code> APIs according to the DOM4 standard."
             },
             "webview_android": {
               "version_added": true,
@@ -1149,6 +1197,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1192,6 +1243,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -1246,7 +1300,9 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "5.0",
+              "notes": "This API was moved to the <code>Element</code> and <code>Attr</code> APIs according to the DOM4 standard."
             },
             "webview_android": {
               "version_added": true,
@@ -1396,7 +1452,9 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "5.0",
+              "notes": "This API was moved to the <code>Element</code> and <code>Attr</code> APIs according to the DOM4 standard."
             },
             "webview_android": {
               "version_added": true,
@@ -1539,6 +1597,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -1896,6 +1957,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1940,6 +2004,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -2034,6 +2101,9 @@
               "version_added": false
             },
             "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
               "version_added": false
             },
             "webview_android": {

--- a/api/NonDocumentTypeChildNode.json
+++ b/api/NonDocumentTypeChildNode.json
@@ -35,6 +35,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -77,6 +80,9 @@
               "version_added": "4"
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -126,6 +132,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -171,6 +180,9 @@
               "version_added": "4"
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/Notation.json
+++ b/api/Notation.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": null
+          },
           "webview_android": {
             "version_added": null
           }
@@ -76,6 +79,9 @@
               "version_added": null
             },
             "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
               "version_added": null
             },
             "webview_android": {
@@ -121,6 +127,9 @@
               "version_added": null
             },
             "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
               "version_added": null
             },
             "webview_android": {

--- a/api/Notification.json
+++ b/api/Notification.json
@@ -120,7 +120,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -168,7 +168,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false
@@ -216,7 +216,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false
@@ -522,7 +522,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false
@@ -906,7 +906,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -958,7 +958,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -1054,7 +1054,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": false
@@ -1102,7 +1102,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": false
@@ -1296,7 +1296,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "6.0",
               "notes": "<a href='https://crbug.com/971422'>Does not work</a> on Android O or later regardless of Chrome version."
             },
             "webview_android": {
@@ -1345,7 +1345,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/OfflineAudioCompletionEvent.json
+++ b/api/OfflineAudioCompletionEvent.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -85,7 +85,8 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "6.0",
+              "notes": "Before Samsung Internet 7.0, the default values were not supported."
             },
             "webview_android": {
               "version_added": "57",
@@ -134,7 +135,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/OfflineAudioContext.json
+++ b/api/OfflineAudioContext.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -85,7 +85,8 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "6.0",
+              "notes": "Before Samsung Internet 7.0, the default values were not supported."
             },
             "webview_android": {
               "version_added": "55",
@@ -133,7 +134,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "8.0"
               },
               "webview_android": {
                 "version_added": "62"
@@ -183,7 +184,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -279,7 +280,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -375,7 +376,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -51,7 +51,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "10.0"
           },
           "webview_android": {
             "version_added": false
@@ -115,7 +115,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false
@@ -181,7 +181,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false
@@ -245,7 +245,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false
@@ -372,7 +372,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "10.0"
               },
               "webview_android": {
                 "version_added": false
@@ -436,7 +436,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "10.0"
               },
               "webview_android": {
                 "version_added": false
@@ -484,7 +484,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "10.0"
               },
               "webview_android": {
                 "version_added": false
@@ -549,7 +549,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false
@@ -613,7 +613,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false
@@ -677,7 +677,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/OrientationSensor.json
+++ b/api/OrientationSensor.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "10.0"
           },
           "webview_android": {
             "version_added": "69"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "69"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "69"

--- a/api/OscillatorNode.json
+++ b/api/OscillatorNode.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -85,7 +85,8 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "6.0",
+              "notes": "Before Samsung Internet 7.0, the default values were not supported."
             },
             "webview_android": {
               "version_added": "55",
@@ -134,7 +135,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -182,7 +183,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -230,7 +231,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -278,7 +279,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -328,7 +329,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -378,7 +379,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -426,7 +427,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/OverconstrainedError.json
+++ b/api/OverconstrainedError.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "8.0"
           },
           "webview_android": {
             "version_added": "63"
@@ -83,7 +83,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "63"
@@ -131,7 +131,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "63"
@@ -179,7 +179,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "63"
@@ -227,7 +227,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "63"

--- a/api/PaintRenderingContext2D.json
+++ b/api/PaintRenderingContext2D.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "65"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -178,7 +178,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -226,7 +226,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -274,7 +274,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -322,7 +322,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -370,7 +370,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -418,7 +418,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -466,7 +466,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -514,7 +514,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -562,7 +562,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -610,7 +610,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -658,7 +658,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "68"
@@ -706,7 +706,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -754,7 +754,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -802,7 +802,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -850,7 +850,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -898,7 +898,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -946,7 +946,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -994,7 +994,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1042,7 +1042,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1090,7 +1090,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1138,7 +1138,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1186,7 +1186,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1234,7 +1234,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1282,7 +1282,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1330,7 +1330,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1378,7 +1378,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1426,7 +1426,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1474,7 +1474,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1522,7 +1522,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "68"
@@ -1570,7 +1570,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1618,7 +1618,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1666,7 +1666,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1714,7 +1714,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1762,7 +1762,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1810,7 +1810,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1858,7 +1858,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1906,7 +1906,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -1954,7 +1954,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"

--- a/api/PaintSize.json
+++ b/api/PaintSize.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "65"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"

--- a/api/PaintWorkletGlobalScope.json
+++ b/api/PaintWorkletGlobalScope.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "65"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"

--- a/api/PannerNode.json
+++ b/api/PannerNode.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -85,7 +85,8 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "6.0",
+              "notes": "Before Samsung Internet 7.0, the default values were not supported."
             },
             "webview_android": {
               "version_added": "55",
@@ -134,7 +135,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -182,7 +183,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -230,7 +231,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -278,7 +279,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -326,7 +327,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -518,7 +519,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -710,7 +711,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -758,7 +759,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -806,7 +807,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -854,7 +855,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -908,7 +909,8 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0",
+              "version_removed": "6.0"
             },
             "webview_android": {
               "version_added": true,

--- a/api/ParentNode.json
+++ b/api/ParentNode.json
@@ -322,7 +322,7 @@
                 "version_added": "9"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true

--- a/api/PasswordCredential.json
+++ b/api/PasswordCredential.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": "5.0"
+          },
           "webview_android": {
             "version_added": "51"
           }
@@ -78,6 +81,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "51"
@@ -124,6 +130,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            },
             "webview_android": {
               "version_added": "51"
             }
@@ -168,6 +177,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "52"
@@ -214,6 +226,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            },
             "webview_android": {
               "version_added": "51"
             }
@@ -258,6 +273,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "52"
@@ -304,6 +322,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
             "webview_android": {
               "version_added": "60"
             }
@@ -348,6 +369,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "51"

--- a/api/PayerErrors.json
+++ b/api/PayerErrors.json
@@ -113,7 +113,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": "6.0"
+            "version_added": false
           },
           "webview_android": {
             "version_added": false
@@ -238,7 +238,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -364,7 +364,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -490,7 +490,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/PaymentAddress.json
+++ b/api/PaymentAddress.json
@@ -75,7 +75,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": "6.0"
+            "version_added": false
           },
           "webview_android": {
             "version_added": false
@@ -152,7 +152,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -230,7 +230,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -308,7 +308,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -386,7 +386,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -466,7 +466,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -544,7 +544,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -622,7 +622,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -700,7 +700,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -778,7 +778,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -856,7 +856,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -920,7 +920,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -998,7 +998,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/PaymentCurrencyAmount.json
+++ b/api/PaymentCurrencyAmount.json
@@ -87,7 +87,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "6.0"
           },
           "webview_android": {
             "version_added": "56"
@@ -176,7 +176,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "56"
@@ -242,7 +242,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -332,7 +332,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "56"

--- a/api/PaymentDetailsBase.json
+++ b/api/PaymentDetailsBase.json
@@ -124,7 +124,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": false
@@ -188,7 +188,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": false
@@ -252,7 +252,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PaymentDetailsInit.json
+++ b/api/PaymentDetailsInit.json
@@ -124,7 +124,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": false
@@ -188,7 +188,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PaymentDetailsUpdate.json
+++ b/api/PaymentDetailsUpdate.json
@@ -124,7 +124,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": false
@@ -188,7 +188,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": false
@@ -252,7 +252,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PaymentInstruments.json
+++ b/api/PaymentInstruments.json
@@ -49,7 +49,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": "7.0"
+            "version_added": false
           },
           "webview_android": {
             "version_added": false

--- a/api/PaymentItem.json
+++ b/api/PaymentItem.json
@@ -75,7 +75,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": "6.0"
+            "version_added": false
           },
           "webview_android": {
             "version_added": false
@@ -150,7 +150,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -226,7 +226,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -302,7 +302,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/PaymentManager.json
+++ b/api/PaymentManager.json
@@ -48,6 +48,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": false
+          },
           "webview_android": {
             "version_added": false
           }
@@ -105,6 +108,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -166,6 +172,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -224,6 +233,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/PaymentMethodChangeEvent.json
+++ b/api/PaymentMethodChangeEvent.json
@@ -61,7 +61,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
             "version_added": false
@@ -124,7 +124,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -188,7 +188,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -319,7 +319,7 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": false
@@ -512,7 +512,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -771,7 +771,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/PaymentRequestEvent.json
+++ b/api/PaymentRequestEvent.json
@@ -49,7 +49,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": "7.0"
+            "version_added": false
           },
           "webview_android": {
             "version_added": false
@@ -547,7 +547,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "7.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/PaymentResponse.json
+++ b/api/PaymentResponse.json
@@ -355,7 +355,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -406,7 +406,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -688,7 +688,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": false
@@ -738,7 +738,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false
@@ -956,7 +956,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/Performance.json
+++ b/api/Performance.json
@@ -42,6 +42,9 @@
           "safari_ios": {
             "version_added": "9"
           },
+          "samsunginternet_android": {
+            "version_added": "1.0"
+          },
           "webview_android": {
             "version_added": true
           }
@@ -103,6 +106,16 @@
             "safari_ios": {
               "version_added": "11"
             },
+            "samsunginternet_android": [
+              {
+                "version_added": "2.0"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.5",
+                "version_removed": "2.0"
+              }
+            ],
             "webview_android": {
               "version_added": true
             }
@@ -165,6 +178,16 @@
             "safari_ios": {
               "version_added": "11"
             },
+            "samsunginternet_android": [
+              {
+                "version_added": "2.0"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.5",
+                "version_removed": "2.0"
+              }
+            ],
             "webview_android": {
               "version_added": true
             }
@@ -227,6 +250,16 @@
             "safari_ios": {
               "version_added": "11"
             },
+            "samsunginternet_android": [
+              {
+                "version_added": "5.0"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.5",
+                "version_removed": "7.0"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "46"
@@ -296,6 +329,16 @@
             "safari_ios": {
               "version_added": "11"
             },
+            "samsunginternet_android": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.5",
+                "version_removed": "3.0"
+              }
+            ],
             "webview_android": {
               "version_added": true
             }
@@ -358,6 +401,16 @@
             "safari_ios": {
               "version_added": "11"
             },
+            "samsunginternet_android": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.5",
+                "version_removed": "3.0"
+              }
+            ],
             "webview_android": {
               "version_added": true
             }
@@ -434,6 +487,16 @@
             "safari_ios": {
               "version_added": "11"
             },
+            "samsunginternet_android": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.5",
+                "version_removed": "3.0"
+              }
+            ],
             "webview_android": {
               "version_added": true
             }
@@ -496,6 +559,16 @@
             "safari_ios": {
               "version_added": "11"
             },
+            "samsunginternet_android": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": true,
+                "version_removed": true
+              }
+            ],
             "webview_android": {
               "version_added": true
             }
@@ -558,6 +631,16 @@
             "safari_ios": {
               "version_added": "11"
             },
+            "samsunginternet_android": [
+              {
+                "version_added": "1.5"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": true,
+                "version_removed": true
+              }
+            ],
             "webview_android": {
               "version_added": "46"
             }
@@ -606,6 +689,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -653,6 +739,9 @@
             },
             "safari_ios": {
               "version_added": "9"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -719,6 +808,9 @@
             "safari_ios": {
               "version_added": "9"
             },
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -781,6 +873,16 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": [
+              {
+                "version_added": "5.0"
+              },
+              {
+                "alternative_name": "onwebkitresourcetimingbufferfull",
+                "version_added": "1.5",
+                "version_removed": "7.0"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "46"
@@ -851,6 +953,16 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": [
+              {
+                "version_added": "5.0"
+              },
+              {
+                "alternative_name": "webkitresourcetimingbufferfull",
+                "version_added": "1.5",
+                "version_removed": "7.0"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "46"
@@ -920,6 +1032,16 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": [
+              {
+                "version_added": "5.0"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.5",
+                "version_removed": "7.0"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "46"
@@ -975,6 +1097,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
             "webview_android": {
               "version_added": "62"
             }
@@ -1026,6 +1151,9 @@
             "safari_ios": {
               "version_added": "9"
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1073,6 +1201,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "56"

--- a/api/PerformanceEntry.json
+++ b/api/PerformanceEntry.json
@@ -50,9 +50,15 @@
           "safari_ios": {
             "version_added": "11"
           },
-          "samsunginternet_android": {
-            "version_added": true
-          },
+          "samsunginternet_android": [
+            {
+              "version_added": "5.0"
+            },
+            {
+              "prefix": "webkit",
+              "version_added": "1.5"
+            }
+          ],
           "webview_android": [
             {
               "version_added": "46"
@@ -362,7 +368,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "62"

--- a/api/PerformanceFrameTiming.json
+++ b/api/PerformanceFrameTiming.json
@@ -37,6 +37,10 @@
           "safari_ios": {
             "version_added": false
           },
+          "samsunginternet_android": {
+            "version_added": false,
+            "notes": "See <a href='https://crbug.com/120796'>Chrome bug 120796</a>"
+          },
           "webview_android": {
             "version_added": false,
             "notes": "See <a href='https://crbug.com/120796'>Chrome bug 120796</a>"

--- a/api/PerformanceLongTaskTiming.json
+++ b/api/PerformanceLongTaskTiming.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "7.0"
           },
           "webview_android": {
             "version_added": "58"
@@ -85,7 +85,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "58"

--- a/api/PerformanceMark.json
+++ b/api/PerformanceMark.json
@@ -38,7 +38,7 @@
             "version_added": "11"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "4.0"
           },
           "webview_android": {
             "version_added": "43"

--- a/api/PerformanceMeasure.json
+++ b/api/PerformanceMeasure.json
@@ -38,7 +38,7 @@
             "version_added": "11"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": true

--- a/api/PerformanceNavigation.json
+++ b/api/PerformanceNavigation.json
@@ -132,7 +132,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "56"

--- a/api/PerformanceObserver.json
+++ b/api/PerformanceObserver.json
@@ -42,6 +42,9 @@
           "safari_ios": {
             "version_added": "11"
           },
+          "samsunginternet_android": {
+            "version_added": "6.0"
+          },
           "webview_android": {
             "version_added": "52"
           }
@@ -89,6 +92,9 @@
             },
             "safari_ios": {
               "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "52"
@@ -140,6 +146,9 @@
             "safari_ios": {
               "version_added": "11"
             },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
             "webview_android": {
               "version_added": "52"
             }
@@ -187,6 +196,9 @@
             },
             "safari_ios": {
               "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "52"
@@ -236,6 +248,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": "73"
             }
@@ -284,6 +299,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "9.0"
+            },
             "webview_android": {
               "version_added": "65"
             }
@@ -331,6 +349,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "62"

--- a/api/PerformanceObserverEntryList.json
+++ b/api/PerformanceObserverEntryList.json
@@ -39,7 +39,7 @@
             "version_added": "11"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "6.0"
           },
           "webview_android": {
             "version_added": false
@@ -89,7 +89,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false
@@ -140,7 +140,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false
@@ -191,7 +191,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PerformancePaintTiming.json
+++ b/api/PerformancePaintTiming.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "8.0"
           },
           "webview_android": {
             "version_added": "60"

--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -466,7 +466,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "61"
@@ -802,7 +802,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"

--- a/api/PerformanceServerTiming.json
+++ b/api/PerformanceServerTiming.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "65"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -178,7 +178,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -226,7 +226,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"

--- a/api/PerformanceTiming.json
+++ b/api/PerformanceTiming.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": "8"
           },
+          "samsunginternet_android": {
+            "version_added": "1.0"
+          },
           "webview_android": {
             "version_added": true
           }
@@ -77,6 +80,9 @@
             },
             "safari_ios": {
               "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -123,6 +129,9 @@
             "safari_ios": {
               "version_added": "11"
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -167,6 +176,9 @@
             },
             "safari_ios": {
               "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -213,6 +225,9 @@
             "safari_ios": {
               "version_added": "11"
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -257,6 +272,9 @@
             },
             "safari_ios": {
               "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -303,6 +321,9 @@
             "safari_ios": {
               "version_added": "8"
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -347,6 +368,9 @@
             },
             "safari_ios": {
               "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -393,6 +417,9 @@
             "safari_ios": {
               "version_added": "11"
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -437,6 +464,9 @@
             },
             "safari_ios": {
               "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -483,6 +513,9 @@
             "safari_ios": {
               "version_added": "11"
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -527,6 +560,9 @@
             },
             "safari_ios": {
               "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -573,6 +609,9 @@
             "safari_ios": {
               "version_added": "11"
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -617,6 +656,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -663,6 +705,9 @@
             "safari_ios": {
               "version_added": "11"
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -707,6 +752,9 @@
             },
             "safari_ios": {
               "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -753,6 +801,9 @@
             "safari_ios": {
               "version_added": "11"
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -797,6 +848,9 @@
             },
             "safari_ios": {
               "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -843,6 +897,9 @@
             "safari_ios": {
               "version_added": "11"
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -887,6 +944,9 @@
             },
             "safari_ios": {
               "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -933,6 +993,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
             "webview_android": {
               "version_added": "44"
             }
@@ -978,6 +1041,9 @@
             "safari_ios": {
               "version_added": "11"
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1022,6 +1088,9 @@
             },
             "safari_ios": {
               "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/PeriodicWave.json
+++ b/api/PeriodicWave.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -85,7 +85,8 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "6.0",
+              "notes": "Before Samsung Internet 7.0, the default values were not supported."
             },
             "webview_android": {
               "version_added": "55",

--- a/api/PermissionStatus.json
+++ b/api/PermissionStatus.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "4.0"
           },
           "webview_android": {
             "version_added": false
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": false
@@ -144,7 +144,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "4.0"
           },
           "webview_android": {
             "version_added": "43"
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "62"
@@ -130,7 +130,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "62"
@@ -178,7 +178,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "62"
@@ -226,7 +226,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "62"
@@ -274,7 +274,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "64"
@@ -322,7 +322,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "64"
@@ -370,7 +370,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "64"
@@ -418,7 +418,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": false
@@ -466,7 +466,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "51"
@@ -514,7 +514,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "62"
@@ -562,7 +562,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "64"
@@ -610,7 +610,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": false
@@ -658,7 +658,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": false
@@ -706,7 +706,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -754,7 +754,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "71"
@@ -802,7 +802,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": false
@@ -850,7 +850,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -898,7 +898,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "46"
@@ -946,7 +946,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "48"
@@ -1020,7 +1020,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "46"

--- a/api/PhotoCapabilities.json
+++ b/api/PhotoCapabilities.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": "7.0"
+          },
           "webview_android": {
             "version_added": "59"
           }
@@ -77,6 +80,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "59"
@@ -123,6 +129,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "7.0"
+            },
             "webview_android": {
               "version_added": "59"
             }
@@ -168,6 +177,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "7.0"
+            },
             "webview_android": {
               "version_added": "59"
             }
@@ -212,6 +224,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "59"

--- a/api/PhotoCapabilities.json
+++ b/api/PhotoCapabilities.json
@@ -43,7 +43,7 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": false,
+          "standard_track": true,
           "deprecated": false
         }
       },
@@ -90,7 +90,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -138,7 +138,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -186,7 +186,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -234,7 +234,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/PictureInPicture.json
+++ b/api/PictureInPicture.json
@@ -51,6 +51,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": false
+          },
           "webview_android": {
             "version_added": false
           }
@@ -111,6 +114,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -174,6 +180,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -235,6 +244,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/Plugin.json
+++ b/api/Plugin.json
@@ -180,7 +180,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Starting with Samsung Internet 7.0, method parameters are required instead of optional."
             },
             "webview_android": {
               "version_added": true,
@@ -279,7 +280,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Starting with Samsung Internet 7.0, method parameters are required instead of optional."
             },
             "webview_android": {
               "version_added": true,
@@ -328,7 +330,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/PluginArray.json
+++ b/api/PluginArray.json
@@ -84,7 +84,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Starting with Samsung Internet 7.0, method parameters are required instead of optional."
             },
             "webview_android": {
               "version_added": true,
@@ -183,7 +184,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Starting with Samsung Internet 7.0, method parameters are required instead of optional."
             },
             "webview_android": {
               "version_added": true,
@@ -234,7 +236,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Starting with Samsung Internet 7.0, method parameters are required instead of optional."
             },
             "webview_android": {
               "version_added": true,

--- a/api/PointerEvent.json
+++ b/api/PointerEvent.json
@@ -522,7 +522,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "9.0"
               },
               "webview_android": {
                 "version_added": "64"

--- a/api/PopStateEvent.json
+++ b/api/PopStateEvent.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": "1.0"
+          },
           "webview_android": {
             "version_added": true
           }
@@ -77,6 +80,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/Position.json
+++ b/api/Position.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": "1.0"
+          },
           "webview_android": {
             "version_added": true
           }
@@ -77,6 +80,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -123,6 +129,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            },
             "webview_android": {
               "version_added": "47"
             }
@@ -167,6 +176,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/PositionError.json
+++ b/api/PositionError.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": "1.0"
+          },
           "webview_android": {
             "version_added": true
           }
@@ -77,6 +80,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -123,6 +129,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -167,6 +176,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "47"

--- a/api/PositionOptions.json
+++ b/api/PositionOptions.json
@@ -47,7 +47,7 @@
             "version_added": "5"
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -106,7 +106,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -166,7 +166,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -214,7 +214,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "51",
@@ -275,7 +275,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/Presentation.json
+++ b/api/Presentation.json
@@ -49,7 +49,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": false
@@ -110,7 +110,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -172,7 +172,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PresentationAvailability.json
+++ b/api/PresentationAvailability.json
@@ -49,7 +49,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": false
@@ -110,7 +110,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -172,7 +172,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PresentationConnection.json
+++ b/api/PresentationConnection.json
@@ -49,7 +49,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": false
@@ -172,7 +172,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -234,7 +234,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -296,7 +296,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -358,7 +358,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -482,7 +482,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -544,7 +544,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -606,7 +606,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -730,7 +730,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PresentationConnectionAvailableEvent.json
+++ b/api/PresentationConnectionAvailableEvent.json
@@ -49,7 +49,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": false
@@ -111,7 +111,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -173,7 +173,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PresentationConnectionCloseEvent.json
+++ b/api/PresentationConnectionCloseEvent.json
@@ -49,7 +49,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": false
@@ -111,7 +111,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -173,7 +173,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -235,7 +235,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PresentationConnectionList.json
+++ b/api/PresentationConnectionList.json
@@ -49,7 +49,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": false
@@ -110,7 +110,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -172,7 +172,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PresentationReceiver.json
+++ b/api/PresentationReceiver.json
@@ -49,7 +49,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "6.0"
           },
           "webview_android": {
             "version_added": false
@@ -110,7 +110,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PresentationRequest.json
+++ b/api/PresentationRequest.json
@@ -49,7 +49,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": false
@@ -111,7 +111,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -173,7 +173,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -235,7 +235,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -297,7 +297,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -345,7 +345,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": false
@@ -407,7 +407,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -469,7 +469,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/ProcessingInstruction.json
+++ b/api/ProcessingInstruction.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -78,6 +81,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -121,6 +127,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/ProgressEvent.json
+++ b/api/ProgressEvent.json
@@ -187,7 +187,7 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "50"

--- a/api/PromiseRejectionEvent.json
+++ b/api/PromiseRejectionEvent.json
@@ -54,7 +54,7 @@
             "version_added": "11.3"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": "49"
@@ -121,7 +121,7 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -188,7 +188,7 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -255,7 +255,7 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"

--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -50,7 +50,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "10.0"
           },
           "webview_android": {
             "version_added": "70"
@@ -112,7 +112,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "70"
@@ -175,7 +175,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "70"
@@ -238,7 +238,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "70"
@@ -301,7 +301,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "70"

--- a/api/PublicKeyCredentialCreationOptions.json
+++ b/api/PublicKeyCredentialCreationOptions.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": "9.0"
+          },
           "webview_android": {
             "version_added": false
           }
@@ -77,6 +80,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": false
@@ -123,6 +129,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "9.0"
+            },
             "webview_android": {
               "version_added": false
             }
@@ -167,6 +176,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": false
@@ -213,6 +225,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "9.0"
+            },
             "webview_android": {
               "version_added": false
             }
@@ -257,6 +272,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": false
@@ -303,6 +321,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "9.0"
+            },
             "webview_android": {
               "version_added": false
             }
@@ -347,6 +368,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": false
@@ -393,6 +417,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "9.0"
+            },
             "webview_android": {
               "version_added": false
             }
@@ -437,6 +464,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PublicKeyCredentialRequestOptions.json
+++ b/api/PublicKeyCredentialRequestOptions.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": "9.0"
+          },
           "webview_android": {
             "version_added": "67"
           }
@@ -77,6 +80,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "67"
@@ -123,6 +129,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "9.0"
+            },
             "webview_android": {
               "version_added": "67"
             }
@@ -167,6 +176,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "67"
@@ -213,6 +225,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "9.0"
+            },
             "webview_android": {
               "version_added": "67"
             }
@@ -258,6 +273,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "9.0"
+            },
             "webview_android": {
               "version_added": "67"
             }
@@ -302,6 +320,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "67"

--- a/api/PushSubscription.json
+++ b/api/PushSubscription.json
@@ -132,7 +132,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/RTCAnswerOptions.json
+++ b/api/RTCAnswerOptions.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": "50"

--- a/api/RTCCertificate.json
+++ b/api/RTCCertificate.json
@@ -178,7 +178,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/RTCDTMFSender.json
+++ b/api/RTCDTMFSender.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": "4.4"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -178,7 +178,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true
@@ -226,7 +226,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -275,7 +275,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true

--- a/api/RTCDTMFToneChangeEvent.json
+++ b/api/RTCDTMFToneChangeEvent.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": "4.4"
@@ -83,7 +83,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -131,7 +131,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4"

--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -49,7 +49,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "2.0"
           },
           "webview_android": {
             "version_added": "4.4"
@@ -96,7 +96,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -197,7 +197,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "7.0"
+              "version_added": "7.0",
+              "notes": "The default for <code>rtcpMuxPolicy<code> is <code>require<code>."
             },
             "webview_android": {
               "version_added": "57",
@@ -733,7 +734,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "7.0"
+              "version_added": "7.0",
+              "notes": "The default for <code>rtcpMuxPolicy</code> is <code>require</code>."
             },
             "webview_android": {
               "version_added": "57",
@@ -1071,7 +1073,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -1263,7 +1265,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "58"

--- a/api/RTCDataChannelEvent.json
+++ b/api/RTCDataChannelEvent.json
@@ -35,7 +35,7 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": true
@@ -131,7 +131,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": true

--- a/api/RTCDtlsTransport.json
+++ b/api/RTCDtlsTransport.json
@@ -37,7 +37,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
             "version_added": "72"
@@ -86,7 +86,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "72"
@@ -137,7 +137,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "72"
@@ -187,7 +187,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "72"
@@ -238,7 +238,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "72"
@@ -288,7 +288,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "72"
@@ -340,7 +340,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "72"

--- a/api/RTCErrorEvent.json
+++ b/api/RTCErrorEvent.json
@@ -35,7 +35,7 @@
             "version_added": "6"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": null
           },
           "webview_android": {
             "version_added": null
@@ -82,7 +82,7 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": null
             },
             "webview_android": {
               "version_added": null

--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -133,7 +133,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"
@@ -229,7 +229,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"
@@ -277,7 +277,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"
@@ -325,7 +325,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -373,7 +373,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"
@@ -421,7 +421,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"
@@ -469,7 +469,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"
@@ -517,7 +517,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"
@@ -565,7 +565,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"
@@ -709,7 +709,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"
@@ -805,7 +805,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"
@@ -853,7 +853,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"

--- a/api/RTCIceCandidatePairStats.json
+++ b/api/RTCIceCandidatePairStats.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "6.0"
           },
           "webview_android": {
             "version_added": "56"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -178,7 +178,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -226,7 +226,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -429,9 +429,15 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": null
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "10.0"
+              },
+              {
+                "alternative_name": "currentRtt",
+                "version_added": true
+              }
+            ],
             "webview_android": {
               "version_added": true
             }
@@ -1066,7 +1072,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1114,7 +1120,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1162,7 +1168,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1210,7 +1216,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1413,9 +1419,15 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": false
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "10.0"
+              },
+              {
+                "alternative_name": "totalRtt",
+                "version_added": true
+              }
+            ],
             "webview_android": {
               "version_added": false
             }
@@ -1524,7 +1536,8 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true,
+              "notes": "Samsung Internet does not currently use the specification's algorithm to determine the value of <code>writable</code>; it may not match the behavior of other browsers."
             },
             "webview_android": {
               "version_added": true

--- a/api/RTCIceCandidateStats.json
+++ b/api/RTCIceCandidateStats.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
             "version_added": false
@@ -94,7 +94,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -142,7 +142,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -192,7 +192,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -240,7 +240,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -288,7 +288,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -338,7 +338,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -386,7 +386,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -446,7 +446,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -506,7 +506,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -556,7 +556,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -604,7 +604,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/RTCIceCandidateType.json
+++ b/api/RTCIceCandidateType.json
@@ -39,7 +39,8 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false,
+            "notes": "An <code>RTCIceCandidate</code> object's <code>type</code> is not maintained by this browser."
           },
           "webview_android": {
             "version_added": false,

--- a/api/RTCIceComponent.json
+++ b/api/RTCIceComponent.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
             "version_added": false

--- a/api/RTCOfferAnswerOptions.json
+++ b/api/RTCOfferAnswerOptions.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": "50"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "50"

--- a/api/RTCOfferOptions.json
+++ b/api/RTCOfferOptions.json
@@ -47,7 +47,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": "50"
@@ -94,7 +94,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "50"

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -425,7 +425,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "69"
@@ -1028,7 +1028,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "70"
@@ -1311,7 +1311,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -1660,9 +1660,19 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "7.0",
+                "notes": "Promise resolves with <code>RTCStatsReport</code>."
+              },
+              {
+                "version_added": "6.0",
+                "notes": "Promise-based version."
+              },
+              {
+                "version_added": true
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "58",
@@ -1718,7 +1728,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "9.0"
               },
               "webview_android": {
                 "version_added": "67"
@@ -1767,7 +1777,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
                 "version_added": true
@@ -1833,7 +1843,8 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "6.0",
+              "version_removed": "8.0"
             },
             "webview_android": {
               "version_added": "56",
@@ -2596,7 +2607,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -4067,9 +4078,15 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": "6.0"
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "5.0",
+                "notes": "Promise-based version."
+              },
+              {
+                "version_added": true
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "51",

--- a/api/RTCPeerConnectionIceEvent.json
+++ b/api/RTCPeerConnectionIceEvent.json
@@ -48,9 +48,16 @@
           "safari_ios": {
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": "6.0"
-          },
+          "samsunginternet_android": [
+            {
+              "alternative_name": "RTCIceCandidateEvent",
+              "version_added": true,
+              "version_removed": "6.0"
+            },
+            {
+              "version_added": "6.0"
+            }
+          ],
           "webview_android": [
             {
               "alternative_name": "RTCIceCandidateEvent",
@@ -200,7 +207,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/RTCRtpEncodingParameters.json
+++ b/api/RTCRtpEncodingParameters.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "67"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "67"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -178,7 +178,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -275,7 +275,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "67"
@@ -323,7 +323,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -374,7 +374,8 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0",
+              "notes": "The standard version of this property is <a href='https://developer.mozilla.org/docs/Web/API/RTCRtpSendParameters/priority'><code>RTCRtpSendParameters.priority</code></a>."
             },
             "webview_android": {
               "version_added": "67",
@@ -423,7 +424,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -569,7 +570,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -246,7 +246,7 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": "73"

--- a/api/RTCRtpSendParameters.json
+++ b/api/RTCRtpSendParameters.json
@@ -37,7 +37,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "10.0"
           },
           "webview_android": {
             "version_added": "69"
@@ -134,7 +134,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "69"
@@ -230,7 +230,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "69"

--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -131,7 +131,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -180,7 +180,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -229,7 +229,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "67"
@@ -278,7 +278,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -387,7 +387,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/RTCRtpStreamStats.json
+++ b/api/RTCRtpStreamStats.json
@@ -47,7 +47,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": false
           },
           "webview_android": {
             "version_added": false
@@ -94,7 +94,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -142,7 +142,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -192,7 +192,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -240,7 +240,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -288,7 +288,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -336,7 +336,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -384,7 +384,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -432,7 +432,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -480,7 +480,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -528,7 +528,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -576,7 +576,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -624,7 +624,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -672,7 +672,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/RTCRtpTransceiverDirection.json
+++ b/api/RTCRtpTransceiverDirection.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true

--- a/api/RTCRtpTransceiverInit.json
+++ b/api/RTCRtpTransceiverInit.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": true
           },
           "webview_android": {
             "version_added": true
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -132,7 +132,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -180,7 +180,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/Range.json
+++ b/api/Range.json
@@ -36,6 +36,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -79,6 +82,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -126,6 +132,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -169,6 +178,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -216,6 +228,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -259,6 +274,9 @@
                 "version_added": true
               },
               "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
                 "version_added": true
               },
               "webview_android": {
@@ -307,6 +325,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -350,6 +371,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -397,6 +421,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -440,6 +467,9 @@
               "version_added": false
             },
             "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
               "version_added": false
             },
             "webview_android": {
@@ -487,6 +517,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -532,6 +565,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -575,6 +611,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -629,6 +668,9 @@
               "version_added": true,
               "notes": "Since August 2015 this method is a no-op in <a href='https://webkit.org/b/148454'>WebKit-based browsers</a>."
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -672,6 +714,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -719,6 +764,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -762,6 +810,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -809,6 +860,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -852,6 +906,9 @@
               "version_added": "5"
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -899,6 +956,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -941,6 +1001,9 @@
                 "version_added": true
               },
               "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
                 "version_added": true
               },
               "webview_android": {
@@ -989,6 +1052,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1032,6 +1098,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -1079,6 +1148,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1122,6 +1194,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -1169,6 +1244,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1212,6 +1290,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -1259,6 +1340,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1302,6 +1386,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -1349,6 +1436,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1392,6 +1482,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -1439,6 +1532,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1482,6 +1578,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -1529,6 +1628,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1572,6 +1674,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/ReadableByteStreamController.json
+++ b/api/ReadableByteStreamController.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": false
           },
+          "samsunginternet_android": {
+            "version_added": false
+          },
           "webview_android": {
             "version_added": false
           }
@@ -77,6 +80,9 @@
               "version_added": false
             },
             "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
               "version_added": false
             },
             "webview_android": {
@@ -124,6 +130,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -167,6 +176,9 @@
               "version_added": false
             },
             "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
               "version_added": false
             },
             "webview_android": {
@@ -214,6 +226,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -259,6 +274,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -302,6 +320,9 @@
               "version_added": false
             },
             "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
               "version_added": false
             },
             "webview_android": {

--- a/api/ReadableStreamBYOBReader.json
+++ b/api/ReadableStreamBYOBReader.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": false
           },
+          "samsunginternet_android": {
+            "version_added": false
+          },
           "webview_android": {
             "version_added": false
           }
@@ -77,6 +80,9 @@
               "version_added": false
             },
             "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
               "version_added": false
             },
             "webview_android": {
@@ -124,6 +130,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -167,6 +176,9 @@
               "version_added": false
             },
             "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
               "version_added": false
             },
             "webview_android": {
@@ -214,6 +226,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -257,6 +272,9 @@
               "version_added": false
             },
             "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
               "version_added": false
             },
             "webview_android": {

--- a/api/ReadableStreamBYOBRequest.json
+++ b/api/ReadableStreamBYOBRequest.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": false
           },
+          "samsunginternet_android": {
+            "version_added": false
+          },
           "webview_android": {
             "version_added": false
           }
@@ -77,6 +80,9 @@
               "version_added": false
             },
             "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
               "version_added": false
             },
             "webview_android": {
@@ -124,6 +130,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -169,6 +178,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -212,6 +224,9 @@
               "version_added": false
             },
             "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
               "version_added": false
             },
             "webview_android": {

--- a/api/ReadableStreamDefaultController.json
+++ b/api/ReadableStreamDefaultController.json
@@ -69,7 +69,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "6.0"
           },
           "webview_android": {
             "version_added": "52"

--- a/api/ReadableStreamDefaultReader.json
+++ b/api/ReadableStreamDefaultReader.json
@@ -69,7 +69,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "6.0"
           },
           "webview_android": {
             "version_added": "52"

--- a/api/RelativeOrientationSensor.json
+++ b/api/RelativeOrientationSensor.json
@@ -29,7 +29,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "10.0"
           },
           "webview_android": {
             "version_added": "69"
@@ -71,7 +71,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "69"

--- a/api/Request.json
+++ b/api/Request.json
@@ -480,7 +480,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "64"
@@ -673,7 +673,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "4.0",
+              "version_removed": "5.0"
             },
             "webview_android": {
               "version_added": "42",
@@ -813,7 +814,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
                 "version_added": "72"
@@ -862,7 +863,7 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "65"
@@ -955,7 +956,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "4.0",
+              "version_removed": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -1051,7 +1053,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -1144,7 +1146,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "4.0",
+              "version_removed": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -1465,7 +1468,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -1528,7 +1531,8 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "4.0",
+              "notes": "Fragment support added in Samsung Internet 7.0."
             },
             "webview_android": {
               "version_added": "42",

--- a/api/RequestDestination.json
+++ b/api/RequestDestination.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": "9.0"
+          },
           "webview_android": {
             "version_added": "65"
           }

--- a/api/ResizeObserver.json
+++ b/api/ResizeObserver.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "64"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "64"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "64"
@@ -179,7 +179,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "64"
@@ -227,7 +227,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "64"

--- a/api/ResizeObserverEntry.json
+++ b/api/ResizeObserverEntry.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "64"
@@ -178,7 +178,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "64"
@@ -226,7 +226,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "64"

--- a/api/Response.json
+++ b/api/Response.json
@@ -709,7 +709,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"
@@ -941,7 +941,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/SVGAElement.json
+++ b/api/SVGAElement.json
@@ -81,7 +81,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/SVGAltGlyphDefElement.json
+++ b/api/SVGAltGlyphDefElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": null
+          },
           "webview_android": {
             "version_added": null
           }

--- a/api/SVGAltGlyphElement.json
+++ b/api/SVGAltGlyphElement.json
@@ -36,6 +36,9 @@
           "safari_ios": {
             "version_added": "4"
           },
+          "samsunginternet_android": {
+            "version_added": "1.0"
+          },
           "webview_android": {
             "version_added": "37"
           }
@@ -79,6 +82,9 @@
             },
             "safari_ios": {
               "version_added": "4"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -124,6 +130,9 @@
             },
             "safari_ios": {
               "version_added": "4"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/api/SVGAltGlyphItemElement.json
+++ b/api/SVGAltGlyphItemElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": null
+          },
           "webview_android": {
             "version_added": null
           }

--- a/api/SVGAngle.json
+++ b/api/SVGAngle.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGAnimateColorElement.json
+++ b/api/SVGAnimateColorElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": false
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGAnimateMotionElement.json
+++ b/api/SVGAnimateMotionElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": "9"
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGAnimateTransformElement.json
+++ b/api/SVGAnimateTransformElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": "3"
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGAnimatedAngle.json
+++ b/api/SVGAnimatedAngle.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": "3"
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGAnimatedBoolean.json
+++ b/api/SVGAnimatedBoolean.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGAnimatedEnumeration.json
+++ b/api/SVGAnimatedEnumeration.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGAnimatedInteger.json
+++ b/api/SVGAnimatedInteger.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGAnimatedLength.json
+++ b/api/SVGAnimatedLength.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGAnimatedLengthList.json
+++ b/api/SVGAnimatedLengthList.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGAnimatedNumber.json
+++ b/api/SVGAnimatedNumber.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGAnimatedNumberList.json
+++ b/api/SVGAnimatedNumberList.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGAnimatedPoints.json
+++ b/api/SVGAnimatedPoints.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": null
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGAnimatedPreserveAspectRatio.json
+++ b/api/SVGAnimatedPreserveAspectRatio.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGAnimatedRect.json
+++ b/api/SVGAnimatedRect.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGAnimatedString.json
+++ b/api/SVGAnimatedString.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": false
+          },
           "webview_android": {
             "version_added": true
           }
@@ -77,6 +80,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": false
             },
             "webview_android": {
               "version_added": true
@@ -122,6 +128,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": false
             },
             "webview_android": {
               "version_added": true

--- a/api/SVGAnimatedTransformList.json
+++ b/api/SVGAnimatedTransformList.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGAnimationElement.json
+++ b/api/SVGAnimationElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -78,6 +81,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -125,6 +131,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -169,6 +178,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -215,6 +227,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -259,6 +274,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -306,6 +324,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -350,6 +371,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/SVGCircleElement.json
+++ b/api/SVGCircleElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": "3.1"
           },
+          "samsunginternet_android": {
+            "version_added": "1.0"
+          },
           "webview_android": {
             "version_added": "3"
           }
@@ -76,6 +79,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -122,6 +128,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -164,6 +173,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/SVGClipPathElement.json
+++ b/api/SVGClipPathElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }
@@ -75,6 +78,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/SVGColorProfileElement.json
+++ b/api/SVGColorProfileElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": null
+          },
           "webview_android": {
             "version_added": null
           }

--- a/api/SVGComponentTransferFunctionElement.json
+++ b/api/SVGComponentTransferFunctionElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGCursorElement.json
+++ b/api/SVGCursorElement.json
@@ -38,6 +38,10 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true,
+            "version_removed": "7.0"
+          },
           "webview_android": {
             "version_added": true,
             "version_removed": "57"

--- a/api/SVGDefsElement.json
+++ b/api/SVGDefsElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGDescElement.json
+++ b/api/SVGDescElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -126,6 +129,9 @@
             },
             "safari_ios": {
               "version_added": "10"
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "55"
@@ -268,6 +274,9 @@
               "safari_ios": {
                 "version_added": null
               },
+              "samsunginternet_android": {
+                "version_added": false
+              },
               "webview_android": {
                 "version_added": false
               }
@@ -318,7 +327,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -367,6 +376,10 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0"
             },
             "webview_android": {
               "version_added": true,
@@ -417,6 +430,10 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0"
+            },
             "webview_android": {
               "version_added": true,
               "version_removed": "50"
@@ -465,6 +482,10 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0"
             },
             "webview_android": {
               "version_added": true,
@@ -515,6 +536,10 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0"
+            },
             "webview_android": {
               "version_added": true,
               "version_removed": "50"
@@ -564,6 +589,10 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0"
+            },
             "webview_android": {
               "version_added": true,
               "version_removed": "50"
@@ -612,7 +641,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/SVGEllipseElement.json
+++ b/api/SVGEllipseElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -75,6 +78,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -121,6 +127,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -165,6 +174,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -207,6 +219,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/SVGExternalResourcesRequired.json
+++ b/api/SVGExternalResourcesRequired.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": null
+          },
           "webview_android": {
             "version_added": null
           }

--- a/api/SVGFEBlendElement.json
+++ b/api/SVGFEBlendElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGFEComponentTransferElement.json
+++ b/api/SVGFEComponentTransferElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGFECompositeElement.json
+++ b/api/SVGFECompositeElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGFEConvolveMatrixElement.json
+++ b/api/SVGFEConvolveMatrixElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGFEDiffuseLightingElement.json
+++ b/api/SVGFEDiffuseLightingElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGFEDisplacementMapElement.json
+++ b/api/SVGFEDisplacementMapElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGFEDistantLightElement.json
+++ b/api/SVGFEDistantLightElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGFEDropShadowElement.json
+++ b/api/SVGFEDropShadowElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGFEFloodElement.json
+++ b/api/SVGFEFloodElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGFEFuncAElement.json
+++ b/api/SVGFEFuncAElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGFEFuncBElement.json
+++ b/api/SVGFEFuncBElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGFEFuncGElement.json
+++ b/api/SVGFEFuncGElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGFEFuncRElement.json
+++ b/api/SVGFEFuncRElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGFEGaussianBlurElement.json
+++ b/api/SVGFEGaussianBlurElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGFEImageElement.json
+++ b/api/SVGFEImageElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGFEMergeElement.json
+++ b/api/SVGFEMergeElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGFEMergeNodeElement.json
+++ b/api/SVGFEMergeNodeElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGFEMorphologyElement.json
+++ b/api/SVGFEMorphologyElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGFEOffsetElement.json
+++ b/api/SVGFEOffsetElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGFEPointLightElement.json
+++ b/api/SVGFEPointLightElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGFESpecularLightingElement.json
+++ b/api/SVGFESpecularLightingElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGFESpotLightElement.json
+++ b/api/SVGFESpotLightElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGFETileElement.json
+++ b/api/SVGFETileElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGFETurbulenceElement.json
+++ b/api/SVGFETurbulenceElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGFilterElement.json
+++ b/api/SVGFilterElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGFilterPrimitiveStandardAttributes.json
+++ b/api/SVGFilterPrimitiveStandardAttributes.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": null
+          },
           "webview_android": {
             "version_added": null
           }

--- a/api/SVGFontElement.json
+++ b/api/SVGFontElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": null
+          },
           "webview_android": {
             "version_added": null
           }

--- a/api/SVGFontFaceElement.json
+++ b/api/SVGFontFaceElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": false
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGFontFaceFormatElement.json
+++ b/api/SVGFontFaceFormatElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": null
+          },
           "webview_android": {
             "version_added": null
           }

--- a/api/SVGFontFaceNameElement.json
+++ b/api/SVGFontFaceNameElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": null
+          },
           "webview_android": {
             "version_added": null
           }

--- a/api/SVGFontFaceSrcElement.json
+++ b/api/SVGFontFaceSrcElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": null
+          },
           "webview_android": {
             "version_added": null
           }

--- a/api/SVGFontFaceUriElement.json
+++ b/api/SVGFontFaceUriElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": null
+          },
           "webview_android": {
             "version_added": null
           }

--- a/api/SVGForeignObjectElement.json
+++ b/api/SVGForeignObjectElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGGElement.json
+++ b/api/SVGGElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGGeometryElement.json
+++ b/api/SVGGeometryElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -78,6 +81,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -127,6 +133,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -170,6 +179,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -217,6 +229,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -262,6 +277,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -305,6 +323,9 @@
               "version_added": null
             },
             "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
               "version_added": null
             },
             "webview_android": {

--- a/api/SVGGlyphElement.json
+++ b/api/SVGGlyphElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": null
+          },
           "webview_android": {
             "version_added": null
           }

--- a/api/SVGGlyphRefElement.json
+++ b/api/SVGGlyphRefElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": null
+          },
           "webview_android": {
             "version_added": null
           }

--- a/api/SVGGradientElement.json
+++ b/api/SVGGradientElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGGraphicsElement.json
+++ b/api/SVGGraphicsElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -85,6 +88,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -127,6 +133,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -173,6 +182,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -215,6 +227,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/SVGHKernElement.json
+++ b/api/SVGHKernElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": null
+          },
           "webview_android": {
             "version_added": null
           }

--- a/api/SVGImageElement.json
+++ b/api/SVGImageElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -77,6 +80,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -124,6 +130,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "9.0"
+            },
             "webview_android": {
               "version_added": "65"
             }
@@ -169,6 +178,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "9.0"
+            },
             "webview_android": {
               "version_added": "65"
             }
@@ -212,6 +224,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -259,6 +274,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -302,6 +320,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -349,6 +370,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -394,6 +418,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -437,6 +464,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/SVGLength.json
+++ b/api/SVGLength.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGLengthList.json
+++ b/api/SVGLengthList.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGLineElement.json
+++ b/api/SVGLineElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -75,6 +78,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -121,6 +127,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -165,6 +174,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -207,6 +219,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/SVGLinearGradientElement.json
+++ b/api/SVGLinearGradientElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGMPathElement.json
+++ b/api/SVGMPathElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGMaskElement.json
+++ b/api/SVGMaskElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -75,6 +78,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -121,6 +127,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -163,6 +172,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -209,6 +221,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -253,6 +268,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -295,6 +313,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/SVGMatrix.json
+++ b/api/SVGMatrix.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGMeshElement.json
+++ b/api/SVGMeshElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": false
           },
+          "samsunginternet_android": {
+            "version_added": false
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGMetadataElement.json
+++ b/api/SVGMetadataElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGMissingGlyphElement.json
+++ b/api/SVGMissingGlyphElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": null
+          },
           "webview_android": {
             "version_added": null
           }

--- a/api/SVGNumber.json
+++ b/api/SVGNumber.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGNumberList.json
+++ b/api/SVGNumberList.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGPathElement.json
+++ b/api/SVGPathElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -80,6 +83,10 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0"
             },
             "webview_android": {
               "version_added": true,
@@ -130,6 +137,10 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0"
+            },
             "webview_android": {
               "version_added": true,
               "version_removed": "48"
@@ -178,6 +189,10 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0"
             },
             "webview_android": {
               "version_added": true,
@@ -228,6 +243,10 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0"
+            },
             "webview_android": {
               "version_added": true,
               "version_removed": "48"
@@ -276,6 +295,10 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0"
             },
             "webview_android": {
               "version_added": true,
@@ -326,6 +349,10 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0"
+            },
             "webview_android": {
               "version_added": true,
               "version_removed": "48"
@@ -374,6 +401,10 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0"
             },
             "webview_android": {
               "version_added": true,
@@ -424,6 +455,10 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0"
+            },
             "webview_android": {
               "version_added": true,
               "version_removed": "48"
@@ -472,6 +507,10 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0"
             },
             "webview_android": {
               "version_added": true,
@@ -522,6 +561,10 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0"
+            },
             "webview_android": {
               "version_added": true,
               "version_removed": "48"
@@ -570,6 +613,10 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0"
             },
             "webview_android": {
               "version_added": true,
@@ -620,6 +667,10 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0"
+            },
             "webview_android": {
               "version_added": true,
               "version_removed": "48"
@@ -668,6 +719,10 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0"
             },
             "webview_android": {
               "version_added": true,
@@ -718,6 +773,10 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0"
+            },
             "webview_android": {
               "version_added": true,
               "version_removed": "48"
@@ -766,6 +825,10 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0"
             },
             "webview_android": {
               "version_added": true,
@@ -816,6 +879,10 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0"
+            },
             "webview_android": {
               "version_added": true,
               "version_removed": "48"
@@ -864,6 +931,10 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0"
             },
             "webview_android": {
               "version_added": true,
@@ -914,6 +985,10 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0"
+            },
             "webview_android": {
               "version_added": true,
               "version_removed": "48"
@@ -962,6 +1037,10 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0"
             },
             "webview_android": {
               "version_added": true,
@@ -1012,6 +1091,10 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "8.0"
+            },
             "webview_android": {
               "version_added": true,
               "version_removed": "62"
@@ -1060,6 +1143,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1106,6 +1192,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1155,6 +1244,10 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0"
             },
             "webview_android": {
               "version_added": true,

--- a/api/SVGPatternElement.json
+++ b/api/SVGPatternElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }
@@ -75,6 +78,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -121,6 +127,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": false
             }
@@ -163,6 +172,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -209,6 +221,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": false
             }
@@ -251,6 +266,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -297,6 +315,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": false
             }
@@ -339,6 +360,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/SVGPoint.json
+++ b/api/SVGPoint.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -77,6 +80,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -123,6 +129,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -167,6 +176,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/SVGPolygonElement.json
+++ b/api/SVGPolygonElement.json
@@ -37,6 +37,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGPolylineElement.json
+++ b/api/SVGPolylineElement.json
@@ -37,6 +37,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGPreserveAspectRatio.json
+++ b/api/SVGPreserveAspectRatio.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGRadialGradientElement.json
+++ b/api/SVGRadialGradientElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGRect.json
+++ b/api/SVGRect.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": "3.1"
           },
+          "samsunginternet_android": {
+            "version_added": "1.0"
+          },
           "webview_android": {
             "version_added": "1"
           }
@@ -76,6 +79,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"
@@ -121,6 +127,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": "1"
             }
@@ -165,6 +174,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": "1"
             }
@@ -208,6 +220,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"

--- a/api/SVGRectElement.json
+++ b/api/SVGRectElement.json
@@ -37,6 +37,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -78,6 +81,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -124,6 +130,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -166,6 +175,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -212,6 +224,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -256,6 +271,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -298,6 +316,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/SVGRenderingIntent.json
+++ b/api/SVGRenderingIntent.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": null
+          },
           "webview_android": {
             "version_added": null
           }

--- a/api/SVGSVGElement.json
+++ b/api/SVGSVGElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -75,6 +78,9 @@
               "version_added": null
             },
             "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
               "version_added": null
             },
             "webview_android": {
@@ -121,6 +127,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -163,6 +172,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -210,6 +222,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": null
+            },
             "webview_android": {
               "version_added": null
             }
@@ -253,6 +268,9 @@
               "version_added": null
             },
             "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
               "version_added": null
             },
             "webview_android": {
@@ -299,6 +317,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -341,6 +362,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -387,6 +411,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -429,6 +456,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -475,6 +505,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -517,6 +550,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -563,6 +599,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -605,6 +644,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -651,6 +693,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -693,6 +738,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -743,6 +791,10 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "6.0"
+            },
             "webview_android": {
               "version_added": true,
               "version_removed": "56"
@@ -786,6 +838,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -832,6 +887,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -874,6 +932,9 @@
               "version_added": null
             },
             "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
               "version_added": null
             },
             "webview_android": {
@@ -920,6 +981,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -962,6 +1026,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -1008,6 +1075,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1052,6 +1122,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1094,6 +1167,9 @@
               "version_added": null
             },
             "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
               "version_added": null
             },
             "webview_android": {
@@ -1146,6 +1222,10 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0"
+            },
             "webview_android": {
               "version_added": true,
               "version_removed": "47"
@@ -1196,6 +1276,10 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0"
             },
             "webview_android": {
               "version_added": true,
@@ -1248,6 +1332,10 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0"
+            },
             "webview_android": {
               "version_added": true,
               "version_removed": "47"
@@ -1299,6 +1387,10 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0"
+            },
             "webview_android": {
               "version_added": true,
               "version_removed": "47"
@@ -1342,6 +1434,9 @@
               "version_added": null
             },
             "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
               "version_added": null
             },
             "webview_android": {
@@ -1388,6 +1483,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1430,6 +1528,9 @@
               "version_added": null
             },
             "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
               "version_added": null
             },
             "webview_android": {
@@ -1476,6 +1577,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1518,6 +1622,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -1568,6 +1675,10 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "6.0"
+            },
             "webview_android": {
               "version_added": true,
               "version_removed": "56"
@@ -1611,6 +1722,9 @@
               "version_added": null
             },
             "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
               "version_added": null
             },
             "webview_android": {
@@ -1657,6 +1771,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1701,6 +1818,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1743,6 +1863,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/SVGScriptElement.json
+++ b/api/SVGScriptElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGSetElement.json
+++ b/api/SVGSetElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGSolidcolorElement.json
+++ b/api/SVGSolidcolorElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": null
+          },
           "webview_android": {
             "version_added": null
           }

--- a/api/SVGStopElement.json
+++ b/api/SVGStopElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGStringList.json
+++ b/api/SVGStringList.json
@@ -36,6 +36,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -78,6 +81,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/SVGStylable.json
+++ b/api/SVGStylable.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": null
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGStyleElement.json
+++ b/api/SVGStyleElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGSwitchElement.json
+++ b/api/SVGSwitchElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGSymbolElement.json
+++ b/api/SVGSymbolElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGTRefElement.json
+++ b/api/SVGTRefElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": null
+          },
           "webview_android": {
             "version_added": null
           }

--- a/api/SVGTSpanElement.json
+++ b/api/SVGTSpanElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGTests.json
+++ b/api/SVGTests.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -80,6 +83,11 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0",
+              "notes": "Removed because it is not part of the SVG2 spec."
             },
             "webview_android": {
               "version_added": true,
@@ -130,6 +138,11 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "7.0",
+              "notes": "Removed because it is not part of the SVG2 spec."
             },
             "webview_android": {
               "version_added": true,

--- a/api/SVGTextContentElement.json
+++ b/api/SVGTextContentElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -75,6 +78,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -121,6 +127,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -163,6 +172,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -209,6 +221,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -251,6 +266,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -297,6 +315,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -339,6 +360,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -385,6 +409,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -427,6 +454,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -473,6 +503,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -515,6 +548,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/SVGTextElement.json
+++ b/api/SVGTextElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGTextPathElement.json
+++ b/api/SVGTextPathElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -75,6 +78,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -121,6 +127,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -163,6 +172,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/SVGTextPositioningElement.json
+++ b/api/SVGTextPositioningElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -75,6 +78,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -121,6 +127,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -163,6 +172,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -209,6 +221,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -251,6 +266,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/SVGTitleElement.json
+++ b/api/SVGTitleElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGTransform.json
+++ b/api/SVGTransform.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGTransformList.json
+++ b/api/SVGTransformList.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -76,6 +79,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/SVGTransformable.json
+++ b/api/SVGTransformable.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": null
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGURIReference.json
+++ b/api/SVGURIReference.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": null
+          },
           "webview_android": {
             "version_added": null
           }

--- a/api/SVGUnitTypes.json
+++ b/api/SVGUnitTypes.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/SVGUnknownElement.json
+++ b/api/SVGUnknownElement.json
@@ -50,6 +50,9 @@
           "safari_ios": {
             "version_added": false
           },
+          "samsunginternet_android": {
+            "version_added": false
+          },
           "webview_android": {
             "version_added": false
           }

--- a/api/SVGUseElement.json
+++ b/api/SVGUseElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -77,6 +80,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -119,6 +125,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -165,6 +174,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -207,6 +219,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -253,6 +268,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -295,6 +313,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/SVGVKernElement.json
+++ b/api/SVGVKernElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": null
+          },
           "webview_android": {
             "version_added": null
           }

--- a/api/SVGViewElement.json
+++ b/api/SVGViewElement.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -82,6 +85,10 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "6.0"
             },
             "webview_android": {
               "version_added": true,

--- a/api/SVGZoomAndPan.json
+++ b/api/SVGZoomAndPan.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/ScopedCredential.json
+++ b/api/ScopedCredential.json
@@ -46,6 +46,9 @@
           "safari_ios": {
             "version_added": false
           },
+          "samsunginternet_android": {
+            "version_added": false
+          },
           "webview_android": {
             "version_added": false
           }
@@ -100,6 +103,9 @@
               "version_added": false
             },
             "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
               "version_added": false
             },
             "webview_android": {
@@ -157,6 +163,9 @@
               "version_added": false
             },
             "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
               "version_added": false
             },
             "webview_android": {

--- a/api/ScopedCredentialInfo.json
+++ b/api/ScopedCredentialInfo.json
@@ -46,6 +46,9 @@
           "safari_ios": {
             "version_added": false
           },
+          "samsunginternet_android": {
+            "version_added": false
+          },
           "webview_android": {
             "version_added": false
           }
@@ -100,6 +103,9 @@
               "version_added": false
             },
             "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
               "version_added": false
             },
             "webview_android": {
@@ -157,6 +163,9 @@
               "version_added": false
             },
             "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
               "version_added": false
             },
             "webview_android": {

--- a/api/Screen.json
+++ b/api/Screen.json
@@ -83,7 +83,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "40"
@@ -179,7 +179,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "40"
@@ -278,7 +278,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0",
+              "notes": "Starting with Samsung Internet 7.0 this property is no longer required to always return 24."
             },
             "webview_android": {
               "version_added": "40",
@@ -427,7 +428,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"
@@ -665,7 +666,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": false
@@ -715,7 +716,8 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Starting with Samsung Internet 7.0 this property is no longer required to always return 24."
             },
             "webview_android": {
               "version_added": true,
@@ -816,7 +818,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"
@@ -864,7 +866,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "40"

--- a/api/ScreenOrientation.json
+++ b/api/ScreenOrientation.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "5.0"
+            "version_added": "3.0"
           },
           "webview_android": {
             "version_added": "38"
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"
@@ -130,7 +130,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"
@@ -178,7 +178,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"
@@ -226,7 +226,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"
@@ -274,7 +274,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"

--- a/api/ScriptProcessorNode.json
+++ b/api/ScriptProcessorNode.json
@@ -113,7 +113,7 @@
               "prefix": "webkit"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/ScrollToOptions.json
+++ b/api/ScrollToOptions.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": "45"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -179,7 +179,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"

--- a/api/Selection.json
+++ b/api/Selection.json
@@ -36,6 +36,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -78,6 +81,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -125,6 +131,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -168,6 +177,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -215,6 +227,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -260,6 +275,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -303,6 +321,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -352,6 +373,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -394,6 +418,9 @@
                 "version_added": true
               },
               "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
                 "version_added": true
               },
               "webview_android": {
@@ -442,6 +469,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -486,6 +516,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -533,6 +566,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": false
             }
@@ -575,6 +611,9 @@
                 "version_added": true
               },
               "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
                 "version_added": true
               },
               "webview_android": {
@@ -623,6 +662,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -666,6 +708,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -713,6 +758,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -756,6 +804,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -803,6 +854,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -845,6 +899,9 @@
                 "version_added": true
               },
               "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
                 "version_added": true
               },
               "webview_android": {
@@ -890,6 +947,9 @@
                 "version_added": true
               },
               "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
                 "version_added": true
               },
               "webview_android": {
@@ -938,6 +998,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -981,6 +1044,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -1028,6 +1094,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "7.0"
+            },
             "webview_android": {
               "version_added": "58"
             }
@@ -1073,6 +1142,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1116,6 +1188,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -1164,6 +1239,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1209,6 +1287,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1252,6 +1333,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/Sensor.json
+++ b/api/Sensor.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "10.0"
           },
           "webview_android": {
             "version_added": "69"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "69"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "69"
@@ -178,7 +178,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "69"
@@ -226,7 +226,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "69"
@@ -274,7 +274,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "69"
@@ -322,7 +322,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "69"
@@ -370,7 +370,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "69"
@@ -418,7 +418,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "69"

--- a/api/SensorErrorEvent.json
+++ b/api/SensorErrorEvent.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "10.0"
           },
           "webview_android": {
             "version_added": "69"
@@ -83,7 +83,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "69"
@@ -131,7 +131,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "69"

--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -515,7 +515,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -683,7 +683,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": "74"

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -395,7 +395,7 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -506,7 +506,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -861,7 +861,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -408,7 +408,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": true
@@ -1156,7 +1156,11 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "4.0",
+              "notes": [
+                "Starting with Samsung Internet 5.0, update() returns a promise that resolves with 'undefined' if the operation completed successfully or there was no update, and rejects if update failed. If the new worker ran but installation failed, the promise still resolves. Formerly, it raised an exception.",
+                "Before Samsung Internet 5.0, this method always bypassed the browser cache. Starting with Samsung Internet 5.0, it only bypasses the cache when the previous service worker check was more than twenty-four hours ago."
+              ]
             },
             "webview_android": {
               "version_added": "45",
@@ -1208,7 +1212,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "68"

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -109,7 +109,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "57"

--- a/api/SharedWorkerGlobalScope.json
+++ b/api/SharedWorkerGlobalScope.json
@@ -181,7 +181,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -277,7 +277,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -77,6 +77,16 @@
           "safari_ios": {
             "version_added": false
           },
+          "samsunginternet_android": [
+            {
+              "version_added": "3.0"
+            },
+            {
+              "prefix": "WebKit",
+              "version_added": "2.0",
+              "version_removed": "3.0"
+            }
+          ],
           "webview_android": {
             "version_added": "4.4.3"
           }
@@ -135,6 +145,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -196,6 +209,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
             "webview_android": {
               "version_added": "4.4.3"
             }
@@ -247,6 +263,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -344,6 +363,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
             "webview_android": {
               "version_added": "4.4.3"
             }
@@ -403,6 +425,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -464,6 +489,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
             "webview_android": {
               "version_added": "4.4.3"
             }
@@ -523,6 +551,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -608,6 +639,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
             "webview_android": {
               "version_added": "70"
             }
@@ -667,6 +701,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -1013,6 +1050,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
             "webview_android": {
               "version_added": "4.4.3"
             }
@@ -1064,6 +1104,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": false
@@ -1125,6 +1168,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
             "webview_android": {
               "version_added": "4.4.3"
             }
@@ -1184,6 +1230,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -1281,6 +1330,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
             "webview_android": {
               "version_added": "4.4.3"
             }
@@ -1340,6 +1392,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "4.4.3"

--- a/api/SourceBufferList.json
+++ b/api/SourceBufferList.json
@@ -55,6 +55,9 @@
           "safari_ios": {
             "version_added": false
           },
+          "samsunginternet_android": {
+            "version_added": "3.0"
+          },
           "webview_android": {
             "version_added": "4.4.3"
           }
@@ -112,6 +115,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "45"
@@ -172,6 +178,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
             "webview_android": {
               "version_added": "4.4.3"
             }
@@ -231,6 +240,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
             "webview_android": {
               "version_added": "53"
             }
@@ -289,6 +301,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "53"

--- a/api/SpeechGrammar.json
+++ b/api/SpeechGrammar.json
@@ -45,7 +45,8 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "9.0",
+            "prefix": "webkit"
           },
           "webview_android": {
             "version_added": false
@@ -103,7 +104,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "9.0",
+              "prefix": "webkit"
             },
             "webview_android": {
               "version_added": false
@@ -159,7 +161,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": false
@@ -215,7 +217,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/SpeechGrammarList.json
+++ b/api/SpeechGrammarList.json
@@ -38,6 +38,11 @@
           "safari_ios": {
             "version_added": false
           },
+          "samsunginternet_android": {
+            "prefix": "webkit",
+            "version_added": true,
+            "notes": "You'll need to serve your code through a web server for recognition to work."
+          },
           "webview_android": {
             "prefix": "webkit",
             "version_added": true,
@@ -87,6 +92,10 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
               "prefix": "webkit",
@@ -139,6 +148,11 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
             "webview_android": {
               "prefix": "webkit",
               "version_added": true,
@@ -190,6 +204,11 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
             "webview_android": {
               "prefix": "webkit",
               "version_added": true,
@@ -238,6 +257,10 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true
             },
             "webview_android": {
               "prefix": "webkit",
@@ -289,6 +312,11 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
               "prefix": "webkit",

--- a/api/SpeechRecognition.json
+++ b/api/SpeechRecognition.json
@@ -38,6 +38,11 @@
           "safari_ios": {
             "version_added": false
           },
+          "samsunginternet_android": {
+            "prefix": "webkit",
+            "version_added": true,
+            "notes": "You'll need to serve your code through a web server for recognition to work."
+          },
           "webview_android": {
             "prefix": "webkit",
             "version_added": true,
@@ -88,6 +93,11 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
               "prefix": "webkit",
@@ -140,6 +150,11 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
             "webview_android": {
               "prefix": "webkit",
               "version_added": true,
@@ -188,6 +203,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -233,6 +251,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -283,6 +304,11 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
             "webview_android": {
               "prefix": "webkit",
               "version_added": true,
@@ -331,6 +357,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -376,6 +405,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -425,6 +457,11 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
               "prefix": "webkit",
@@ -477,6 +514,11 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
             "webview_android": {
               "prefix": "webkit",
               "version_added": true,
@@ -527,6 +569,11 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
               "prefix": "webkit",
@@ -579,6 +626,11 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
             "webview_android": {
               "prefix": "webkit",
               "version_added": true,
@@ -626,6 +678,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -675,6 +730,11 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
               "prefix": "webkit",
@@ -727,6 +787,11 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
             "webview_android": {
               "prefix": "webkit",
               "version_added": true,
@@ -777,6 +842,11 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
               "prefix": "webkit",
@@ -829,6 +899,11 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
             "webview_android": {
               "prefix": "webkit",
               "version_added": true,
@@ -879,6 +954,11 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
               "prefix": "webkit",
@@ -931,6 +1011,11 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
             "webview_android": {
               "prefix": "webkit",
               "version_added": true,
@@ -981,6 +1066,11 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
               "prefix": "webkit",
@@ -1033,6 +1123,11 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
             "webview_android": {
               "prefix": "webkit",
               "version_added": true,
@@ -1083,6 +1178,11 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
               "prefix": "webkit",
@@ -1135,6 +1235,11 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
             "webview_android": {
               "prefix": "webkit",
               "version_added": true,
@@ -1186,6 +1291,11 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
             "webview_android": {
               "prefix": "webkit",
               "version_added": true,
@@ -1233,6 +1343,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1283,6 +1396,11 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
             "webview_android": {
               "prefix": "webkit",
               "version_added": true,
@@ -1331,6 +1449,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1376,6 +1497,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1423,6 +1547,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -1468,6 +1595,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1518,6 +1648,11 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
             "webview_android": {
               "prefix": "webkit",
               "version_added": true,
@@ -1565,6 +1700,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -1614,6 +1752,11 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
               "prefix": "webkit",

--- a/api/SpeechRecognitionAlternative.json
+++ b/api/SpeechRecognitionAlternative.json
@@ -38,6 +38,11 @@
           "safari_ios": {
             "version_added": false
           },
+          "samsunginternet_android": {
+            "prefix": "webkit",
+            "version_added": true,
+            "notes": "You'll need to serve your code through a web server for recognition to work."
+          },
           "webview_android": {
             "prefix": "webkit",
             "version_added": true,
@@ -87,6 +92,11 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
               "prefix": "webkit",
@@ -138,6 +148,11 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
               "prefix": "webkit",

--- a/api/SpeechRecognitionError.json
+++ b/api/SpeechRecognitionError.json
@@ -38,6 +38,11 @@
           "safari_ios": {
             "version_added": false
           },
+          "samsunginternet_android": {
+            "prefix": "webkit",
+            "version_added": true,
+            "notes": "You'll need to serve your code through a web server for recognition to work."
+          },
           "webview_android": {
             "prefix": "webkit",
             "version_added": true,
@@ -87,6 +92,11 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
               "prefix": "webkit",
@@ -138,6 +148,11 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
               "prefix": "webkit",

--- a/api/SpeechRecognitionEvent.json
+++ b/api/SpeechRecognitionEvent.json
@@ -38,6 +38,11 @@
           "safari_ios": {
             "version_added": false
           },
+          "samsunginternet_android": {
+            "prefix": "webkit",
+            "version_added": true,
+            "notes": "You'll need to serve your code through a web server for recognition to work."
+          },
           "webview_android": {
             "prefix": "webkit",
             "version_added": true,
@@ -87,6 +92,11 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
               "prefix": "webkit",
@@ -139,6 +149,11 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
             "webview_android": {
               "prefix": "webkit",
               "version_added": true,
@@ -190,6 +205,11 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
             "webview_android": {
               "prefix": "webkit",
               "version_added": true,
@@ -240,6 +260,11 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
               "prefix": "webkit",

--- a/api/SpeechRecognitionResult.json
+++ b/api/SpeechRecognitionResult.json
@@ -38,6 +38,11 @@
           "safari_ios": {
             "version_added": false
           },
+          "samsunginternet_android": {
+            "prefix": "webkit",
+            "version_added": true,
+            "notes": "You'll need to serve your code through a web server for recognition to work."
+          },
           "webview_android": {
             "prefix": "webkit",
             "version_added": true,
@@ -87,6 +92,11 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
               "prefix": "webkit",
@@ -139,6 +149,11 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
+            },
             "webview_android": {
               "prefix": "webkit",
               "version_added": true,
@@ -189,6 +204,11 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
               "prefix": "webkit",

--- a/api/SpeechRecognitionResultList.json
+++ b/api/SpeechRecognitionResultList.json
@@ -38,6 +38,11 @@
           "safari_ios": {
             "version_added": false
           },
+          "samsunginternet_android": {
+            "prefix": "webkit",
+            "version_added": true,
+            "notes": "You'll need to serve your code through a web server for recognition to work."
+          },
           "webview_android": {
             "prefix": "webkit",
             "version_added": true,
@@ -87,6 +92,11 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
               "prefix": "webkit",
@@ -138,6 +148,11 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true,
+              "notes": "You'll need to serve your code through a web server for recognition to work."
             },
             "webview_android": {
               "prefix": "webkit",

--- a/api/SpeechSynthesis.json
+++ b/api/SpeechSynthesis.json
@@ -47,6 +47,9 @@
           "safari_ios": {
             "version_added": "7"
           },
+          "samsunginternet_android": {
+            "version_added": "3.0"
+          },
           "webview_android": {
             "version_added": "4.4.3"
           }
@@ -103,6 +106,9 @@
             },
             "safari_ios": {
               "version_added": "7"
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -162,6 +168,9 @@
             "safari_ios": {
               "version_added": "7"
             },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
             "webview_android": {
               "version_added": "4.4.3"
             }
@@ -219,6 +228,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -281,6 +293,10 @@
             "safari_ios": {
               "version_added": "7"
             },
+            "samsunginternet_android": {
+              "version_added": "3.0",
+              "notes": "In Android, <code>pause()</code> ends the current utterance. <code>pause()</code> behaves the same as <code>cancel()</code>."
+            },
             "webview_android": {
               "version_added": "4.4.3",
               "notes": "In Android, <code>pause()</code> ends the current utterance. <code>pause()</code> behaves the same as <code>cancel()</code>."
@@ -340,6 +356,9 @@
             "safari_ios": {
               "version_added": "7"
             },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
             "webview_android": {
               "version_added": "4.4.3"
             }
@@ -397,6 +416,9 @@
             },
             "safari_ios": {
               "version_added": "7"
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -456,6 +478,9 @@
             "safari_ios": {
               "version_added": "7"
             },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
             "webview_android": {
               "version_added": "4.4.3"
             }
@@ -513,6 +538,9 @@
             },
             "safari_ios": {
               "version_added": "7"
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -572,6 +600,9 @@
             "safari_ios": {
               "version_added": "7"
             },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
             "webview_android": {
               "version_added": "4.4.3"
             }
@@ -630,6 +661,9 @@
             },
             "safari_ios": {
               "version_added": "7"
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "4.4.3"

--- a/api/SpeechSynthesisErrorEvent.json
+++ b/api/SpeechSynthesisErrorEvent.json
@@ -47,6 +47,9 @@
           "safari_ios": {
             "version_added": "7"
           },
+          "samsunginternet_android": {
+            "version_added": "3.0"
+          },
           "webview_android": {
             "version_added": false
           }
@@ -103,6 +106,9 @@
             },
             "safari_ios": {
               "version_added": "7"
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/SpeechSynthesisEvent.json
+++ b/api/SpeechSynthesisEvent.json
@@ -47,6 +47,9 @@
           "safari_ios": {
             "version_added": "7"
           },
+          "samsunginternet_android": {
+            "version_added": "3.0"
+          },
           "webview_android": {
             "version_added": false
           }
@@ -103,6 +106,9 @@
             },
             "safari_ios": {
               "version_added": "7"
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": false
@@ -162,6 +168,9 @@
             "safari_ios": {
               "version_added": "7"
             },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
             "webview_android": {
               "version_added": false
             }
@@ -220,6 +229,9 @@
             "safari_ios": {
               "version_added": "7"
             },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
             "webview_android": {
               "version_added": false
             }
@@ -277,6 +289,9 @@
             },
             "safari_ios": {
               "version_added": "7"
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/SpeechSynthesisUtterance.json
+++ b/api/SpeechSynthesisUtterance.json
@@ -47,6 +47,9 @@
           "safari_ios": {
             "version_added": "7"
           },
+          "samsunginternet_android": {
+            "version_added": "3.0"
+          },
           "webview_android": {
             "version_added": false
           }
@@ -104,6 +107,9 @@
             },
             "safari_ios": {
               "version_added": "7"
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": false
@@ -164,6 +170,9 @@
             "safari_ios": {
               "version_added": "7"
             },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
             "webview_android": {
               "version_added": false
             }
@@ -222,6 +231,9 @@
             },
             "safari_ios": {
               "version_added": "7"
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": false
@@ -282,6 +294,9 @@
             "safari_ios": {
               "version_added": "7"
             },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
             "webview_android": {
               "version_added": false
             }
@@ -339,6 +354,9 @@
             },
             "safari_ios": {
               "version_added": "7"
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": false
@@ -399,6 +417,9 @@
             "safari_ios": {
               "version_added": "7"
             },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
             "webview_android": {
               "version_added": false
             }
@@ -456,6 +477,9 @@
             },
             "safari_ios": {
               "version_added": "7"
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": false
@@ -515,6 +539,9 @@
             "safari_ios": {
               "version_added": "7"
             },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
             "webview_android": {
               "version_added": false
             }
@@ -572,6 +599,9 @@
             },
             "safari_ios": {
               "version_added": "7"
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": false
@@ -631,6 +661,9 @@
             "safari_ios": {
               "version_added": "7"
             },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
             "webview_android": {
               "version_added": false
             }
@@ -688,6 +721,9 @@
             },
             "safari_ios": {
               "version_added": "7"
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": false
@@ -747,6 +783,9 @@
             "safari_ios": {
               "version_added": "7"
             },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
             "webview_android": {
               "version_added": false
             }
@@ -804,6 +843,9 @@
             },
             "safari_ios": {
               "version_added": "7"
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": false
@@ -864,6 +906,9 @@
             "safari_ios": {
               "version_added": "7"
             },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
             "webview_android": {
               "version_added": false
             }
@@ -922,6 +967,9 @@
             "safari_ios": {
               "version_added": "7"
             },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
             "webview_android": {
               "version_added": false
             }
@@ -979,6 +1027,9 @@
             },
             "safari_ios": {
               "version_added": "7"
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": false
@@ -1039,6 +1090,9 @@
             "safari_ios": {
               "version_added": "7"
             },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
             "webview_android": {
               "version_added": false
             }
@@ -1098,6 +1152,9 @@
             "safari_ios": {
               "version_added": "7"
             },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
             "webview_android": {
               "version_added": false
             }
@@ -1155,6 +1212,9 @@
             },
             "safari_ios": {
               "version_added": "7"
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": false
@@ -1214,6 +1274,9 @@
             "safari_ios": {
               "version_added": "7"
             },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
             "webview_android": {
               "version_added": false
             }
@@ -1271,6 +1334,9 @@
             },
             "safari_ios": {
               "version_added": "7"
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/SpeechSynthesisVoice.json
+++ b/api/SpeechSynthesisVoice.json
@@ -47,6 +47,9 @@
           "safari_ios": {
             "version_added": "7"
           },
+          "samsunginternet_android": {
+            "version_added": "3.0"
+          },
           "webview_android": {
             "version_added": "4.4.3"
           }
@@ -103,6 +106,9 @@
             },
             "safari_ios": {
               "version_added": "7"
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -162,6 +168,9 @@
             "safari_ios": {
               "version_added": "7"
             },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
             "webview_android": {
               "version_added": "4.4.3"
             }
@@ -219,6 +228,9 @@
             },
             "safari_ios": {
               "version_added": "7"
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "4.4.3"
@@ -278,6 +290,9 @@
             "safari_ios": {
               "version_added": "7"
             },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
             "webview_android": {
               "version_added": "4.4.3"
             }
@@ -335,6 +350,9 @@
             },
             "safari_ios": {
               "version_added": "7"
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "4.4.3"

--- a/api/StaticRange.json
+++ b/api/StaticRange.json
@@ -36,7 +36,7 @@
             "version_added": "10.3"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "8.0"
           },
           "webview_android": {
             "version_added": "60"
@@ -132,7 +132,7 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"
@@ -180,7 +180,7 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"
@@ -228,7 +228,7 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"
@@ -276,7 +276,7 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"
@@ -324,7 +324,7 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"
@@ -373,7 +373,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
               "version_added": "60"

--- a/api/StereoPannerNode.json
+++ b/api/StereoPannerNode.json
@@ -85,7 +85,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "6.0",
+              "notes": "Before Samsung Internet 7.0, the default values were not supported."
             },
             "webview_android": {
               "version_added": "55",

--- a/api/Storage.json
+++ b/api/Storage.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": "3.2"
           },
+          "samsunginternet_android": {
+            "version_added": "1.0"
+          },
           "webview_android": {
             "version_added": true
           }
@@ -77,6 +80,9 @@
             },
             "safari_ios": {
               "version_added": "3.2"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -123,6 +129,9 @@
             "safari_ios": {
               "version_added": "3.2"
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -167,6 +176,9 @@
             },
             "safari_ios": {
               "version_added": "3.2"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -213,6 +225,9 @@
             "safari_ios": {
               "version_added": "3.2"
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -258,6 +273,9 @@
             "safari_ios": {
               "version_added": "3.2"
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -302,6 +320,9 @@
             },
             "safari_ios": {
               "version_added": "3.2"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/StorageEstimate.json
+++ b/api/StorageEstimate.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": null
           },
+          "samsunginternet_android": {
+            "version_added": "6.0"
+          },
           "webview_android": {
             "version_added": "52"
           }
@@ -77,6 +80,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "52"
@@ -122,6 +128,9 @@
             },
             "safari_ios": {
               "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "52"

--- a/api/StorageEvent.json
+++ b/api/StorageEvent.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -79,6 +82,9 @@
             "safari_ios": {
               "version_added": null
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -122,6 +128,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -169,6 +178,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -212,6 +224,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -259,6 +274,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -304,6 +322,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -347,6 +368,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/StorageManager.json
+++ b/api/StorageManager.json
@@ -57,7 +57,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": "48"
@@ -104,7 +104,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "52"
@@ -165,9 +165,16 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "6.0"
+              },
+              {
+                "alternative_name": "requestPersistent",
+                "version_added": "5.0",
+                "version_removed": "6.0"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "52"
@@ -234,9 +241,16 @@
             "safari_ios": {
               "version_added": null
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "6.0"
+              },
+              {
+                "alternative_name": "persistentPermission",
+                "version_added": "5.0",
+                "version_removed": "6.0"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "52"

--- a/api/StorageQuota.json
+++ b/api/StorageQuota.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": null
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": "37"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"
@@ -178,7 +178,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "37"

--- a/api/StylePropertyMap.json
+++ b/api/StylePropertyMap.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -130,7 +130,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -178,7 +178,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -226,7 +226,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/StylePropertyMapReadOnly.json
+++ b/api/StylePropertyMapReadOnly.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "9.0"
           },
           "webview_android": {
             "version_added": "66"
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -130,7 +130,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -178,7 +178,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -226,7 +226,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -274,7 +274,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -322,7 +322,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -370,7 +370,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -418,7 +418,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"
@@ -466,7 +466,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "66"

--- a/api/StyleSheet.json
+++ b/api/StyleSheet.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -76,6 +79,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -123,6 +129,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -166,6 +175,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -213,6 +225,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -256,6 +271,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -303,6 +321,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -346,6 +367,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/StyleSheetList.json
+++ b/api/StyleSheetList.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -76,6 +79,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
@@ -121,6 +127,9 @@
               "version_added": true
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/SyncManager.json
+++ b/api/SyncManager.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "5.0"
           },
           "webview_android": {
             "version_added": "49"
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -130,7 +130,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49"
@@ -191,9 +191,16 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": false
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "8.0"
+              },
+              {
+                "partial_implementation": true,
+                "version_added": "5.0",
+                "notes": "Only available in the <code>Window</code> and <code>ServiceWorker</code> global scopes."
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "61"

--- a/api/TaskAttributionTiming.json
+++ b/api/TaskAttributionTiming.json
@@ -38,7 +38,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "7.0"
           },
           "webview_android": {
             "version_added": "58"
@@ -85,7 +85,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "58"
@@ -133,7 +133,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "58"
@@ -181,7 +181,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "58"
@@ -229,7 +229,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": "58"

--- a/api/Text.json
+++ b/api/Text.json
@@ -76,6 +76,9 @@
             "safari_ios": {
               "version_added": "8"
             },
+            "samsunginternet_android": {
+              "version_added": "2.0"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -122,7 +125,7 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "53"
@@ -169,6 +172,9 @@
               "version_added": false
             },
             "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
               "version_added": false
             },
             "webview_android": {
@@ -222,6 +228,10 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "5.0"
+            },
             "webview_android": {
               "version_added": true,
               "version_removed": "45"
@@ -273,6 +283,10 @@
             "safari_ios": {
               "version_added": true,
               "notes": "The <code>offset</code> argument is optional."
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "notes": "Before Samsung Internet 2.0, the <code>offset</code> argument was optional."
             },
             "webview_android": {
               "version_added": true,

--- a/api/TextDecoder.json
+++ b/api/TextDecoder.json
@@ -59,7 +59,7 @@
             "version_added": "10.3"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "3.0"
           },
           "webview_android": {
             "version_added": "38"
@@ -124,7 +124,7 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"
@@ -195,7 +195,7 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"
@@ -260,7 +260,7 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"
@@ -413,7 +413,7 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"

--- a/api/TextEncoder.json
+++ b/api/TextEncoder.json
@@ -57,7 +57,7 @@
             "version_added": "10.3"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "3.0"
           },
           "webview_android": {
             "version_added": "38"
@@ -156,7 +156,7 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"
@@ -219,7 +219,7 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"
@@ -333,7 +333,7 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"
@@ -384,7 +384,7 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"

--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -95,7 +95,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -156,7 +156,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -217,7 +217,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -278,7 +278,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -339,7 +339,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -400,7 +400,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -461,7 +461,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -522,7 +522,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -583,7 +583,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -644,7 +644,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -705,7 +705,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/TextTrack.json
+++ b/api/TextTrack.json
@@ -36,7 +36,7 @@
             "version_added": "7"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": "4.4"
@@ -84,7 +84,7 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -132,7 +132,7 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -227,7 +227,7 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -275,7 +275,7 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -323,7 +323,7 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -371,7 +371,7 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -419,7 +419,7 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -467,7 +467,7 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -516,7 +516,7 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -609,7 +609,7 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -657,7 +657,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/TextTrackCue.json
+++ b/api/TextTrackCue.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": true
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -131,7 +131,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -180,7 +180,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -228,7 +228,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -276,7 +276,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -324,7 +324,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -372,7 +372,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/TextTrackList.json
+++ b/api/TextTrackList.json
@@ -83,7 +83,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -132,7 +132,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true
@@ -228,7 +228,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "44"
@@ -277,7 +277,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": true
             },
             "webview_android": {
               "version_added": true

--- a/api/Touch.json
+++ b/api/Touch.json
@@ -91,7 +91,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "48"
@@ -467,7 +467,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -515,7 +515,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -563,7 +563,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"

--- a/api/TouchEvent.json
+++ b/api/TouchEvent.json
@@ -99,7 +99,8 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "5.0",
+              "notes": "Samsung Internet only supports the following <code>touchEventInit</code> properties: <code>touches</code>, <code>targetTouches</code>, <code>changedTouches</code>."
             },
             "webview_android": {
               "version_added": "48",

--- a/api/TouchList.json
+++ b/api/TouchList.json
@@ -40,6 +40,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }
@@ -82,6 +85,9 @@
               "version_added": false
             },
             "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
               "version_added": null
             },
             "webview_android": {
@@ -135,6 +141,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": true
             }
@@ -184,6 +193,9 @@
               "version_added": false
             },
             "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {

--- a/api/TrackDefault.json
+++ b/api/TrackDefault.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": false
           },
+          "samsunginternet_android": {
+            "version_added": null
+          },
           "webview_android": {
             "version_added": null
           }
@@ -78,6 +81,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": null
             },
             "webview_android": {
               "version_added": null
@@ -124,6 +130,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": null
+            },
             "webview_android": {
               "version_added": null
             }
@@ -168,6 +177,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": null
             },
             "webview_android": {
               "version_added": null
@@ -214,6 +226,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": null
+            },
             "webview_android": {
               "version_added": null
             }
@@ -259,6 +274,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": null
+            },
             "webview_android": {
               "version_added": null
             }
@@ -303,6 +321,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": null
             },
             "webview_android": {
               "version_added": null

--- a/api/TrackDefaultList.json
+++ b/api/TrackDefaultList.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": false
           },
+          "samsunginternet_android": {
+            "version_added": null
+          },
           "webview_android": {
             "version_added": null
           }
@@ -77,6 +80,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": null
             },
             "webview_android": {
               "version_added": null
@@ -124,6 +130,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": null
+            },
             "webview_android": {
               "version_added": null
             }
@@ -168,6 +177,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": null
             },
             "webview_android": {
               "version_added": null

--- a/api/Transferable.json
+++ b/api/Transferable.json
@@ -35,6 +35,9 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": true
           }

--- a/api/TransformStream.json
+++ b/api/TransformStream.json
@@ -43,7 +43,7 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": false,
+          "standard_track": true,
           "deprecated": false
         }
       },
@@ -91,7 +91,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -139,7 +139,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -187,7 +187,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/TransitionEvent.json
+++ b/api/TransitionEvent.json
@@ -48,6 +48,16 @@
           "safari_ios": {
             "version_added": true
           },
+          "samsunginternet_android": [
+            {
+              "version_added": "2.0"
+            },
+            {
+              "prefix": "WebKit",
+              "version_added": "1.0",
+              "version_removed": "10.0"
+            }
+          ],
           "webview_android": [
             {
               "version_added": true
@@ -100,6 +110,9 @@
             "safari_ios": {
               "version_added": false
             },
+            "samsunginternet_android": {
+              "version_added": "2.0"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -145,6 +158,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -189,6 +205,9 @@
             },
             "safari_ios": {
               "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true
@@ -241,6 +260,10 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": false,
+              "notes": "Removal version unknown."
+            },
             "webview_android": {
               "version_added": false,
               "notes": "Removal version unknown."
@@ -287,6 +310,9 @@
             "safari_ios": {
               "version_added": true
             },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
             "webview_android": {
               "version_added": true
             }
@@ -331,6 +357,9 @@
             },
             "safari_ios": {
               "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": true

--- a/api/TreeWalker.json
+++ b/api/TreeWalker.json
@@ -34,6 +34,9 @@
           "safari_ios": {
             "version_added": "3"
           },
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": "3"
           }
@@ -77,6 +80,9 @@
             },
             "safari_ios": {
               "version_added": "3"
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": "3"
@@ -125,6 +131,9 @@
             "safari_ios": {
               "version_added": "3"
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": "3"
             }
@@ -169,6 +178,9 @@
             },
             "safari_ios": {
               "version_added": "3"
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": "3"
@@ -215,6 +227,9 @@
             "safari_ios": {
               "version_added": "3"
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": "3"
             }
@@ -259,6 +274,9 @@
             },
             "safari_ios": {
               "version_added": "3"
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": "3"
@@ -305,6 +323,9 @@
             "safari_ios": {
               "version_added": "3"
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": "3"
             }
@@ -349,6 +370,9 @@
             },
             "safari_ios": {
               "version_added": "3"
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": "3"
@@ -395,6 +419,9 @@
             "safari_ios": {
               "version_added": "3"
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": "3"
             }
@@ -439,6 +466,9 @@
             },
             "safari_ios": {
               "version_added": "3"
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": "3"
@@ -485,6 +515,9 @@
             "safari_ios": {
               "version_added": "3"
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": "3"
             }
@@ -530,6 +563,9 @@
             "safari_ios": {
               "version_added": "3"
             },
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": "3"
             }
@@ -574,6 +610,9 @@
             },
             "safari_ios": {
               "version_added": "3"
+            },
+            "samsunginternet_android": {
+              "version_added": true
             },
             "webview_android": {
               "version_added": "3"

--- a/api/WebKitCSSMatrix.json
+++ b/api/WebKitCSSMatrix.json
@@ -1,8 +1,8 @@
 {
   "api": {
-    "CSSMatrix": {
+    "WebKitCSSMatrix": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMatrix",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebKitCSSMatrix",
         "support": {
           "chrome": {
             "version_added": null
@@ -21,12 +21,11 @@
           },
           "ie": [
             {
-              "version_added": "11",
-              "prefix": "WebKit"
+              "version_added": "11"
             },
             {
               "version_added": "10",
-              "prefix": "MS"
+              "alternative_name": "MSCSSMatrix"
             }
           ],
           "opera": {
@@ -36,12 +35,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": true,
-            "prefix": "WebKit"
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": true,
-            "prefix": "WebKit"
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": null
@@ -52,7 +49,7 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": false,
+          "standard_track": true,
           "deprecated": false
         }
       }

--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -267,7 +267,8 @@
               }
             ],
             "ie": {
-              "version_added": "4"
+              "version_added": "4",
+              "notes": "From Internet Explorer 4 through 8, <code>clearInterval</code> is an Object rather than a Function. This behavior was fixed in Internet Explorer 9."
             },
             "nodejs": {
               "version_added": true,
@@ -332,7 +333,8 @@
               }
             ],
             "ie": {
-              "version_added": "4"
+              "version_added": "4",
+              "notes": "From Internet Explorer 4 through 8, <code>clearTimeout</code> is an Object rather than a Function. This behavior was fixed in Internet Explorer 9."
             },
             "nodejs": {
               "version_added": true,

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -387,7 +387,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -783,7 +783,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }
@@ -832,7 +832,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }
@@ -1452,7 +1452,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }

--- a/css/at-rules/supports.json
+++ b/css/at-rules/supports.json
@@ -142,7 +142,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/-ms-scrollbar-track-color.json
+++ b/css/properties/-ms-scrollbar-track-color.json
@@ -1,9 +1,9 @@
 {
   "css": {
     "properties": {
-      "scrollbar-track-color": {
+      "-ms-scrollbar-track-color": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scrollbar-track-color",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-ms-scrollbar-track-color",
           "support": {
             "chrome": {
               "version_added": false
@@ -22,11 +22,11 @@
             },
             "ie": [
               {
-                "version_added": "5"
+                "version_added": "5",
+                "alternative_name": "scrollbar-track-color"
               },
               {
-                "version_added": "8",
-                "prefix": "-ms-"
+                "version_added": "8"
               }
             ],
             "opera": {

--- a/css/properties/hanging-punctuation.json
+++ b/css/properties/hanging-punctuation.json
@@ -43,7 +43,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/letter-spacing.json
+++ b/css/properties/letter-spacing.json
@@ -62,13 +62,13 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": false
+                "version_added": "72"
               },
               "firefox_android": {
                 "version_added": false
               },
               "ie": {
-                "version_added": "10"
+                "version_added": "9"
               },
               "opera": {
                 "version_added": true
@@ -77,16 +77,16 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": "1"
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": "1"
+                "version_added": "5.1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "1"
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -962,7 +962,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -1058,7 +1058,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -1106,7 +1106,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -2124,7 +2124,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/list-style.json
+++ b/css/properties/list-style.json
@@ -90,7 +90,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/mask-clip.json
+++ b/css/properties/mask-clip.json
@@ -77,7 +77,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -124,7 +124,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": false,
               "deprecated": false
             }
@@ -172,7 +172,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": false,
               "deprecated": false
             }
@@ -220,7 +220,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": false,
               "deprecated": false
             }
@@ -268,7 +268,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": false,
               "deprecated": false
             }

--- a/css/properties/mask-composite.json
+++ b/css/properties/mask-composite.json
@@ -51,7 +51,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/mask-image.json
+++ b/css/properties/mask-image.json
@@ -56,7 +56,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -103,7 +103,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -151,7 +151,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/mask-mode.json
+++ b/css/properties/mask-mode.json
@@ -43,7 +43,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/mask-origin.json
+++ b/css/properties/mask-origin.json
@@ -85,7 +85,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -132,7 +132,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -188,7 +188,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": false,
               "deprecated": false
             }
@@ -236,7 +236,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -284,7 +284,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/mask-position.json
+++ b/css/properties/mask-position.json
@@ -77,7 +77,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -165,7 +165,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/mask-repeat.json
+++ b/css/properties/mask-repeat.json
@@ -77,7 +77,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/mask-size.json
+++ b/css/properties/mask-size.json
@@ -77,7 +77,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/offset-anchor.json
+++ b/css/properties/offset-anchor.json
@@ -14,16 +14,22 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "70",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.motion-path.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "72"
+              },
+              {
+                "version_added": "70",
+                "version_removed": "72",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.motion-path.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -50,7 +56,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/offset-distance.json
+++ b/css/properties/offset-distance.json
@@ -26,16 +26,22 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.motion-path.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "72"
+              },
+              {
+                "version_added": "69",
+                "version_removed": "72",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.motion-path.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -80,7 +86,7 @@
             ]
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/offset-path.json
+++ b/css/properties/offset-path.json
@@ -202,7 +202,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/offset-path.json
+++ b/css/properties/offset-path.json
@@ -26,16 +26,22 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.motion-path.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "72"
+              },
+              {
+                "version_added": "63",
+                "version_removed": "72",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.motion-path.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": "63",
               "flags": [
@@ -94,7 +100,7 @@
             ]
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -141,7 +147,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/offset-rotate.json
+++ b/css/properties/offset-rotate.json
@@ -34,16 +34,22 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.motion-path.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "72"
+              },
+              {
+                "version_added": "69",
+                "version_removed": "72",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.motion-path.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -100,7 +106,7 @@
             ]
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/offset.json
+++ b/css/properties/offset.json
@@ -26,16 +26,22 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "71",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.motion-path.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "72"
+              },
+              {
+                "version_added": "71",
+                "version_removed": "72",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.motion-path.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -80,7 +86,7 @@
             ]
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/overflow-x.json
+++ b/css/properties/overflow-x.json
@@ -53,6 +53,54 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "clip": {
+          "__compat": {
+            "description": "<code>clip</code> value",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/overflow-y.json
+++ b/css/properties/overflow-y.json
@@ -53,6 +53,54 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "clip": {
+          "__compat": {
+            "description": "<code>clip</code> value",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -50,6 +50,54 @@
             "deprecated": false
           }
         },
+        "clip": {
+          "__compat": {
+            "description": "<code>clip</code> value",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "multiple_keywords": {
           "__compat": {
             "description": "Multiple keyword syntax for <code>overflow-x</code> and <code>overflow-y</code>",

--- a/css/properties/rotate.json
+++ b/css/properties/rotate.json
@@ -14,17 +14,22 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "60",
-              "notes": "Enabled by default in Firefox Nightly 71.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.individual-transform.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "72"
+              },
+              {
+                "version_added": "60",
+                "version_removed": "72",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.individual-transform.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": "60",
               "flags": [
@@ -58,7 +63,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -76,16 +81,22 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.individual-transform.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "72"
+                },
+                {
+                  "version_added": "65",
+                  "version_removed": "72",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.individual-transform.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": {
                 "version_added": "65",
                 "flags": [
@@ -119,7 +130,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/scale.json
+++ b/css/properties/scale.json
@@ -14,17 +14,22 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "60",
-              "notes": "Enabled by default in Firefox Nightly 71.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.individual-transform.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "72"
+              },
+              {
+                "version_added": "60",
+                "version_removed": "72",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.individual-transform.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": "60",
               "flags": [
@@ -58,7 +63,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/scrollbar-color.json
+++ b/css/properties/scrollbar-color.json
@@ -68,7 +68,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/scrollbar-width.json
+++ b/css/properties/scrollbar-width.json
@@ -67,7 +67,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/tab-size.json
+++ b/css/properties/tab-size.json
@@ -68,7 +68,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -116,7 +116,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/text-align-last.json
+++ b/css/properties/text-align-last.json
@@ -90,7 +90,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/text-align.json
+++ b/css/properties/text-align.json
@@ -207,7 +207,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -255,7 +255,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/text-indent.json
+++ b/css/properties/text-indent.json
@@ -90,7 +90,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -138,7 +138,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/text-justify.json
+++ b/css/properties/text-justify.json
@@ -103,7 +103,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/text-overflow.json
+++ b/css/properties/text-overflow.json
@@ -158,7 +158,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -206,7 +206,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -254,7 +254,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/text-transform.json
+++ b/css/properties/text-transform.json
@@ -194,7 +194,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -242,7 +242,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/touch-action.json
+++ b/css/properties/touch-action.json
@@ -470,7 +470,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/transition.json
+++ b/css/properties/transition.json
@@ -212,7 +212,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/translate.json
+++ b/css/properties/translate.json
@@ -14,17 +14,22 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "60",
-              "notes": "Enabled by default in Firefox Nightly 71.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.individual-transform.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "72"
+              },
+              {
+                "version_added": "60",
+                "version_removed": "72",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.individual-transform.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": "60",
               "flags": [
@@ -58,7 +63,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/word-spacing.json
+++ b/css/properties/word-spacing.json
@@ -27,7 +27,7 @@
               "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": "1"
@@ -74,7 +74,7 @@
                 "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": "6.1"
@@ -87,6 +87,54 @@
               },
               "webview_android": {
                 "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "svg": {
+          "__compat": {
+            "description": "SVG support",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": "18"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "72"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": "9"
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "5.1"
+              },
+              "safari_ios": {
+                "version_added": "5.1"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0"
+              },
+              "webview_android": {
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/selectors/attribute.json
+++ b/css/selectors/attribute.json
@@ -148,7 +148,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/selectors/dir.json
+++ b/css/selectors/dir.json
@@ -58,7 +58,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/selectors/empty.json
+++ b/css/selectors/empty.json
@@ -92,7 +92,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/selectors/focus-visible.json
+++ b/css/selectors/focus-visible.json
@@ -74,7 +74,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/selectors/host-context.json
+++ b/css/selectors/host-context.json
@@ -46,7 +46,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/types/clamp.json
+++ b/css/types/clamp.json
@@ -44,7 +44,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -120,7 +120,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -2056,7 +2056,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -2119,7 +2119,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -2168,7 +2168,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -1160,8 +1160,8 @@
               },
               "status": {
                 "experimental": true,
-                "standard_track": true,
-                "deprecated": false
+                "standard_track": false,
+                "deprecated": true
               }
             }
           },

--- a/http/headers/if-match.json
+++ b/http/headers/if-match.json
@@ -43,9 +43,9 @@
             }
           },
           "status": {
-            "experimental": true,
-            "standard_track": false,
-            "deprecated": true
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/http/headers/x-content-type-options.json
+++ b/http/headers/x-content-type-options.json
@@ -72,7 +72,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/javascript/builtins/AsyncFunction.json
+++ b/javascript/builtins/AsyncFunction.json
@@ -45,10 +45,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -107,10 +107,10 @@
                 "version_added": "42"
               },
               "safari": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": "6.0"

--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -34,10 +34,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -85,10 +85,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -135,10 +135,10 @@
                   "version_added": true
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": "6"
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": "6"
                 },
                 "samsunginternet_android": {
                   "version_added": "1.0"
@@ -188,10 +188,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -343,10 +343,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -394,10 +394,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "3"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -445,10 +445,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -550,10 +550,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -600,10 +600,10 @@
                   "version_added": "30"
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "samsunginternet_android": {
                   "version_added": "4.0"
@@ -653,10 +653,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "6"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "6"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -703,10 +703,10 @@
                   "version_added": null
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "samsunginternet_android": {
                   "version_added": "4.0"
@@ -756,10 +756,10 @@
                   "version_added": null
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": "10"
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": "10"
                 },
                 "samsunginternet_android": {
                   "version_added": "5.0"
@@ -809,10 +809,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -915,10 +915,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"

--- a/javascript/builtins/GeneratorFunction.json
+++ b/javascript/builtins/GeneratorFunction.json
@@ -34,10 +34,10 @@
               "version_added": "26"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -85,10 +85,10 @@
                 "version_added": "26"
               },
               "safari": {
-                "version_added": null
+                "version_added": "10"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10"
               },
               "samsunginternet_android": {
                 "version_added": "4.0"

--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -519,6 +519,7 @@
           "formatRange": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/formatRange",
+              "spec_url": "https://tc39.es/proposal-intl-DateTimeFormat-formatRange/#sec-intl.datetimeformat.prototype.formatRange",
               "support": {
                 "chrome": {
                   "version_added": "76"
@@ -570,6 +571,7 @@
           "formatRangeToParts": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/formatRangeToParts",
+              "spec_url": "https://tc39.es/proposal-intl-DateTimeFormat-formatRange/#sec-Intl.DateTimeFormat.prototype.formatRangeToParts",
               "support": {
                 "chrome": {
                   "version_added": "76"

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -3007,7 +3007,7 @@
         "trimEnd": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/trimEnd",
-            "spec_url": "https://github.com/tc39/proposal-string-left-right-trim/#stringprototypetrimstart--stringprototypetrimend",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.trimend",
             "support": {
               "chrome": [
                 {
@@ -3114,7 +3114,7 @@
         "trimStart": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/trimStart",
-            "spec_url": "https://github.com/tc39/proposal-string-left-right-trim/#stringprototypetrimstart--stringprototypetrimend",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.trimstart",
             "support": {
               "chrome": [
                 {

--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -33,10 +33,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": true
+            "version_added": "1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -84,10 +84,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -135,10 +135,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -239,10 +239,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -406,10 +406,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": null
+                "version_added": "10"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10"
               },
               "samsunginternet_android": {
                 "version_added": "7.0"
@@ -458,10 +458,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -561,10 +561,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": "10"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -1058,10 +1058,10 @@
                 "version_added": "36"
               },
               "safari": {
-                "version_added": null
+                "version_added": "10"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"

--- a/mathml/elements/mfrac.json
+++ b/mathml/elements/mfrac.json
@@ -30,10 +30,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "5.1"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -172,6 +172,54 @@
               },
               "safari": {
                 "version_added": "10"
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "linethickness": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "5.1",
+                "notes": "Before Safari 9, &lt;length&gt; values are not supported. Only <code>0</code>, <code>thin</code>, <code>medium</code>, and <code>thick</code> are supported."
               },
               "safari_ios": {
                 "version_added": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mdn-browser-compat-data",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdn-browser-compat-data",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Browser compatibility data provided by MDN Web Docs",
   "main": "index.js",
   "types": "index.d.ts",

--- a/svg/attributes/presentation.json
+++ b/svg/attributes/presentation.json
@@ -1543,40 +1543,40 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/letter-spacing",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "72"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
-                "version_added": null
+                "version_added": "9"
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -3079,40 +3079,40 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/word-spacing",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "72"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
-                "version_added": null
+                "version_added": "9"
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "≤37"
               }
             },
             "status": {


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1575144

Basically, the following updates have occurred

* `Coordinates` -> `GeolocationCoordinates`
* `Position` -> `GeolocationPosition`
* `PositionError` -> `GeolocationPositionError`

This has happened only in Firefox 72, and Chrome Canary (I think version 79, but I'm not 100% certain).

So I've attempted to communicate this via a combination of `alternative_name` data for the ones that haven't yet changed over, and `note`s for the ones that have, to say what version they changed over on.

So far I have only done this on the data for the actual interfaces, and not for all their methods/properties — I did this because:

a. I'm not sure if it is the right approach
b. I wasn't sure if it would be worth repeating this information over every data point.

Any thoughts and suggestions much appreciated. Thanks!
