### PR TITLE
updating experimental flags text-overflow

### DIFF
--- a/css/properties/text-overflow.json
+++ b/css/properties/text-overflow.json
@@ -158,7 +158,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -206,7 +206,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -254,7 +254,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
As part of my work on https://github.com/mdn/sprints/issues/2402 updating the experimental flags on `text-overflow` leaving the  fade function as this does seem experimental with issues in the spec.