### PR TITLE
Samsung Internet 11.0 released

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -154,7 +154,7 @@
           "engine_version": "71"
         },
         "11.0": {
-          "release_date": "2019-12-22",
+          "release_date": "2019-12-05",
           "status": "current",
           "engine": "Blink",
           "engine_version": "75"

--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -154,7 +154,7 @@
           "engine_version": "71"
         },
         "11.0": {
-          "release_date": "2019-10-22",
+          "release_date": "2019-12-22",
           "status": "current",
           "engine": "Blink",
           "engine_version": "75"

--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -143,15 +143,21 @@
         },
         "10.0": {
           "release_date": "2019-08-22",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "71"
         },
         "10.2": {
           "release_date": "2019-10-09",
-          "status": "beta",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "71"
+        },
+        "11.0": {
+          "release_date": "2019-10-22",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "75"
         }
       }
     }


### PR DESCRIPTION
This PR is opened based upon https://github.com/mdn/browser-compat-data/pull/5182#issuecomment-564528891.  Looks like Samsung Internet 11 is already out, which is based on Chrome 75.

Sources:
- https://www.androidpolice.com/2019/10/22/samsung-internet-v11-includes-ui-changes-and-newer-chromium-base-apk-download/
- https://www.apkmirror.com/apk/samsung-electronics-co-ltd/samsung-internet-for-android/samsung-internet-for-android-11-0-00-49-release/samsung-internet-browser-11-0-00-49-android-apk-download/