### PR TITLE
Firefox: Remove VideoPlaybackQuality.corruptedVideoFrames

### DIFF
--- a/api/VideoPlaybackQuality.json
+++ b/api/VideoPlaybackQuality.json
@@ -67,7 +67,8 @@
             },
             "firefox": [
               {
-                "version_added": "42"
+                "version_added": "42",
+                "version_removed": "73"
               },
               {
                 "version_added": "25",


### PR DESCRIPTION
Obsoleted.

* Spec: https://wicg.github.io/media-playback-quality/#dom-videoplaybackquality-corruptedvideoframes
* Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1602163

All others either still support it as of PR date, or no information
can be found.
