### PR TITLE
Mark color-index at-media property as standard

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -387,7 +387,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }


### PR DESCRIPTION
https://drafts.csswg.org/mediaqueries-3/#color-index (Rec) and https://drafts.csswg.org/mediaqueries-4/#color-index (CR) both define the color-index at-media property as a standard feature.