### PR TITLE
Update MutationObserverInit.attributeFilter on IE11 usage known issue

### DIFF
--- a/api/MutationObserverInit.json
+++ b/api/MutationObserverInit.json
@@ -114,7 +114,7 @@
             },
             "ie": {
               "version_added": "11",
-              "notes": "On IE11 using <code>attributeFilter</code> without setting <code>attributes: true</code> will throw a syntax error."
+              "notes": "Internet Explorer requires <code>attributes: true</code> when using <code>attributeFilter</code>.  If <code>attributes: true</code> is not present, Internet Explorer will throw a syntax error."
             },
             "opera": {
               "version_added": "15"

--- a/api/MutationObserverInit.json
+++ b/api/MutationObserverInit.json
@@ -185,7 +185,8 @@
               }
             ],
             "edge": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Microsoft Edge (EdgeHTML) requires <code>attributes: true</code> when using <code>attributeFilter</code>. If <code>attributes: true</code> is not present, Edge will throw a syntax error. This behavior is not present in Chromium based editions of Edge."
             },
             "firefox": {
               "version_added": "14",

--- a/api/MutationObserverInit.json
+++ b/api/MutationObserverInit.json
@@ -113,7 +113,8 @@
               "version_added": "14"
             },
             "ie": {
-              "version_added": "11"
+              "version_added": "11",
+              "notes": "On IE11 using <code>attributeFilter</code> without setting <code>attributes: true</code> will throw a syntax error."
             },
             "opera": {
               "version_added": "15"

--- a/api/MutationObserverInit.json
+++ b/api/MutationObserverInit.json
@@ -185,7 +185,7 @@
               }
             ],
             "edge": {
-              "version_added": true,
+              "version_added": "12",
               "notes": "Microsoft Edge (EdgeHTML) requires <code>attributes: true</code> when using <code>attributeFilter</code>. If <code>attributes: true</code> is not present, Edge will throw a syntax error. This behavior is not present in Chromium based editions of Edge."
             },
             "firefox": {


### PR DESCRIPTION
# Summary
When using `attributeFilter` with `MutationObserverInit` API for IE11 a syntax error is thrown if one does not provide the property `attributes` with the value `true`.

# Resources to support the information
1. My painful experience facing this issue in production.
2. [MutationObserver syntax error on IE11 (stackoverflow)](https://stackoverflow.com/questions/50593385/mutationobserver-syntax-error-on-ie-11)
3. [Pull Request in ampproject addressing this same issue (github)](https://github.com/ampproject/amphtml/pull/23328/files)

# How to test
1. Use `MutationObserver` with `attributeFilter`.
2. See that syntax error is thrown.
3. Add `attributes: true` to your `MutationObserver` configuration and see that it fixes the "issue".

# Related issues
--

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
