### PR TITLE
Mark DataTransferItem:webkitGetAsEntry() standard

### DIFF
--- a/api/DataTransferItem.json
+++ b/api/DataTransferItem.json
@@ -282,7 +282,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
https://wicg.github.io/entries-api/#ref-for-dom-datatransferitem-webkitgetasentry defines DataTransferItem:webkitGetAsEntry as a standard feature.