### PR TITLE
Multiple args with add()/remove()

### DIFF
--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -99,10 +99,10 @@
             "description": "Multiple arguments for <code>add()</code>",
             "support": {
               "chrome": {
-                "version_added": "25"
+                "version_added": "24"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "25"
               },
               "edge": {
                 "version_added": "12"
@@ -120,7 +120,7 @@
                 "version_added": "15"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "7"
@@ -129,7 +129,7 @@
                 "version_added": "7"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.5"
               },
               "webview_android": {
                 "version_added": "≤37"
@@ -483,10 +483,10 @@
             "description": "Multiple arguments for <code>remove()</code>",
             "support": {
               "chrome": {
-                "version_added": "25"
+                "version_added": "24"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "25"
               },
               "edge": {
                 "version_added": "12"
@@ -504,7 +504,7 @@
                 "version_added": "15"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "7"
@@ -513,10 +513,10 @@
                 "version_added": "7"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.5"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -93,6 +93,54 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "add_multiple_arguments": {
+          "__compat": {
+            "description": "Multiple arguments for <code>add()</code>",
+            "support": {
+              "chrome": {
+                "version_added": "24"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "26"
+              },
+              "firefox_android": {
+                "version_added": "26"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7"
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "contains": {
@@ -428,6 +476,54 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "remove_multiple_arguments": {
+          "__compat": {
+            "description": "Multiple arguments for <code>remove()</code>",
+            "support": {
+              "chrome": {
+                "version_added": "24"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "26"
+              },
+              "firefox_android": {
+                "version_added": "26"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7"
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -99,7 +99,7 @@
             "description": "Multiple arguments for <code>add()</code>",
             "support": {
               "chrome": {
-                "version_added": "24"
+                "version_added": "25"
               },
               "chrome_android": {
                 "version_added": true
@@ -132,7 +132,7 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {
@@ -483,7 +483,7 @@
             "description": "Multiple arguments for <code>remove()</code>",
             "support": {
               "chrome": {
-                "version_added": "24"
+                "version_added": "25"
               },
               "chrome_android": {
                 "version_added": true


### PR DESCRIPTION
The main page for [classList](https://developer.mozilla.org/en-US/docs/Web/API/Element/classList) includes compat info for using multiple arguments with `add()` and `remove()`, but the individual articles for [add()](https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList/add) and [remove()](https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList/remove) don't include this info. This adds the missing compat info to those pages too.