### PR TITLE
Set Safari versions for JavaScript functions

### DIFF
--- a/javascript/builtins/AsyncFunction.json
+++ b/javascript/builtins/AsyncFunction.json
@@ -45,10 +45,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -107,10 +107,10 @@
                 "version_added": "42"
               },
               "safari": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": "6.0"

--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -34,10 +34,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -85,10 +85,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -135,10 +135,10 @@
                   "version_added": true
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": "6"
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": "6"
                 },
                 "samsunginternet_android": {
                   "version_added": "1.0"
@@ -188,10 +188,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -343,10 +343,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -394,10 +394,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "3"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -445,10 +445,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -550,10 +550,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -600,10 +600,10 @@
                   "version_added": "30"
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "samsunginternet_android": {
                   "version_added": "4.0"
@@ -653,10 +653,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "6"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "6"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -703,10 +703,10 @@
                   "version_added": null
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "samsunginternet_android": {
                   "version_added": "4.0"
@@ -756,10 +756,10 @@
                   "version_added": null
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": "10"
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": "10"
                 },
                 "samsunginternet_android": {
                   "version_added": "5.0"
@@ -809,10 +809,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -915,10 +915,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"

--- a/javascript/builtins/GeneratorFunction.json
+++ b/javascript/builtins/GeneratorFunction.json
@@ -34,10 +34,10 @@
               "version_added": "26"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -85,10 +85,10 @@
                 "version_added": "26"
               },
               "safari": {
-                "version_added": null
+                "version_added": "10"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10"
               },
               "samsunginternet_android": {
                 "version_added": "4.0"

--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -33,10 +33,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": true
+            "version_added": "1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -84,10 +84,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -135,10 +135,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -239,10 +239,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -406,10 +406,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": null
+                "version_added": "10"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10"
               },
               "samsunginternet_android": {
                 "version_added": "7.0"
@@ -458,10 +458,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -561,10 +561,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": "10"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -1058,10 +1058,10 @@
                 "version_added": "36"
               },
               "safari": {
-                "version_added": null
+                "version_added": "10"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"


### PR DESCRIPTION
This PR sets the Safari data for the JavaScript function data based upon manual testing.  The data is as follows:

javascript.builtins.AsyncFunction - 10.1
javascript.builtins.AsyncFunction.prototype - 10.1
javascript.builtins.Function - 1
javascript.builtins.Function.apply - 1
javascript.builtins.Function.apply.generic_arrays_as_arguments - 6
javascript.builtins.Function.arguments - 1
javascript.builtins.Function.call - 1
javascript.builtins.Function.caller - 3
javascript.builtins.Function.displayName - false
javascript.builtins.Function.length - 1
javascript.builtins.Function.length.configurable_true - false
javascript.builtins.Function.name - 6
javascript.builtins.Function.name.configurable_true - false
javascript.builtins.Function.name.inferred_names - 10
javascript.builtins.Function.prototype - 1
javascript.builtins.Function.toString - 1
javascript.builtins.GeneratorFunction - 10
javascript.builtins.GeneratorFunction.prototype - 10
javascript.functions - 1
javascript.functions.arguments - 1
javascript.functions.arguments.callee - 1
javascript.functions.arguments.length - 1
javascript.functions.arrow_functions.trailing_comma - 10
javascript.functions.block_level_functions - 10
javascript.functions.default_parameters.destructured_parameter_with_default_value_assignment - 10
javascript.functions.rest_parameters.destructuring - 10