### PR TITLE
update experimental flag on :empty

### DIFF
--- a/css/selectors/empty.json
+++ b/css/selectors/empty.json
@@ -92,7 +92,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
As part of my work on https://github.com/mdn/sprints/issues/2402 updating the `:empty` pseudo experimental flag on matching whitespace as per the L4 spec.

https://drafts.csswg.org/selectors-4/#the-empty-pseudo