### PR TITLE
Mark ImageBitmapRenderingContext as standard-track

### DIFF
--- a/api/ImageBitmapRenderingContext.json
+++ b/api/ImageBitmapRenderingContext.json
@@ -43,7 +43,7 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": false,
+          "standard_track": true,
           "deprecated": false
         }
       },
@@ -104,7 +104,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
https://html.spec.whatwg.org/multipage/#the-imagebitmaprenderingcontext-interface defines ImageBitmapRenderingContext as a standard feature.