### PR TITLE
Feature Policy enabled by default on Firefox 73

### DIFF
--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -108,7 +108,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": "73"
             },
             "firefox_android": {
               "version_added": null

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -112,8 +112,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1572461'>bug 1572461</a>."
+                "version_added": "73"
               },
               "firefox_android": {
                 "version_added": false

--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -14,16 +14,21 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "65",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.security.featurePolicy.header.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "73"
+              },
+              {
+                "version_added": "65",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.featurePolicy.header.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": "65",
               "flags": [
@@ -231,16 +236,21 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.featurePolicy.header.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "73"
+                },
+                {
+                  "version_added": "65",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.security.featurePolicy.header.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": {
                 "version_added": "65",
                 "flags": [
@@ -343,16 +353,21 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.featurePolicy.header.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "73"
+                },
+                {
+                  "version_added": "65",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.security.featurePolicy.header.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": {
                 "version_added": "65",
                 "flags": [
@@ -405,16 +420,21 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "67",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.featurePolicy.header.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "73"
+                },
+                {
+                  "version_added": "67",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.security.featurePolicy.header.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": {
                 "version_added": "67",
                 "flags": [
@@ -467,16 +487,21 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.featurePolicy.header.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "73"
+                },
+                {
+                  "version_added": "65",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.security.featurePolicy.header.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": {
                 "version_added": "65",
                 "flags": [
@@ -529,16 +554,21 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.featurePolicy.header.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "73"
+                },
+                {
+                  "version_added": "65",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.security.featurePolicy.header.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": {
                 "version_added": "65",
                 "flags": [
@@ -591,16 +621,21 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.featurePolicy.header.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "73"
+                },
+                {
+                  "version_added": "65",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.security.featurePolicy.header.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": {
                 "version_added": "65",
                 "flags": [
@@ -653,16 +688,21 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.featurePolicy.header.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "73"
+                },
+                {
+                  "version_added": "65",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.security.featurePolicy.header.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": {
                 "version_added": "65",
                 "flags": [
@@ -991,16 +1031,21 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.featurePolicy.header.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "73"
+                },
+                {
+                  "version_added": "65",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.security.featurePolicy.header.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": {
                 "version_added": "65",
                 "flags": [
@@ -1053,16 +1098,21 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.featurePolicy.header.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "73"
+                },
+                {
+                  "version_added": "65",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.security.featurePolicy.header.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": {
                 "version_added": "65",
                 "flags": [
@@ -1191,16 +1241,21 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.featurePolicy.header.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "73"
+                },
+                {
+                  "version_added": "65",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.security.featurePolicy.header.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": {
                 "version_added": "65",
                 "flags": [


### PR DESCRIPTION
The Feature Policy API is now available by default on Firefox 73,
with both preference enabled and the `<iframe>` element's
`allow` property supported.

Source: https://bugzilla.mozilla.org/show_bug.cgi?id=1600883
