### PR TITLE
Fix Chrome version for \(?:)\ as empty Regex string

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -1229,10 +1229,10 @@
               "description": "\"(?:)\" for empty regexps",
               "support": {
                 "chrome": {
-                  "version_added": "73"
+                  "version_added": "6"
                 },
                 "chrome_android": {
-                  "version_added": "73"
+                  "version_added": "18"
                 },
                 "edge": {
                   "version_added": "12"
@@ -1250,10 +1250,10 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": "60"
+                  "version_added": "15"
                 },
                 "opera_android": {
-                  "version_added": "52"
+                  "version_added": "14"
                 },
                 "safari": {
                   "version_added": true
@@ -1262,10 +1262,10 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "1.0"
                 },
                 "webview_android": {
-                  "version_added": "73"
+                  "version_added": "≤37"
                 }
               },
               "status": {


### PR DESCRIPTION
It appears that the Chromium version for the regex empty strings was inaccurate.  During my investigations of the Safari versions, I found that it was introduced in Safari 5, which equates to Chrome 6.  This PR fixes said version.