### PR TITLE
Mirror Safari -> Safari iOS for api/FormData.json

### DIFF
--- a/api/FormData.json
+++ b/api/FormData.json
@@ -33,7 +33,7 @@
             "version_added": "5"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "5"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -82,7 +82,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -130,7 +130,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -181,7 +181,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -229,7 +229,7 @@
                 "version_added": "9"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "9"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -326,7 +326,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -518,7 +518,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -566,7 +566,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -614,7 +614,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "5.0"


### PR DESCRIPTION
Fixes #5517 by performing a quick data mirror from Safari Desktop to Safari iOS.