### PR TITLE
updating experimental flag on :dir

### DIFF
--- a/css/selectors/dir.json
+++ b/css/selectors/dir.json
@@ -58,7 +58,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
As part of the work on https://github.com/mdn/sprints/issues/2402 updating the experimental flag on the `:dir` pseudo-class.
