### PR TITLE
Set real values for Opera CSS types

### DIFF
--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -242,12 +242,12 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true,
+                "version_added": "33",
                 "partial_implementation": true,
                 "notes": "Only supported on the <code>offset-path</code> property."
               },
               "opera_android": {
-                "version_added": true,
+                "version_added": "33",
                 "partial_implementation": true,
                 "notes": "Only supported on the <code>offset-path</code> property."
               },

--- a/css/types/counter.json
+++ b/css/types/counter.json
@@ -25,10 +25,10 @@
               "version_added": "8"
             },
             "opera": {
-              "version_added": true
+              "version_added": "9.2"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"

--- a/css/types/dimension.json
+++ b/css/types/dimension.json
@@ -25,10 +25,10 @@
               "version_added": "5"
             },
             "opera": {
-              "version_added": true
+              "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/types/global_keywords.json
+++ b/css/types/global_keywords.json
@@ -24,10 +24,10 @@
               "version_added": "3"
             },
             "opera": {
-              "version_added": true
+              "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -234,10 +234,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "28"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "28"
               },
               "safari": {
                 "version_added": "9.1"

--- a/css/types/integer.json
+++ b/css/types/integer.json
@@ -25,10 +25,10 @@
               "version_added": "3"
             },
             "opera": {
-              "version_added": true
+              "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/types/percentage.json
+++ b/css/types/percentage.json
@@ -25,10 +25,10 @@
               "version_added": "3"
             },
             "opera": {
-              "version_added": true
+              "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/css/types/resolution.json
+++ b/css/types/resolution.json
@@ -256,10 +256,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "55"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "48"
               },
               "safari": {
                 "version_added": false

--- a/css/types/string.json
+++ b/css/types/string.json
@@ -25,10 +25,10 @@
               "version_added": "3"
             },
             "opera": {
-              "version_added": true
+              "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -72,10 +72,10 @@
                 "version_added": "6"
               },
               "opera": {
-                "version_added": true
+                "version_added": "7"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"


### PR DESCRIPTION
This PR sets real values for CSS types for Opera when Opera is set to `true` or `null`.  Data is as follows:

css.types.basic-shape.path - Blink
css.types.counter - 9.2
css.types.dimension - 3.5
css.types.global_keywords - 3.5
css.types.global_keywords.unset - Blink
css.types.integer - 3.5
css.types.percentage - 3.5
css.types.resolution.x - Blink
css.types.string - 3.5
css.types.string.unicode_escaped_characters - 7

(I've never actually figured out how to "test" CSS types to be honest.  I've based these values off of the CSS properties that require said types, or just base it off of Chrome.)