### PR TITLE
Print events supported in Safari 13

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -177,7 +177,7 @@
               "version_added": "13"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -548,7 +548,7 @@
               "version_added": "13"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "8.0"

--- a/api/Window.json
+++ b/api/Window.json
@@ -174,7 +174,7 @@
               "version_added": "46"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
               "version_added": null
@@ -545,7 +545,7 @@
               "version_added": "46"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
               "version_added": null

--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -79,7 +79,7 @@
               "version_added": "13"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -127,7 +127,7 @@
               "version_added": "13"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "8.0"

--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -76,7 +76,7 @@
               "version_added": "46"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
               "version_added": null
@@ -124,7 +124,7 @@
               "version_added": "46"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
               "version_added": null

--- a/html/elements/body.json
+++ b/html/elements/body.json
@@ -362,7 +362,7 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "13"
               },
               "safari_ios": {
                 "version_added": true
@@ -409,7 +409,7 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "13"
               },
               "safari_ios": {
                 "version_added": true

--- a/html/elements/body.json
+++ b/html/elements/body.json
@@ -365,7 +365,7 @@
                 "version_added": "13"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "13"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -412,7 +412,7 @@
                 "version_added": "13"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "13"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] updated safari desktop values to support since version 13 for afterprint/beforeprint
- [x] Data: could not find any mention in any updated bugtracker or changelog 🤷 https://bugs.webkit.org/show_bug.cgi?id=19937
- [x] tested via browserstack in safari 5, 12.1 and 13 with mentioned tests from caniuse-test-suite in linked issue
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issue: https://github.com/mdn/browser-compat-data/issues/5313

