### PR TITLE
Remove 'stop' member from AudioBufferSourceNode

### DIFF
--- a/api/AudioBufferSourceNode.json
+++ b/api/AudioBufferSourceNode.json
@@ -488,56 +488,6 @@
             "deprecated": false
           }
         }
-      },
-      "stop": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioBufferSourceNode/stop",
-          "support": {
-            "chrome": {
-              "version_added": "14"
-            },
-            "chrome_android": {
-              "version_added": "18"
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": true,
-              "version_removed": "44"
-            },
-            "opera_android": {
-              "version_added": true,
-              "version_removed": "43"
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": "1.0"
-            },
-            "webview_android": {
-              "version_added": true
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
The `AudioBufferSourceNode` interface actually has no `stop` member. See https://webaudio.github.io/web-audio-api/#ref-for-AudioBufferSourceNode%E2%91%A0%E2%91%A3

https://developer.mozilla.org/docs/Web/API/AudioBufferSourceNode/stop redirects to https://developer.mozilla.org/en-US/docs/Web/API/AudioScheduledSourceNode/stop