### PR TITLE
Set Safari versions for JavaScript statements

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -152,10 +152,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -204,10 +204,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -372,10 +372,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -424,10 +424,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -478,10 +478,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -627,10 +627,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -680,10 +680,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -826,10 +826,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -998,10 +998,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -1053,10 +1053,10 @@
               "version_added": "25"
             },
             "safari": {
-              "version_added": "8"
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "8"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1103,10 +1103,10 @@
                 "version_added": "46"
               },
               "safari": {
-                "version_added": null
+                "version_added": "7"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": "8.0"
@@ -1154,10 +1154,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "7"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -1207,10 +1207,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1257,10 +1257,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": null
+                "version_added": "10"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10"
               },
               "samsunginternet_android": {
                 "version_added": "7.0"
@@ -1372,10 +1372,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "10"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "10"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -1474,10 +1474,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": null
+                "version_added": "10"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10"
               },
               "samsunginternet_android": {
                 "version_added": "7.0"
@@ -1528,10 +1528,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1899,10 +1899,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -2077,10 +2077,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -2129,10 +2129,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -2181,10 +2181,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -2234,10 +2234,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -2390,10 +2390,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -2442,10 +2442,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -2494,10 +2494,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR sets the Safari versions for various JavaScript statements.  Data is as follows:

javascript.statements.block - 1
javascript.statements.break - 1
javascript.statements.continue - 1
javascript.statements.debugger - 5
javascript.statements.default.switch - 1
javascript.statements.do_while - 1
javascript.statements.empty - 5
javascript.statements.for - 1
javascript.statements.for_in - 7
javascript.statements.for_of - 7 (previously set to "8", but was proven incorrect in my testing)
javascript.statements.for_of.async_iterators - 7
javascript.statements.for_of.closing_iterators - 7
javascript.statements.function - 1
javascript.statements.function.trailing_comma_in_parameters - 10
javascript.statements.generator_function.IteratorResult_object - 10
javascript.statements.generator_function.trailing_comma_in_parameters - 10
javascript.statements.if_else - 1
javascript.statements.label - 1
javascript.statements.return - 1
javascript.statements.switch - 1
javascript.statements.throw - 1
javascript.statements.try_catch - 1
javascript.statements.var - 1
javascript.statements.while - 1
javascript.statements.with - 1