### PR TITLE
Add CSS properties for IE 10 Grid syntax

### DIFF
--- a/css/properties/-ms-grid-column-align.json
+++ b/css/properties/-ms-grid-column-align.json
@@ -3,7 +3,6 @@
     "properties": {
       "-ms-grid-column-align": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-ms-grid-column-align",
           "support": {
             "chrome": {
               "version_added": false

--- a/css/properties/-ms-grid-column-align.json
+++ b/css/properties/-ms-grid-column-align.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "properties": {
+      "-ms-grid-column-align": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-ms-grid-column-align",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "12",
+              "version_removed": "16"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/-ms-grid-column-span.json
+++ b/css/properties/-ms-grid-column-span.json
@@ -3,7 +3,6 @@
     "properties": {
       "-ms-grid-column-span": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-ms-grid-column-span",
           "support": {
             "chrome": {
               "version_added": false

--- a/css/properties/-ms-grid-column-span.json
+++ b/css/properties/-ms-grid-column-span.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "properties": {
+      "-ms-grid-column-span": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-ms-grid-column-span",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "12",
+              "version_removed": "16"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/-ms-grid-column.json
+++ b/css/properties/-ms-grid-column.json
@@ -3,7 +3,6 @@
     "properties": {
       "-ms-grid-column": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-ms-grid-column",
           "support": {
             "chrome": {
               "version_added": false

--- a/css/properties/-ms-grid-column.json
+++ b/css/properties/-ms-grid-column.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "properties": {
+      "-ms-grid-column": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-ms-grid-column",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "12",
+              "version_removed": "16"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/-ms-grid-columns.json
+++ b/css/properties/-ms-grid-columns.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "properties": {
+      "-ms-grid-columns": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-ms-grid-columns",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "12",
+              "version_removed": "16"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/-ms-grid-columns.json
+++ b/css/properties/-ms-grid-columns.json
@@ -3,7 +3,6 @@
     "properties": {
       "-ms-grid-columns": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-ms-grid-columns",
           "support": {
             "chrome": {
               "version_added": false

--- a/css/properties/-ms-grid-row-align.json
+++ b/css/properties/-ms-grid-row-align.json
@@ -3,7 +3,6 @@
     "properties": {
       "-ms-grid-row-align": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-ms-grid-row-align",
           "support": {
             "chrome": {
               "version_added": false

--- a/css/properties/-ms-grid-row-align.json
+++ b/css/properties/-ms-grid-row-align.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "properties": {
+      "-ms-grid-row-align": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-ms-grid-row-align",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "12",
+              "version_removed": "16"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/-ms-grid-row-span.json
+++ b/css/properties/-ms-grid-row-span.json
@@ -3,7 +3,6 @@
     "properties": {
       "-ms-grid-row-span": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-ms-grid-row-span",
           "support": {
             "chrome": {
               "version_added": false

--- a/css/properties/-ms-grid-row-span.json
+++ b/css/properties/-ms-grid-row-span.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "properties": {
+      "-ms-grid-row-span": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-ms-grid-row-span",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "12",
+              "version_removed": "16"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/-ms-grid-row.json
+++ b/css/properties/-ms-grid-row.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "properties": {
+      "-ms-grid-row": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-ms-grid-row",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "12",
+              "version_removed": "16"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/-ms-grid-row.json
+++ b/css/properties/-ms-grid-row.json
@@ -3,7 +3,6 @@
     "properties": {
       "-ms-grid-row": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-ms-grid-row",
           "support": {
             "chrome": {
               "version_added": false

--- a/css/properties/-ms-grid-rows.json
+++ b/css/properties/-ms-grid-rows.json
@@ -1,0 +1,55 @@
+{
+  "css": {
+    "properties": {
+      "-ms-grid-rows": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-ms-grid-rows",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "12",
+              "version_removed": "16"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/-ms-grid-rows.json
+++ b/css/properties/-ms-grid-rows.json
@@ -3,7 +3,6 @@
     "properties": {
       "-ms-grid-rows": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-ms-grid-rows",
           "support": {
             "chrome": {
               "version_added": false


### PR DESCRIPTION
This PR is an attempt to resolve #3031 by adding JSON files for all of the `-ms-` prefixed grid properties implemented in Internet Explorer 10.  Rather than attempting to modify the data in the existing grid properties, since they are more in reference to the newer spec, I figured creating new files would be more reasonable, since there's enough differences between the specs.