### PR TITLE
Mark CanvasRenderingContext2D as standard

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -42,8 +42,8 @@
           }
         },
         "status": {
-          "experimental": true,
-          "standard_track": false,
+          "experimental": false,
+          "standard_track": true,
           "deprecated": false
         }
       },


### PR DESCRIPTION
CanvasRenderingContext2D is standard, and not experimental.