### PR TITLE
Rename DeviceAcceleration to DeviceMotionEventAcceleration

### DIFF
--- a/api/DeviceMotionEventAcceleration.json
+++ b/api/DeviceMotionEventAcceleration.json
@@ -1,8 +1,8 @@
 {
   "api": {
-    "DeviceAcceleration": {
+    "DeviceMotionEventAcceleration": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceAcceleration",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceMotionEventAcceleration",
         "support": {
           "chrome": {
             "version_added": null
@@ -49,7 +49,7 @@
       },
       "x": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceAcceleration/x",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceMotionEventAcceleration/x",
           "support": {
             "chrome": {
               "version_added": null
@@ -97,7 +97,7 @@
       },
       "y": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceAcceleration/y",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceMotionEventAcceleration/y",
           "support": {
             "chrome": {
               "version_added": null
@@ -145,7 +145,7 @@
       },
       "z": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceAcceleration/z",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceMotionEventAcceleration/z",
           "support": {
             "chrome": {
               "version_added": null


### PR DESCRIPTION
In the Device Orientation spec, the `DeviceAcceleration` interface was renamed (about a year ago) to `DeviceMotionEventAcceleration`. See https://github.com/w3c/deviceorientation/commit/b363303