### PR TITLE
Safari does not support "DataTransfer() constructor".

### DIFF
--- a/api/DataTransfer.json
+++ b/api/DataTransfer.json
@@ -78,7 +78,7 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
I manually tested it on Safari 13.0.4 by calling "new DataTransfer()" in the console.

Output:
```
TypeError: function is not a constructor (evaluating 'new DataTransfer()')
```