### PR TITLE
WebExtensions proxy.RequestDetails and webRequest expose thirdParty

### DIFF
--- a/webextensions/api/proxy.json
+++ b/webextensions/api/proxy.json
@@ -101,6 +101,216 @@
                 "version_added": false
               }
             }
+          },
+          "connectionIsolationKey": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "failoverTimeout": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "host": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "password": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "port": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "proxyAuthorizationHeader": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "proxyDNS": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "thirdParty": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "72"
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "type": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "username": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
           }
         },
         "register": {

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -1234,6 +1234,27 @@
                 }
               }
             },
+            "thirdParty": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "72"
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
             "timeStamp": {
               "__compat": {
                 "support": {
@@ -1594,6 +1615,27 @@
                 }
               }
             },
+            "thirdParty": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "72"
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
             "timeStamp": {
               "__compat": {
                 "support": {
@@ -1896,6 +1938,27 @@
                 }
               }
             },
+            "thirdParty": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "72"
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
             "timeStamp": {
               "__compat": {
                 "support": {
@@ -2173,6 +2236,27 @@
                   },
                   "opera": {
                     "version_added": true
+                  }
+                }
+              }
+            },
+            "thirdParty": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "72"
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": false
                   }
                 }
               }
@@ -2537,6 +2621,27 @@
                 }
               }
             },
+            "thirdParty": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "72"
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
             "timeStamp": {
               "__compat": {
                 "support": {
@@ -2851,6 +2956,27 @@
                   },
                   "opera": {
                     "version_added": true
+                  }
+                }
+              }
+            },
+            "thirdParty": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "72"
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": false
                   }
                 }
               }
@@ -3180,6 +3306,27 @@
                   },
                   "opera": {
                     "version_added": true
+                  }
+                }
+              }
+            },
+            "thirdParty": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "72"
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": false
                   }
                 }
               }
@@ -3544,6 +3691,27 @@
                 }
               }
             },
+            "thirdParty": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "72"
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
             "timeStamp": {
               "__compat": {
                 "support": {
@@ -3795,6 +3963,27 @@
                   },
                   "opera": {
                     "version_added": true
+                  }
+                }
+              }
+            },
+            "thirdParty": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "72"
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": false
                   }
                 }
               }

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -3968,27 +3968,6 @@
                 }
               }
             },
-            "thirdParty": {
-              "__compat": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": {
-                    "version_added": false
-                  },
-                  "firefox": {
-                    "version_added": "72"
-                  },
-                  "firefox_android": {
-                    "version_added": true
-                  },
-                  "opera": {
-                    "version_added": false
-                  }
-                }
-              }
-            },
             "tabId": {
               "__compat": {
                 "support": {
@@ -4006,6 +3985,27 @@
                   },
                   "opera": {
                     "version_added": true
+                  }
+                }
+              }
+            },
+            "thirdParty": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "72"
+                  },
+                  "firefox_android": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": false
                   }
                 }
               }


### PR DESCRIPTION
## Summary
Firefox 72 exposes third-party state in WebRequest and proxy onRequest details. This PR:
 - populates attributes of `webextensions.api.proxy.RequestDetails` with names documented on the [`proxy.RequesDetails` page](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/proxy/RequestDetails)
 - adds `thirdParty` to `proxy.RequesDetails` and `webRequest`

## Data
`thirdParty` is supported in Firefox 72:
 - blog post ["Extensions in Firefox 72"](https://blog.mozilla.org/addons/2020/01/22/extensions-in-firefox-72/)
 - [bug 1591900](https://bugzilla.mozilla.org/show_bug.cgi?id=1591900)

Attributes of `webextensions.api.proxy.RequestDetails` are taken from [`proxy.RequesDetails` page](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/proxy/RequestDetails).

## Related issues
This advances #5539.

A checklist to help your pull request get merged faster:
- [ ] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
