### PR TITLE
Set Safari versions for JavaScript RegExp data

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -34,10 +34,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -85,10 +85,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "2"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -199,10 +199,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -251,10 +251,10 @@
                 "version_added": "41"
               },
               "safari": {
-                "version_added": true
+                "version_added": "9"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "9"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -303,10 +303,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -353,10 +353,10 @@
                   "version_added": "35"
                 },
                 "safari": {
-                  "version_added": true
+                  "version_added": "1.3"
                 },
                 "safari_ios": {
-                  "version_added": true
+                  "version_added": "1"
                 },
                 "samsunginternet_android": {
                   "version_added": "5.0"
@@ -406,10 +406,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -456,10 +456,10 @@
                   "version_added": "35"
                 },
                 "safari": {
-                  "version_added": true
+                  "version_added": "1.3"
                 },
                 "safari_ios": {
-                  "version_added": true
+                  "version_added": "1"
                 },
                 "samsunginternet_android": {
                   "version_added": "5.0"
@@ -509,10 +509,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "3"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -561,10 +561,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -613,10 +613,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "3"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -665,10 +665,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "3"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -717,10 +717,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "3"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -822,10 +822,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -872,10 +872,10 @@
                   "version_added": "35"
                 },
                 "safari": {
-                  "version_added": true
+                  "version_added": "1.3"
                 },
                 "safari_ios": {
-                  "version_added": true
+                  "version_added": "1"
                 },
                 "samsunginternet_android": {
                   "version_added": "5.0"
@@ -925,10 +925,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -1102,10 +1102,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -1154,10 +1154,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "3"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -1206,10 +1206,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -1256,10 +1256,10 @@
                   "version_added": "52"
                 },
                 "safari": {
-                  "version_added": true
+                  "version_added": "5"
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": "4.2"
                 },
                 "samsunginternet_android": {
                   "version_added": false
@@ -1307,10 +1307,10 @@
                   "version_added": "52"
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": "6"
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": "6"
                 },
                 "samsunginternet_android": {
                   "version_added": false
@@ -1358,10 +1358,10 @@
                   "version_added": "35"
                 },
                 "safari": {
-                  "version_added": true
+                  "version_added": "1.3"
                 },
                 "safari_ios": {
-                  "version_added": true
+                  "version_added": "1"
                 },
                 "samsunginternet_android": {
                   "version_added": "5.0"
@@ -1461,10 +1461,10 @@
                   "version_added": "36"
                 },
                 "safari": {
-                  "version_added": true
+                  "version_added": "10"
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": "10"
                 },
                 "samsunginternet_android": {
                   "version_added": "5.0"
@@ -1512,10 +1512,10 @@
                   "version_added": "36"
                 },
                 "safari": {
-                  "version_added": true
+                  "version_added": "10"
                 },
                 "safari_ios": {
-                  "version_added": true
+                  "version_added": "10"
                 },
                 "samsunginternet_android": {
                   "version_added": "5.0"
@@ -1565,10 +1565,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -1668,10 +1668,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -1718,10 +1718,10 @@
                   "version_added": "52"
                 },
                 "safari": {
-                  "version_added": true
+                  "version_added": "6"
                 },
                 "safari_ios": {
-                  "version_added": true
+                  "version_added": "6"
                 },
                 "samsunginternet_android": {
                   "version_added": false
@@ -1824,10 +1824,10 @@
                 "version_added": "37"
               },
               "safari": {
-                "version_added": true
+                "version_added": "10"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "10"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -1928,10 +1928,10 @@
                 "version_added": "37"
               },
               "safari": {
-                "version_added": true
+                "version_added": "10"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "10"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -1980,10 +1980,10 @@
                 "version_added": "37"
               },
               "safari": {
-                "version_added": true
+                "version_added": "10"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "10"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -2043,10 +2043,10 @@
                 "version_added": "37"
               },
               "safari": {
-                "version_added": true
+                "version_added": "10"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "10"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -2095,10 +2095,10 @@
                 "version_added": "37"
               },
               "safari": {
-                "version_added": true
+                "version_added": "10"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "10"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"


### PR DESCRIPTION
This PR sets the Safari versions for the remaining JavaScript regex (RegExp) data based upon manual testing.  Data is as follows:

javascript.builtins.RegExp - 1
javascript.builtins.RegExp.compile - 3.1
javascript.builtins.RegExp.exec - 1
javascript.builtins.RegExp.flags - 9
javascript.builtins.RegExp.global - 1
javascript.builtins.RegExp.global.prototype_accessor - 1.3
javascript.builtins.RegExp.ignoreCase - 1
javascript.builtins.RegExp.ignoreCase.prototype_accessor - 1.3
javascript.builtins.RegExp.input - 3
javascript.builtins.RegExp.lastIndex - 1
javascript.builtins.RegExp.lastMatch - 3
javascript.builtins.RegExp.lastParen - 3
javascript.builtins.RegExp.leftContext - 3
javascript.builtins.RegExp.multiline - 1
javascript.builtins.RegExp.multiline.prototype_accessor - 1.3
javascript.builtins.RegExp.n - 1
javascript.builtins.RegExp.prototype - 1
javascript.builtins.RegExp.rightContext - 3
javascript.builtins.RegExp.source - 1
javascript.builtins.RegExp.source.empty_regex_string - 5
javascript.builtins.RegExp.source.escaping - 6
javascript.builtins.RegExp.source.prototype_accessor - 1.3
javascript.builtins.RegExp.sticky.anchored_sticky_flag - 10
javascript.builtins.RegExp.sticky.prototype_accessor - 10
javascript.builtins.RegExp.test - 1
javascript.builtins.RegExp.toString - 1
javascript.builtins.RegExp.toString.escaping - 6
javascript.builtins.RegExp.@@match - 10
javascript.builtins.RegExp.@@replace - 10
javascript.builtins.RegExp.@@search - 10
javascript.builtins.RegExp.@@species - 10
javascript.builtins.RegExp.@@split - 10