### PR TITLE
fix: File.type support on Safari iOS

### DIFF
--- a/api/File.json
+++ b/api/File.json
@@ -287,7 +287,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
- Update support list for File.
 You can try it here https://unopl.csb.app/

