### PR TITLE
Add Safari versions for Error JavaScript builtins

### DIFF
--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -34,10 +34,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -238,10 +238,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -290,10 +290,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -342,10 +342,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -496,10 +496,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"

--- a/javascript/builtins/EvalError.json
+++ b/javascript/builtins/EvalError.json
@@ -34,10 +34,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/javascript/builtins/RangeError.json
+++ b/javascript/builtins/RangeError.json
@@ -34,10 +34,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/javascript/builtins/ReferenceError.json
+++ b/javascript/builtins/ReferenceError.json
@@ -34,10 +34,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/javascript/builtins/SyntaxError.json
+++ b/javascript/builtins/SyntaxError.json
@@ -34,10 +34,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/javascript/builtins/TypeError.json
+++ b/javascript/builtins/TypeError.json
@@ -34,10 +34,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/javascript/builtins/URIError.json
+++ b/javascript/builtins/URIError.json
@@ -34,10 +34,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds the Safari versions for the Error builtins for JavaScript.  All data was found to be supported since Safari 1:

javascript.builtins.Error - 1
javascript.builtins.Error.message - 1
javascript.builtins.Error.name - 1
javascript.builtins.Error.prototype - 1
javascript.builtins.Error.toString - 1
javascript.builtins.EvalError - 1
javascript.builtins.RangeError - 1
javascript.builtins.ReferenceError - 1
javascript.builtins.SyntaxError - 1
javascript.builtins.TypeError - 1
javascript.builtins.URIError - 1