### PR TITLE
Mark *HitRegion methods as deprecated/non-standard

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -385,8 +385,8 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+              "standard_track": false,
+              "deprecated": true
             }
           }
         }
@@ -692,8 +692,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -3247,8 +3247,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
The canvas "hit regions" feature was removed from the HTML spec in https://github.com/whatwg/html/pull/1942 (commit https://github.com/whatwg/html/commit/9d493a3).

This BCD change marks the associated CanvasRenderingContext2D addHitRegion, removeHitRegion, and clearHitRegions methods as standard_track: false, deprecated: true