### PR TITLE
Update experimental flag fonts

### DIFF
--- a/css/properties/font-family.json
+++ b/css/properties/font-family.json
@@ -101,7 +101,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/font-language-override.json
+++ b/css/properties/font-language-override.json
@@ -77,7 +77,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/font-synthesis.json
+++ b/css/properties/font-synthesis.json
@@ -56,7 +56,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/font-variant-alternates.json
+++ b/css/properties/font-variant-alternates.json
@@ -69,7 +69,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": true
           }
@@ -143,7 +143,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": true
             }
@@ -218,7 +218,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": true
             }
@@ -293,7 +293,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": true
             }
@@ -368,7 +368,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": true
             }
@@ -443,7 +443,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": true
             }
@@ -518,7 +518,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": true
             }

--- a/css/properties/font-variant-caps.json
+++ b/css/properties/font-variant-caps.json
@@ -69,7 +69,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/font-variant-east-asian.json
+++ b/css/properties/font-variant-east-asian.json
@@ -69,7 +69,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/font-variant-position.json
+++ b/css/properties/font-variant-position.json
@@ -69,7 +69,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
As part of the work on https://github.com/mdn/sprints/issues/2402 a set of updates regarding fonts. This spec is at CR with no issues against these properties.
