### PR TITLE
Add Chrome data to DeviceMotion APIs

### DIFF
--- a/api/DeviceMotionEventAcceleration.json
+++ b/api/DeviceMotionEventAcceleration.json
@@ -5,11 +5,18 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceMotionEventAcceleration",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": false
           },
-          "chrome_android": {
-            "version_added": null
-          },
+          "chrome_android": [
+            {
+              "version_added": "74"
+            },
+            {
+              "alternative_name": "DeviceAcceleration",
+              "version_added": "28",
+              "version_removed": "73"
+            }
+          ],
           "edge": {
             "version_added": true
           },
@@ -37,9 +44,16 @@
           "samsunginternet_android": {
             "version_added": null
           },
-          "webview_android": {
-            "version_added": null
-          }
+          "webview_android": [
+            {
+              "version_added": "74"
+            },
+            {
+              "alternative_name": "DeviceAcceleration",
+              "version_added": "28",
+              "version_removed": "73"
+            }
+          ]
         },
         "status": {
           "experimental": true,
@@ -47,15 +61,63 @@
           "deprecated": false
         }
       },
+      "secure_context_required": {
+        "__compat": {
+          "description": "Secure context required",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "28"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "28"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "x": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceMotionEventAcceleration/x",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "28"
             },
             "edge": {
               "version_added": "12"
@@ -85,7 +147,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "28"
             }
           },
           "status": {
@@ -100,10 +162,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceMotionEventAcceleration/y",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "28"
             },
             "edge": {
               "version_added": "12"
@@ -133,7 +195,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "28"
             }
           },
           "status": {
@@ -148,10 +210,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceMotionEventAcceleration/z",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "28"
             },
             "edge": {
               "version_added": "12"
@@ -181,7 +243,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "28"
             }
           },
           "status": {

--- a/api/DeviceMotionEventAcceleration.json
+++ b/api/DeviceMotionEventAcceleration.json
@@ -50,7 +50,7 @@
             },
             {
               "alternative_name": "DeviceAcceleration",
-              "version_added": "28",
+              "version_added": "≤37",
               "version_removed": "73"
             }
           ]
@@ -99,7 +99,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "28"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -147,7 +147,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "28"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -195,7 +195,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "28"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -243,7 +243,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": "28"
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/DeviceMotionEventRotationRate.json
+++ b/api/DeviceMotionEventRotationRate.json
@@ -5,11 +5,18 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceMotionEventRotationRate",
         "support": {
           "chrome": {
-            "version_added": null
+            "version_added": false
           },
-          "chrome_android": {
-            "version_added": null
-          },
+          "chrome_android": [
+            {
+              "version_added": "74"
+            },
+            {
+              "alternative_name": "DeviceRotation",
+              "version_added": "28",
+              "version_removed": "73"
+            }
+          ],
           "edge": {
             "version_added": true
           },
@@ -37,9 +44,16 @@
           "samsunginternet_android": {
             "version_added": null
           },
-          "webview_android": {
-            "version_added": null
-          }
+          "webview_android": [
+            {
+              "version_added": "74"
+            },
+            {
+              "alternative_name": "DeviceAcceleration",
+              "version_added": "≤37",
+              "version_removed": "73"
+            }
+          ]
         },
         "status": {
           "experimental": true,
@@ -52,10 +66,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceMotionEventRotationRate/alpha",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "28"
             },
             "edge": {
               "version_added": "12"
@@ -85,7 +99,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -100,10 +114,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceMotionEventRotationRate/beta",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "28"
             },
             "edge": {
               "version_added": "12"
@@ -133,7 +147,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -148,10 +162,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceMotionEventRotationRate/gamma",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "28"
             },
             "edge": {
               "version_added": "12"
@@ -181,7 +195,55 @@
               "version_added": null
             },
             "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "secure_context_required": {
+        "__compat": {
+          "description": "Secure context required",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "28"
+            },
+            "edge": {
               "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
Amends #5467, and #5468  with Chrome data. 

Name change in 74: https://storage.googleapis.com/chromium-find-releases-static/821.html#821702141fa0373cabc0aaa538fc3783e0753806

Original implementation: https://osscs.corp.google.com/chromium/chromium/src/+/01ac3e5db1c524785ce3c4086db127601629bb0e

Restrict to secure origin: https://osscs.corp.google.com/chromium/chromium/src/+/130ab80784123014a0e205433955f2a0450a85f4