### PR TITLE
Drop old spec URL for Function: toString revision

### DIFF
--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -882,10 +882,7 @@
         "toString": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/toString",
-            "spec_url": [
-              "https://tc39.es/Function-prototype-toString-revision/#sec-introduction",
-              "https://tc39.es/ecma262/#sec-function.prototype.tostring"
-            ],
+            "spec_url": "https://tc39.es/ecma262/#sec-function.prototype.tostring",
             "support": {
               "chrome": {
                 "version_added": "1"


### PR DESCRIPTION
The changes in the proposal for revisions to `Function.prototype.toString` have already been incorporated in the latest ES spec (draft).