### PR TITLE
[Chrome] Bug 1041095: Track `[attr=val s]` implementation

### DIFF
--- a/css/selectors/attribute.json
+++ b/css/selectors/attribute.json
@@ -102,10 +102,12 @@
             "description": "Case-sensitive modifier (<code>s</code>)",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/1041095'>bug 1041095</a>."
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/1041095'>bug 1041095</a>."
               },
               "edge": {
                 "version_added": false
@@ -120,10 +122,12 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/1041095'>bug 1041095</a>."
               },
               "opera_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/1041095'>bug 1041095</a>."
               },
               "qq_android": {
                 "version_added": false
@@ -135,7 +139,8 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/1041095'>bug 1041095</a>."
               },
               "uc_android": {
                 "version_added": false
@@ -144,7 +149,8 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/1041095'>bug 1041095</a>."
               }
             },
             "status": {


### PR DESCRIPTION
**Chromium** has&nbsp;[bug&nbsp;1041095](https://bugs.chromium.org/p/chromium/issues/detail?id=1041095)&nbsp;open to&nbsp;implement&nbsp;this.

---

review?(@jpmedley)