### PR TITLE
Drop Array.prototype and BigInt.prototype, add Array() and BigInt() constructors

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -52,6 +52,58 @@
             "deprecated": false
           }
         },
+        "Array": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/Array",
+            "spec_url": "https://tc39.es/ecma262/#sec-array-constructor",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": "18"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "4"
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": "1"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0"
+              },
+              "webview_android": {
+                "version_added": "≤37"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "concat": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/concat",
@@ -1283,58 +1335,6 @@
               },
               "webview_android": {
                 "version_added": true
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "prototype": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype",
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": {
-                "version_added": "18"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "1"
-              },
-              "firefox_android": {
-                "version_added": "4"
-              },
-              "ie": {
-                "version_added": "4"
-              },
-              "nodejs": {
-                "version_added": true
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": "3"
-              },
-              "safari_ios": {
-                "version_added": "1"
-              },
-              "samsunginternet_android": {
-                "version_added": "1.0"
-              },
-              "webview_android": {
-                "version_added": "≤37"
               }
             },
             "status": {

--- a/javascript/builtins/BigInt.json
+++ b/javascript/builtins/BigInt.json
@@ -52,6 +52,58 @@
             "deprecated": false
           }
         },
+        "BigInt": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt/BigInt",
+            "spec_url": "https://tc39.es/ecma262/#sec-bigint-constructor",
+            "support": {
+              "chrome": {
+                "version_added": "67"
+              },
+              "chrome_android": {
+                "version_added": "67"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "68"
+              },
+              "firefox_android": {
+                "version_added": "68"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "10.4.0"
+              },
+              "opera": {
+                "version_added": "54"
+              },
+              "opera_android": {
+                "version_added": "48"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "9.0"
+              },
+              "webview_android": {
+                "version_added": "67"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "asIntN": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt/asIntN",
@@ -108,58 +160,6 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt/asUintN",
             "spec_url": "https://tc39.es/ecma262/#sec-bigint.asuintn",
-            "support": {
-              "chrome": {
-                "version_added": "67"
-              },
-              "chrome_android": {
-                "version_added": "67"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "68"
-              },
-              "firefox_android": {
-                "version_added": "68"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "10.4.0"
-              },
-              "opera": {
-                "version_added": "54"
-              },
-              "opera_android": {
-                "version_added": "48"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": "9.0"
-              },
-              "webview_android": {
-                "version_added": "67"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "prototype": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt",
-            "spec_url": "https://tc39.es/ecma262/#sec-bigint.prototype",
             "support": {
               "chrome": {
                 "version_added": "67"


### PR DESCRIPTION
This change drops data for the `Array.prototype` and `BigInt.prototype` features and adds data for the `Array()` and `BigInt()` constructors, per discussion at https://github.com/mdn/browser-compat-data/pull/5440#issuecomment-571165182

---

Original PR description:

<strike>
Array.prototype and BigInt.prototype both previously has their own MDN articles, but in https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array$compare?to=1589607&from=1589603 and https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt$compare?to=1589609&from=1585550 the content of those articles was moved to their parent Array and BigInt articles.

So in https://github.com/mdn/browser-compat-data/pull/5204 we changed the mdn_url values for the BCD Array.prototype and BigInt.prototype subfeatures to point to the MDN articles for their parent BCD features.

However, given the parent Array and BigInt features already have mdn_url values that point to their articles, it’s not necessary or useful to repeat those exact same URLs in mdn_url values for the Array.prototype and BigInt.prototype subfeatures. So this change drops them.
</strike>