### PR TITLE
updating experimental flags flex-basis

### DIFF
--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -312,7 +312,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -371,7 +371,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
As part of the work on https://github.com/mdn/sprints/issues/2402 updating the flag on `min-content` and `max-content` for flex basis as the spec is stable, the property should take anything value for `width`.