### PR TITLE
Drop the Event: createEvent() feature

### DIFF
--- a/api/Event.json
+++ b/api/Event.json
@@ -386,54 +386,6 @@
           }
         }
       },
-      "createEvent": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Event/createEvent",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "currentTarget": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Event/currentTarget",


### PR DESCRIPTION
No `createEvent()` method for the `Event` interface was ever actually specified anywhere, and never implemented anywhere.

https://www.w3.org/TR/DOM-Level-2-Events/events.html#Events-document specified a `DocumentEvent` interface with a `createEvent()` method, but that interface was just a mixin abstraction for providing a `createEvent()` method for the Document interface:

> It is expected that the `DocumentEvent` interface will be implemented on the same object which implements the `Document` interface in an implementation which supports the `Event` model

...but BCD already has a `createEvent` feature defined in `api/Document.json`, and a corresponding MDN article:

https://wiki.developer.mozilla.org/en-US/docs/Web/API/Document/createEvent