### PR TITLE
update transition gradient experimental flag

### DIFF
--- a/css/properties/transition.json
+++ b/css/properties/transition.json
@@ -212,7 +212,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
As part of my work on https://github.com/mdn/sprints/issues/2402 updating gradient support for `transition`.
