### PR TITLE
updating experimental flag on url positioning

### DIFF
--- a/css/properties/cursor.json
+++ b/css/properties/cursor.json
@@ -1244,7 +1244,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
Updating the experimental flag for `url() positioning syntax` value for `cursor`. Spec is a REC. Part of the work for https://github.com/mdn/sprints/issues/2402