### PR TITLE
Print prettier to stdio

### DIFF
--- a/test/test-format.js
+++ b/test/test-format.js
@@ -4,7 +4,7 @@ const chalk = require('chalk');
 
 const testFormat = () => {
   try {
-    execSync('npx prettier --check "**/*.js" "**/*.ts"');
+    execSync('npx prettier --check "**/*.js" "**/*.ts"', { stdio: 'inherit' });
   } catch (err) {
     let errorText = err.stdout.toString();
     console.error(chalk`{red   Prettier – formatting errors:}`);


### PR DESCRIPTION
Congrats on landing prettier while I was away! :smile: 
So, updated everything locally but it always throws at me: 

> ...
> ✔ xslt/exslt/set.json
> ✔ xslt/exslt/str.json
>   Prettier – formatting errors:
> 
> Tip: Run npm run fix to fix formatting automatically
> 
> Problems in 0 files:
> npm ERR! code ELIFECYCLE
> npm ERR! errno 1
> npm ERR! mdn-browser-compat-data@1.0.3 lint: `node test/lint`
> npm ERR! Exit status 1

I wasn't able to see whether prettier was checking or not, so I've added that. Weirdly it then also fixed the bogus exit status for me.

I think it is a good thing for us to see it in CI as well: https://travis-ci.org/mdn/browser-compat-data/builds/634285153#L2377