### PR TITLE
Mark TransformStream and its members as standard

### DIFF
--- a/api/TransformStream.json
+++ b/api/TransformStream.json
@@ -43,7 +43,7 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": false,
+          "standard_track": true,
           "deprecated": false
         }
       },
@@ -91,7 +91,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -139,7 +139,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -187,7 +187,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
https://streams.spec.whatwg.org/#ts-class normatively defines the TransformStream interface and its members as standard features.