### PR TITLE
Add toggle to the sidebarAction API

### DIFF
--- a/webextensions/api/sidebarAction.json
+++ b/webextensions/api/sidebarAction.json
@@ -46,6 +46,48 @@
             }
           }
         },
+        "getBadgeBackgroundColor": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "30"
+              }
+            }
+          }
+        },
+        "getBadgeText": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "30"
+              }
+            }
+          }
+        },
         "getPanel": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sidebarAction/getPanel",
@@ -158,6 +200,48 @@
             }
           }
         },
+        "onBlur": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "30"
+              }
+            }
+          }
+        },
+        "onFocus": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "30"
+              }
+            }
+          }
+        },
         "open": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sidebarAction/open",
@@ -176,6 +260,48 @@
               },
               "opera": {
                 "version_added": false
+              }
+            }
+          }
+        },
+        "setBadgeBackgroundColor": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "30"
+              }
+            }
+          }
+        },
+        "setBadgeText": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "30"
               }
             }
           }
@@ -377,6 +503,28 @@
                 "opera": {
                   "version_added": false
                 }
+              }
+            }
+          }
+        },
+        "toggle": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/sidebarAction/toggle",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "73"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
               }
             }
           }


### PR DESCRIPTION
See [add sidebar.toggle api](https://bugzilla.mozilla.org/show_bug.cgi?id=1453355).

In addition, added missing API functions and events from the Opera version. See [Opera Sidebar Action API](https://dev.opera.com/extensions/sidebar-action-api/).

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
