### PR TITLE
updating experimental flag subgrid

### DIFF
--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -519,7 +519,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -518,7 +518,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
As part of the work on https://github.com/mdn/sprints/issues/2402 updating `grid-template-columns` and `grid-template-rows` to mark the subgrid value as not experimental.
