### PR TITLE
Fix spec URLs for ArrayBuffer and DataView

### DIFF
--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -4,7 +4,7 @@
       "ArrayBuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer",
-          "spec_url": "https://tc39.es/ecma262/#sec-arraybuffer-constructor",
+          "spec_url": "https://tc39.es/ecma262/#sec-arraybuffer-objects",
           "support": {
             "chrome": {
               "version_added": "7"

--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -4,7 +4,7 @@
       "DataView": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView",
-          "spec_url": "https://tc39.es/ecma262/#sec-dataview-constructor",
+          "spec_url": "https://tc39.es/ecma262/#sec-dataview-objects",
           "support": {
             "chrome": {
               "version_added": "9"


### PR DESCRIPTION
The existing spec URLs in BCD for the ArrayBuffer and DataView object incorrectly linked to the spec section for the constructors for those objects. This change changes the spec URLs to link to the spec sections for the objects themselves.