### PR TITLE
Chrome 80 registerProtocolHandler needs secure ctx

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1780,10 +1780,10 @@
             "description": "Secure context required",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "80"
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "80"
               },
               "edge": {
                 "version_added": null


### PR DESCRIPTION
## Summary
Chrome 80+ restricts Navigator.registerProtocolHandler() to secure contexts.

## Data
 - Chrome Platform Status: https://www.chromestatus.com/feature/5756636801007616

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
