### PR TITLE
adding clip value

### DIFF
--- a/css/properties/overflow-x.json
+++ b/css/properties/overflow-x.json
@@ -53,6 +53,54 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "clip": {
+          "__compat": {
+            "description": "<code>clip</code> value",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/overflow-y.json
+++ b/css/properties/overflow-y.json
@@ -53,6 +53,54 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "clip": {
+          "__compat": {
+            "description": "<code>clip</code> value",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -50,6 +50,54 @@
             "deprecated": false
           }
         },
+        "clip": {
+          "__compat": {
+            "description": "<code>clip</code> value",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "multiple_keywords": {
           "__compat": {
             "description": "Multiple keyword syntax for <code>overflow-x</code> and <code>overflow-y</code>",


### PR DESCRIPTION
The `clip` value of `overflow`/`overflow-x`/`overflow-y` is in the spec, and we also mention it on our ref pages and in our formal syntax.

But it's not supported anywhere yet (I just tested it), so I think it is important to point that out in the BCD to avopid any confusion.