### PR TITLE
Async generators supported since Safari 12

### DIFF
--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -830,10 +830,10 @@
                 "version_added": "46"
               },
               "safari": {
-                "version_added": false
+                "version_added": "12"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "12"
               },
               "samsunginternet_android": {
                 "version_added": "8.0"

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -910,7 +910,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
Confirmed locally that they work in v13.0, and kangax has them in since v12: http://kangax.github.io/compat-table/es2016plus/#test-Asynchronous_Iterators_async_generators. The webkit bug tracker is pretty sparse as far as I can tell, https://bugs.webkit.org/show_bug.cgi?id=166693 is the closest bug I could find.

Also mark `for await ... of` as no longer experimental, as it's a stage 4 proposal and part of the ES2018 standard.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
