### PR TITLE
Opera 65 is released

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -503,19 +503,26 @@
         "64": {
           "release_date": "2019-10-07",
           "release_notes": "https://blogs.opera.com/desktop/2019/10/opera-64-faster-more-private-more-fun/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "77"
         },
         "65": {
-          "status": "beta",
+          "release_date": "2019-11-13",
+          "release_notes": "https://blogs.opera.com/desktop/2019/11/opera-65-comes-with-an-improved-tracker-blocker-and-redesigned-address-bar/",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "78"
         },
         "66": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "79"
+        },
+        "67": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "80"
         }
       }
     }


### PR DESCRIPTION
Opera 65 has been out since November 13th.  This PR updates BCD to represent this data.