### PR TITLE
Update spec URLs for some TC39 propsals

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1557,7 +1557,7 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/import",
           "spec_url": [
-            "https://github.com/tc39/proposal-dynamic-import/#import",
+            "https://tc39.es/proposal-dynamic-import/#sec-import-calls",
             "https://tc39.es/ecma262/#sec-imports"
           ],
           "support": {
@@ -1824,7 +1824,7 @@
           "description": "<code>import.meta</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/import.meta",
           "spec_url": [
-            "https://github.com/tc39/proposal-import-meta/#importmeta",
+            "https://tc39.es/proposal-import-meta/#prod-ImportMeta",
             "https://html.spec.whatwg.org/multipage/webappapis.html#hostgetimportmetaproperties"
           ],
           "support": {


### PR DESCRIPTION
This change replaces the old https://github.com/tc39 spec_url values for two TC39 spec proposals with corresponding https://tc39.es values.