### PR TITLE
Update Firefox releases

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -537,7 +537,7 @@
           "engine_version": "72"
         },
         "73": {
-          "release_date": "2020-02-20",
+          "release_date": "2020-02-11",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/73",
           "status": "beta",
           "engine": "Gecko",
@@ -586,7 +586,7 @@
           "engine_version": "79"
         },
         "80": {
-          "release_date": "2020-07-28",
+          "release_date": "2020-08-25",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/80",
           "status": "planned",
           "engine": "Gecko",

--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -518,23 +518,79 @@
         "70": {
           "release_date": "2019-10-22",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/70",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "70"
         },
         "71": {
           "release_date": "2019-12-10",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/71",
-          "status": "beta",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "71"
         },
         "72": {
           "release_date": "2020-01-07",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/72",
-          "status": "nightly",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "72"
+        },
+        "73": {
+          "release_date": "2020-02-20",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/73",
+          "status": "beta",
+          "engine": "Gecko",
+          "engine_version": "73"
+        },
+        "74": {
+          "release_date": "2020-03-10",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/74",
+          "status": "nightly",
+          "engine": "Gecko",
+          "engine_version": "74"
+        },
+        "75": {
+          "release_date": "2020-04-07",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/75",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "75"
+        },
+        "76": {
+          "release_date": "2020-05-05",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/76",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "76"
+        },
+        "77": {
+          "release_date": "2020-06-02",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/77",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "77"
+        },
+        "78": {
+          "release_date": "2020-06-30",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/78",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "78"
+        },
+        "79": {
+          "release_date": "2020-07-28",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/79",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "79"
+        },
+        "80": {
+          "release_date": "2020-07-28",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/80",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "80"
         }
       }
     }


### PR DESCRIPTION
Update/add Firefox releases 70 to 80.
Source: https://wiki.mozilla.org/Release_Management/Calendar