### PR TITLE
Mark the X-Content-Type-Options header as standard

### DIFF
--- a/http/headers/x-content-type-options.json
+++ b/http/headers/x-content-type-options.json
@@ -72,7 +72,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
https://fetch.spec.whatwg.org/#x-content-type-options-header is the standard that normatively defines the X-Content-Type-Options header’s semantics and the standard processing behavior that browsers must follow for processing it.