### PR TITLE
Mark execCommand etc as deprecated & non-standard

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -3777,8 +3777,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         },
         "ClearAuthenticationCache": {
@@ -8538,8 +8538,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -8634,8 +8634,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -8696,8 +8696,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
This change marks the following as deprecated & non-standard:

* `document.execCommand()`
* `document.queryCommandEnabled()`
* `document.queryCommandState()`
* `document.queryCommandSupported()`

None are defined in any specification that is on the standards track.
Instead, https://w3c.github.io/editing/execCommand.html documents them,
but has a big red warning with the following text:

> This spec is incomplete and it is not expected that it will advance beyond draft status. Authors should not use most of these features directly, but instead use JavaScript editing libraries. The features described in this document are not implemented consistently or fully by user agents, and it is not expected that this will change in the foreseeable future.