### PR TITLE
Mark Event:srcElement as standard but deprecated

### DIFF
--- a/api/Event.json
+++ b/api/Event.json
@@ -1094,8 +1094,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
-            "deprecated": false
+            "standard_track": true,
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
https://dom.spec.whatwg.org/#dom-event-srcelement defines Event:srcElement as a standard feature. It is already supported in all major browser engines.

However, it’s marked as “historical” in the spec; so for BCD, it’s appropriate to flag it as deprecated.