### PR TITLE
update experimental flag hanging-punctuation

### DIFF
--- a/css/properties/hanging-punctuation.json
+++ b/css/properties/hanging-punctuation.json
@@ -43,7 +43,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
As part of my work on https://github.com/mdn/sprints/issues/2402 updating the experimental flag on the CSS `hanging-punctuation` property as the spec is stable and Safari have implemented.