### PR TITLE
Traverse script: take "all" as value for folder argument

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -17,4 +17,12 @@ To see how changes will affect the statistics of real (either `false` or a versi
 
 ## Traverse
 
-To find all the entries that are non-real, or of a specified value, you can run `npm run traverse <browser> [folder] [value]`. The browser may be any single browser defined in the [`browsers/` folder](https://github.com/mdn/browser-compat-data/blob/master/browsers/). The folder may be omitted to search through all data folders, or a comma-separated list of folders to search through. The value may be omitted to search for all non-real values (or more specifically, `true` and `null` values), or any value accepted by `version_added` and `version_removed`. For example, to search for all Safari entries that are non-real, run `npm run traverse safari`. To search for all WebView entries that are marked as `true` in `api` and `javascript`, run `npm run traverse webview_android api,javascript true`.
+To find all the entries that are non-real, or of a specified value, you can run `npm run traverse <browser> [folder] [value]`.
+
+The browser may be any single browser defined in the [`browsers/` folder](https://github.com/mdn/browser-compat-data/blob/master/browsers/).
+
+The folder may be omitted or set to `all` to search through all data folders, or a comma-separated list of folders to search through.
+
+The value may be omitted to search for all non-real values (or more specifically, `true` and `null` values), or any value accepted by `version_added` and `version_removed`.
+
+For example, to search for all Safari entries that are non-real, run `npm run traverse safari`. To search for all WebView entries that are marked as `true` in `api` and `javascript`, run `npm run traverse webview_android api,javascript true`. To search for all Firefox entries supported since `10` across all folders, run `npm run traverse firefox all 10`.

--- a/scripts/traverse.js
+++ b/scripts/traverse.js
@@ -11,20 +11,9 @@ const { argv } = require('yargs').command(
         type: 'string',
       })
       .positional('folder', {
-        describe: 'The folder(s) to test',
+        describe: 'The folder(s) to test (set to "all" for all folders)',
         type: 'array',
-        default: [
-          'api',
-          'css',
-          'html',
-          'http',
-          'svg',
-          'javascript',
-          'mathml',
-          'webdriver',
-          'xpath',
-          'xslt',
-        ],
+        default: 'all',
       })
       .positional('value', {
         describe: 'The value(s) to test against',
@@ -68,9 +57,21 @@ function traverseFeatures(obj, depth, identifier) {
 }
 
 let features = [];
-const folders = Array.isArray(argv.folder)
-  ? argv.folder
-  : argv.folder.split(',');
+const folders =
+  argv.folder == 'all'
+    ? [
+        'api',
+        'css',
+        'html',
+        'http',
+        'svg',
+        'javascript',
+        'mathml',
+        'webdriver',
+        'xpath',
+        'xslt',
+      ]
+    : argv.folder.split(',');
 const values = Array.isArray(argv.value)
   ? argv.value
   : argv.value.toString().split(',');


### PR DESCRIPTION
When setting up the traverse script, I had the folder argument default to an array of all the possible folders.  However, there was a slight issue with this.  Since the `folder` argument is positional and comes before the `value` argument, a user had to type out every single folder when setting a custom `value` to check for.  This PR modifies the argument to accept (and default to) "all" as a value, which selects all of the folders.