### PR TITLE
updating experimental flag host-context()

### DIFF
--- a/css/selectors/host-context.json
+++ b/css/selectors/host-context.json
@@ -46,7 +46,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
As part of my work on https://github.com/mdn/sprints/issues/2402 updating the experimental flag for the `host-context()` CSS pseudo-class function.
