### PR TITLE
updating experimental flag @supports selector

### DIFF
--- a/css/at-rules/supports.json
+++ b/css/at-rules/supports.json
@@ -142,7 +142,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
As part of my work on https://github.com/mdn/sprints/issues/2402 updating the experimental flag on the selector test for `@supports`.
