### PR TITLE
DeviceRotationRate > DeviceMotionEventRotationRate

### DIFF
--- a/api/DeviceMotionEventRotationRate.json
+++ b/api/DeviceMotionEventRotationRate.json
@@ -1,8 +1,8 @@
 {
   "api": {
-    "DeviceRotationRate": {
+    "DeviceMotionEventRotationRate": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceRotationRate",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceMotionEventRotationRate",
         "support": {
           "chrome": {
             "version_added": null
@@ -49,7 +49,7 @@
       },
       "alpha": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceRotationRate/alpha",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceMotionEventRotationRate/alpha",
           "support": {
             "chrome": {
               "version_added": null
@@ -97,7 +97,7 @@
       },
       "beta": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceRotationRate/beta",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceMotionEventRotationRate/beta",
           "support": {
             "chrome": {
               "version_added": null
@@ -145,7 +145,7 @@
       },
       "gamma": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceRotationRate/gamma",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceMotionEventRotationRate/gamma",
           "support": {
             "chrome": {
               "version_added": null


### PR DESCRIPTION
In the Device Orientation spec, the `DeviceRotationRate` interface was renamed (about a year ago) to `DeviceMotionEventRotationRate`. See https://github.com/w3c/deviceorientation/commit/b363303