### PR TITLE
experimental flag on focus-visible

### DIFF
--- a/css/selectors/focus-visible.json
+++ b/css/selectors/focus-visible.json
@@ -74,7 +74,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
As part of my work on https://github.com/mdn/sprints/issues/2402 updating the experimental flag on `:focus-visible`.
