### PR TITLE
Mark document.contentType as standard

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -1265,7 +1265,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
https://dom.spec.whatwg.org/#dom-document-contenttype defines document.contentType as a standard feature.