### PR TITLE
Specified notes for clearInterval and clearTimeout below IE8 and itself

### DIFF
--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -267,7 +267,8 @@
               }
             ],
             "ie": {
-              "version_added": "4"
+              "version_added": "4",
+              "notes": "From Internet Explorer 4 through 8, <code>clearInterval</code> is an Object rather than a Function. This behavior was fixed in Internet Explorer 9."
             },
             "nodejs": {
               "version_added": true,
@@ -332,7 +333,8 @@
               }
             ],
             "ie": {
-              "version_added": "4"
+              "version_added": "4",
+              "notes": "From Internet Explorer 4 through 8, <code>clearTimeout</code> is an Object rather than a Function. This behavior was fixed in Internet Explorer 9."
             },
             "nodejs": {
               "version_added": true,


### PR DESCRIPTION
According to https://github.com/aleen42/PersonalWiki/issues/32#issuecomment-565353002, it may be significant to specify that `clearTimeout` or `clearInterval` is not what we expected under IE8 or below.