### PR TITLE
Add Safari version for stable-sorted Array

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -1789,10 +1789,10 @@
                   "version_added": null
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": "10.1"
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": "10.3"
                 },
                 "samsunginternet_android": {
                   "version_added": "10.0"


### PR DESCRIPTION
At first, I wasn't sure how to test this, but after some digging around, it turns out [someone has already written a test!](https://mathiasbynens.be/demo/sort-stability)  Running that webpage in multiple versions of Safari, I was able to trace it down to Safari 10.1.  This PR reflects said findings.