### PR TITLE
Original topSites.get options added in Firefox 63

### DIFF
--- a/webextensions/api/topSites.json
+++ b/webextensions/api/topSites.json
@@ -86,6 +86,48 @@
                 }
               }
             },
+            "includeBlocked": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "63"
+                  },
+                  "firefox_android": {
+                    "version_added": "63"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
+            "includeFavicon": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "63"
+                  },
+                  "firefox_android": {
+                    "version_added": "63"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
             "includePinned": {
               "__compat": {
                 "support": {
@@ -121,6 +163,69 @@
                   },
                   "firefox_android": {
                     "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
+            "limit": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "63"
+                  },
+                  "firefox_android": {
+                    "version_added": "63"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
+            "newtab": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "63"
+                  },
+                  "firefox_android": {
+                    "version_added": "63"
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
+            "onePerDomain": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "63"
+                  },
+                  "firefox_android": {
+                    "version_added": "63"
                   },
                   "opera": {
                     "version_added": false


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/sprints/issues/2565 which says:
> In Firefox 69 new parameters were added to topSites.get. These parameters were added to the compatibility data in mdn/browser-compat-data#5271. However, the compatibility data does not include the original set of parameters. These should be added for completeness.

## Data

Compat data is taken from `get.options.__compat`.

CC @rebloor 

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
