### PR TITLE
Added Safari version for IntersectionObserverEntry#isIntersecting

### DIFF
--- a/api/IntersectionObserverEntry.json
+++ b/api/IntersectionObserverEntry.json
@@ -36,7 +36,7 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": "12.1"
           },
           "samsunginternet_android": {
             "version_added": "5.0"

--- a/api/IntersectionObserverEntry.json
+++ b/api/IntersectionObserverEntry.json
@@ -243,7 +243,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "samsunginternet_android": {
               "version_added": "5.0"


### PR DESCRIPTION
Added Safari version for `IntersectionObserverEntry#isIntersecting`, which was added at the same time as `IntersectionObserver` support. 

Docs:
WebKit blog post announcing IntersectionObserver support (with use of .isIntersecting): https://webkit.org/blog/8582/intersectionobserver-in-webkit/

