### PR TITLE
Update the Geolocation APIs

### DIFF
--- a/api/GeolocationCoordinates.json
+++ b/api/GeolocationCoordinates.json
@@ -1,29 +1,54 @@
 {
   "api": {
-    "Coordinates": {
+    "GeolocationCoordinates": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/Coordinates",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationCoordinates",
         "support": {
-          "chrome": {
-            "version_added": "5"
-          },
-          "chrome_android": {
-            "version_added": "18"
-          },
+          "chrome": [
+            {
+              "version_added": "79"
+            },
+            {
+              "version_added": "5",
+              "version_removed": "78",
+              "alternative_name": "Coordinates"
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "79"
+            },
+            {
+              "version_added": "18",
+              "version_removed": "78",
+              "alternative_name": "Coordinates"
+            }
+          ],
           "edge": {
+            "alternative_name": "Coordinates",
             "version_added": true
           },
-          "firefox": {
-            "version_added": "3.5"
-          },
+          "firefox": [
+            {
+              "version_added": "72"
+            },
+            {
+              "version_added": "3.5",
+              "version_removed": "71",
+              "alternative_name": "Coordinates"
+            }
+          ],
           "firefox_android": {
+            "alternative_name": "Coordinates",
             "version_added": "4"
           },
           "ie": {
+            "alternative_name": "Coordinates",
             "version_added": "9"
           },
           "opera": [
             {
+              "alternative_name": "Coordinates",
               "version_added": "16"
             },
             {
@@ -41,17 +66,27 @@
             }
           ],
           "safari": {
+            "alternative_name": "Coordinates",
             "version_added": "5"
           },
           "safari_ios": {
+            "alternative_name": "Coordinates",
             "version_added": "4.2"
           },
           "samsunginternet_android": {
+            "alternative_name": "Coordinates",
             "version_added": "1.0"
           },
-          "webview_android": {
-            "version_added": true
-          }
+          "webview_android": [
+            {
+              "version_added": "79"
+            },
+            {
+              "version_added": true,
+              "version_removed": "78",
+              "alternative_name": "Coordinates"
+            }
+          ]
         },
         "status": {
           "experimental": false,
@@ -61,7 +96,7 @@
       },
       "accuracy": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Coordinates/accuracy",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationCoordinates/accuracy",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -121,7 +156,7 @@
       },
       "altitude": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Coordinates/altitude",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationCoordinates/altitude",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -181,7 +216,7 @@
       },
       "altitudeAccuracy": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Coordinates/altitudeAccuracy",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationCoordinates/altitudeAccuracy",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -241,7 +276,7 @@
       },
       "heading": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Coordinates/heading",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationCoordinates/heading",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -301,7 +336,7 @@
       },
       "latitude": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Coordinates/latitude",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationCoordinates/latitude",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -361,7 +396,7 @@
       },
       "longitude": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Coordinates/longitude",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationCoordinates/longitude",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -469,7 +504,7 @@
       },
       "speed": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Coordinates/speed",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationCoordinates/speed",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/api/GeolocationPosition.json
+++ b/api/GeolocationPosition.json
@@ -1,45 +1,77 @@
 {
   "api": {
-    "Position": {
+    "GeolocationPosition": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/Position",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationPosition",
         "support": {
-          "chrome": {
-            "version_added": "5"
-          },
-          "chrome_android": {
-            "version_added": "18"
-          },
+          "chrome": [
+            {
+              "version_added": "79"
+            },
+            {
+              "version_added": "5",
+              "version_removed": "78",
+              "alternative_name": "Position"
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "79"
+            },
+            {
+              "version_added": "18",
+              "version_removed": "78",
+              "alternative_name": "Position"
+            }
+          ],
           "edge": {
+            "alternative_name": "Position",
             "version_added": true
           },
-          "firefox": {
-            "version_added": "3.5"
-          },
+          "firefox": [
+            {
+              "version_added": "72"
+            },
+            {
+              "version_added": "3.5",
+              "version_removed": "71",
+              "alternative_name": "Position"
+            }
+          ],
           "firefox_android": {
+            "alternative_name": "Position",
             "version_added": "4"
           },
           "ie": {
+            "alternative_name": "Position",
             "version_added": "9"
           },
           "opera": {
+            "alternative_name": "Position",
             "version_added": "16"
           },
           "opera_android": {
+            "alternative_name": "Position",
             "version_added": "16"
           },
           "safari": {
+            "alternative_name": "Position",
             "version_added": "5"
           },
           "safari_ios": {
+            "alternative_name": "Position",
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": "1.0"
-          },
-          "webview_android": {
-            "version_added": true
-          }
+          "webview_android": [
+            {
+              "version_added": "79"
+            },
+            {
+              "version_added": true,
+              "version_removed": "78",
+              "alternative_name": "Position"
+            }
+          ]
         },
         "status": {
           "experimental": false,
@@ -49,7 +81,7 @@
       },
       "coords": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Position/coords",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationPosition/coords",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -145,7 +177,7 @@
       },
       "timestamp": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Position/timestamp",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationPosition/timestamp",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/api/GeolocationPositionError.json
+++ b/api/GeolocationPositionError.json
@@ -1,45 +1,77 @@
 {
   "api": {
-    "PositionError": {
+    "GeolocationPositionError": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/PositionError",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationPositionError",
         "support": {
-          "chrome": {
-            "version_added": "5"
-          },
-          "chrome_android": {
-            "version_added": "18"
-          },
+          "chrome": [
+            {
+              "version_added": "79"
+            },
+            {
+              "version_added": "5",
+              "version_removed": "78",
+              "alternative_name": "PositionError"
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "79"
+            },
+            {
+              "version_added": "18",
+              "version_removed": "78",
+              "alternative_name": "PositionError"
+            }
+          ],
           "edge": {
+            "alternative_name": "PositionError",
             "version_added": true
           },
-          "firefox": {
-            "version_added": "3.5"
-          },
+          "firefox": [
+            {
+              "version_added": "72"
+            },
+            {
+              "version_added": "3.5",
+              "version_removed": "71",
+              "alternative_name": "PositionError"
+            }
+          ],
           "firefox_android": {
+            "alternative_name": "PositionError",
             "version_added": "4"
           },
           "ie": {
+            "alternative_name": "PositionError",
             "version_added": "9"
           },
           "opera": {
+            "alternative_name": "PositionError",
             "version_added": "16"
           },
           "opera_android": {
+            "alternative_name": "PositionError",
             "version_added": "16"
           },
           "safari": {
+            "alternative_name": "PositionError",
             "version_added": "5"
           },
           "safari_ios": {
+            "alternative_name": "PositionError",
             "version_added": true
           },
-          "samsunginternet_android": {
-            "version_added": "1.0"
-          },
-          "webview_android": {
-            "version_added": true
-          }
+          "webview_android": [
+            {
+              "version_added": "79"
+            },
+            {
+              "version_added": true,
+              "version_removed": "78",
+              "alternative_name": "PositionError"
+            }
+          ]
         },
         "status": {
           "experimental": false,
@@ -49,7 +81,7 @@
       },
       "code": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PositionError/code",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationPositionError/code",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -97,7 +129,7 @@
       },
       "message": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PositionError/message",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationPositionError/message",
           "support": {
             "chrome": {
               "version_added": "5"


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1575144

Basically, the following updates have occurred

    Coordinates -> GeolocationCoordinates
    Position -> GeolocationPosition
    PositionError -> GeolocationPositionError

This has happened only in Firefox 72, and Chrome Canary (I think version 79, but I'm not 100% certain).

This is my 2nd attempt to do this: https://github.com/mdn/browser-compat-data/pull/5314, which got totally screwed up. cc @vinyldarkscratch ;-)