### PR TITLE
updating word and letter spacing

### DIFF
--- a/svg/attributes/presentation.json
+++ b/svg/attributes/presentation.json
@@ -1552,7 +1552,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "72"
+                "version_added": "73"
               },
               "firefox_android": {
                 "version_added": false
@@ -3088,7 +3088,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "72"
+                "version_added": "73"
               },
               "firefox_android": {
                 "version_added": false


### PR DESCRIPTION
Support for SVG `word-spacing` and `letter-spacing` was backed out of 72 and re-added for 73. PR updates this. https://bugzilla.mozilla.org/show_bug.cgi?id=371787