### PR TITLE
Mirror Chrome -> Opera for api/HTMLHyperlinkElementUtils.json

### DIFF
--- a/api/HTMLHyperlinkElementUtils.json
+++ b/api/HTMLHyperlinkElementUtils.json
@@ -33,10 +33,12 @@
             "version_added": "5"
           },
           "opera": {
-            "version_added": false
+            "version_added": true,
+            "notes": "Starting in Opera 39, the members of this interface were moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": true,
+            "notes": "Starting in Opera 39, the members of this interface were moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
           },
           "safari": {
             "version_added": true
@@ -86,10 +88,12 @@
               "version_added": "5"
             },
             "opera": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
               "version_added": true
@@ -141,10 +145,12 @@
               "notes": "In Internet Explorer 9, the host of an <a href='https://developer.mozilla.org/docs/Web/HTML/Element/a'><code><a></code></a> always include the port (e.g. <code>developer.mozilla.org:443</code>), even if there is no explicit port in the <code>href</code> attribute value."
             },
             "opera": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
               "version_added": true
@@ -195,10 +201,12 @@
               "version_added": "5"
             },
             "opera": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
               "version_added": true
@@ -249,10 +257,12 @@
               "version_added": "5"
             },
             "opera": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
               "version_added": true
@@ -309,10 +319,12 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
               "version_added": true
@@ -363,10 +375,12 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
               "version_added": true
@@ -423,10 +437,12 @@
               "version_added": "5"
             },
             "opera": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
               "version_added": true
@@ -477,10 +493,12 @@
               "version_added": "5"
             },
             "opera": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
               "version_added": true
@@ -531,10 +549,12 @@
               "version_added": "5"
             },
             "opera": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
               "version_added": true
@@ -591,10 +611,12 @@
               "version_added": "5"
             },
             "opera": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
               "version_added": true
@@ -643,10 +665,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": true
@@ -695,10 +717,12 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Starting in Opera 39, this property was moved to <a href='https://developer.mozilla.org/docs/Web/API/URL'>URL</a>"
             },
             "safari": {
               "version_added": true


### PR DESCRIPTION
This PR fixes #5159 by mirroring all of the Chrome data to Opera.