### PR TITLE
Fix compatibility data for Navigator.cookieEnabled

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -478,10 +478,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/cookieEnabled",
           "support": {
             "chrome": {
-              "version_added": "59"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "59"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -504,16 +504,16 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": "59"
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
Fixes #5508.  It was found that `Navigator.cookieEnabled` was actually supported since Safari 1.0.