### PR TITLE
Mark HTMLCanvasElement.captureStream as standard

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -92,7 +92,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
https://w3c.github.io/mediacapture-fromelement/#dom-htmlcanvaselement-capturestream defines the captureStream() method for the HTMLCanvasElement as a standard feature.