### PR TITLE
Added HTMLFormElement.requestSubmit()

### DIFF
--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -747,7 +747,7 @@
               "version_added": "63"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": false

--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -720,6 +720,55 @@
           }
         }
       },
+      "requestSubmit": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFormElement/requestSubmit",
+          "description": "<code>requestSubmit()</code>",
+          "support": {
+            "chrome": {
+              "version_added": "76"
+            },
+            "chrome_android": {
+              "version_added": "76"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "73"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "63"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "76"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
       "reset": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFormElement/reset",


### PR DESCRIPTION
New method.

* Chrome: https://www.chromestatus.com/feature/6097749495775232
* Edge: https://developer.microsoft.com/en-us/microsoft-edge/platform/catalog/?page=1&q=HTMLFormElement
* Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1552301
* Opera: Looked up the version correlating to Chromium 76 at https://en.wikipedia.org/wiki/History_of_the_Opera_web_browser#Opera_2019
* Safari: Loaded up Safari 13 and found that HTMLFormElement.requestSubmit() isn't present

