### PR TITLE
Set Safari versions for JavaScript Number

### DIFF
--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -34,10 +34,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -189,10 +189,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -293,10 +293,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -345,10 +345,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -397,10 +397,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -449,10 +449,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -813,10 +813,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -865,10 +865,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "2"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -917,10 +917,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "2"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -1025,10 +1025,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -1177,10 +1177,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "2"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -1280,10 +1280,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -1332,10 +1332,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -553,10 +553,10 @@
                 "version_added": "21"
               },
               "safari": {
-                "version_added": true
+                "version_added": "9"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "9"
               },
               "samsunginternet_android": {
                 "version_added": "2.0"


### PR DESCRIPTION
This PR sets the Safari versions for JavaScript Number features based upon manual testing.  Data is as follows:

javascript.builtins.Number - 1
javascript.builtins.Number.MAX_VALUE - 1
javascript.builtins.Number.MIN_VALUE - 1
javascript.builtins.Number.NaN - 1
javascript.builtins.Number.NEGATIVE_INFINITY - 1
javascript.builtins.Number.POSITIVE_INFINITY - 1
javascript.builtins.Number.isInteger - 9
javascript.builtins.Number.prototype - 1
javascript.builtins.Number.toExponential - 2
javascript.builtins.Number.toFixed - 2
javascript.builtins.Number.toLocaleString - 1
javascript.builtins.Number.toPrecision - 2
javascript.builtins.Number.toString - 1
javascript.builtins.Number.valueOf - 1