### PR TITLE
Mark document.origin deprecated + non-standard

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -7485,8 +7485,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
document.origin was removed from the DOM standard in https://github.com/whatwg/dom/pull/815 (change https://github.com/whatwg/dom/commit/55379a7).