### PR TITLE
Drop Content-Security-Policy: require-sri-for

### DIFF
--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -1160,8 +1160,8 @@
               },
               "status": {
                 "experimental": true,
-                "standard_track": true,
-                "deprecated": false
+                "standard_track": false,
+                "deprecated": true
               }
             }
           },


### PR DESCRIPTION
In https://github.com/w3c/webappsec-subresource-integrity/pull/82, the require-sri-for feature was dropped from the spec. So this change updates its BCD status to "standard_track": false, "deprecated": true

---

＊ https://wiki.developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-sri-for$compare?to=1596945&from=1587515 updated the corresponding MDN article