### PR TITLE
SVG support for letter and word spacing

### DIFF
--- a/css/properties/letter-spacing.json
+++ b/css/properties/letter-spacing.json
@@ -62,13 +62,13 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": false
+                "version_added": "72"
               },
               "firefox_android": {
                 "version_added": false
               },
               "ie": {
-                "version_added": "10"
+                "version_added": "9"
               },
               "opera": {
                 "version_added": true
@@ -77,10 +77,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": "1"
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": "1"
+                "version_added": "5.1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"

--- a/css/properties/letter-spacing.json
+++ b/css/properties/letter-spacing.json
@@ -86,7 +86,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "1"
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/properties/word-spacing.json
+++ b/css/properties/word-spacing.json
@@ -134,7 +134,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "1"
+                "version_added": "37"
               }
             },
             "status": {

--- a/css/properties/word-spacing.json
+++ b/css/properties/word-spacing.json
@@ -134,7 +134,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "37"
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/css/properties/word-spacing.json
+++ b/css/properties/word-spacing.json
@@ -27,7 +27,7 @@
               "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": "1"
@@ -74,7 +74,7 @@
                 "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": "6.1"
@@ -87,6 +87,54 @@
               },
               "webview_android": {
                 "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "svg": {
+          "__compat": {
+            "description": "SVG support",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": "18"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "72"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": "9"
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "5.1"
+              },
+              "safari_ios": {
+                "version_added": "5.1"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0"
+              },
+              "webview_android": {
+                "version_added": "1"
               }
             },
             "status": {

--- a/svg/attributes/presentation.json
+++ b/svg/attributes/presentation.json
@@ -1543,40 +1543,40 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/letter-spacing",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "72"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
-                "version_added": null
+                "version_added": "9"
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "1"
               }
             },
             "status": {
@@ -3079,40 +3079,40 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/word-spacing",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "edge": {
-                "version_added": null
+                "version_added": "12"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "72"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
-                "version_added": null
+                "version_added": "9"
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "1"
               }
             },
             "status": {

--- a/svg/attributes/presentation.json
+++ b/svg/attributes/presentation.json
@@ -3112,7 +3112,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "37"
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/svg/attributes/presentation.json
+++ b/svg/attributes/presentation.json
@@ -1576,7 +1576,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "1"
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -3112,7 +3112,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "1"
+                "version_added": "37"
               }
             },
             "status": {


### PR DESCRIPTION
Firefox 72 is shipping support for `word-spacing` and `letter-spacing` https://bugzilla.mozilla.org/show_bug.cgi?id=371787. It seems like every other browser has had support for a long time. It was a bit tricky to find out support for SVG over the CSS property itself so I did a bunch of testing in Browserstack.

Updated support data for Safari, and for IE based on that testing, and confirmed support in other browsers (though I couldn't find a copy of Chrome as old as version 1).

Also added the data in the SVG presentation attributes file, which seems to be null for everything right now.
