### PR TITLE
Add caveat for IE use of createObjectUrl

### DIFF
--- a/api/URL.json
+++ b/api/URL.json
@@ -187,7 +187,8 @@
               "notes": "<code>createObjectURL()</code> is no longer available within the context of a <code>ServiceWorker</code>."
             },
             "ie": {
-              "version_added": "10"
+              "version_added": "10",
+              "notes": "If the underlying object does not have a content type set, using this URL as the <code>src</code> of an <code>img</code> tag fails intermittently with error DOM7009."
             },
             "nodejs": {
               "version_added": false


### PR DESCRIPTION
For instance: https://github.com/mozilla/pdf.js/issues/3977 

When reading a image out of a pdf, the resulting Blob does not have its readonly `type` property set.

As a result, IE11 will only sometimes display the image. I'm as yet unclear why it does not behave predictably; I have had the same file fail or succeed on different runs.

I have confirmed this behavior on IE11 in virtualbox, using the free image from Microsoft.


