### PR TITLE
Mark console.dir & console.dirxml as standard

### DIFF
--- a/api/Console.json
+++ b/api/Console.json
@@ -401,7 +401,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -456,7 +456,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
https://console.spec.whatwg.org/#dir and https://console.spec.whatwg.org/#dirxml define console.dir and console.dirxml as standard features.