### PR TITLE
Mark FileSystemFileEntry as standard

### DIFF
--- a/api/FileSystemFileEntry.json
+++ b/api/FileSystemFileEntry.json
@@ -48,7 +48,7 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": false,
+          "standard_track": true,
           "deprecated": false
         }
       },
@@ -147,7 +147,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
`FileSystemFileEntry` is a core feature of the _File and Directory Entries API_ https://wicg.github.io/entries-api/, an actively-maintained spec https://github.com/WICG/entries-api that’s supported in Firefox as well as in Chrome. So it should not be marked as non-standard.