### PR TITLE
Set real values for Opera CSS @rules

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -659,10 +659,10 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "3.2"

--- a/css/at-rules/import.json
+++ b/css/at-rules/import.json
@@ -25,10 +25,10 @@
               "version_added": "5.5"
             },
             "opera": {
-              "version_added": true
+              "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -171,10 +171,10 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "10"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "4.1"
@@ -269,10 +269,10 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "10"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3"
@@ -416,10 +416,10 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "10"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3"
@@ -465,10 +465,10 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "10"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3"
@@ -514,10 +514,10 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "10"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3"
@@ -614,10 +614,10 @@
                 "version_added": "10"
               },
               "opera": {
-                "version_added": true
+                "version_added": "10"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3"
@@ -663,10 +663,10 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "10"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3"
@@ -957,10 +957,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "10"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3"
@@ -1006,10 +1006,10 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "10.6"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "11"
               },
               "safari": {
                 "version_added": "4.1"
@@ -1578,10 +1578,10 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "10"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3"
@@ -1678,11 +1678,11 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true,
+                "version_added": "15",
                 "version_removed": "23"
               },
               "opera_android": {
-                "version_added": true,
+                "version_added": "14",
                 "version_removed": "24"
               },
               "safari": {
@@ -1791,10 +1791,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "3"
@@ -1900,10 +1900,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "3"
@@ -2009,10 +2009,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "3"
@@ -2060,11 +2060,11 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true,
+                "version_added": "15",
                 "version_removed": "23"
               },
               "opera_android": {
-                "version_added": true,
+                "version_added": "14",
                 "version_removed": "24"
               },
               "safari": {
@@ -2139,11 +2139,11 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true,
+                "version_added": "15",
                 "version_removed": "23"
               },
               "opera_android": {
-                "version_added": true,
+                "version_added": "14",
                 "version_removed": "24"
               },
               "safari": {
@@ -2194,11 +2194,11 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true,
+                "version_added": "15",
                 "version_removed": "23"
               },
               "opera_android": {
-                "version_added": true,
+                "version_added": "14",
                 "version_removed": "24"
               },
               "safari": {


### PR DESCRIPTION
This PR sets the version numbers for various CSS @rules for Opera and Opera Android, based upon manual testing.  This is a part of a personal project to eliminate as many true/null values as we can, as well as eliminate any inaccurate statements that are marked as Opera 15 (#5138 also plans to help with that).

The versions are as follows:

css.at-rules.font-face.unicode-range - Blink
css.at-rules.import - 3.5
css.at-rules.media.aspect-ratio - 10
css.at-rules.media.color - 10
css.at-rules.media.device-aspect-ratio - 10
css.at-rules.media.device-height - 10
css.at-rules.media.device-width - 10
css.at-rules.media.grid - 10
css.at-rules.media.height - 10
css.at-rules.media.monochrome - 10
css.at-rules.media.orientation - 10.6
css.at-rules.media.width - 10
css.at-rules.media.-webkit-animation - Blink
css.at-rules.media.-webkit-device-pixel-ratio - Blink
css.at-rules.media.-webkit-max-device-pixel-ratio - Blink
css.at-rules.media.-webkit-min-device-pixel-ratio - Blink
css.at-rules.media.-webkit-transform-2d - Blink
css.at-rules.media.-webkit-transform-3d - Blink
css.at-rules.media.-webkit-transition - Blink