### PR TITLE
Add Edge v79 support of prefers-color-scheme

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1190,7 +1190,7 @@
                 "version_added": "76"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "67"


### PR DESCRIPTION
Added support by Edge on version 79 of prefers-color-scheme

- Added support of MS Edge v79 of prefers-color-scheme  now that they use Chromium as backend
- Test: I made a test using version 79.0.309.68 on Win10 19.09 and MacOS 10.15.2 https://dark-mode-baseline.glitch.me/ https://kevinchen.co/blog/support-macos-mojave-dark-mode-on-websites/