### PR TITLE
Update String: trimStart/trimEnd spec URLs

### DIFF
--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -3007,7 +3007,7 @@
         "trimEnd": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/trimEnd",
-            "spec_url": "https://github.com/tc39/proposal-string-left-right-trim/#stringprototypetrimstart--stringprototypetrimend",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.trimend",
             "support": {
               "chrome": [
                 {
@@ -3114,7 +3114,7 @@
         "trimStart": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/trimStart",
-            "spec_url": "https://github.com/tc39/proposal-string-left-right-trim/#stringprototypetrimstart--stringprototypetrimend",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype.trimstart",
             "support": {
               "chrome": [
                 {


### PR DESCRIPTION
String.prototype.trimStart and String.prototype.trimEnd are now part of the ECMAScript spec; update the spec URLs.