### PR TITLE
Set Samsung Internet version for CSS :is selector

### DIFF
--- a/css/selectors/is.json
+++ b/css/selectors/is.json
@@ -171,7 +171,7 @@
               },
               {
                 "alternative_name": ":-webkit-any()",
-                "version_added": true
+                "version_added": "1.0"
               }
             ],
             "webview_android": {


### PR DESCRIPTION
This PR sets the Samsung Internet version for the CSS `:is` selector with the `:-webkit-any()` alternative name based upon the data from Chrome Android.  (This is actually the last data point for Samsung Internet css/ until we reach 100% real values.)