### PR TITLE
Mark FileSystemDirectoryEntry as not deprecated

### DIFF
--- a/api/FileSystemDirectoryEntry.json
+++ b/api/FileSystemDirectoryEntry.json
@@ -49,8 +49,8 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": false,
-          "deprecated": true
+          "standard_track": true,
+          "deprecated": false
         }
       },
       "createReader": {
@@ -96,8 +96,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
-            "deprecated": true
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
@@ -146,8 +146,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
-            "deprecated": true
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
@@ -196,8 +196,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
-            "deprecated": true
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },

--- a/api/FileSystemDirectoryEntry.json
+++ b/api/FileSystemDirectoryEntry.json
@@ -48,7 +48,7 @@
           }
         },
         "status": {
-          "experimental": false,
+          "experimental": true,
           "standard_track": true,
           "deprecated": false
         }


### PR DESCRIPTION
`FileSystemDirectoryEntry` is a core feature of the _File and Directory Entries API_ https://wicg.github.io/entries-api/, an actively-maintained spec https://github.com/WICG/entries-api that’s supported in Firefox as well as in Chrome. So it should not be marked as deprecated.

`FileSystemDirectoryEntry` is also not non-standard — at least no more non-standard than any of the dozens of other WICG spec that are also documented in MDN (and some of which are even already supported in all three major browser engines).