### PR TITLE
Update Origin header data for Firefox 70

### DIFF
--- a/http/headers/origin.json
+++ b/http/headers/origin.json
@@ -17,6 +17,9 @@
             },
             "firefox": [
               {
+                "version_added": "70"
+              },
+              {
                 "version_added": "59",
                 "flags": [
                   {


### PR DESCRIPTION
Firefox 70 switched on the `Origin` header by default, according to [bug 1424076](https://bugzilla.mozilla.org/show_bug.cgi?id=1424076).

This fixes #5470. Thanks to @jakub-g for the original report and details needed to open this PR.