### PR TITLE
Mark HTTP If-Match header "deprecated": false

### DIFF
--- a/http/headers/if-match.json
+++ b/http/headers/if-match.json
@@ -43,9 +43,9 @@
             }
           },
           "status": {
-            "experimental": true,
-            "standard_track": false,
-            "deprecated": true
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }


### PR DESCRIPTION
https://tools.ietf.org/html/rfc7232#section-3.1 has no indication that the If-Match HTTP header is deprecated, nor that it’s experimental, so this change marks it as "experimental": false, "standard_track": true, "deprecated": false.