### PR TITLE
test(versions): Fix bug when only one version is a range

### DIFF
--- a/test/linter/test-versions.js
+++ b/test/linter/test-versions.js
@@ -87,20 +87,22 @@ function checkVersions(supportData, relPath, logger) {
             typeof statement.version_added === 'string' &&
             typeof statement.version_removed === 'string'
           ) {
+            const addedIsRange = statement.version_added.startsWith('≤');
+            const removedIsRange = statement.version_removed.startsWith('≤');
+
             if (
-              (statement.version_added.startsWith('≤') &&
-                statement.version_removed.startsWith('≤') &&
+              (addedIsRange &&
+                removedIsRange &&
                 compareVersions.compare(
                   statement.version_added.replace('≤', ''),
                   statement.version_removed.replace('≤', ''),
                   '<',
                 )) ||
-              ((!statement.version_added.startsWith('≤') ||
-                !statement.version_removed.startsWith('≤')) &&
+              ((!addedIsRange || !removedIsRange) &&
                 compareVersions.compare(
                   statement.version_added.replace('≤', ''),
                   statement.version_removed.replace('≤', ''),
-                  '>=',
+                  addedIsRange ? '>' : '>=',
                 ))
             ) {
               logger.error(


### PR DESCRIPTION
Encountered&nbsp;in&nbsp;<https://github.com/mdn/browser-compat-data/pull/5246>.

---

The&nbsp;issue is&nbsp;described in&nbsp;<https://github.com/mdn/browser-compat-data/pull/5246#discussion_r366836209>:

> _\[The&nbsp;linter\]_&nbsp;disallows:
> ```json
> "webview_android": {
>   "version_added": "≤37",
>   "version_removed": "37"
> }
> ```
>
> As&nbsp;it&nbsp;treats it&nbsp;as:
> ```json
> "webview_android": {
>   "version_added": "37",
>   "version_removed": "37"
> }
> ```
>
> Instead&nbsp;of:
> ```json
> "webview_android": {
>   "version_added": true,
>   "version_removed": "37"
> }
> ```
>
> When&nbsp;comparing the&nbsp;two&nbsp;versions to&nbsp;determine&nbsp;whether <code><var>version_added</var>&nbsp;&lt;&nbsp;<var>version_removed</var></code>.
>
> ---
>
> This&nbsp;causes it&nbsp;to&nbsp;be&nbsp;disallowed, even&nbsp;though it’s&nbsp;perfectly&nbsp;valid in&nbsp;my&nbsp;opinion, but&nbsp;I&nbsp;forgot about&nbsp;that&nbsp;edge‑case when&nbsp;writing&nbsp;<https://github.com/mdn/browser-compat-data/pull/3881>, which&nbsp;got&nbsp;merged&nbsp;as&nbsp;<https://github.com/mdn/browser-compat-data/pull/4583>.