### PR TITLE
Set real values for Opera CSS selectors

### DIFF
--- a/css/selectors/adjacent_sibling.json
+++ b/css/selectors/adjacent_sibling.json
@@ -29,10 +29,10 @@
               ]
             },
             "opera": {
-              "version_added": true
+              "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/selectors/child.json
+++ b/css/selectors/child.json
@@ -25,10 +25,10 @@
               "version_added": "7"
             },
             "opera": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/selectors/class.json
+++ b/css/selectors/class.json
@@ -25,10 +25,10 @@
               "version_added": "3"
             },
             "opera": {
-              "version_added": true
+              "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/selectors/descendant.json
+++ b/css/selectors/descendant.json
@@ -37,10 +37,10 @@
               "version_added": "3"
             },
             "opera": {
-              "version_added": true
+              "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/selectors/hover.json
+++ b/css/selectors/hover.json
@@ -174,10 +174,10 @@
                 "version_added": "11"
               },
               "opera": {
-                "version_added": null
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "2"

--- a/css/selectors/hover.json
+++ b/css/selectors/hover.json
@@ -28,7 +28,7 @@
               "version_added": "4"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "2"
@@ -76,7 +76,7 @@
                 "version_added": "4"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "2"
@@ -129,7 +129,7 @@
                 "version_added": "7"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "2"

--- a/css/selectors/id.json
+++ b/css/selectors/id.json
@@ -25,10 +25,10 @@
               "version_added": "3"
             },
             "opera": {
-              "version_added": true
+              "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/selectors/indeterminate.json
+++ b/css/selectors/indeterminate.json
@@ -25,10 +25,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"

--- a/css/selectors/is.json
+++ b/css/selectors/is.json
@@ -105,7 +105,7 @@
                 "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
               },
               {
-                "version_added": true,
+                "version_added": "15",
                 "alternative_name": ":-webkit-any()",
                 "notes": "Doesn't support combinators."
               }
@@ -136,7 +136,7 @@
                 "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
               },
               {
-                "version_added": true,
+                "version_added": "14",
                 "alternative_name": ":-webkit-any()",
                 "notes": "Doesn't support combinators."
               }

--- a/css/selectors/list.json
+++ b/css/selectors/list.json
@@ -25,10 +25,10 @@
               "version_added": "3"
             },
             "opera": {
-              "version_added": true
+              "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/selectors/read-only.json
+++ b/css/selectors/read-only.json
@@ -29,10 +29,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "4"

--- a/css/selectors/read-write.json
+++ b/css/selectors/read-write.json
@@ -29,10 +29,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "4"

--- a/css/selectors/right.json
+++ b/css/selectors/right.json
@@ -25,12 +25,10 @@
               "version_added": "8"
             },
             "opera": {
-              "version_added": "9.2",
-              "version_removed": "15"
+              "version_added": "9.2"
             },
             "opera_android": {
-              "version_added": "10.1",
-              "version_removed": "14"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "5.1"

--- a/css/selectors/type.json
+++ b/css/selectors/type.json
@@ -25,10 +25,10 @@
               "version_added": "3"
             },
             "opera": {
-              "version_added": true
+              "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/selectors/universal.json
+++ b/css/selectors/universal.json
@@ -25,10 +25,10 @@
               "version_added": "7"
             },
             "opera": {
-              "version_added": true
+              "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"


### PR DESCRIPTION
This PR sets real values for various CSS selectors for Opera (when Opera was set to `true`, `null`, or `15`) based upon manual testing.  Data is as follows:

css.selectors.adjacent_sibling - 3.5
css.selectors.child - 4
css.selectors.class - 3.5
css.selectors.descendant - 3.5
css.selectors.hover - 4
css.selectors.hover.pseudo_elements - Blink
css.selectors.id - 3.5
css.selectors.indeterminate - 9
css.selectors.is (as :-webkit-any()) - Blink
css.selectors.list - 3.5
css.selectors.read-only - 9
css.selectors.read-write - 9
css.selectors.type - 3.5
css.selectors.universal - 3.5
css.selectors.right - set to "false" even though Chrome supports it