### PR TITLE
Mark CustomEvent.initCustomEvent as not deprecated

### DIFF
--- a/api/CustomEvent.json
+++ b/api/CustomEvent.json
@@ -212,7 +212,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },


### PR DESCRIPTION
https://dom.spec.whatwg.org/#dom-customevent-initcustomevent says nothing about CustomEvent.prototype.initCustomEvent being deprecated.