### PR TITLE
Shadow parts update

### DIFF
--- a/css/selectors/part.json
+++ b/css/selectors/part.json
@@ -20,16 +20,17 @@
                 "version_added": "72",
               },
               {
-              "version_added": "69",
-              "version_removed": "72",
-              "flags": [
-                {
-                  "name": "layout.css.shadow-parts.enabled",
-                  "type": "preference",
-                  "value_to_set": "true"
-                }
-              ]
-            }],
+                "version_added": "69",
+                "version_removed": "72",
+                "flags": [
+                  {
+                    "name": "layout.css.shadow-parts.enabled",
+                    "type": "preference",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },

--- a/css/selectors/part.json
+++ b/css/selectors/part.json
@@ -15,8 +15,13 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
+            "firefox": [
+              {
+                "version_added": "72",
+              },
+              {
               "version_added": "69",
+              "version_removed": "72",
               "flags": [
                 {
                   "name": "layout.css.shadow-parts.enabled",
@@ -24,7 +29,7 @@
                   "value_to_set": "true"
                 }
               ]
-            },
+            }],
             "firefox_android": {
               "version_added": false
             },

--- a/css/selectors/part.json
+++ b/css/selectors/part.json
@@ -17,7 +17,7 @@
             },
             "firefox": [
               {
-                "version_added": "72",
+                "version_added": "72"
               },
               {
                 "version_added": "69",

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1453,7 +1453,7 @@
             },
             "firefox": [
               {
-                "version_added": "72",
+                "version_added": "72"
               },
               {
                 "version_added": "69",

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1451,8 +1451,13 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
+            "firefox": [
+              {
+                "version_added": "72",
+              },
+              {
               "version_added": "69",
+              "version_removed": "72",
               "flags": [
                 {
                   "name": "layout.css.shadow-parts.enabled",
@@ -1460,7 +1465,7 @@
                   "value_to_set": "true"
                 }
               ]
-            },
+            }],
             "firefox_android": {
               "version_added": false
             },

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1456,16 +1456,17 @@
                 "version_added": "72",
               },
               {
-              "version_added": "69",
-              "version_removed": "72",
-              "flags": [
-                {
-                  "name": "layout.css.shadow-parts.enabled",
-                  "type": "preference",
-                  "value_to_set": "true"
-                }
-              ]
-            }],
+                "version_added": "69",
+                "version_removed": "72",
+                "flags": [
+                  {
+                    "name": "layout.css.shadow-parts.enabled",
+                    "type": "preference",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },


### PR DESCRIPTION
Shadow Parts is shipping in Firefox 72. This PR updates the data for the `part` attribute, and `::part` pseudo.

https://bugzilla.mozilla.org/show_bug.cgi?id=1559074
