### PR TITLE
Set Safari versions for remaining Intl data

### DIFF
--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -135,10 +135,10 @@
                   "version_added": true
                 },
                 "safari": {
-                  "version_added": true
+                  "version_added": false
                 },
                 "safari_ios": {
-                  "version_added": true
+                  "version_added": false
                 },
                 "samsunginternet_android": {
                   "version_added": "1.5"
@@ -445,10 +445,10 @@
                   "version_added": "54"
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "samsunginternet_android": {
                   "version_added": false
@@ -1015,10 +1015,10 @@
                   "version_added": "54"
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "samsunginternet_android": {
                   "version_added": false


### PR DESCRIPTION
This PR sets the remaining Safari data for the `Intl` features without a real value, based upon manual testing.  All were determined to be unsupported by Safari. 
 (There was also an odd discrepancy where Safari supports `Intl` since version 10, however Chrome supported it since version 24.  Apparently, this data is oddly accurate.)

Part of #4948.