### PR TITLE
Mark PhotoCapabilities as standard-track

### DIFF
--- a/api/PhotoCapabilities.json
+++ b/api/PhotoCapabilities.json
@@ -43,7 +43,7 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": false,
+          "standard_track": true,
           "deprecated": false
         }
       },
@@ -90,7 +90,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -138,7 +138,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -186,7 +186,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -234,7 +234,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
https://w3c.github.io/mediacapture-image/#photocapabilities-section defines PhotoCapabilities and its members as standards-track features.