### PR TITLE
Updated Object rest/spread for Edge 79

### DIFF
--- a/javascript/operators/destructuring.json
+++ b/javascript/operators/destructuring.json
@@ -174,7 +174,7 @@
                 "version_added": "60"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79" 
               },
               "firefox": {
                 "version_added": "55"

--- a/javascript/operators/spread.json
+++ b/javascript/operators/spread.json
@@ -191,7 +191,7 @@
                 "version_added": "60"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "55"


### PR DESCRIPTION
Updated JavaScript operators Object Rest and Object Spread to reflect the Chromium-based Edge 79 status.

Official platform status can be found here:
https://developer.microsoft.com/en-us/microsoft-edge/status/objectrestspreadproperties/?q=object%20rest%20spread