### PR TITLE
Mirror Safari -> Safari iOS for JavaScript

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -1791,14 +1791,14 @@
                 "safari": {
                   "version_added": null
                 },
+                "safari_ios": {
+                  "version_added": null
+                },
                 "samsunginternet_android": {
                   "version_added": "10.0"
                 },
                 "webview_android": {
                   "version_added": "70"
-                },
-                "safari_ios": {
-                  "version_added": null
                 }
               },
               "status": {

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -193,7 +193,7 @@
                 "version_added": "9"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -746,7 +746,7 @@
                 "version_added": "9"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -913,7 +913,7 @@
                 "version_added": "5"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "5"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -1277,7 +1277,7 @@
                 "version_added": "9"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "4.0"
@@ -1796,6 +1796,9 @@
                 },
                 "webview_android": {
                   "version_added": "70"
+                },
+                "safari_ios": {
+                  "version_added": null
                 }
               },
               "status": {

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -193,7 +193,7 @@
                 "version_added": "9"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "9"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -746,7 +746,7 @@
                 "version_added": "9"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "9"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -1277,7 +1277,7 @@
                 "version_added": "9"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "9"
               },
               "samsunginternet_android": {
                 "version_added": "4.0"

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -1182,7 +1182,7 @@
                 "version_added": "4"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "4"
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/javascript/builtins/JSON.json
+++ b/javascript/builtins/JSON.json
@@ -37,7 +37,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -140,7 +140,7 @@
                 "version_added": "4"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "4"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -192,7 +192,7 @@
                 "version_added": "4"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "4"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"

--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -1910,7 +1910,7 @@
                 "version_added": "9"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "9"
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -1910,7 +1910,7 @@
                 "version_added": "9"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -557,7 +557,7 @@
                 "version_added": "9"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "9"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -713,7 +713,7 @@
                 "version_added": "10"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "10"
               },
               "samsunginternet_android": {
                 "version_added": "2.0"

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -557,7 +557,7 @@
                 "version_added": "9"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -713,7 +713,7 @@
                 "version_added": "10"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "2.0"

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -141,7 +141,7 @@
                 "version_added": "9"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "9"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -458,7 +458,7 @@
               },
               "safari_ios": {
                 "version_added": "6",
-                "notes": "Also supported in Safari 5, but not on DOM objects."
+                "notes": "Also supported in Safari for iOS 4.2, but not on DOM objects."
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -897,7 +897,7 @@
                 "version_added": "10"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "10"
               },
               "samsunginternet_android": {
                 "version_added": "6.0"
@@ -1993,7 +1993,7 @@
                 "version_added": "9"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "9"
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -141,7 +141,7 @@
                 "version_added": "9"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -297,7 +297,7 @@
                 "version_added": "5"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "5"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -403,7 +403,7 @@
                 "version_added": "5"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "5"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -457,7 +457,8 @@
                 "notes": "Also supported in Safari 5, but not on DOM objects."
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "6",
+                "notes": "Also supported in Safari 5, but not on DOM objects."
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -677,7 +678,7 @@
                 "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "6"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -833,7 +834,7 @@
                 "version_added": "5"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "5"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -896,7 +897,7 @@
                 "version_added": "10"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "6.0"
@@ -948,7 +949,7 @@
                 "version_added": "5"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "5"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -1052,7 +1053,7 @@
                 "version_added": "5"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "5"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -1208,7 +1209,7 @@
                 "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "6"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -1260,7 +1261,7 @@
                 "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "6"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -1364,7 +1365,7 @@
                 "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "6"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -1416,7 +1417,7 @@
                 "version_added": "5"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "5"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -1732,7 +1733,7 @@
                 "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "6"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -1940,7 +1941,7 @@
                 "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "6"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -1992,7 +1993,7 @@
                 "version_added": "9"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -2989,7 +2989,7 @@
                 "version_added": "5"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "5"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -711,7 +711,7 @@
                 "version_added": "10"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "10"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -711,7 +711,7 @@
                 "version_added": "10"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "5.0"

--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -668,7 +668,7 @@
               "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1114,7 +1114,7 @@
               "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -100,7 +100,7 @@
               "version_added": "9"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -516,7 +516,7 @@
               "version_added": "9"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -724,7 +724,7 @@
               "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -775,7 +775,7 @@
               "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -100,7 +100,7 @@
               "version_added": "9"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -516,7 +516,7 @@
               "version_added": "9"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -724,7 +724,7 @@
               "version_added": "9"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -775,7 +775,7 @@
               "version_added": "9"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -894,7 +894,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "8.0"

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -323,7 +323,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -894,7 +894,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "8.0"


### PR DESCRIPTION
This PR mirrors the remaining JavaScript features from Safari to Safari iOS.