### PR TITLE
update experimental flag on ray

### DIFF
--- a/css/properties/offset-path.json
+++ b/css/properties/offset-path.json
@@ -202,7 +202,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
As part of my work on https://github.com/mdn/sprints/issues/2402 updating ray support for `object-path` to remove experimental flag.
