### PR TITLE
Drop spec_url for function.arguments

### DIFF
--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -201,7 +201,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": true
             }
           }

--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -158,7 +158,6 @@
         "arguments": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/arguments",
-            "spec_url": "https://tc39.es/ecma262/#sec-arguments-object",
             "support": {
               "chrome": {
                 "version_added": "1"


### PR DESCRIPTION
function.arguments is deprecated and no longer in the ES spec; drop the broken https://tc39.es/ecma262/#sec-arguments-object spec_url for it.