### PR TITLE
`getOwnPropertyDescriptor`: not actually supported in IE 8

### DIFF
--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -439,10 +439,16 @@
               "firefox_android": {
                 "version_added": "4"
               },
-              "ie": {
-                "version_added": "9",
-                "notes": "Also supported in Internet Explorer 8, but only on DOM objects and with some non-standard behaviors."
-              },
+              "ie": [
+                {
+                  "version_added": "9"
+                },
+                {
+                  "version_added": "8",
+                  "partial_implementation": true,
+                  "notes": "In Internet Explorer 8, this was only supported on DOM objects and with some non-standard behaviors.  This was later fixed in Internet Explorer 9."
+                }
+              ],
               "nodejs": {
                 "version_added": true
               },
@@ -818,9 +824,16 @@
               "firefox_android": {
                 "version_added": "4"
               },
-              "ie": {
-                "version_added": "8"
-              },
+              "ie": [
+                {
+                  "version_added": "9"
+                },
+                {
+                  "version_added": "8",
+                  "partial_implementation": true,
+                  "notes": "In Internet Explorer 8, this was only supported on DOM objects and with some non-standard behaviors.  This was later fixed in Internet Explorer 9."
+                }
+              ],
               "nodejs": {
                 "version_added": true
               },


### PR DESCRIPTION
follows the precedent set by defineProperty.

Fixes #5202.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
