### PR TITLE
Mark FileSystemEntry as standard

### DIFF
--- a/api/FileSystemEntry.json
+++ b/api/FileSystemEntry.json
@@ -48,7 +48,7 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": false,
+          "standard_track": true,
           "deprecated": false
         }
       },
@@ -96,7 +96,7 @@
           "status": {
             "experimental": true,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -143,7 +143,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -191,7 +191,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -240,7 +240,7 @@
           "status": {
             "experimental": true,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -287,7 +287,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -335,7 +335,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -383,7 +383,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -432,7 +432,7 @@
           "status": {
             "experimental": true,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -479,7 +479,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -528,7 +528,7 @@
           "status": {
             "experimental": true,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -576,7 +576,7 @@
           "status": {
             "experimental": true,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
`FileSystemEntry` is a core feature of the _File and Directory Entries API_ https://wicg.github.io/entries-api/, an actively-maintained spec https://github.com/WICG/entries-api that’s supported in Firefox as well as in Chrome. So it should not be marked as non-standard.

However, the copyTo, moveTo, remove, getMetadata, and toURL members of FileSystemEntry are obsolete and no longer in the spec — and so this change marks them as deprecated.