### PR TITLE
Update labels.yml with new "scripts" label

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -41,5 +41,7 @@ infra :building_construction::
   - "package*"
 linter :house_with_garden::
   - "test/**"
+scripts :scroll::
+  - "scripts/**"
 schema :gear::
   - "schemas/**"


### PR DESCRIPTION
I realized that we didn't have a label for the script files, so I have just added a new label for the scripts (I'd been applying the "infra" label before, but it's probably better to have a specific label instead).  This PR updates the auto labeler with this new label.

(P.S. if preferred, I'm happy to remove this new label!)