### PR TITLE
Add Chrome OS in getDisplayMedia() audio notes

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -249,7 +249,7 @@
             "support": {
               "chrome": {
                 "version_added": "74",
-                "notes": "On Windows the entire system audio can be captured, but on Linux and Mac only the audio of a tab can be captured."
+                "notes": "On Windows and Chrome OS the entire system audio can be captured, but on Linux and Mac only the audio of a tab can be captured."
               },
               "chrome_android": {
                 "version_added": false


### PR DESCRIPTION
Chrome OS also supports sharing the full system audio, so I've added it to the notes about which OS's have the feature.

I have personally confirmed that sharing full system audio works in Chrome OS version 79. I successfully shared the audio from Chrome OS via the website: https://2n.fm

In this specific case, Chrome OS's feature doesn't fall into either the Chrome browser, nor Linux despite Chrome OS's origins as Linux. Hence, I believe a note is appropriate here, just as it was for the Windows OS, since this information can not be conveyed via the existing chart of compatibility.