### PR TITLE
Update WebAuthN API on Safari Desktop

### DIFF
--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -44,7 +44,7 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": "13"
           },
           "safari_ios": {
             "version_added": false
@@ -106,7 +106,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
               "version_added": false
@@ -169,7 +169,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
               "version_added": false
@@ -232,7 +232,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
               "version_added": false
@@ -295,7 +295,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
Here's the link to the feature on WebKit Feature Status: https://webkit.org/status/#feature-web-authentication
The change was pushed to MacOS with Safari 13 and is mentionned in these release notes: https://developer.apple.com/documentation/safari_release_notes/safari_13_release_notes

Here's the umbrella bug report about WebAuthn on WebKit Bugzilla: https://bugs.webkit.org/show_bug.cgi?id=181943

caniuse.com has more data: https://caniuse.com/#search=webauthn - but I don't have access to many Apple devices to test. Seems to be enabled on iOS 13.3.