### PR TITLE
Replace prototypes with constructors

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -54,6 +54,7 @@
         },
         "Array": {
           "__compat": {
+            "description": "<code>Array()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/Array",
             "spec_url": "https://tc39.es/ecma262/#sec-array-constructor",
             "support": {

--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -207,10 +207,11 @@
             }
           }
         },
-        "prototype": {
+        "ArrayBuffer": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/prototype",
-            "spec_url": "https://tc39.es/ecma262/#sec-arraybuffer.prototype",
+            "description": "<code>ArrayBuffer()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/ArrayBuffer",
+            "spec_url": "https://tc39.es/ecma262/#sec-arraybuffer-constructor",
             "support": {
               "chrome": {
                 "version_added": "7"

--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -52,6 +52,59 @@
             "deprecated": false
           }
         },
+        "ArrayBuffer": {
+          "__compat": {
+            "description": "<code>ArrayBuffer()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/ArrayBuffer",
+            "spec_url": "https://tc39.es/ecma262/#sec-arraybuffer-constructor",
+            "support": {
+              "chrome": {
+                "version_added": "7"
+              },
+              "chrome_android": {
+                "version_added": "18"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "4"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "10"
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "11.6"
+              },
+              "opera_android": {
+                "version_added": "12"
+              },
+              "safari": {
+                "version_added": "5.1"
+              },
+              "safari_ios": {
+                "version_added": "4.2"
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": "4"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "byteLength": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/byteLength",
@@ -198,59 +251,6 @@
               },
               "webview_android": {
                 "version_added": "≤37"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "ArrayBuffer": {
-          "__compat": {
-            "description": "<code>ArrayBuffer()</code> constructor",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/ArrayBuffer",
-            "spec_url": "https://tc39.es/ecma262/#sec-arraybuffer-constructor",
-            "support": {
-              "chrome": {
-                "version_added": "7"
-              },
-              "chrome_android": {
-                "version_added": "18"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "4"
-              },
-              "firefox_android": {
-                "version_added": "4"
-              },
-              "ie": {
-                "version_added": "10"
-              },
-              "nodejs": {
-                "version_added": true
-              },
-              "opera": {
-                "version_added": "11.6"
-              },
-              "opera_android": {
-                "version_added": "12"
-              },
-              "safari": {
-                "version_added": "5.1"
-              },
-              "safari_ios": {
-                "version_added": "4.2"
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "4"
               }
             },
             "status": {

--- a/javascript/builtins/AsyncFunction.json
+++ b/javascript/builtins/AsyncFunction.json
@@ -62,69 +62,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "prototype": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncFunction/prototype",
-            "spec_url": "https://tc39.es/ecma262/#sec-async-function-constructor-prototype",
-            "support": {
-              "chrome": {
-                "version_added": "55"
-              },
-              "chrome_android": {
-                "version_added": "55"
-              },
-              "edge": {
-                "version_added": "15"
-              },
-              "firefox": {
-                "version_added": "52"
-              },
-              "firefox_android": {
-                "version_added": "52"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": [
-                {
-                  "version_added": "7.6.0"
-                },
-                {
-                  "version_added": "7.0.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
-              "opera": {
-                "version_added": "42"
-              },
-              "opera_android": {
-                "version_added": "42"
-              },
-              "safari": {
-                "version_added": "10.1"
-              },
-              "safari_ios": {
-                "version_added": "10.3"
-              },
-              "samsunginternet_android": {
-                "version_added": "6.0"
-              },
-              "webview_android": {
-                "version_added": "55"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       }
     }

--- a/javascript/builtins/BigInt.json
+++ b/javascript/builtins/BigInt.json
@@ -54,6 +54,7 @@
         },
         "BigInt": {
           "__compat": {
+            "description": "<code>BigInt()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt/BigInt",
             "spec_url": "https://tc39.es/ecma262/#sec-bigint-constructor",
             "support": {

--- a/javascript/builtins/Boolean.json
+++ b/javascript/builtins/Boolean.json
@@ -52,10 +52,11 @@
             "deprecated": false
           }
         },
-        "prototype": {
+        "Boolean": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean/prototype",
-            "spec_url": "https://tc39.es/ecma262/#sec-boolean.prototype",
+            "description": "<code>Boolean()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean/Boolean",
+            "spec_url": "https://tc39.es/ecma262/#sec-boolean-constructor",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -52,6 +52,59 @@
             "deprecated": false
           }
         },
+        "DataView": {
+          "__compat": {
+            "description": "<code>DataView()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/DataView",
+            "spec_url": "https://tc39.es/ecma262/#sec-dataview-constructor",
+            "support": {
+              "chrome": {
+                "version_added": "9"
+              },
+              "chrome_android": {
+                "version_added": "18"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "15"
+              },
+              "firefox_android": {
+                "version_added": "15"
+              },
+              "ie": {
+                "version_added": "10"
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "12.1"
+              },
+              "opera_android": {
+                "version_added": "12.1"
+              },
+              "safari": {
+                "version_added": "5.1"
+              },
+              "safari_ios": {
+                "version_added": "4.2"
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": "4"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "buffer": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/buffer",
@@ -823,59 +876,6 @@
               },
               "webview_android": {
                 "version_added": "≤37"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "DataView": {
-          "__compat": {
-            "description": "<code>DataView()</code> constructor",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/DataView",
-            "spec_url": "https://tc39.es/ecma262/#sec-dataview-constructor",
-            "support": {
-              "chrome": {
-                "version_added": "9"
-              },
-              "chrome_android": {
-                "version_added": "18"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "15"
-              },
-              "firefox_android": {
-                "version_added": "15"
-              },
-              "ie": {
-                "version_added": "10"
-              },
-              "nodejs": {
-                "version_added": true
-              },
-              "opera": {
-                "version_added": "12.1"
-              },
-              "opera_android": {
-                "version_added": "12.1"
-              },
-              "safari": {
-                "version_added": "5.1"
-              },
-              "safari_ios": {
-                "version_added": "4.2"
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "4"
               }
             },
             "status": {

--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -832,10 +832,11 @@
             }
           }
         },
-        "prototype": {
+        "DataView": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/prototype",
-            "spec_url": "https://tc39.es/ecma262/#sec-dataview.prototype",
+            "description": "<code>DataView()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/DataView",
+            "spec_url": "https://tc39.es/ecma262/#sec-dataview-constructor",
             "support": {
               "chrome": {
                 "version_added": "9"

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -1248,10 +1248,11 @@
             }
           }
         },
-        "prototype": {
+        "Date": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/prototype",
-            "spec_url": "https://tc39.es/ecma262/#sec-properties-of-the-date-prototype-object",
+            "description": "<code>Date()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/Date",
+            "spec_url": "https://tc39.es/ecma262/#sec-date-constructor",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1263,12 +1264,10 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "1",
-                "notes": "Prior to version 41, this has not been an ordinary object as specified in ES2015."
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "4",
-                "notes": "Prior to version 41, this has not been an ordinary object as specified in ES2015."
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "3"

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -53,6 +53,59 @@
             "deprecated": false
           }
         },
+        "Date": {
+          "__compat": {
+            "description": "<code>Date()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/Date",
+            "spec_url": "https://tc39.es/ecma262/#sec-date-constructor",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": "18"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "3"
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": "1"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0"
+              },
+              "webview_android": {
+                "version_added": "1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "UTC": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/UTC",
@@ -1245,59 +1298,6 @@
                 "standard_track": true,
                 "deprecated": false
               }
-            }
-          }
-        },
-        "Date": {
-          "__compat": {
-            "description": "<code>Date()</code> constructor",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/Date",
-            "spec_url": "https://tc39.es/ecma262/#sec-date-constructor",
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": {
-                "version_added": "18"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "1"
-              },
-              "firefox_android": {
-                "version_added": "4"
-              },
-              "ie": {
-                "version_added": "3"
-              },
-              "nodejs": {
-                "version_added": true
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": "1"
-              },
-              "safari_ios": {
-                "version_added": "1"
-              },
-              "samsunginternet_android": {
-                "version_added": "1.0"
-              },
-              "webview_android": {
-                "version_added": "1"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
             }
           }
         },

--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -52,6 +52,59 @@
             "deprecated": false
           }
         },
+        "Error": {
+          "__compat": {
+            "description": "<code>Error()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error/Error",
+            "spec_url": "https://tc39.es/ecma262/#sec-error-constructor",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": "18"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "6"
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": "1"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0"
+              },
+              "webview_android": {
+                "version_added": "1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "columnNumber": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error/columnNumber",
@@ -261,59 +314,6 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error/name",
             "spec_url": "https://tc39.es/ecma262/#sec-error.prototype.name",
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": {
-                "version_added": "18"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "1"
-              },
-              "firefox_android": {
-                "version_added": "4"
-              },
-              "ie": {
-                "version_added": "6"
-              },
-              "nodejs": {
-                "version_added": true
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": "1"
-              },
-              "safari_ios": {
-                "version_added": "1"
-              },
-              "samsunginternet_android": {
-                "version_added": "1.0"
-              },
-              "webview_android": {
-                "version_added": "1"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "Error": {
-          "__compat": {
-            "description": "<code>Error()</code> constructor",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error/Error",
-            "spec_url": "https://tc39.es/ecma262/#sec-error-constructor",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -309,10 +309,11 @@
             }
           }
         },
-        "prototype": {
+        "Error": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error/prototype",
-            "spec_url": "https://tc39.es/ecma262/#sec-error.prototype",
+            "description": "<code>Error()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error/Error",
+            "spec_url": "https://tc39.es/ecma262/#sec-error-constructor",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -775,10 +775,11 @@
             }
           }
         },
-        "prototype": {
+        "Function": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/prototype",
-            "spec_url": "https://tc39.es/ecma262/#sec-function-instances-prototype",
+            "description": "<code>Function()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/Function",
+            "spec_url": "https://tc39.es/ecma262/#sec-function-constructor",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -52,6 +52,59 @@
             "deprecated": false
           }
         },
+        "Function": {
+          "__compat": {
+            "description": "<code>Function()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/Function",
+            "spec_url": "https://tc39.es/ecma262/#sec-function-constructor",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": "18"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "4"
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": "1"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0"
+              },
+              "webview_android": {
+                "version_added": "1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "apply": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/apply",
@@ -772,59 +825,6 @@
                 "standard_track": true,
                 "deprecated": false
               }
-            }
-          }
-        },
-        "Function": {
-          "__compat": {
-            "description": "<code>Function()</code> constructor",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/Function",
-            "spec_url": "https://tc39.es/ecma262/#sec-function-constructor",
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": {
-                "version_added": "18"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "1"
-              },
-              "firefox_android": {
-                "version_added": "4"
-              },
-              "ie": {
-                "version_added": "4"
-              },
-              "nodejs": {
-                "version_added": true
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": "1"
-              },
-              "safari_ios": {
-                "version_added": "1"
-              },
-              "samsunginternet_android": {
-                "version_added": "1.0"
-              },
-              "webview_android": {
-                "version_added": "1"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
             }
           }
         },

--- a/javascript/builtins/GeneratorFunction.json
+++ b/javascript/builtins/GeneratorFunction.json
@@ -51,58 +51,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "prototype": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/GeneratorFunction/prototype",
-            "spec_url": "https://tc39.es/ecma262/#sec-generatorfunction.prototype",
-            "support": {
-              "chrome": {
-                "version_added": "39"
-              },
-              "chrome_android": {
-                "version_added": "39"
-              },
-              "edge": {
-                "version_added": "13"
-              },
-              "firefox": {
-                "version_added": "26"
-              },
-              "firefox_android": {
-                "version_added": "26"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": true
-              },
-              "opera": {
-                "version_added": "26"
-              },
-              "opera_android": {
-                "version_added": "26"
-              },
-              "safari": {
-                "version_added": "10"
-              },
-              "safari_ios": {
-                "version_added": "10"
-              },
-              "samsunginternet_android": {
-                "version_added": "4.0"
-              },
-              "webview_android": {
-                "version_added": "39"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       }
     }

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -63,6 +63,59 @@
             "deprecated": false
           }
         },
+        "Map": {
+          "__compat": {
+            "description": "<code>Map()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/Map",
+            "spec_url": "https://tc39.es/ecma262/#sec-map-constructor",
+            "support": {
+              "chrome": {
+                "version_added": "38"
+              },
+              "chrome_android": {
+                "version_added": "38"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "13"
+              },
+              "firefox_android": {
+                "version_added": "14"
+              },
+              "ie": {
+                "version_added": "11"
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "25"
+              },
+              "opera_android": {
+                "version_added": "25"
+              },
+              "safari": {
+                "version_added": "8"
+              },
+              "safari_ios": {
+                "version_added": "8"
+              },
+              "samsunginternet_android": {
+                "version_added": "3.0"
+              },
+              "webview_android": {
+                "version_added": "38"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "clear": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/clear",
@@ -638,59 +691,6 @@
               },
               "safari_ios": {
                 "version_added": "9"
-              },
-              "samsunginternet_android": {
-                "version_added": "3.0"
-              },
-              "webview_android": {
-                "version_added": "38"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "Map": {
-          "__compat": {
-            "description": "<code>Map()</code> constructor",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/Map",
-            "spec_url": "https://tc39.es/ecma262/#sec-map-constructor",
-            "support": {
-              "chrome": {
-                "version_added": "38"
-              },
-              "chrome_android": {
-                "version_added": "38"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "13"
-              },
-              "firefox_android": {
-                "version_added": "14"
-              },
-              "ie": {
-                "version_added": "11"
-              },
-              "nodejs": {
-                "version_added": true
-              },
-              "opera": {
-                "version_added": "25"
-              },
-              "opera_android": {
-                "version_added": "25"
-              },
-              "safari": {
-                "version_added": "8"
-              },
-              "safari_ios": {
-                "version_added": "8"
               },
               "samsunginternet_android": {
                 "version_added": "3.0"

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -653,10 +653,11 @@
             }
           }
         },
-        "prototype": {
+        "Map": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/prototype",
-            "spec_url": "https://tc39.es/ecma262/#sec-map.prototype",
+            "description": "<code>Map()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/Map",
+            "spec_url": "https://tc39.es/ecma262/#sec-map-constructor",
             "support": {
               "chrome": {
                 "version_added": "38"

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -416,6 +416,59 @@
             }
           }
         },
+        "Number": {
+          "__compat": {
+            "description": "<code>Number()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/Number",
+            "spec_url": "https://tc39.es/ecma262/#sec-number-constructor",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": "18"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "3"
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": "1"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0"
+              },
+              "webview_android": {
+                "version_added": "1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "POSITIVE_INFINITY": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/POSITIVE_INFINITY",
@@ -771,59 +824,6 @@
               },
               "webview_android": {
                 "version_added": "≤37"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "Number": {
-          "__compat": {
-            "description": "<code>Number()</code> constructor",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/Number",
-            "spec_url": "https://tc39.es/ecma262/#sec-number-constructor",
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": {
-                "version_added": "18"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "1"
-              },
-              "firefox_android": {
-                "version_added": "4"
-              },
-              "ie": {
-                "version_added": "3"
-              },
-              "nodejs": {
-                "version_added": true
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": "1"
-              },
-              "safari_ios": {
-                "version_added": "1"
-              },
-              "samsunginternet_android": {
-                "version_added": "1.0"
-              },
-              "webview_android": {
-                "version_added": "1"
               }
             },
             "status": {

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -780,10 +780,11 @@
             }
           }
         },
-        "prototype": {
+        "Number": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/prototype",
-            "spec_url": "https://tc39.es/ecma262/#sec-properties-of-the-number-prototype-object",
+            "description": "<code>Number()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/Number",
+            "spec_url": "https://tc39.es/ecma262/#sec-number-constructor",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -1851,10 +1851,11 @@
             }
           }
         },
-        "prototype": {
+        "Object": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/prototype",
-            "spec_url": "https://tc39.es/ecma262/#sec-object.prototype",
+            "description": "<code>Object()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/Object",
+            "spec_url": "https://tc39.es/ecma262/#sec-object-constructor",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -52,6 +52,59 @@
             "deprecated": false
           }
         },
+        "Object": {
+          "__compat": {
+            "description": "<code>Object()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/Object",
+            "spec_url": "https://tc39.es/ecma262/#sec-object-constructor",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": "18"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "3"
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": "1"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0"
+              },
+              "webview_android": {
+                "version_added": "1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "assign": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/assign",
@@ -1848,59 +1901,6 @@
               "experimental": false,
               "standard_track": true,
               "deprecated": true
-            }
-          }
-        },
-        "Object": {
-          "__compat": {
-            "description": "<code>Object()</code> constructor",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/Object",
-            "spec_url": "https://tc39.es/ecma262/#sec-object-constructor",
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": {
-                "version_added": "18"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "1"
-              },
-              "firefox_android": {
-                "version_added": "4"
-              },
-              "ie": {
-                "version_added": "3"
-              },
-              "nodejs": {
-                "version_added": true
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": "1"
-              },
-              "safari_ios": {
-                "version_added": "1"
-              },
-              "samsunginternet_android": {
-                "version_added": "1.0"
-              },
-              "webview_android": {
-                "version_added": "1"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
             }
           }
         },

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -322,58 +322,6 @@
             }
           }
         },
-        "prototype": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/prototype",
-            "spec_url": "https://tc39.es/ecma262/#sec-promise.prototype",
-            "support": {
-              "chrome": {
-                "version_added": "32"
-              },
-              "chrome_android": {
-                "version_added": "32"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "29"
-              },
-              "firefox_android": {
-                "version_added": "29"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "0.12"
-              },
-              "opera": {
-                "version_added": "19"
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": "8"
-              },
-              "safari_ios": {
-                "version_added": "8"
-              },
-              "samsunginternet_android": {
-                "version_added": "2.0"
-              },
-              "webview_android": {
-                "version_added": "4.4.3"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "race": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/race",

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -52,6 +52,59 @@
             "deprecated": false
           }
         },
+        "RegExp": {
+          "__compat": {
+            "description": "<code>RegExp()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/RegExp",
+            "spec_url": "https://tc39.es/ecma262/#sec-regexp-constructor",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": "18"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "4"
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": "1"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0"
+              },
+              "webview_android": {
+                "version_added": "1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "compile": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/compile",
@@ -1060,59 +1113,6 @@
               },
               "webview_android": {
                 "version_added": "64"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "RegExp": {
-          "__compat": {
-            "description": "<code>RegExp()</code> constructor",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/RegExp",
-            "spec_url": "https://tc39.es/ecma262/#sec-regexp-constructor",
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": {
-                "version_added": "18"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "1"
-              },
-              "firefox_android": {
-                "version_added": "4"
-              },
-              "ie": {
-                "version_added": "4"
-              },
-              "nodejs": {
-                "version_added": true
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": "1"
-              },
-              "safari_ios": {
-                "version_added": "1"
-              },
-              "samsunginternet_android": {
-                "version_added": "1.0"
-              },
-              "webview_android": {
-                "version_added": "1"
               }
             },
             "status": {

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -1069,10 +1069,11 @@
             }
           }
         },
-        "prototype": {
+        "RegExp": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/prototype",
-            "spec_url": "https://tc39.es/ecma262/#sec-regexp.prototype",
+            "description": "<code>RegExp()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/RegExp",
+            "spec_url": "https://tc39.es/ecma262/#sec-regexp-constructor",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/javascript/builtins/Set.json
+++ b/javascript/builtins/Set.json
@@ -63,6 +63,59 @@
             "deprecated": false
           }
         },
+        "Set": {
+          "__compat": {
+            "description": "<code>Set()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/Set",
+            "spec_url": "https://tc39.es/ecma262/#sec-set-constructor",
+            "support": {
+              "chrome": {
+                "version_added": "38"
+              },
+              "chrome_android": {
+                "version_added": "38"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "13"
+              },
+              "firefox_android": {
+                "version_added": "14"
+              },
+              "ie": {
+                "version_added": "11"
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "25"
+              },
+              "opera_android": {
+                "version_added": "25"
+              },
+              "safari": {
+                "version_added": "8"
+              },
+              "safari_ios": {
+                "version_added": "8"
+              },
+              "samsunginternet_android": {
+                "version_added": "3.0"
+              },
+              "webview_android": {
+                "version_added": "38"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "add": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/add",
@@ -424,59 +477,6 @@
               },
               "safari_ios": {
                 "version_added": "9"
-              },
-              "samsunginternet_android": {
-                "version_added": "3.0"
-              },
-              "webview_android": {
-                "version_added": "38"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "Set": {
-          "__compat": {
-            "description": "<code>Set()</code> constructor",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/Set",
-            "spec_url": "https://tc39.es/ecma262/#sec-set-constructor",
-            "support": {
-              "chrome": {
-                "version_added": "38"
-              },
-              "chrome_android": {
-                "version_added": "38"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "13"
-              },
-              "firefox_android": {
-                "version_added": "14"
-              },
-              "ie": {
-                "version_added": "11"
-              },
-              "nodejs": {
-                "version_added": true
-              },
-              "opera": {
-                "version_added": "25"
-              },
-              "opera_android": {
-                "version_added": "25"
-              },
-              "safari": {
-                "version_added": "8"
-              },
-              "safari_ios": {
-                "version_added": "8"
               },
               "samsunginternet_android": {
                 "version_added": "3.0"

--- a/javascript/builtins/Set.json
+++ b/javascript/builtins/Set.json
@@ -439,10 +439,11 @@
             }
           }
         },
-        "prototype": {
+        "Set": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/prototype",
-            "spec_url": "https://tc39.es/ecma262/#sec-set.prototype",
+            "description": "<code>Set()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/Set",
+            "spec_url": "https://tc39.es/ecma262/#sec-set-constructor",
             "support": {
               "chrome": {
                 "version_added": "38"

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -118,124 +118,6 @@
             "deprecated": false
           }
         },
-        "byteLength": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/byteLength",
-            "spec_url": "https://tc39.es/ecma262/#sec-get-sharedarraybuffer.prototype.bytelength",
-            "support": {
-              "chrome": [
-                {
-                  "version_added": "68"
-                },
-                {
-                  "version_added": "60",
-                  "version_removed": "63",
-                  "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This was a temporary removal while mitigations were put in place."
-                }
-              ],
-              "chrome_android": {
-                "version_added": "60",
-                "version_removed": "63",
-                "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
-              },
-              "edge": {
-                "version_added": "16",
-                "version_removed": "17",
-                "notes": "Support was removed to mitigate <a href='https://blogs.windows.com/msedgedev/2018/01/03/speculative-execution-mitigations-microsoft-edge-internet-explorer'>speculative execution side-channel attacks (Windows blog)</a>."
-              },
-              "firefox": [
-                {
-                  "version_added": "57",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.shared_memory",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
-                },
-                {
-                  "version_added": "55",
-                  "version_removed": "57"
-                },
-                {
-                  "version_added": "46",
-                  "version_removed": "55",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.shared_memory",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "57",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.shared_memory",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
-                },
-                {
-                  "version_added": "55",
-                  "version_removed": "57"
-                },
-                {
-                  "version_added": "46",
-                  "version_removed": "55",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.shared_memory",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "8.10.0"
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": "10.1",
-                "version_removed": "11"
-              },
-              "safari_ios": {
-                "version_added": "10.3",
-                "version_removed": "11"
-              },
-              "samsunginternet_android": {
-                "version_added": false,
-                "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
-              },
-              "webview_android": {
-                "version_added": "60",
-                "version_removed": "63",
-                "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "SharedArrayBuffer": {
           "__compat": {
             "description": "<code>SharedArrayBuffer()</code> constructor",
@@ -323,6 +205,124 @@
               },
               "nodejs": {
                 "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "10.1",
+                "version_removed": "11"
+              },
+              "safari_ios": {
+                "version_added": "10.3",
+                "version_removed": "11"
+              },
+              "samsunginternet_android": {
+                "version_added": false,
+                "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
+              },
+              "webview_android": {
+                "version_added": "60",
+                "version_removed": "63",
+                "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "byteLength": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/byteLength",
+            "spec_url": "https://tc39.es/ecma262/#sec-get-sharedarraybuffer.prototype.bytelength",
+            "support": {
+              "chrome": [
+                {
+                  "version_added": "68"
+                },
+                {
+                  "version_added": "60",
+                  "version_removed": "63",
+                  "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This was a temporary removal while mitigations were put in place."
+                }
+              ],
+              "chrome_android": {
+                "version_added": "60",
+                "version_removed": "63",
+                "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
+              },
+              "edge": {
+                "version_added": "16",
+                "version_removed": "17",
+                "notes": "Support was removed to mitigate <a href='https://blogs.windows.com/msedgedev/2018/01/03/speculative-execution-mitigations-microsoft-edge-internet-explorer'>speculative execution side-channel attacks (Windows blog)</a>."
+              },
+              "firefox": [
+                {
+                  "version_added": "57",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
+                  "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
+                },
+                {
+                  "version_added": "55",
+                  "version_removed": "57"
+                },
+                {
+                  "version_added": "46",
+                  "version_removed": "55",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "57",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ],
+                  "notes": "Support was disabled by default to mitigate <a href='https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/'>speculative execution side-channel attacks (Mozilla Security Blog)</a>."
+                },
+                {
+                  "version_added": "55",
+                  "version_removed": "57"
+                },
+                {
+                  "version_added": "46",
+                  "version_removed": "55",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.shared_memory",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "8.10.0"
               },
               "opera": {
                 "version_added": false

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -236,10 +236,11 @@
             }
           }
         },
-        "prototype": {
+        "SharedArrayBuffer": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/prototype",
-            "spec_url": "https://tc39.es/ecma262/#sec-sharedarraybuffer.prototype",
+            "description": "<code>SharedArrayBuffer()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/SharedArrayBuffer",
+            "spec_url": "https://tc39.es/ecma262/#sec-sharedarraybuffer-constructor",
             "support": {
               "chrome": [
                 {

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -52,6 +52,59 @@
             "deprecated": false
           }
         },
+        "String": {
+          "__compat": {
+            "description": "<code>String()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/String",
+            "spec_url": "https://tc39.es/ecma262/#sec-string-constructor",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": "18"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "3"
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": "1"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0"
+              },
+              "webview_android": {
+                "version_added": "1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "anchor": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/anchor",
@@ -1619,59 +1672,6 @@
               },
               "webview_android": {
                 "version_added": "57"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "String": {
-          "__compat": {
-            "description": "<code>String()</code> constructor",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/String",
-            "spec_url": "https://tc39.es/ecma262/#sec-string-constructor",
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": {
-                "version_added": "18"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "1"
-              },
-              "firefox_android": {
-                "version_added": "4"
-              },
-              "ie": {
-                "version_added": "3"
-              },
-              "nodejs": {
-                "version_added": true
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": "1"
-              },
-              "safari_ios": {
-                "version_added": "1"
-              },
-              "samsunginternet_android": {
-                "version_added": "1.0"
-              },
-              "webview_android": {
-                "version_added": "1"
               }
             },
             "status": {

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -1628,10 +1628,11 @@
             }
           }
         },
-        "prototype": {
+        "String": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/prototype",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.prototype",
+            "description": "<code>String()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/String",
+            "spec_url": "https://tc39.es/ecma262/#sec-string-constructor",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -53,6 +53,59 @@
             "deprecated": false
           }
         },
+        "Symbol": {
+          "__compat": {
+            "description": "<code>Symbol()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/Symbol",
+            "spec_url": "https://tc39.es/ecma262/#sec-symbol-constructor",
+            "support": {
+              "chrome": {
+                "version_added": "38"
+              },
+              "chrome_android": {
+                "version_added": "38"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "36"
+              },
+              "firefox_android": {
+                "version_added": "36"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": true
+              },
+              "opera": {
+                "version_added": "25"
+              },
+              "opera_android": {
+                "version_added": "25"
+              },
+              "safari": {
+                "version_added": "9"
+              },
+              "safari_ios": {
+                "version_added": "9"
+              },
+              "samsunginternet_android": {
+                "version_added": "3.0"
+              },
+              "webview_android": {
+                "version_added": "38"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "asyncIterator": {
           "__compat": {
             "support": {
@@ -535,59 +588,6 @@
               },
               "webview_android": {
                 "version_added": "73"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "Symbol": {
-          "__compat": {
-            "description": "<code>Symbol()</code> constructor",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/Symbol",
-            "spec_url": "https://tc39.es/ecma262/#sec-symbol-constructor",
-            "support": {
-              "chrome": {
-                "version_added": "38"
-              },
-              "chrome_android": {
-                "version_added": "38"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "36"
-              },
-              "firefox_android": {
-                "version_added": "36"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": true
-              },
-              "opera": {
-                "version_added": "25"
-              },
-              "opera_android": {
-                "version_added": "25"
-              },
-              "safari": {
-                "version_added": "9"
-              },
-              "safari_ios": {
-                "version_added": "9"
-              },
-              "samsunginternet_android": {
-                "version_added": "3.0"
-              },
-              "webview_android": {
-                "version_added": "38"
               }
             },
             "status": {

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -544,10 +544,11 @@
             }
           }
         },
-        "prototype": {
+        "Symbol": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/prototype",
-            "spec_url": "https://tc39.es/ecma262/#sec-symbol.prototype",
+            "description": "<code>Symbol()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/Symbol",
+            "spec_url": "https://tc39.es/ecma262/#sec-symbol-constructor",
             "support": {
               "chrome": {
                 "version_added": "38"

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -1532,58 +1532,6 @@
             }
           }
         },
-        "prototype": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/prototype",
-            "spec_url": "https://tc39.es/ecma262/#sec-properties-of-the-%typedarrayprototype%-object",
-            "support": {
-              "chrome": {
-                "version_added": "7"
-              },
-              "chrome_android": {
-                "version_added": "18"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "4"
-              },
-              "firefox_android": {
-                "version_added": "4"
-              },
-              "ie": {
-                "version_added": "10"
-              },
-              "nodejs": {
-                "version_added": true
-              },
-              "opera": {
-                "version_added": "11.6"
-              },
-              "opera_android": {
-                "version_added": "12"
-              },
-              "safari": {
-                "version_added": "5.1"
-              },
-              "safari_ios": {
-                "version_added": "4.2"
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": "4"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "reduce": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/reduce",

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -319,10 +319,11 @@
             }
           }
         },
-        "prototype": {
+        "WeakMap": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/prototype",
-            "spec_url": "https://tc39.es/ecma262/#sec-weakmap.prototype",
+            "description": "<code>WeakMap()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/WeakMap",
+            "spec_url": "https://tc39.es/ecma262/#sec-weakmap-constructor",
             "support": {
               "chrome": {
                 "version_added": "36"

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -63,6 +63,70 @@
             "deprecated": false
           }
         },
+        "WeakMap": {
+          "__compat": {
+            "description": "<code>WeakMap()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/WeakMap",
+            "spec_url": "https://tc39.es/ecma262/#sec-weakmap-constructor",
+            "support": {
+              "chrome": {
+                "version_added": "36"
+              },
+              "chrome_android": {
+                "version_added": "36"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "6"
+              },
+              "firefox_android": {
+                "version_added": "6"
+              },
+              "ie": {
+                "version_added": "11"
+              },
+              "nodejs": [
+                {
+                  "version_added": "0.12"
+                },
+                {
+                  "version_added": "0.10",
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--harmony"
+                    }
+                  ]
+                }
+              ],
+              "opera": {
+                "version_added": "23"
+              },
+              "opera_android": {
+                "version_added": "24"
+              },
+              "safari": {
+                "version_added": "8"
+              },
+              "safari_ios": {
+                "version_added": "8"
+              },
+              "samsunginternet_android": {
+                "version_added": "3.0"
+              },
+              "webview_android": {
+                "version_added": "37"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "clear": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/clear",
@@ -275,70 +339,6 @@
               "firefox_android": {
                 "version_added": "6",
                 "notes": "Prior to Firefox 38, this method threw a <code>TypeError</code> when the key parameter was not an object. This has been fixed in version 38 and later to return <code>false</code> as per the ES2015 standard."
-              },
-              "ie": {
-                "version_added": "11"
-              },
-              "nodejs": [
-                {
-                  "version_added": "0.12"
-                },
-                {
-                  "version_added": "0.10",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
-              "opera": {
-                "version_added": "23"
-              },
-              "opera_android": {
-                "version_added": "24"
-              },
-              "safari": {
-                "version_added": "8"
-              },
-              "safari_ios": {
-                "version_added": "8"
-              },
-              "samsunginternet_android": {
-                "version_added": "3.0"
-              },
-              "webview_android": {
-                "version_added": "37"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "WeakMap": {
-          "__compat": {
-            "description": "<code>WeakMap()</code> constructor",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/WeakMap",
-            "spec_url": "https://tc39.es/ecma262/#sec-weakmap-constructor",
-            "support": {
-              "chrome": {
-                "version_added": "36"
-              },
-              "chrome_android": {
-                "version_added": "36"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "6"
-              },
-              "firefox_android": {
-                "version_added": "6"
               },
               "ie": {
                 "version_added": "11"

--- a/javascript/builtins/WeakSet.json
+++ b/javascript/builtins/WeakSet.json
@@ -267,10 +267,11 @@
             }
           }
         },
-        "prototype": {
+        "WeakSet": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/prototype",
-            "spec_url": "https://tc39.es/ecma262/#sec-weakset.prototype",
+            "description": "<code>WeakSet()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/WeakSet",
+            "spec_url": "https://tc39.es/ecma262/#sec-weakset-constructor",
             "support": {
               "chrome": {
                 "version_added": "36"

--- a/javascript/builtins/WeakSet.json
+++ b/javascript/builtins/WeakSet.json
@@ -52,6 +52,59 @@
             "deprecated": false
           }
         },
+        "WeakSet": {
+          "__compat": {
+            "description": "<code>WeakSet()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/WeakSet",
+            "spec_url": "https://tc39.es/ecma262/#sec-weakset-constructor",
+            "support": {
+              "chrome": {
+                "version_added": "36"
+              },
+              "chrome_android": {
+                "version_added": "36"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "34"
+              },
+              "firefox_android": {
+                "version_added": "34"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "0.12"
+              },
+              "opera": {
+                "version_added": "23"
+              },
+              "opera_android": {
+                "version_added": "24"
+              },
+              "safari": {
+                "version_added": "9"
+              },
+              "safari_ios": {
+                "version_added": "9"
+              },
+              "samsunginternet_android": {
+                "version_added": "3.0"
+              },
+              "webview_android": {
+                "version_added": "37"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "add": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/add",
@@ -219,59 +272,6 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/has",
             "spec_url": "https://tc39.es/ecma262/#sec-weakset.prototype.has",
-            "support": {
-              "chrome": {
-                "version_added": "36"
-              },
-              "chrome_android": {
-                "version_added": "36"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "34"
-              },
-              "firefox_android": {
-                "version_added": "34"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "0.12"
-              },
-              "opera": {
-                "version_added": "23"
-              },
-              "opera_android": {
-                "version_added": "24"
-              },
-              "safari": {
-                "version_added": "9"
-              },
-              "safari_ios": {
-                "version_added": "9"
-              },
-              "samsunginternet_android": {
-                "version_added": "3.0"
-              },
-              "webview_android": {
-                "version_added": "37"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "WeakSet": {
-          "__compat": {
-            "description": "<code>WeakSet()</code> constructor",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/WeakSet",
-            "spec_url": "https://tc39.es/ecma262/#sec-weakset-constructor",
             "support": {
               "chrome": {
                 "version_added": "36"


### PR DESCRIPTION
This is the BCD part of https://github.com/mdn/sprints/issues/2571

It can be reviewed best when looking at the individual commits:

- https://github.com/mdn/browser-compat-data/commit/dcae198ca8c556d3088352eb35884fb1b49495b2 adds two missing constructor descriptions that were forgotten in https://github.com/mdn/browser-compat-data/pull/5440
- https://github.com/mdn/browser-compat-data/commit/c2c48b4781b475bb0b2656947c8e3049d3664876 replaces `prototype` compat entries with constructor entries. There was one case where the notes didn't make any sense for the constructor, but otherwise it should be safe to say that the compat is the same, so just changing the names should be ok.
- https://github.com/mdn/browser-compat-data/commit/1370bedc9877ae6a3cc0406f685fddef2758f731 removes a few prototypes. These objects have no real constructors and I don't think we need to have the prototype pages around either. They add no benefit. For promise, prototype is removed as it already has an entry for the Promise constructor. Here someone wanted to apply the API convention already before we did this project :-)
- https://github.com/mdn/browser-compat-data/commit/cc21d94079f5d378a335ca4fe348a9ca7367bf08 sorts the files using `npm run fix`. I guess this diff not really reviewable, but sorting files alphabetically is required to pass linting.

I have not done this for the `WebAssembly` and `Intl` pages. It will be in follow-up PRs. I hope this is reviewable. If not, please let me know and we can try to split this up differently (while not breaking the build).