### PR TITLE
Mark as standard CSS @media: inverted-colors, light-level, scripting 

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -783,7 +783,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }
@@ -832,7 +832,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1452,7 +1452,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }


### PR DESCRIPTION
https://drafts.csswg.org/mediaqueries-5 normatively defines as standard
features the following:

* https://drafts.csswg.org/mediaqueries-5/#light-level
* https://drafts.csswg.org/mediaqueries-5/#inverted
* https://drafts.csswg.org/mediaqueries-5/#scripting