### PR TITLE
Safari requires prefix for box-decoration-break

### DIFF
--- a/css/properties/box-decoration-break.json
+++ b/css/properties/box-decoration-break.json
@@ -63,10 +63,12 @@
             ],
             "safari": {
               "version_added": "6.1",
+              "prefix": "-webkit-",
               "notes": "This property is only supported for inline elements."
             },
             "safari_ios": {
               "version_added": "7",
+              "prefix": "-webkit-",
               "notes": "This property is only supported for inline elements."
             },
             "samsunginternet_android": {


### PR DESCRIPTION
Fixes #5330.  Safari requires a `-webkit-` prefix for the `box-decoration-break` property, confirmed by both mirroring from Chrome and manual testing with Safari 13.