### PR TITLE
Remove the incorrect Firefox status for IndexedDB getAll

### DIFF
--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -237,22 +237,10 @@
               "version_added": true
             },
             "firefox": {
-              "version_added": "44",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.indexedDB.experimental"
-                }
-              ]
+              "version_added": "44"
             },
             "firefox_android": {
-              "version_added": "44",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.indexedDB.experimental"
-                }
-              ]
+              "version_added": "44"
             },
             "ie": {
               "version_added": false

--- a/api/IDBObjectStore.json
+++ b/api/IDBObjectStore.json
@@ -769,13 +769,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "44",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.indexedDB.experimental"
-                }
-              ]
+              "version_added": "44"
             },
             "firefox_android": {
               "version_added": "48"


### PR DESCRIPTION
### Summary

The `getAll` method of IndexedDB's IDBIndex and IDBObjectStore interfaces is exposed by default in Firefox 44 so this PR removes the wrong info about an experimental flag. 

### Source

https://bugzilla.mozilla.org/show_bug.cgi?id=1196841

* the browser version (44) in the info block and in the [comment 6](https://bugzilla.mozilla.org/show_bug.cgi?id=1196841#c6) with the final fix
* the [diff of the final fix](https://hg.mozilla.org/mozilla-central/rev/64dbcad7bc6c) linked inside the bugzilla ticket removes the `experimental` tags in WebIDL
* current WebIDL files don't mark getAll as experimental either: [IDBIndex](https://dxr.mozilla.org/mozilla-central/source/dom/webidl/IDBIndex.webidl), [IDBObjectStore](https://dxr.mozilla.org/mozilla-central/source/dom/webidl/IDBObjectStore.webidl)

### Historical trivia

To be precise, it was experimental since [around FF25](https://bugzilla.mozilla.org/show_bug.cgi?id=888597) but that's a different story as it wasn't spec-compliant back then if I read the tickets correctly so for the sake of simplicity let's just assume it's implemented in FF44.