### PR TITLE
Fix missing semicolons in HTML entities

### DIFF
--- a/html/elements/input/reset.json
+++ b/html/elements/input/reset.json
@@ -18,11 +18,11 @@
               },
               "firefox": {
                 "version_added": "1",
-                "notes": "Unlike other browsers, Firefox by default <a href='http://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing'>persists the dynamic disabled state</a> of a <code>&ltbutton&gt</code> across page loads. Use the <code><a href='https://developer.mozilla.org/docs/Web/HTML/Element/button#attr-autocomplete'>autocomplete</a></code> attribute to control this feature."
+                "notes": "Unlike other browsers, Firefox by default <a href='http://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing'>persists the dynamic disabled state</a> of a <code>&lt;button&gt;</code> across page loads. Use the <code><a href='https://developer.mozilla.org/docs/Web/HTML/Element/button#attr-autocomplete'>autocomplete</a></code> attribute to control this feature."
               },
               "firefox_android": {
                 "version_added": "4",
-                "notes": "Unlike other browsers, Firefox by default <a href='http://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing'>persists the dynamic disabled state</a> of a <code>&ltbutton&gt</code> across page loads. Use the <code><a href='https://developer.mozilla.org/docs/Web/HTML/Element/button#attr-autocomplete'>autocomplete</a></code> attribute to control this feature."
+                "notes": "Unlike other browsers, Firefox by default <a href='http://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing'>persists the dynamic disabled state</a> of a <code>&lt;button&gt;</code> across page loads. Use the <code><a href='https://developer.mozilla.org/docs/Web/HTML/Element/button#attr-autocomplete'>autocomplete</a></code> attribute to control this feature."
               },
               "ie": {
                 "version_added": true


### PR DESCRIPTION
The semicolons were missing in the "\&gt;" and "\&lt;" HTML entities, causing them to be interpreted as plain text.

This is a simple typo fix.