### PR TITLE
Add api.Navigator.presentaion Firefox data

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1590,10 +1590,24 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "51",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.presentation.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "51",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.presentation.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
## Summary
Firefox 51 added support for Presentation API behind a flag, and MDN BCD already reflects it in [most data](https://wiki.developer.mozilla.org/en-US/docs/Web/API/Presentation_API#Browser_compatibility) except for `api.Navigator.presentation`.

## Data
Flag value `dom.presentation.enabled` is taken from [WebIDL](https://github.com/mozilla/gecko-dev/blob/923eec8d2fb8078ebc7a33a9e1ce73eac01f7446/dom/webidl/Navigator.webidl#L290).

A checklist to help your pull request get merged faster:
- [ ] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
