### PR TITLE
updating the motion path properties

### DIFF
--- a/css/properties/offset-anchor.json
+++ b/css/properties/offset-anchor.json
@@ -14,16 +14,22 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "70",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.motion-path.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "72"
+              },
+              {
+                "version_added": "70",
+                "version_removed": "72",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.motion-path.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -50,7 +56,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/offset-distance.json
+++ b/css/properties/offset-distance.json
@@ -26,16 +26,22 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.motion-path.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "72"
+              },
+              {
+                "version_added": "69",
+                "version_removed": "72",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.motion-path.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -80,7 +86,7 @@
             ]
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/offset-path.json
+++ b/css/properties/offset-path.json
@@ -26,16 +26,22 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.motion-path.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "72"
+              },
+              {
+                "version_added": "63",
+                "version_removed": "72",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.motion-path.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": "63",
               "flags": [
@@ -94,7 +100,7 @@
             ]
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -141,7 +147,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/offset-rotate.json
+++ b/css/properties/offset-rotate.json
@@ -34,16 +34,22 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "69",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.motion-path.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "72"
+              },
+              {
+                "version_added": "69",
+                "version_removed": "72",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.motion-path.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -100,7 +106,7 @@
             ]
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/offset.json
+++ b/css/properties/offset.json
@@ -26,16 +26,22 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "71",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.motion-path.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "72"
+              },
+              {
+                "version_added": "71",
+                "version_removed": "72",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.motion-path.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -80,7 +86,7 @@
             ]
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
The Motion Path properties are being shipped in Firefox 72. Updated BCD, also removed experimental flags.