### PR TITLE
removing feature-policy speaker

### DIFF
--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -1337,54 +1337,6 @@
             }
           }
         },
-        "speaker": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/speaker",
-            "support": {
-              "chrome": {
-                "version_added": "60"
-              },
-              "chrome_android": {
-                "version_added": "60"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "48"
-              },
-              "opera_android": {
-                "version_added": "45"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": "8.0"
-              },
-              "webview_android": {
-                "version_added": "60"
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "sync-xhr": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/sync-xhr",


### PR DESCRIPTION
The feature-policy speaker directive has been removed, as per https://github.com/w3c/webappsec-feature-policy/pull/360

We were asked to remove details of speaker, as per https://github.com/mdn/sprints/issues/2675