### PR TITLE
Mark transferControlToOffscreen as standard_track

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -879,7 +879,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
https://html.spec.whatwg.org/multipage/#dom-canvas-transfercontroltooffscreen normatively defines HTMLCanvasElement: transferControlToOffscreen() as a standard feature.