### PR TITLE
update experimental flags for CSS fragmentation properties

### DIFF
--- a/css/properties/box-decoration-break.json
+++ b/css/properties/box-decoration-break.json
@@ -81,7 +81,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/break-after.json
+++ b/css/properties/break-after.json
@@ -407,7 +407,7 @@
                 }
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }

--- a/css/properties/break-before.json
+++ b/css/properties/break-before.json
@@ -407,7 +407,7 @@
                 }
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }


### PR DESCRIPTION
As part of the work on https://github.com/mdn/sprints/issues/2402 updating experimental flags on some of the CSS fragmentation properties. Leaving their application to regions as experimental for now.