### PR TITLE
Fix WebAssembly spec_url values w/ broken fragment

### DIFF
--- a/javascript/builtins/WebAssembly.json
+++ b/javascript/builtins/WebAssembly.json
@@ -321,7 +321,7 @@
           "exports": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance/exports",
-              "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblyinstance-objects",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#instance",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -375,7 +375,7 @@
           "prototype": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance/prototype",
-              "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblymodule-objects",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#module",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -540,7 +540,7 @@
           "buffer": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/buffer",
-              "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblymemoryprototypebuffer",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#dom-memory-buffer",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -594,7 +594,7 @@
           "grow": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/grow",
-              "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblymemoryprototypegrow",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#dom-memory-grow",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -648,7 +648,7 @@
           "prototype": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/prototype",
-              "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblymemory-objects",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#memory",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -756,7 +756,7 @@
           "customSections": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/customSections",
-              "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblymodulecustomsections",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#dom-module-customsections",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -810,7 +810,7 @@
           "exports": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/exports",
-              "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblymoduleexports",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#dom-module-exports",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -864,7 +864,7 @@
           "imports": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/imports",
-              "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblymoduleimports",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#dom-module-imports",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -1083,7 +1083,7 @@
           "get": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/get",
-              "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblytableprototypeget",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#dom-table-get",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -1137,7 +1137,7 @@
           "grow": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/grow",
-              "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblytableprototypegrow",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#dom-table-grow",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -1191,7 +1191,7 @@
           "length": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/length",
-              "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblytableprototypelength",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#dom-table-length",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -1245,7 +1245,7 @@
           "prototype": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/prototype",
-              "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblytable-objects",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#table",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -1299,7 +1299,7 @@
           "set": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/set",
-              "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblytableprototypeset",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#dom-table-set",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -1354,7 +1354,7 @@
         "compile": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/compile",
-            "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblycompile",
+            "spec_url": "https://webassembly.github.io/spec/js-api/#dom-webassembly-compile",
             "support": {
               "chrome": {
                 "version_added": "57"
@@ -1460,7 +1460,7 @@
         "instantiate": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiate",
-            "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblyinstantiate",
+            "spec_url": "https://webassembly.github.io/spec/js-api/#dom-webassembly-instantiate",
             "support": {
               "chrome": {
                 "version_added": "57"
@@ -1566,7 +1566,7 @@
         "validate": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/validate",
-            "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblyvalidate",
+            "spec_url": "https://webassembly.github.io/spec/js-api/#dom-webassembly-validate",
             "support": {
               "chrome": {
                 "version_added": "57"

--- a/javascript/builtins/WebAssembly.json
+++ b/javascript/builtins/WebAssembly.json
@@ -4,7 +4,7 @@
       "WebAssembly": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly",
-          "spec_url": "https://webassembly.github.io/spec/js-api/#the-webassembly-object",
+          "spec_url": "https://webassembly.github.io/spec/js-api/#webassembly-namespace",
           "support": {
             "chrome": {
               "version_added": "57"
@@ -58,7 +58,7 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/CompileError",
             "spec_url": [
-              "https://webassembly.github.io/spec/js-api/#constructor-properties-of-the-webassembly-object",
+              "https://webassembly.github.io/spec/js-api/#exceptiondef-compileerror",
               "https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard"
             ],
             "support": {
@@ -268,7 +268,7 @@
         "Instance": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance",
-            "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblyinstance-objects",
+            "spec_url": "https://webassembly.github.io/spec/js-api/#instances",
             "support": {
               "chrome": {
                 "version_added": "57"
@@ -321,7 +321,7 @@
           "exports": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance/exports",
-              "spec_url": "https://webassembly.github.io/spec/js-api/#instance",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#dom-instance-exports",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -375,7 +375,7 @@
           "prototype": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance/prototype",
-              "spec_url": "https://webassembly.github.io/spec/js-api/#module",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#instance",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -431,7 +431,7 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/LinkError",
             "spec_url": [
-              "https://webassembly.github.io/spec/js-api/#constructor-properties-of-the-webassembly-object",
+              "https://webassembly.github.io/spec/js-api/#exceptiondef-linkerror",
               "https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard"
             ],
             "support": {
@@ -487,7 +487,7 @@
         "Memory": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory",
-            "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblymemory-objects",
+            "spec_url": "https://webassembly.github.io/spec/js-api/#memories",
             "support": {
               "chrome": {
                 "version_added": "57"
@@ -703,7 +703,7 @@
         "Module": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module",
-            "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblymodule-objects",
+            "spec_url": "https://webassembly.github.io/spec/js-api/#modules",
             "support": {
               "chrome": {
                 "version_added": "57"
@@ -918,7 +918,7 @@
           "prototype": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/prototype",
-              "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblymodule-objects",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#module",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -974,7 +974,7 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/RuntimeError",
             "spec_url": [
-              "https://webassembly.github.io/spec/js-api/#constructor-properties-of-the-webassembly-object",
+              "https://webassembly.github.io/spec/js-api/#exceptiondef-runtimeerror",
               "https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard"
             ],
             "support": {
@@ -1030,7 +1030,7 @@
         "Table": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table",
-            "spec_url": "https://webassembly.github.io/spec/js-api/#webassemblytable-objects",
+            "spec_url": "https://webassembly.github.io/spec/js-api/#tables",
             "support": {
               "chrome": {
                 "version_added": "57"


### PR DESCRIPTION
This change fixes the data for several WebAssembly features that had `spec_url` values with broken fragment IDs.