### PR TITLE
experimental flag on background-image values

### DIFF
--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -94,7 +94,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -204,7 +204,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -267,7 +267,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
As part of this work https://github.com/mdn/sprints/issues/2402 I've updated the experimental flag on the background-image values of `element()`, `image-rect`, `image-set`.