### PR TITLE
MathML mfenced is gone

### DIFF
--- a/mathml/elements/mfenced.json
+++ b/mathml/elements/mfenced.json
@@ -45,8 +45,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         },
         "href": {
@@ -92,8 +92,8 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+              "standard_track": false,
+              "deprecated": true
             }
           }
         },
@@ -140,8 +140,8 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+              "standard_track": false,
+              "deprecated": true
             }
           }
         },

--- a/mathml/elements/mfenced.json
+++ b/mathml/elements/mfenced.json
@@ -15,7 +15,8 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "73"
             },
             "firefox_android": {
               "version_added": "4"
@@ -61,7 +62,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "7"
+                "version_added": "7",
+                "version_removed": "73"
               },
               "firefox_android": {
                 "version_added": "7"
@@ -108,7 +110,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "4"
+                "version_added": "4",
+                "version_removed": "73"
               },
               "firefox_android": {
                 "version_added": "4"
@@ -155,7 +158,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "4"
+                "version_added": "4",
+                "version_removed": "73"
               },
               "firefox_android": {
                 "version_added": "4"
@@ -184,8 +188,8 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+              "standard_track": false,
+              "deprecated": true
             }
           }
         }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1603773
https://developer.mozilla.org/en-US/docs/Web/MathML/Element/mfenced

Depends on https://github.com/mdn/browser-compat-data/pull/5456