### PR TITLE
Mark FileSystem as standard, and not deprecated

### DIFF
--- a/api/FileSystem.json
+++ b/api/FileSystem.json
@@ -51,8 +51,8 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": false,
-          "deprecated": true
+          "standard_track": true,
+          "deprecated": false
         }
       },
       "name": {
@@ -98,8 +98,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
-            "deprecated": true
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
@@ -146,8 +146,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
-            "deprecated": true
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }


### PR DESCRIPTION
`FileSystem` is a core feature of the _File and Directory Entries API_ https://wicg.github.io/entries-api/, an actively-maintained spec https://github.com/WICG/entries-api that’s supported in Firefox as well as in Chrome. So it should not be marked as deprecated.

`FileSystem` is also not non-standard — at least no more non-standard than any of the dozens of other WICG spec that are also documented in MDN (and some of which are even already supported in all three major browser engines).