### PR TITLE
updates to text alignment experimental flags

### DIFF
--- a/css/properties/text-align-last.json
+++ b/css/properties/text-align-last.json
@@ -90,7 +90,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/text-align.json
+++ b/css/properties/text-align.json
@@ -207,7 +207,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -255,7 +255,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
As part of my work on https://github.com/mdn/sprints/issues/2402 updating flags on `text-align` and `text-align-last` I left the `string` value of `text-align` as this has a number of issues in the spec.