### PR TITLE
Fix javascript spec URLs with broken fragments

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -494,7 +494,7 @@
         "findIndex": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex",
-            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.findIndex",
+            "spec_url": "https://tc39.es/ecma262/#sec-array.prototype.findindex",
             "support": {
               "chrome": {
                 "version_added": "45"

--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -157,7 +157,7 @@
           "compare": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Collator/compare",
-              "spec_url": "https://tc39.es/ecma402/#sec-Intl.Collator.prototype.compare",
+              "spec_url": "https://tc39.es/ecma402/#sec-intl.collator.prototype.compare",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -209,7 +209,7 @@
           "prototype": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Collator/prototype",
-              "spec_url": "https://tc39.es/ecma402/#sec-Intl.Collator.prototype",
+              "spec_url": "https://tc39.es/ecma402/#sec-intl.collator.prototype",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -261,7 +261,7 @@
           "resolvedOptions": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Collator/resolvedOptions",
-              "spec_url": "https://tc39.es/ecma402/#sec-Intl.Collator.prototype.resolvedOptions",
+              "spec_url": "https://tc39.es/ecma402/#sec-intl.collator.prototype.resolvedoptions",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -313,7 +313,7 @@
           "supportedLocalesOf": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Collator/supportedLocalesOf",
-              "spec_url": "https://tc39.es/ecma402/#sec-Intl.Collator.supportedLocalesOf",
+              "spec_url": "https://tc39.es/ecma402/#sec-intl.collator.supportedlocalesof",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -467,7 +467,7 @@
           "format": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/format",
-              "spec_url": "https://tc39.es/ecma402/#sec-Intl.DateTimeFormat.prototype.format",
+              "spec_url": "https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype.format",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -780,7 +780,7 @@
           "prototype": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/prototype",
-              "spec_url": "https://tc39.es/ecma402/#sec-Intl.DateTimeFormat.prototype",
+              "spec_url": "https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -832,7 +832,7 @@
           "resolvedOptions": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/resolvedOptions",
-              "spec_url": "https://tc39.es/ecma402/#sec-Intl.DateTimeFormat.prototype.resolvedOptions",
+              "spec_url": "https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype.resolvedoptions",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -2181,7 +2181,7 @@
           "format": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat/format",
-              "spec_url": "https://tc39.es/ecma402/#sec-Intl.NumberFormat.prototype.format",
+              "spec_url": "https://tc39.es/ecma402/#sec-intl.numberformat.prototype.format",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -2233,7 +2233,7 @@
           "formatToParts": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat/formatToParts",
-              "spec_url": "https://tc39.es/ecma402/#sec-Intl.NumberFormat.prototype.formatToParts",
+              "spec_url": "https://tc39.es/ecma402/#sec-intl.numberformat.prototype.formattoparts",
               "support": {
                 "chrome": {
                   "version_added": "64"
@@ -2285,7 +2285,7 @@
           "prototype": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat/prototype",
-              "spec_url": "https://tc39.es/ecma402/#sec-Intl.NumberFormat.prototype",
+              "spec_url": "https://tc39.es/ecma402/#sec-intl.numberformat.prototype",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -2337,7 +2337,7 @@
           "resolvedOptions": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat/resolvedOptions",
-              "spec_url": "https://tc39.es/ecma402/#sec-Intl.NumberFormat.prototype.resolvedOptions",
+              "spec_url": "https://tc39.es/ecma402/#sec-intl.numberformat.prototype.resolvedoptions",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -2389,7 +2389,7 @@
           "supportedLocalesOf": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat/supportedLocalesOf",
-              "spec_url": "https://tc39.es/ecma402/#sec-Intl.NumberFormat.supportedLocalesOf",
+              "spec_url": "https://tc39.es/ecma402/#sec-intl.numberformat.supportedlocalesof",
               "support": {
                 "chrome": {
                   "version_added": "24"

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -754,7 +754,7 @@
         "fromCharCode": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/fromCharCode",
-            "spec_url": "https://tc39.es/ecma262/#sec-string.fromcharcodes",
+            "spec_url": "https://tc39.es/ecma262/#sec-string.fromcharcode",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -1587,7 +1587,7 @@
         "reduceRight": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/reduceRight",
-            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.reduceRight",
+            "spec_url": "https://tc39.es/ecma262/#sec-%typedarray%.prototype.reduceright",
             "support": {
               "chrome": {
                 "version_added": "45"


### PR DESCRIPTION
This change fixes some spec URLs with broken fragment IDs (in the javascript tree).
