### PR TITLE
Tag StyleSheetSet features deprecated/non-standard

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -3681,8 +3681,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -6200,8 +6200,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -8476,8 +8476,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -9530,8 +9530,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -9724,8 +9724,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
All StyleSheetSet (aka "alternative stylesheets") features are no longer part of any spec. https://github.com/w3c/csswg-drafts/commit/e5353d0 dropped them from the CSSOM spec.

See also https://drafts.csswg.org/cssom/#changes-from-5-december-2013:

> API for alternative stylesheets is removed: selectedStyleSheetSet, lastStyleSheetSet, preferredStyleSheetSet, styleSheetSets, enableStyleSheetsForSet() on Document.