### PR TITLE
Mark MediaStreamTrack: onmute as standard

### DIFF
--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -911,7 +911,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack-onmute is the standard that normatively defines `MediaStreamTrack: onmute`.