### PR TITLE
Update ReadableStream compatibility in Safari

### DIFF
--- a/api/ReadableStream.json
+++ b/api/ReadableStream.json
@@ -63,10 +63,10 @@
             "version_added": "30"
           },
           "safari": {
-            "version_added": null
+            "version_added": "10.0"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "9.0"
           },
           "samsunginternet_android": {
             "version_added": "4.0"
@@ -227,10 +227,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -309,10 +309,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.0"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.0"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -391,10 +391,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.0"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.0"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -439,10 +439,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -487,10 +487,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9.0"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -569,10 +569,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.0"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.0"
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/api/ReadableStream.json
+++ b/api/ReadableStream.json
@@ -63,10 +63,10 @@
             "version_added": "30"
           },
           "safari": {
-            "version_added": "10.0"
+            "version_added": "10"
           },
           "safari_ios": {
-            "version_added": "9.0"
+            "version_added": "9"
           },
           "samsunginternet_android": {
             "version_added": "4.0"
@@ -227,10 +227,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": "9.0"
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": "9.0"
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -309,10 +309,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": "10.0"
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": "10.0"
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -391,10 +391,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": "10.0"
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": "10.0"
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -439,10 +439,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": "9.0"
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": "9.0"
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -487,10 +487,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": "9.0"
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": "9.0"
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -569,10 +569,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": "10.0"
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": "10.0"
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/api/ReadableStream.json
+++ b/api/ReadableStream.json
@@ -145,10 +145,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/api/ReadableStream.json
+++ b/api/ReadableStream.json
@@ -63,10 +63,10 @@
             "version_added": "30"
           },
           "safari": {
-            "version_added": "9"
+            "version_added": "10"
           },
           "safari_ios": {
-            "version_added": "9"
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": "4.0"
@@ -148,7 +148,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": "9"
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -227,10 +227,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": "9"
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": "9"
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -312,7 +312,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -394,7 +394,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -439,10 +439,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": "9"
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": "9"
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -487,10 +487,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": "9"
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": "9"
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -572,7 +572,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/api/ReadableStream.json
+++ b/api/ReadableStream.json
@@ -63,7 +63,7 @@
             "version_added": "30"
           },
           "safari": {
-            "version_added": "10"
+            "version_added": "9"
           },
           "safari_ios": {
             "version_added": "9"


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any

According to Apple developer guide, ReadableStream is supported. Currently, this API is shown as not supported in MDN. The source of these changes come from Apple Developer Guide as below:

* ReadableStream interface: https://developer.apple.com/documentation/webkitjs/readablestream
* ReadableStream.cancel: https://developer.apple.com/documentation/webkitjs/readablestream/1629178-cancel
* ReadableStream.getReader: https://developer.apple.com/documentation/webkitjs/readablestream/1632243-getreader
* ReadableStream.locked: https://developer.apple.com/documentation/webkitjs/readablestream/1631657-locked
* ReadableStream.pipeThrough: https://developer.apple.com/documentation/webkitjs/readablestream/1630648-pipethrough
* ReadableStream.pipeTo: https://developer.apple.com/documentation/webkitjs/readablestream/1631507-pipeto
* ReadableStream.tee: https://developer.apple.com/documentation/webkitjs/readablestream/1777742-tee

Tested on safari 13 and safari_ios 13 with following cases:
https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=6670

