### PR TITLE
Make the SVG mfenced element deprecated

### DIFF
--- a/mathml/elements/mfenced.json
+++ b/mathml/elements/mfenced.json
@@ -45,7 +45,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         },
         "href": {
@@ -91,7 +91,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },
@@ -138,7 +138,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },
@@ -185,7 +185,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         }


### PR DESCRIPTION
See https://github.com/mathml-refresh/mathml/issues/2 and https://bugzilla.mozilla.org/show_bug.cgi?id=1587577