### PR TITLE
adding categories of regex syntax

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -52,6 +52,218 @@
             "deprecated": false
           }
         },
+        "assertions": {
+          "__compat": {
+            "description": "Assertions",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Guide/Regular_Expressions/Assertions",
+            "spec_url": "https://tc39.es/ecma262/#sec-assertion",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": "18"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "4"
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0"
+              },
+              "webview_android": {
+                "version_added": "1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          },
+          "lookbehind_assertion": {
+            "__compat": {
+              "description": "lookbehind assertions (<code>(?&lt;= )</code> and <code>(?&lt;! )</code>)",
+              "support": {
+                "chrome": {
+                  "version_added": "62"
+                },
+                "chrome_android": {
+                  "version_added": "62"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false,
+                  "notes": "See <a href='https://bugzil.la/1225665'>bug 1225665</a>."
+                },
+                "firefox_android": {
+                  "version_added": false,
+                  "notes": "See <a href='https://bugzil.la/1225665'>bug 1225665</a>."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "8.10.0"
+                },
+                "opera": {
+                  "version_added": "49"
+                },
+                "opera_android": {
+                  "version_added": "46"
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": "8.0"
+                },
+                "webview_android": {
+                  "version_added": "62"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          }
+        },
+        "boundaries": {
+          "__compat": {
+            "description": "Boundaries",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Guide/Regular_Expressions/Boundaries",
+            "spec_url": "https://tc39.es/ecma262/#sec-assertion",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": "18"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "4"
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0"
+              },
+              "webview_android": {
+                "version_added": "1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "character_classes": {
+          "__compat": {
+            "description": "Character classes",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Guide/Regular_Expressions/Character_Classes",
+            "spec_url": "https://tc39.es/ecma262/#sec-characterclass",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": "18"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "4"
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0"
+              },
+              "webview_android": {
+                "version_added": "1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
         "compile": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/compile",
@@ -363,6 +575,122 @@
                 },
                 "webview_android": {
                   "version_added": "48"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          }
+        },
+        "groups_ranges": {
+          "__compat": {
+            "description": "Groups and ranges",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges",
+            "spec_url": "https://tc39.es/ecma262/#sec-classranges",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": "18"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "4"
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0"
+              },
+              "webview_android": {
+                "version_added": "1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          },
+          "named_capture_groups": {
+            "__compat": {
+              "description": "Named capture groups",
+              "spec_url": "https://tc39.es/ecma262/#sec-patterns",
+              "support": {
+                "chrome": {
+                  "version_added": "64"
+                },
+                "chrome_android": {
+                  "version_added": "64"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": [
+                  {
+                    "version_added": "10.0.0"
+                  },
+                  {
+                    "version_added": "8.3.0",
+                    "flags": [
+                      {
+                        "type": "runtime_flag",
+                        "name": "--harmony"
+                      }
+                    ]
+                  }
+                ],
+                "opera": {
+                  "version_added": "51"
+                },
+                "opera_android": {
+                  "version_added": "47"
+                },
+                "safari": {
+                  "version_added": "11.1"
+                },
+                "safari_ios": {
+                  "version_added": "11.3"
+                },
+                "samsunginternet_android": {
+                  "version_added": "9.0"
+                },
+                "webview_android": {
+                  "version_added": "64"
                 }
               },
               "status": {
@@ -736,59 +1064,6 @@
             }
           }
         },
-        "lookbehind_assertion": {
-          "__compat": {
-            "description": "lookbehind assertions (<code>(?&lt;= )</code> and <code>(?&lt;! )</code>)",
-            "support": {
-              "chrome": {
-                "version_added": "62"
-              },
-              "chrome_android": {
-                "version_added": "62"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1225665'>bug 1225665</a>."
-              },
-              "firefox_android": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1225665'>bug 1225665</a>."
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "8.10.0"
-              },
-              "opera": {
-                "version_added": "49"
-              },
-              "opera_android": {
-                "version_added": "46"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": "8.0"
-              },
-              "webview_android": {
-                "version_added": "62"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "multiline": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/multiline",
@@ -944,72 +1219,11 @@
             }
           }
         },
-        "named_capture_groups": {
-          "__compat": {
-            "description": "Named capture groups",
-            "spec_url": "https://tc39.es/ecma262/#sec-patterns",
-            "support": {
-              "chrome": {
-                "version_added": "64"
-              },
-              "chrome_android": {
-                "version_added": "64"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": [
-                {
-                  "version_added": "10.0.0"
-                },
-                {
-                  "version_added": "8.3.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
-              "opera": {
-                "version_added": "51"
-              },
-              "opera_android": {
-                "version_added": "47"
-              },
-              "safari": {
-                "version_added": "11.1"
-              },
-              "safari_ios": {
-                "version_added": "11.3"
-              },
-              "samsunginternet_android": {
-                "version_added": "9.0"
-              },
-              "webview_android": {
-                "version_added": "64"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "property_escapes": {
           "__compat": {
             "description": "Unicode property escapes (<code>\\p{...}</code>)",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes",
+            "spec_url": "https://tc39.es/ecma262/#sec-runtime-semantics-unicodematchproperty-p",
             "support": {
               "chrome": {
                 "version_added": "64"
@@ -1118,6 +1332,59 @@
               "experimental": false,
               "standard_track": true,
               "deprecated": false
+            }
+          }
+        },
+        "quantifiers": {
+          "__compat": {
+            "description": "Quantifiers",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Guide/Regular_Expressions/Quantifiers",
+            "spec_url": "https://tc39.es/ecma262/#sec-quantifier",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": "18"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "4"
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0"
+              },
+              "webview_android": {
+                "version_added": "1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
             }
           }
         },


### PR DESCRIPTION
As per https://github.com/mdn/sprints/issues/1721

@jpmedley created subpages of https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions, namely:

* https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Assertions
* https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Boundaries
* https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Character_Classes
* https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges
* https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Quantifiers
 * https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes

This makes a lot of sense, as the page as it stood was giant and unwieldy, and it is nice to break it down into smaller and easier to digest chunks.

I am adding a few bits to these pages to get them finished off, and one part of this is add browser-compat-data entries for each of the syntax types Joe created a page for, so each one can have a BCD table. This is what this PR is for.

one thing I did was to move the lookbehind assertions data point to be a child of assertions, and move the named capture groups data point to be a child of groups_ranges. This makes sense as they are closely related, but I am worried that this might not be a good idea, as now they won't appear on https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#Browser_compatibility, where they currently do.

But if we just have them as items directly under javascript.builtins.RegExp, like they are now, they won't appear on their relevant syntax subpages.

Any thoughts on the best way to reconcile this? 