### PR TITLE
update experimental flag clamp

### DIFF
--- a/css/types/clamp.json
+++ b/css/types/clamp.json
@@ -44,7 +44,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
As part of my work on https://github.com/mdn/sprints/issues/2402 updating the `clamp()` type as non-experimental.
