### PR TITLE
individual transforms

### DIFF
--- a/css/properties/rotate.json
+++ b/css/properties/rotate.json
@@ -14,17 +14,22 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "60",
-              "notes": "Enabled by default in Firefox Nightly 71.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.individual-transform.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "72"
+              },
+              {
+                "version_added": "60",
+                "version_removed": "72",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.individual-transform.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": "60",
               "flags": [
@@ -58,7 +63,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -76,16 +81,22 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.individual-transform.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "72"
+                },
+                {
+                  "version_added": "65",
+                  "version_removed": "72",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.individual-transform.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": {
                 "version_added": "65",
                 "flags": [
@@ -119,7 +130,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/scale.json
+++ b/css/properties/scale.json
@@ -14,17 +14,22 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "60",
-              "notes": "Enabled by default in Firefox Nightly 71.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.individual-transform.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "72"
+              },
+              {
+                "version_added": "60",
+                "version_removed": "72",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.individual-transform.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": "60",
               "flags": [
@@ -58,7 +63,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/translate.json
+++ b/css/properties/translate.json
@@ -14,17 +14,22 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "60",
-              "notes": "Enabled by default in Firefox Nightly 71.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.individual-transform.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "72"
+              },
+              {
+                "version_added": "60",
+                "version_removed": "72",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.individual-transform.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": "60",
               "flags": [
@@ -58,7 +63,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
The individual tranform properties of `scale`, `translate` and `rotate` are in Firefox 72. This PR updates those, and also marks them as not experimental based on the recent discussions on experimental features. The spec does not have issues outstanding which make these seem likely to change.

https://groups.google.com/forum/#!topic/mozilla.dev.platform/4oyeCHOqt4I
