### PR TITLE
Deprecate feature-policy: vibrate

### DIFF
--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -1645,10 +1645,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/vibrate",
             "support": {
               "chrome": {
-                "version_added": "60"
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": "60"
+                "version_added": false
               },
               "edge": {
                 "version_added": false
@@ -1663,10 +1663,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "47"
+                "version_added": false
               },
               "opera_android": {
-                "version_added": "44"
+                "version_added": false
               },
               "safari": {
                 "version_added": false
@@ -1675,16 +1675,16 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": "8.0"
+                "version_added": false
               },
               "webview_android": {
-                "version_added": "60"
+                "version_added": false
               }
             },
             "status": {
               "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+              "standard_track": false,
+              "deprecated": true
             }
           }
         },


### PR DESCRIPTION
`vibrate` appears to have only ever been an example in a spec, but never actually specified or implemented.

Read https://github.com/w3c/webappsec-feature-policy/issues/263 for details (and shout out to @Malvoz for raising this in #5299).