### PR TITLE
Mark FileSystemFlags as standard

### DIFF
--- a/api/FileSystemFlags.json
+++ b/api/FileSystemFlags.json
@@ -47,7 +47,7 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": false,
+          "standard_track": true,
           "deprecated": false
         }
       },
@@ -102,7 +102,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -158,7 +158,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
`FileSystemFlags` is a standard part of the _File and Directory Entries API_ https://wicg.github.io/entries-api/, an actively-maintained spec https://github.com/WICG/entries-api that’s supported in Firefox as well as in Chrome. So it should not be marked as non-standard.