### PR TITLE
Change PluralRules & RelativeTimeFormat spec URLs

### DIFF
--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -2493,7 +2493,7 @@
           "PluralRules": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/PluralRules",
-              "spec_url": "https://tc39.es/ecma402/#sec-intl-pluralrules-constructor",
+              "spec_url": "https://tc39.es/ecma402/#pluralrules-objects",
               "description": "<code>PluralRules()</code> constructor",
               "support": {
                 "chrome": {
@@ -2802,7 +2802,7 @@
           "RelativeTimeFormat": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat",
-              "spec_url": "https://tc39.es/proposal-intl-relative-time/#sec-intl-relativetimeformat-constructor",
+              "spec_url": "https://tc39.es/proposal-intl-relative-time/#relativetimeformat-objects",
               "description": "<code>RelativeTimeFormat()</code> constructor",
               "support": {
                 "chrome": {


### PR DESCRIPTION
This change switches the spec URLs for `Intl.PluralRules` and `Intl.RelativeTimeFormat` to the fragment IDs for the top-level spec sections for those objects, rather the fragment IDs for the subsections for their constructors.