### PR TITLE
Mark MediaRecorder: ignoreMutedMedia deprecated

### DIFF
--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -268,10 +268,12 @@
               "version_added": null
             },
             "opera": {
-              "version_added": "36"
+              "version_added": "36",
+              "version_removed": "44"
             },
             "opera_android": {
-              "version_added": "36"
+              "version_added": "36",
+              "version_removed": "44"
             },
             "safari": {
               "version_added": null
@@ -289,9 +291,9 @@
             }
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
`ignoreMutedMedia` was removed from the spec long ago, and already dropped from all implementations.

See https://github.com/w3c/mediacapture-record/pull/105 and https://github.com/w3c/mediacapture-record/commit/ec5eae3