### PR TITLE
Mark HTMLObjectElement: width as not-deprecated

### DIFF
--- a/api/HTMLObjectElement.json
+++ b/api/HTMLObjectElement.json
@@ -1291,7 +1291,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },


### PR DESCRIPTION
https://html.spec.whatwg.org/multipage/#dom-dim-width normatively defines 'width' as a standard feature of the HTMLObjectElement interface.