### PR TITLE
Remove an unused variable from fix.js

### DIFF
--- a/scripts/fix.js
+++ b/scripts/fix.js
@@ -5,8 +5,6 @@ const fixBrowserOrder = require('./fix-browser-order');
 const fixFeatureOrder = require('./fix-feature-order');
 const format = require('./fix-format');
 
-const promises = [];
-
 /**
  * @param {string[]} files
  */


### PR DESCRIPTION
`scripts/fix.js` has a unused array variable. This removes it. I noticed this admittedly minor thing in the course of reviewing #5288.