### PR TITLE
Set all "true" values for Edge to "≤18"

### DIFF
--- a/api/AbstractWorker.json
+++ b/api/AbstractWorker.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "3.5"

--- a/api/AnalyserNode.json
+++ b/api/AnalyserNode.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "25"

--- a/api/AnimationEvent.json
+++ b/api/AnimationEvent.json
@@ -23,7 +23,7 @@
             }
           ],
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "6"

--- a/api/Attr.json
+++ b/api/Attr.json
@@ -13,7 +13,7 @@
             "notes": "As of Chrome 45, this property no longer inherits from Node."
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"
@@ -62,7 +62,7 @@
               "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "48",
@@ -107,7 +107,7 @@
               "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "48",
@@ -152,7 +152,7 @@
               "notes": "This API was previously available on the <a href='https://developer.mozilla.org/docs/Web/API/Node'><code>Node</code></a> API."
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "48",

--- a/api/AudioBuffer.json
+++ b/api/AudioBuffer.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "25"

--- a/api/AudioBufferSourceNode.json
+++ b/api/AudioBufferSourceNode.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "25"

--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -25,7 +25,7 @@
             }
           ],
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "25"
@@ -104,7 +104,7 @@
               ]
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "25"
@@ -355,7 +355,7 @@
               "notes": "Available as a part of <code>BaseAudioContext</code>."
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "25",
@@ -480,7 +480,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "25"
@@ -722,7 +722,7 @@
               "version_added": "41"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "40"

--- a/api/AudioDestinationNode.json
+++ b/api/AudioDestinationNode.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "25"

--- a/api/AudioListener.json
+++ b/api/AudioListener.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "25"
@@ -114,7 +114,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false,
@@ -164,7 +164,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false,
@@ -214,7 +214,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false,
@@ -264,7 +264,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false,
@@ -314,7 +314,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false,
@@ -364,7 +364,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false,
@@ -566,7 +566,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false,
@@ -616,7 +616,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false,
@@ -666,7 +666,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false,

--- a/api/AudioNode.json
+++ b/api/AudioNode.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "25"
@@ -345,7 +345,7 @@
                 "version_added": "43"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": false
@@ -393,7 +393,7 @@
                 "version_added": "43"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": false

--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "25"
@@ -400,7 +400,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "53"
@@ -448,7 +448,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "53"

--- a/api/AudioProcessingEvent.json
+++ b/api/AudioProcessingEvent.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "25"

--- a/api/AudioTrack.json
+++ b/api/AudioTrack.json
@@ -11,7 +11,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": null

--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "53"
@@ -120,7 +120,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "53",
@@ -184,7 +184,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "53",
@@ -248,7 +248,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "53",
@@ -312,7 +312,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "53",
@@ -376,7 +376,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "53",
@@ -440,7 +440,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "53",
@@ -552,7 +552,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "53",
@@ -616,7 +616,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "53",
@@ -680,7 +680,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "53",
@@ -744,7 +744,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "53",
@@ -807,7 +807,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "53",
@@ -858,7 +858,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "53",
@@ -922,7 +922,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "53",
@@ -1005,7 +1005,7 @@
               }
             ],
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "53",
@@ -1087,7 +1087,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": false
@@ -1137,7 +1137,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "53",
@@ -1200,7 +1200,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "53",
@@ -1251,7 +1251,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "53",
@@ -1315,7 +1315,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "53",
@@ -1379,7 +1379,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "53",
@@ -1493,7 +1493,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "53",
@@ -1557,7 +1557,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "53"
@@ -1669,7 +1669,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "53",

--- a/api/BasicCardRequest.json
+++ b/api/BasicCardRequest.json
@@ -11,7 +11,7 @@
             "version_added": "57"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "56",
@@ -84,7 +84,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "56",
@@ -148,7 +148,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "56",

--- a/api/BasicCardResponse.json
+++ b/api/BasicCardResponse.json
@@ -11,7 +11,7 @@
             "version_added": "57"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "56",
@@ -84,7 +84,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "56",
@@ -148,7 +148,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "56",
@@ -212,7 +212,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "56",
@@ -276,7 +276,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "56",
@@ -340,7 +340,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "56",
@@ -404,7 +404,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "56",

--- a/api/BeforeUnloadEvent.json
+++ b/api/BeforeUnloadEvent.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1.5"

--- a/api/BiquadFilterNode.json
+++ b/api/BiquadFilterNode.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "25"

--- a/api/Blob.json
+++ b/api/Blob.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "4"

--- a/api/BlobBuilder.json
+++ b/api/BlobBuilder.json
@@ -13,7 +13,7 @@
             "prefix": "Webkit"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "6",

--- a/api/Body.json
+++ b/api/Body.json
@@ -22,7 +22,7 @@
             "version_added": "42"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {
@@ -110,7 +110,7 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -202,7 +202,7 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -283,7 +283,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -376,7 +376,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -527,7 +527,7 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -619,7 +619,7 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {

--- a/api/CDATASection.json
+++ b/api/CDATASection.json
@@ -8,7 +8,7 @@
             "version_added": "1"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/CSS.json
+++ b/api/CSS.json
@@ -11,7 +11,7 @@
             "version_added": "28"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {

--- a/api/CSSConditionRule.json
+++ b/api/CSSConditionRule.json
@@ -11,7 +11,7 @@
             "version_added": "56"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "20"

--- a/api/CSSGroupingRule.json
+++ b/api/CSSGroupingRule.json
@@ -11,7 +11,7 @@
             "version_added": "45"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "20"

--- a/api/CSSKeyframeRule.json
+++ b/api/CSSKeyframeRule.json
@@ -11,7 +11,7 @@
             "version_added": "45"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {

--- a/api/CSSKeyframesRule.json
+++ b/api/CSSKeyframesRule.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {

--- a/api/CSSMediaRule.json
+++ b/api/CSSMediaRule.json
@@ -11,7 +11,7 @@
             "version_added": "45"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "17",

--- a/api/CSSNamespaceRule.json
+++ b/api/CSSNamespaceRule.json
@@ -11,7 +11,7 @@
             "version_added": "47"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "59"

--- a/api/CSSPageRule.json
+++ b/api/CSSPageRule.json
@@ -11,7 +11,7 @@
             "version_added": "45"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "19"

--- a/api/CSSRule.json
+++ b/api/CSSRule.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/CSSRuleList.json
+++ b/api/CSSRuleList.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/CSSStyleRule.json
+++ b/api/CSSStyleRule.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/CSSStyleSheet.json
+++ b/api/CSSStyleSheet.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/CSSSupportsRule.json
+++ b/api/CSSSupportsRule.json
@@ -11,7 +11,7 @@
             "version_added": false
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "17",

--- a/api/Cache.json
+++ b/api/Cache.json
@@ -13,7 +13,7 @@
             "notes": "From 40 to 42, this was only available on service workers."
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "39",

--- a/api/CacheStorage.json
+++ b/api/CacheStorage.json
@@ -19,7 +19,7 @@
             ]
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "44",

--- a/api/CanvasGradient.json
+++ b/api/CanvasGradient.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "3.6",

--- a/api/CanvasPattern.json
+++ b/api/CanvasPattern.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "3.6"

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1.5"
@@ -803,7 +803,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "31"
@@ -1098,7 +1098,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false,
@@ -1766,7 +1766,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "31"
@@ -2498,7 +2498,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "31"
@@ -3940,7 +3940,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "31"

--- a/api/ChannelMergerNode.json
+++ b/api/ChannelMergerNode.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "25"

--- a/api/ChannelSplitterNode.json
+++ b/api/ChannelSplitterNode.json
@@ -13,7 +13,7 @@
             "notes": "Starting in Chrome 56, <code>channelCountMode</code> is set to <code>explicit</code> and <code>channelCount</code> is fixed to the number of outputs, as per the latest spec."
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "25"

--- a/api/CharacterData.json
+++ b/api/CharacterData.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "25",

--- a/api/ChildNode.json
+++ b/api/ChildNode.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "23"

--- a/api/ClipboardEvent.json
+++ b/api/ClipboardEvent.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "22"

--- a/api/CloseEvent.json
+++ b/api/CloseEvent.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "8",

--- a/api/Comment.json
+++ b/api/Comment.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"
@@ -59,7 +59,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "24"

--- a/api/CompositionEvent.json
+++ b/api/CompositionEvent.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "9"

--- a/api/Console.json
+++ b/api/Console.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "2"
@@ -314,7 +314,7 @@
                 "notes": "In version 28, if a negative value is passed to <code>%d</code>, it will be rounded down to the closest negative integer. For example, -0.1 becomes -1."
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "9"
@@ -519,7 +519,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "9"
@@ -617,7 +617,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": true
@@ -860,7 +860,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "9"
@@ -959,7 +959,7 @@
                 "notes": "In version 28, if a negative value is passed to %d, it will be rounded down to the closest negative integer, so -0.1 becomes -1."
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "9"
@@ -1462,7 +1462,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "9"
@@ -1512,7 +1512,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "38"

--- a/api/ConvolverNode.json
+++ b/api/ConvolverNode.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "25"

--- a/api/CryptoKey.json
+++ b/api/CryptoKey.json
@@ -11,7 +11,7 @@
             "version_added": "37"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "34"

--- a/api/CryptoKeyPair.json
+++ b/api/CryptoKeyPair.json
@@ -11,7 +11,7 @@
             "version_added": "37"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "34"

--- a/api/CustomEvent.json
+++ b/api/CustomEvent.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "6"
@@ -59,7 +59,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "11"
@@ -227,7 +227,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "48"

--- a/api/DOMError.json
+++ b/api/DOMError.json
@@ -8,7 +8,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "12",
@@ -42,7 +42,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "12",

--- a/api/DOMErrorHandler.json
+++ b/api/DOMErrorHandler.json
@@ -11,7 +11,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": false
@@ -58,7 +58,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false

--- a/api/DOMException.json
+++ b/api/DOMException.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/DOMHighResTimestamp.json
+++ b/api/DOMHighResTimestamp.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "7"

--- a/api/DOMImplementation.json
+++ b/api/DOMImplementation.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/DOMParser.json
+++ b/api/DOMParser.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"
@@ -59,7 +59,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "1"
@@ -154,7 +154,7 @@
                 "version_added": "31"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "12"
@@ -202,7 +202,7 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "10"
@@ -250,7 +250,7 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "1"

--- a/api/DOMRect.json
+++ b/api/DOMRect.json
@@ -16,7 +16,7 @@
             },
             {
               "alternative_name": "ClientRect",
-              "version_added": true
+              "version_added": "≤18"
             }
           ],
           "firefox": {

--- a/api/DOMRectReadOnly.json
+++ b/api/DOMRectReadOnly.json
@@ -16,7 +16,7 @@
             },
             {
               "alternative_name": "ClientRect",
-              "version_added": true
+              "version_added": "≤18"
             }
           ],
           "firefox": {

--- a/api/DOMStringList.json
+++ b/api/DOMStringList.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/DOMStringMap.json
+++ b/api/DOMStringMap.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "6"

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true
@@ -779,7 +779,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": true
@@ -830,7 +830,7 @@
               "notes": "Before Chrome 50, this property was part of the deprecated child <code>DOMSettableTokenList</code> interface."
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true

--- a/api/DataTransfer.json
+++ b/api/DataTransfer.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "3.5",

--- a/api/DataTransferItem.json
+++ b/api/DataTransferItem.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "50"

--- a/api/DataTransferItemList.json
+++ b/api/DataTransferItemList.json
@@ -11,7 +11,7 @@
             "version_added": false
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "50"

--- a/api/DelayNode.json
+++ b/api/DelayNode.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "25"

--- a/api/DeviceLightEvent.json
+++ b/api/DeviceLightEvent.json
@@ -11,7 +11,7 @@
             "version_added": false
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {

--- a/api/DeviceMotionEvent.json
+++ b/api/DeviceMotionEvent.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "6"

--- a/api/DeviceMotionEventAcceleration.json
+++ b/api/DeviceMotionEventAcceleration.json
@@ -18,7 +18,7 @@
             }
           ],
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": null

--- a/api/DeviceMotionEventRotationRate.json
+++ b/api/DeviceMotionEventRotationRate.json
@@ -18,7 +18,7 @@
             }
           ],
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": null

--- a/api/DeviceOrientationEvent.json
+++ b/api/DeviceOrientationEvent.json
@@ -13,7 +13,7 @@
             "notes": "Before version 50, Chrome provided absolute values instead of relative values for this event. Developers still needing absolute values may use the <code>ondeviceorientationabsolute</code> event."
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "6",

--- a/api/Document.json
+++ b/api/Document.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true
@@ -59,7 +59,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -108,7 +108,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "1"
@@ -884,11 +884,11 @@
             ],
             "edge": [
               {
-                "version_added": true
+                "version_added": "≤18"
               },
               {
                 "alternative_name": "charset",
-                "version_added": true
+                "version_added": "≤18"
               },
               {
                 "alternative_name": "inputEncoding",
@@ -1332,7 +1332,7 @@
               "version_added": "58"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -1378,7 +1378,7 @@
                 "version_added": "58"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "22"
@@ -2605,7 +2605,7 @@
               "version_added": "58"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -2651,7 +2651,7 @@
                 "version_added": "58"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "22"
@@ -3792,7 +3792,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": false
@@ -3840,7 +3840,7 @@
                 "version_added": "42"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "41"
@@ -3888,7 +3888,7 @@
                 "version_added": "42"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "41"
@@ -3936,7 +3936,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "55"
@@ -5918,7 +5918,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "10"
@@ -5968,7 +5968,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -6019,7 +6019,7 @@
               "notes": "Chrome does not fire the <code>keypress</code> event for <a href='https://crbug.com/13891#c50'>known keyboard shortcuts</a>. Which keyboard shortcuts are known depends on the user's system. Use the <code>keydown</code> event to implement keyboard shortcuts."
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true,
@@ -6072,7 +6072,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -7502,7 +7502,7 @@
               "version_added": "58"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -7548,7 +7548,7 @@
                 "version_added": "58"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "22"
@@ -7650,7 +7650,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -7724,7 +7724,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -7798,7 +7798,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -7872,7 +7872,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -8100,7 +8100,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -8174,7 +8174,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -8248,7 +8248,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -8322,7 +8322,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -8968,7 +8968,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -9390,7 +9390,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -10557,7 +10557,7 @@
               "version_added": "61"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true

--- a/api/DocumentFragment.json
+++ b/api/DocumentFragment.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"
@@ -59,7 +59,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "24"

--- a/api/DocumentOrShadowRoot.json
+++ b/api/DocumentOrShadowRoot.json
@@ -11,7 +11,7 @@
             "version_added": "53"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true
@@ -58,7 +58,7 @@
               "version_added": "53"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "63"
@@ -204,7 +204,7 @@
               "notes": "Before Chrome 66, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "63"
@@ -312,7 +312,7 @@
               "prefix": "webkit"
             },
             "edge": {
-              "version_added": true,
+              "version_added": "≤18",
               "prefix": "webkit"
             },
             "firefox": [
@@ -406,7 +406,7 @@
               "version_added": "53"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "63"
@@ -554,7 +554,7 @@
               "version_added": "53"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "63"
@@ -602,7 +602,7 @@
               "version_added": "53"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "63"

--- a/api/DocumentType.json
+++ b/api/DocumentType.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/DragEvent.json
+++ b/api/DragEvent.json
@@ -11,7 +11,7 @@
             "version_added": false
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "3.5"

--- a/api/DynamicsCompressorNode.json
+++ b/api/DynamicsCompressorNode.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "25"

--- a/api/EXT_frag_depth.json
+++ b/api/EXT_frag_depth.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "30"

--- a/api/EXT_texture_filter_anisotropic.json
+++ b/api/EXT_texture_filter_anisotropic.json
@@ -23,7 +23,7 @@
             }
           ],
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "17"

--- a/api/Element.json
+++ b/api/Element.json
@@ -157,7 +157,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -206,7 +206,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false
@@ -255,7 +255,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false
@@ -304,7 +304,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false
@@ -353,7 +353,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false
@@ -402,7 +402,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false
@@ -451,7 +451,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false
@@ -500,7 +500,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false
@@ -1114,7 +1114,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -1419,7 +1419,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true,
@@ -1764,7 +1764,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "9"
@@ -1813,7 +1813,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "9"
@@ -1862,7 +1862,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "9"
@@ -2008,7 +2008,7 @@
               "version_added": "58"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -2054,7 +2054,7 @@
                 "version_added": "58"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "22"
@@ -2290,7 +2290,7 @@
               "version_added": "58"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -2336,7 +2336,7 @@
                 "version_added": "58"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "22"
@@ -2386,7 +2386,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true,
@@ -2485,7 +2485,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -2541,7 +2541,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "52"
@@ -2590,7 +2590,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "52"
@@ -3247,7 +3247,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "3.5"
@@ -3294,7 +3294,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "3.5"
@@ -3598,7 +3598,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": true
@@ -3706,7 +3706,7 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": true
@@ -4245,7 +4245,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -4296,7 +4296,7 @@
               "notes": "Chrome does not fire the <code>keypress</code> event for <a href='https://crbug.com/13891#c50'>known keyboard shortcuts</a>. Which keyboard shortcuts are known depends on the user's system. Use the <code>keydown</code> event to implement keyboard shortcuts."
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true,
@@ -4349,7 +4349,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -4464,14 +4464,14 @@
             ],
             "edge": [
               {
-                "version_added": true
+                "version_added": "≤18"
               },
               {
-                "version_added": true,
+                "version_added": "≤18",
                 "alternative_name": "webkitMatchesSelector"
               },
               {
-                "version_added": true,
+                "version_added": "≤18",
                 "alternative_name": "msMatchesSelector"
               }
             ],
@@ -4594,7 +4594,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -4643,7 +4643,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "10"
@@ -4692,7 +4692,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "10"
@@ -4741,7 +4741,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -4790,7 +4790,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -4839,7 +4839,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -4888,7 +4888,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -4986,7 +4986,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false
@@ -5467,7 +5467,7 @@
               "version_added": "58"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -5513,7 +5513,7 @@
                 "version_added": "58"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "22"
@@ -6405,7 +6405,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -7116,7 +7116,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -8244,7 +8244,7 @@
               "version_added": "61"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true

--- a/api/ErrorEvent.json
+++ b/api/ErrorEvent.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/Event.json
+++ b/api/Event.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true
@@ -59,7 +59,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "11"

--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"
@@ -180,7 +180,7 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "6"
@@ -228,7 +228,7 @@
                 "version_added": "49"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "49"
@@ -275,7 +275,7 @@
                   "version_added": "52"
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": "≤18"
                 },
                 "firefox": {
                   "version_added": true
@@ -323,7 +323,7 @@
                   "version_added": "55"
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": "≤18"
                 },
                 "firefox": {
                   "version_added": "50"
@@ -371,7 +371,7 @@
                   "version_added": "51"
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": "≤18"
                 },
                 "firefox": {
                   "version_added": true
@@ -630,7 +630,7 @@
                 "version_removed": "49"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": true
@@ -680,7 +680,7 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "6"
@@ -728,7 +728,7 @@
                 "version_added": "49"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "49"

--- a/api/ExtendableMessageEvent.json
+++ b/api/ExtendableMessageEvent.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "45",

--- a/api/External.json
+++ b/api/External.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/FetchEvent.json
+++ b/api/FetchEvent.json
@@ -11,7 +11,7 @@
             "version_added": "40"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "44",
@@ -60,7 +60,7 @@
               "version_added": "40"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "44",

--- a/api/File.json
+++ b/api/File.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {
@@ -266,7 +266,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.6"

--- a/api/FileList.json
+++ b/api/FileList.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/FileReader.json
+++ b/api/FileReader.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "3.6",
@@ -108,7 +108,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -217,7 +217,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -266,7 +266,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -315,7 +315,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -364,7 +364,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -653,7 +653,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -990,7 +990,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "46"

--- a/api/FileReaderSync.json
+++ b/api/FileReaderSync.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "8"
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "8"
@@ -106,7 +106,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "8"
@@ -154,7 +154,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "8"
@@ -202,7 +202,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "8"
@@ -306,7 +306,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "8"

--- a/api/FileSystem.json
+++ b/api/FileSystem.json
@@ -13,7 +13,7 @@
             "prefix": "webkit"
           },
           "edge": {
-            "version_added": true,
+            "version_added": "≤18",
             "prefix": "WebKit",
             "notes": "Edge only supports this API in drag-and-drop scenarios using the the <code><a href='https://developer.mozilla.org/docs/Web/API/DataTransferItem/webkitGetAsEntry'>DataTransferItem.webkitGetAsEntry()</a></code> method. It's not available for use in file or folder picker panels (such as when you use an <code><a href='https://developer.mozilla.org/docs/Web/HTML/Element/input'>&lt;input&gt;</a></code> element with the <code><a href='https://developer.mozilla.org/docs/Web/API/HTMLInputElement/webkitdirectory'>HTMLInputElement.webkitdirectory</a></code> attribute."
           },
@@ -66,7 +66,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "50"
@@ -114,7 +114,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "50"

--- a/api/FileSystemDirectoryReader.json
+++ b/api/FileSystemDirectoryReader.json
@@ -13,7 +13,7 @@
             "prefix": "webkit"
           },
           "edge": {
-            "version_added": true,
+            "version_added": "≤18",
             "alternative_name": "WebKitDirectoryReader"
           },
           "firefox": {

--- a/api/FocusEvent.json
+++ b/api/FocusEvent.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "24"
@@ -59,7 +59,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "24"

--- a/api/FormData.json
+++ b/api/FormData.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "4",
@@ -61,7 +61,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "4"
@@ -208,7 +208,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "22"
@@ -641,7 +641,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "39"

--- a/api/GainNode.json
+++ b/api/GainNode.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "25"

--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -25,7 +25,7 @@
             }
           ],
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {

--- a/api/GamepadButton.json
+++ b/api/GamepadButton.json
@@ -18,7 +18,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {

--- a/api/GamepadEvent.json
+++ b/api/GamepadEvent.json
@@ -18,7 +18,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {

--- a/api/GeolocationCoordinates.json
+++ b/api/GeolocationCoordinates.json
@@ -26,7 +26,7 @@
           ],
           "edge": {
             "alternative_name": "Coordinates",
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {

--- a/api/GeolocationPosition.json
+++ b/api/GeolocationPosition.json
@@ -26,7 +26,7 @@
           ],
           "edge": {
             "alternative_name": "Position",
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {
@@ -138,7 +138,7 @@
               "version_added": "47"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "55"

--- a/api/GeolocationPositionError.json
+++ b/api/GeolocationPositionError.json
@@ -26,7 +26,7 @@
           ],
           "edge": {
             "alternative_name": "PositionError",
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {
@@ -186,7 +186,7 @@
               "version_added": "47"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "55"

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true
@@ -418,7 +418,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -610,7 +610,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -658,7 +658,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -754,7 +754,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -864,7 +864,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -912,7 +912,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -960,7 +960,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -1008,7 +1008,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -1056,7 +1056,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -1104,7 +1104,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -1152,7 +1152,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -1200,7 +1200,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -1248,7 +1248,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -1488,7 +1488,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -1632,7 +1632,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "2"
@@ -1728,7 +1728,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -1776,7 +1776,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -1824,7 +1824,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -1872,7 +1872,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -2168,7 +2168,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -2216,7 +2216,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "10"
@@ -2264,7 +2264,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "10"
@@ -2312,7 +2312,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -2360,7 +2360,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -2408,7 +2408,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -2456,7 +2456,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -2696,7 +2696,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -2769,7 +2769,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -2842,7 +2842,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -2915,7 +2915,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -3084,7 +3084,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -3157,7 +3157,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -3230,7 +3230,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -3303,7 +3303,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -3472,7 +3472,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -3520,7 +3520,7 @@
               "version_added": "45"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -3568,7 +3568,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -3712,7 +3712,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -4048,7 +4048,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -4680,7 +4680,7 @@
               "version_added": "61"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true

--- a/api/HTMLAllCollection.json
+++ b/api/HTMLAllCollection.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/HTMLAnchorElement.json
+++ b/api/HTMLAnchorElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "1"
@@ -298,7 +298,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "1"
@@ -634,7 +634,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "1"

--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "1"
@@ -250,7 +250,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "1"
@@ -298,7 +298,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "1"
@@ -586,7 +586,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "1"
@@ -682,7 +682,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "1"

--- a/api/HTMLAudioElement.json
+++ b/api/HTMLAudioElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "3.5"

--- a/api/HTMLBRElement.json
+++ b/api/HTMLBRElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/HTMLBaseElement.json
+++ b/api/HTMLBaseElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/HTMLBaseFontElement.json
+++ b/api/HTMLBaseFontElement.json
@@ -11,7 +11,7 @@
             "version_added": false
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": false

--- a/api/HTMLBodyElement.json
+++ b/api/HTMLBodyElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/HTMLButtonElement.json
+++ b/api/HTMLButtonElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "1"
@@ -684,7 +684,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "1"

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "3.6"
@@ -311,7 +311,7 @@
                 }
               ],
               "edge": {
-                "version_added": true,
+                "version_added": "≤18",
                 "alternative_name": "experimental-webgl"
               },
               "firefox": [

--- a/api/HTMLCollection.json
+++ b/api/HTMLCollection.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/HTMLDListElement.json
+++ b/api/HTMLDListElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/HTMLDataElement.json
+++ b/api/HTMLDataElement.json
@@ -11,7 +11,7 @@
             "version_added": "62"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "22"

--- a/api/HTMLDataListElement.json
+++ b/api/HTMLDataListElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "4"

--- a/api/HTMLDivElement.json
+++ b/api/HTMLDivElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/HTMLDocument.json
+++ b/api/HTMLDocument.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"
@@ -600,7 +600,7 @@
               "version_removed": "61"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "1"
@@ -796,7 +796,7 @@
               "version_removed": "59"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "1"
@@ -1087,7 +1087,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": null
@@ -1184,7 +1184,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true,
+              "version_added": "≤18",
               "partial_implementation": true,
               "notes": "Not supported on <code>select</code>, <code>checkbox</code>, or <code>radio</code> inputs."
             },
@@ -2318,7 +2318,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -2392,7 +2392,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -2466,7 +2466,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -2540,7 +2540,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -2614,7 +2614,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -2688,7 +2688,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -2762,7 +2762,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -2836,7 +2836,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -3010,7 +3010,7 @@
                 "version_added": "18"
               },
               {
-                "version_added": true,
+                "version_added": "≤18",
                 "partial_implementation": true,
                 "notes": "Returns incorrect value for elements without an explicit tabindex attribute. See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/4365703/'>issue 4365703</a> for details."
               }

--- a/api/HTMLEmbedElement.json
+++ b/api/HTMLEmbedElement.json
@@ -13,7 +13,7 @@
             "notes": "Starting with Chrome 58, this interface can no longer be called as a function."
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/HTMLFieldSetElement.json
+++ b/api/HTMLFieldSetElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"
@@ -153,7 +153,7 @@
                 "version_added": "57"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "1"

--- a/api/HTMLFontElement.json
+++ b/api/HTMLFontElement.json
@@ -8,7 +8,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "22"

--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"
@@ -780,7 +780,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -877,7 +877,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true

--- a/api/HTMLFrameElement.json
+++ b/api/HTMLFrameElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/HTMLFrameSetElement.json
+++ b/api/HTMLFrameSetElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/HTMLHRElement.json
+++ b/api/HTMLHRElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/HTMLHeadElement.json
+++ b/api/HTMLHeadElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/HTMLHeadingElement.json
+++ b/api/HTMLHeadingElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/HTMLHtmlElement.json
+++ b/api/HTMLHtmlElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/HTMLHyperlinkElementUtils.json
+++ b/api/HTMLHyperlinkElementUtils.json
@@ -629,7 +629,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22",

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"
@@ -156,7 +156,7 @@
               "notes": "Daily test builds only."
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"
@@ -59,7 +59,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -285,7 +285,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -725,7 +725,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"
@@ -294,7 +294,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "4"
@@ -1604,7 +1604,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "50"
@@ -1651,7 +1651,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "16"

--- a/api/HTMLLIElement.json
+++ b/api/HTMLLIElement.json
@@ -8,7 +8,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1",

--- a/api/HTMLLabelElement.json
+++ b/api/HTMLLabelElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/HTMLLegendElement.json
+++ b/api/HTMLLegendElement.json
@@ -8,7 +8,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/HTMLLinkElement.json
+++ b/api/HTMLLinkElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/HTMLMapElement.json
+++ b/api/HTMLMapElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/HTMLMarqueeElement.json
+++ b/api/HTMLMarqueeElement.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "65",
@@ -106,7 +106,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "65"
@@ -341,7 +341,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "65"
@@ -388,7 +388,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "65"
@@ -435,7 +435,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "65"

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -23,7 +23,7 @@
             }
           ],
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "3.5"
@@ -362,7 +362,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -411,7 +411,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -940,7 +940,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "20"
@@ -1037,7 +1037,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -1086,7 +1086,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -1183,7 +1183,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -1445,7 +1445,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -1494,7 +1494,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -2166,7 +2166,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -2375,7 +2375,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -2568,7 +2568,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -2701,7 +2701,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -2891,7 +2891,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -3030,7 +3030,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -3127,7 +3127,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -3485,7 +3485,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -3534,7 +3534,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -3613,7 +3613,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -3757,7 +3757,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -3806,7 +3806,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true

--- a/api/HTMLMenuElement.json
+++ b/api/HTMLMenuElement.json
@@ -156,7 +156,7 @@
             },
             "edge": {
               "version_added": "12",
-              "version_removed": true
+              "version_removed": "≤18"
             },
             "firefox": {
               "version_added": "8"

--- a/api/HTMLMetaElement.json
+++ b/api/HTMLMetaElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/HTMLMeterElement.json
+++ b/api/HTMLMeterElement.json
@@ -8,7 +8,7 @@
             "version_added": "6"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "16"

--- a/api/HTMLModElement.json
+++ b/api/HTMLModElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"
@@ -106,7 +106,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "1"

--- a/api/HTMLOListElement.json
+++ b/api/HTMLOListElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/HTMLObjectElement.json
+++ b/api/HTMLObjectElement.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/HTMLOptGroupElement.json
+++ b/api/HTMLOptGroupElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/HTMLOptionElement.json
+++ b/api/HTMLOptionElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/HTMLOptionsCollection.json
+++ b/api/HTMLOptionsCollection.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -154,7 +154,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -202,7 +202,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true

--- a/api/HTMLOutputElement.json
+++ b/api/HTMLOutputElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "4"

--- a/api/HTMLParagraphElement.json
+++ b/api/HTMLParagraphElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/HTMLParamElement.json
+++ b/api/HTMLParamElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/HTMLPreElement.json
+++ b/api/HTMLPreElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/HTMLProgressElement.json
+++ b/api/HTMLProgressElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/HTMLQuoteElement.json
+++ b/api/HTMLQuoteElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "2",
@@ -106,7 +106,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "7"
@@ -829,7 +829,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true

--- a/api/HTMLSourceElement.json
+++ b/api/HTMLSourceElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "3.5"
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true,

--- a/api/HTMLSpanElement.json
+++ b/api/HTMLSpanElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/HTMLStyleElement.json
+++ b/api/HTMLStyleElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/HTMLTableCaptionElement.json
+++ b/api/HTMLTableCaptionElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/HTMLTableCellElement.json
+++ b/api/HTMLTableCellElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/HTMLTableColElement.json
+++ b/api/HTMLTableColElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/HTMLTableElement.json
+++ b/api/HTMLTableElement.json
@@ -8,7 +8,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/HTMLTableRowElement.json
+++ b/api/HTMLTableRowElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"
@@ -393,7 +393,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "20"
@@ -441,7 +441,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "20"

--- a/api/HTMLTableSectionElement.json
+++ b/api/HTMLTableSectionElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/HTMLTimeElement.json
+++ b/api/HTMLTimeElement.json
@@ -11,7 +11,7 @@
             "version_added": "62"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "22"

--- a/api/HTMLTitleElement.json
+++ b/api/HTMLTitleElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/HTMLTrackElement.json
+++ b/api/HTMLTrackElement.json
@@ -11,7 +11,7 @@
             "version_added": "25"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {

--- a/api/HTMLUListElement.json
+++ b/api/HTMLUListElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/HTMLUnknownElement.json
+++ b/api/HTMLUnknownElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "4"
@@ -453,7 +453,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false

--- a/api/HashChangeEvent.json
+++ b/api/HashChangeEvent.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "3.6"

--- a/api/Headers.json
+++ b/api/Headers.json
@@ -33,7 +33,7 @@
             }
           ],
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {
@@ -580,7 +580,7 @@
               "version_removed": "60"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {

--- a/api/IDBCursor.json
+++ b/api/IDBCursor.json
@@ -25,7 +25,7 @@
             }
           ],
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {
@@ -729,7 +729,7 @@
               }
             ],
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "37"

--- a/api/IDBCursorWithValue.json
+++ b/api/IDBCursorWithValue.json
@@ -25,7 +25,7 @@
             }
           ],
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {
@@ -157,7 +157,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "42"

--- a/api/IDBDatabase.json
+++ b/api/IDBDatabase.json
@@ -25,7 +25,7 @@
             }
           ],
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {
@@ -222,7 +222,7 @@
               "version_added": "31"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "50"
@@ -650,7 +650,7 @@
               "version_added": "31"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "50"
@@ -1028,7 +1028,7 @@
               }
             ],
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "37"

--- a/api/IDBEnvironment.json
+++ b/api/IDBEnvironment.json
@@ -18,7 +18,7 @@
             "version_added": "25"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {
@@ -73,7 +73,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "37"

--- a/api/IDBFactory.json
+++ b/api/IDBFactory.json
@@ -25,7 +25,7 @@
             }
           ],
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {
@@ -354,7 +354,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "37"

--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -25,7 +25,7 @@
             }
           ],
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {
@@ -234,7 +234,7 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "44"
@@ -282,7 +282,7 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "44",
@@ -1046,7 +1046,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "37"

--- a/api/IDBKeyRange.json
+++ b/api/IDBKeyRange.json
@@ -18,7 +18,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {
@@ -136,7 +136,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "47"
@@ -625,7 +625,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "37"

--- a/api/IDBObjectStore.json
+++ b/api/IDBObjectStore.json
@@ -25,7 +25,7 @@
             }
           ],
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {
@@ -192,7 +192,7 @@
               }
             ],
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -1245,7 +1245,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "49"
@@ -1392,7 +1392,7 @@
               }
             ],
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "44",
@@ -1629,7 +1629,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "37"

--- a/api/IDBOpenDBRequest.json
+++ b/api/IDBOpenDBRequest.json
@@ -25,7 +25,7 @@
             }
           ],
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {

--- a/api/IDBRequest.json
+++ b/api/IDBRequest.json
@@ -25,7 +25,7 @@
             }
           ],
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {
@@ -177,7 +177,7 @@
                 "version_added": "48"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "58"

--- a/api/IDBTransaction.json
+++ b/api/IDBTransaction.json
@@ -25,7 +25,7 @@
             }
           ],
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {
@@ -497,7 +497,7 @@
                 "version_added": "48"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "58"

--- a/api/IDBVersionChangeEvent.json
+++ b/api/IDBVersionChangeEvent.json
@@ -17,7 +17,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {
@@ -240,7 +240,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {

--- a/api/IIRFilterNode.json
+++ b/api/IIRFilterNode.json
@@ -11,7 +11,7 @@
             "version_added": "49"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "50"

--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "14"
@@ -59,7 +59,7 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "29"

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -106,7 +106,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -154,7 +154,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -202,7 +202,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true

--- a/api/LinkStyle.json
+++ b/api/LinkStyle.json
@@ -11,7 +11,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": null

--- a/api/Location.json
+++ b/api/Location.json
@@ -8,7 +8,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true
@@ -690,7 +690,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"

--- a/api/MSGestureEvent.json
+++ b/api/MSGestureEvent.json
@@ -11,7 +11,7 @@
             "version_added": false
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": false
@@ -59,7 +59,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false

--- a/api/MediaDeviceInfo.json
+++ b/api/MediaDeviceInfo.json
@@ -13,7 +13,7 @@
             "notes": "For earlier versions, this interface is available through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "39"

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -11,7 +11,7 @@
             "version_added": "47"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "33"

--- a/api/MediaElementAudioSourceNode.json
+++ b/api/MediaElementAudioSourceNode.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "25"

--- a/api/MediaEncryptedEvent.json
+++ b/api/MediaEncryptedEvent.json
@@ -11,7 +11,7 @@
             "version_added": "42"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/MediaError.json
+++ b/api/MediaError.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "3.5"

--- a/api/MediaKeyMessageEvent.json
+++ b/api/MediaKeyMessageEvent.json
@@ -11,7 +11,7 @@
             "version_added": "42"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true
@@ -59,7 +59,7 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": null

--- a/api/MediaKeySession.json
+++ b/api/MediaKeySession.json
@@ -11,7 +11,7 @@
             "version_added": "42"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/MediaKeyStatusMap.json
+++ b/api/MediaKeyStatusMap.json
@@ -11,7 +11,7 @@
             "version_added": "42"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true
@@ -249,7 +249,7 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": null

--- a/api/MediaKeySystemAccess.json
+++ b/api/MediaKeySystemAccess.json
@@ -11,7 +11,7 @@
             "version_added": "42"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/MediaKeys.json
+++ b/api/MediaKeys.json
@@ -11,7 +11,7 @@
             "version_added": "42"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/MediaList.json
+++ b/api/MediaList.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -106,7 +106,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -154,7 +154,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -202,7 +202,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -250,7 +250,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true

--- a/api/MediaQueryList.json
+++ b/api/MediaQueryList.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "6"

--- a/api/MediaQueryListListener.json
+++ b/api/MediaQueryListListener.json
@@ -11,7 +11,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "6"

--- a/api/MediaSource.json
+++ b/api/MediaSource.json
@@ -25,7 +25,7 @@
             }
           ],
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {
@@ -115,7 +115,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {

--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "15"
@@ -59,7 +59,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "44"

--- a/api/MediaStreamAudioDestinationNode.json
+++ b/api/MediaStreamAudioDestinationNode.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "25"
@@ -111,7 +111,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "25"

--- a/api/MediaStreamAudioSourceNode.json
+++ b/api/MediaStreamAudioSourceNode.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "25"

--- a/api/MediaStreamAudioSourceOptions.json
+++ b/api/MediaStreamAudioSourceOptions.json
@@ -11,7 +11,7 @@
             "version_added": "55"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "53"

--- a/api/MediaStreamEvent.json
+++ b/api/MediaStreamEvent.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true
@@ -59,7 +59,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true

--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "22"

--- a/api/MediaStreamTrackEvent.json
+++ b/api/MediaStreamTrackEvent.json
@@ -11,7 +11,7 @@
             "version_added": "55"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "50"

--- a/api/MediaTrackConstraints.json
+++ b/api/MediaTrackConstraints.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/MessageChannel.json
+++ b/api/MessageChannel.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "41"
@@ -63,7 +63,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "41"
@@ -115,7 +115,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "41"
@@ -166,7 +166,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "41"

--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "4"
@@ -59,7 +59,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "4"

--- a/api/MessagePort.json
+++ b/api/MessagePort.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/MimeType.json
+++ b/api/MimeType.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true
@@ -106,7 +106,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true

--- a/api/MimeTypeArray.json
+++ b/api/MimeTypeArray.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/MutationObserver.json
+++ b/api/MutationObserver.json
@@ -25,7 +25,7 @@
             }
           ],
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "14"
@@ -115,7 +115,7 @@
               }
             ],
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "14"

--- a/api/MutationObserverInit.json
+++ b/api/MutationObserverInit.json
@@ -25,7 +25,7 @@
             }
           ],
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "14"
@@ -104,7 +104,7 @@
               }
             ],
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "14"
@@ -184,7 +184,7 @@
               }
             ],
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "14",
@@ -266,7 +266,7 @@
               }
             ],
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "14",
@@ -348,7 +348,7 @@
               }
             ],
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "14",
@@ -430,7 +430,7 @@
               }
             ],
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "14",
@@ -512,7 +512,7 @@
               }
             ],
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "14"
@@ -592,7 +592,7 @@
               }
             ],
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "14"

--- a/api/MutationRecord.json
+++ b/api/MutationRecord.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true
@@ -106,7 +106,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -154,7 +154,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -202,7 +202,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -250,7 +250,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true

--- a/api/NamedNodeMap.json
+++ b/api/NamedNodeMap.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/NavigatorConcurrentHardware.json
+++ b/api/NavigatorConcurrentHardware.json
@@ -11,7 +11,7 @@
             "version_added": "37"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "48"

--- a/api/NavigatorGeolocation.json
+++ b/api/NavigatorGeolocation.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "3.5"

--- a/api/NavigatorID.json
+++ b/api/NavigatorID.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -106,7 +106,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -154,7 +154,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -202,7 +202,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true,
@@ -254,7 +254,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -302,7 +302,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -350,7 +350,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true

--- a/api/NavigatorLanguage.json
+++ b/api/NavigatorLanguage.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true
@@ -60,7 +60,7 @@
               "notes": "Returns the browser UI language, not the value of the <code>Accept-Language</code> <a href='https://developer.mozilla.org/docs/Web/HTTP/Headers'>HTTP header</a>."
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -120,7 +120,7 @@
               "notes": "In Chrome, <code>navigator.language</code> is the language of the browser UI, and is not guaranteed to be equal to <code>navigator.languages[0]</code>."
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "32",

--- a/api/NavigatorOnLine.json
+++ b/api/NavigatorOnLine.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true
@@ -59,7 +59,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {

--- a/api/Node.json
+++ b/api/Node.json
@@ -13,7 +13,7 @@
             "notes": "WebKit and old versions of Blink incorrectly do not make <code>Node</code> inherit from <code>EventTarget</code>."
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"
@@ -305,7 +305,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": [
                 {

--- a/api/NodeFilter.json
+++ b/api/NodeFilter.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "2"

--- a/api/NodeIterator.json
+++ b/api/NodeIterator.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "3.5"

--- a/api/NodeList.json
+++ b/api/NodeList.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/NonDocumentTypeChildNode.json
+++ b/api/NonDocumentTypeChildNode.json
@@ -12,7 +12,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "3.5"
@@ -59,7 +59,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "25"
@@ -107,7 +107,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -157,7 +157,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"

--- a/api/Notification.json
+++ b/api/Notification.json
@@ -84,7 +84,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -1321,7 +1321,7 @@
               "version_added": "45"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "41"

--- a/api/NotificationEvent.json
+++ b/api/NotificationEvent.json
@@ -11,7 +11,7 @@
             "version_added": "42"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "44",
@@ -60,7 +60,7 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "44",
@@ -109,7 +109,7 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "44",
@@ -158,7 +158,7 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "44",

--- a/api/OES_element_index_uint.json
+++ b/api/OES_element_index_uint.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "24"

--- a/api/OES_standard_derivatives.json
+++ b/api/OES_standard_derivatives.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "10"

--- a/api/OES_texture_float.json
+++ b/api/OES_texture_float.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "6"

--- a/api/OES_texture_float_linear.json
+++ b/api/OES_texture_float_linear.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "24"

--- a/api/OES_texture_half_float.json
+++ b/api/OES_texture_half_float.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "29"

--- a/api/OES_texture_half_float_linear.json
+++ b/api/OES_texture_half_float_linear.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "30"

--- a/api/OfflineAudioCompletionEvent.json
+++ b/api/OfflineAudioCompletionEvent.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "25"

--- a/api/OfflineAudioContext.json
+++ b/api/OfflineAudioContext.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "25"
@@ -304,7 +304,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false
@@ -399,7 +399,7 @@
                 "version_added": "42"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "37"
@@ -448,7 +448,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false

--- a/api/OscillatorNode.json
+++ b/api/OscillatorNode.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "25"

--- a/api/PannerNode.json
+++ b/api/PannerNode.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "25"
@@ -351,7 +351,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "50"
@@ -399,7 +399,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "50"
@@ -447,7 +447,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "50"
@@ -543,7 +543,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "50"
@@ -591,7 +591,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "50"
@@ -639,7 +639,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "50"

--- a/api/ParentNode.json
+++ b/api/ParentNode.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "3.5"
@@ -106,7 +106,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -202,7 +202,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -491,7 +491,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -635,7 +635,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"

--- a/api/Path2D.json
+++ b/api/Path2D.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "31"
@@ -59,7 +59,7 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": true,
+              "version_added": "≤18",
               "notes": "The constructor for <code>Path2D</code> objects in Edge does not support being invoked with a string consisting of SVG path data. See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/8438884/'>issue 8438884</a> for details."
             },
             "firefox": {

--- a/api/PaymentAddress.json
+++ b/api/PaymentAddress.json
@@ -25,7 +25,7 @@
             ]
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "56",

--- a/api/PaymentDetailsBase.json
+++ b/api/PaymentDetailsBase.json
@@ -11,7 +11,7 @@
             "version_added": "53"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "55",
@@ -84,7 +84,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "55",
@@ -148,7 +148,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "55",
@@ -212,7 +212,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "55",

--- a/api/PaymentDetailsInit.json
+++ b/api/PaymentDetailsInit.json
@@ -11,7 +11,7 @@
             "version_added": "53"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "55",
@@ -84,7 +84,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "55",
@@ -148,7 +148,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "55",

--- a/api/PaymentDetailsUpdate.json
+++ b/api/PaymentDetailsUpdate.json
@@ -11,7 +11,7 @@
             "version_added": "53"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "55",
@@ -84,7 +84,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "55",
@@ -148,7 +148,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "55",
@@ -212,7 +212,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "55",

--- a/api/PaymentItem.json
+++ b/api/PaymentItem.json
@@ -25,7 +25,7 @@
             ]
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "55",
@@ -112,7 +112,7 @@
               ]
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "55",
@@ -188,7 +188,7 @@
               ]
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "55",
@@ -264,7 +264,7 @@
               ]
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "55",

--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -11,7 +11,7 @@
             "version_added": "53"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "55",
@@ -85,7 +85,7 @@
               "version_added": "53"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "55",
@@ -795,7 +795,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "55",

--- a/api/PaymentRequestUpdateEvent.json
+++ b/api/PaymentRequestUpdateEvent.json
@@ -24,7 +24,7 @@
             }
           ],
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "56",

--- a/api/PaymentResponse.json
+++ b/api/PaymentResponse.json
@@ -24,7 +24,7 @@
             }
           ],
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "55",

--- a/api/Performance.json
+++ b/api/Performance.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "7"

--- a/api/PerformanceEntry.json
+++ b/api/PerformanceEntry.json
@@ -23,7 +23,7 @@
             }
           ],
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/PerformanceMark.json
+++ b/api/PerformanceMark.json
@@ -11,7 +11,7 @@
             "version_added": "43"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "41"

--- a/api/PerformanceMeasure.json
+++ b/api/PerformanceMeasure.json
@@ -11,7 +11,7 @@
             "version_added": "25"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "41"

--- a/api/PerformanceNavigation.json
+++ b/api/PerformanceNavigation.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "7"

--- a/api/PerformanceNavigationTiming.json
+++ b/api/PerformanceNavigationTiming.json
@@ -11,7 +11,7 @@
             "version_added": "57"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "58",
@@ -396,7 +396,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "58"

--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -11,7 +11,7 @@
             "version_added": "43"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "40"
@@ -826,7 +826,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "40"
@@ -922,7 +922,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "60"

--- a/api/PeriodicWave.json
+++ b/api/PeriodicWave.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "25"

--- a/api/Plugin.json
+++ b/api/Plugin.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/PluginArray.json
+++ b/api/PluginArray.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/Point.json
+++ b/api/Point.json
@@ -11,7 +11,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": false
@@ -59,7 +59,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false
@@ -106,7 +106,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false

--- a/api/PopStateEvent.json
+++ b/api/PopStateEvent.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "4"

--- a/api/PositionOptions.json
+++ b/api/PositionOptions.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "3.5"
@@ -70,7 +70,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -130,7 +130,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"
@@ -239,7 +239,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"

--- a/api/ProcessingInstruction.json
+++ b/api/ProcessingInstruction.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/ProgressEvent.json
+++ b/api/ProgressEvent.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "3.5"

--- a/api/PushSubscription.json
+++ b/api/PushSubscription.json
@@ -11,7 +11,7 @@
             "version_added": "42"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "44",
@@ -255,7 +255,7 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false

--- a/api/PushSubscriptionOptions.json
+++ b/api/PushSubscriptionOptions.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/RTCDTMFToneChangeEvent.json
+++ b/api/RTCDTMFToneChangeEvent.json
@@ -11,7 +11,7 @@
             "version_added": "27"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "52"
@@ -59,7 +59,7 @@
               "version_added": "27"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "52"

--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "22"
@@ -59,7 +59,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22",
@@ -253,7 +253,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false
@@ -301,7 +301,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false
@@ -349,7 +349,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false
@@ -397,7 +397,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false
@@ -445,7 +445,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false
@@ -493,7 +493,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false
@@ -541,7 +541,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false
@@ -685,7 +685,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false
@@ -781,7 +781,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false

--- a/api/RTCIceCandidateInit.json
+++ b/api/RTCIceCandidateInit.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "22"
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22",
@@ -108,7 +108,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -156,7 +156,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -204,7 +204,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "67"

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -11,7 +11,7 @@
             "version_added": "25"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "22"
@@ -89,7 +89,7 @@
               "notes": "Before Chrome 63 the default value for the <code>RTCConfiguration.rtcpMuxPolicy</code> parameter was <code>&quot;negotiate&quot;</code>"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -353,7 +353,7 @@
               "version_added": "64"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -792,7 +792,7 @@
               "version_added": "27"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -942,7 +942,7 @@
               "version_added": "70"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -1053,7 +1053,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -1101,7 +1101,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -1163,7 +1163,7 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -1335,7 +1335,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -1459,7 +1459,7 @@
               "version_added": "59"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -1569,7 +1569,7 @@
               "version_added": "64"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -2092,7 +2092,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -2141,7 +2141,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -2190,7 +2190,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -2459,7 +2459,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -2755,7 +2755,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -2817,7 +2817,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -2879,7 +2879,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -3003,7 +3003,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -3191,7 +3191,7 @@
               "version_added": "64"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -3253,7 +3253,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -3316,7 +3316,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -3364,7 +3364,7 @@
               "version_added": "70"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -3426,7 +3426,7 @@
               "version_added": "70"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -3667,7 +3667,7 @@
               "version_added": "64"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -3814,7 +3814,7 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false,
@@ -3878,7 +3878,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -4275,7 +4275,7 @@
               "version_added": "64"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"

--- a/api/RTCPeerConnectionIceEvent.json
+++ b/api/RTCPeerConnectionIceEvent.json
@@ -25,7 +25,7 @@
             }
           ],
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true
@@ -87,7 +87,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true

--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -11,7 +11,7 @@
             "version_added": "59"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true
@@ -319,7 +319,7 @@
               "version_added": "67"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "55"

--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "34"
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "52"
@@ -205,7 +205,7 @@
               "version_added": "67"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "55"
@@ -254,7 +254,7 @@
               "version_added": "65"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true

--- a/api/RTCRtpTransceiver.json
+++ b/api/RTCRtpTransceiver.json
@@ -11,7 +11,7 @@
             "version_added": false
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "59"

--- a/api/RTCRtpTransceiverDirection.json
+++ b/api/RTCRtpTransceiverDirection.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "59"

--- a/api/RTCRtpTransceiverInit.json
+++ b/api/RTCRtpTransceiverInit.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "59"
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "59"
@@ -106,7 +106,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false,
@@ -156,7 +156,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "59"

--- a/api/RTCSessionDescription.json
+++ b/api/RTCSessionDescription.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "prefix": "moz",
@@ -60,7 +60,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "prefix": "moz",

--- a/api/RTCSessionDescriptionCallback.json
+++ b/api/RTCSessionDescriptionCallback.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "22"

--- a/api/RTCTrackEvent.json
+++ b/api/RTCTrackEvent.json
@@ -11,7 +11,7 @@
             "version_added": "56"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "22"
@@ -58,7 +58,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -106,7 +106,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -154,7 +154,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -202,7 +202,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "59"

--- a/api/RTCTrackEventInit.json
+++ b/api/RTCTrackEventInit.json
@@ -11,7 +11,7 @@
             "version_added": "56"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "22"
@@ -58,7 +58,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -106,7 +106,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -154,7 +154,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -202,7 +202,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "59"

--- a/api/RadioNodeList.json
+++ b/api/RadioNodeList.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "33"

--- a/api/Range.json
+++ b/api/Range.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "4",
@@ -61,7 +61,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "24"
@@ -980,7 +980,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "14"
@@ -1653,7 +1653,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "4"

--- a/api/Request.json
+++ b/api/Request.json
@@ -33,7 +33,7 @@
             }
           ],
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {
@@ -1218,7 +1218,7 @@
                 "version_added": "49"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "46"

--- a/api/Response.json
+++ b/api/Response.json
@@ -33,7 +33,7 @@
             }
           ],
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {
@@ -1160,7 +1160,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {

--- a/api/SVGAElement.json
+++ b/api/SVGAElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true
@@ -104,7 +104,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "61"
@@ -151,7 +151,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "61"
@@ -245,7 +245,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "61"
@@ -292,7 +292,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "61"
@@ -387,7 +387,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "61"
@@ -434,7 +434,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "61"

--- a/api/SVGAngle.json
+++ b/api/SVGAngle.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGAnimatedAngle.json
+++ b/api/SVGAnimatedAngle.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGAnimatedBoolean.json
+++ b/api/SVGAnimatedBoolean.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGAnimatedEnumeration.json
+++ b/api/SVGAnimatedEnumeration.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGAnimatedInteger.json
+++ b/api/SVGAnimatedInteger.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGAnimatedLength.json
+++ b/api/SVGAnimatedLength.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGAnimatedLengthList.json
+++ b/api/SVGAnimatedLengthList.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGAnimatedNumber.json
+++ b/api/SVGAnimatedNumber.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGAnimatedNumberList.json
+++ b/api/SVGAnimatedNumberList.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGAnimatedPoints.json
+++ b/api/SVGAnimatedPoints.json
@@ -11,7 +11,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": null

--- a/api/SVGAnimatedPreserveAspectRatio.json
+++ b/api/SVGAnimatedPreserveAspectRatio.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGAnimatedRect.json
+++ b/api/SVGAnimatedRect.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGAnimatedString.json
+++ b/api/SVGAnimatedString.json
@@ -11,7 +11,7 @@
             "version_added": false
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGAnimatedTransformList.json
+++ b/api/SVGAnimatedTransformList.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "9"

--- a/api/SVGCircleElement.json
+++ b/api/SVGCircleElement.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1.5"

--- a/api/SVGClipPathElement.json
+++ b/api/SVGClipPathElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGComponentTransferFunctionElement.json
+++ b/api/SVGComponentTransferFunctionElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGDefsElement.json
+++ b/api/SVGDefsElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGDescElement.json
+++ b/api/SVGDescElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGEllipseElement.json
+++ b/api/SVGEllipseElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGFEBlendElement.json
+++ b/api/SVGFEBlendElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGFEColorMatrixElement.json
+++ b/api/SVGFEColorMatrixElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true

--- a/api/SVGFEComponentTransferElement.json
+++ b/api/SVGFEComponentTransferElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGFECompositeElement.json
+++ b/api/SVGFECompositeElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGFEConvolveMatrixElement.json
+++ b/api/SVGFEConvolveMatrixElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGFEDiffuseLightingElement.json
+++ b/api/SVGFEDiffuseLightingElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGFEDisplacementMapElement.json
+++ b/api/SVGFEDisplacementMapElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGFEDistantLightElement.json
+++ b/api/SVGFEDistantLightElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGFEFloodElement.json
+++ b/api/SVGFEFloodElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGFEFuncAElement.json
+++ b/api/SVGFEFuncAElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGFEFuncBElement.json
+++ b/api/SVGFEFuncBElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGFEFuncGElement.json
+++ b/api/SVGFEFuncGElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGFEFuncRElement.json
+++ b/api/SVGFEFuncRElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGFEGaussianBlurElement.json
+++ b/api/SVGFEGaussianBlurElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGFEImageElement.json
+++ b/api/SVGFEImageElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGFEMergeElement.json
+++ b/api/SVGFEMergeElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGFEMergeNodeElement.json
+++ b/api/SVGFEMergeNodeElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGFEMorphologyElement.json
+++ b/api/SVGFEMorphologyElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGFEOffsetElement.json
+++ b/api/SVGFEOffsetElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGFEPointLightElement.json
+++ b/api/SVGFEPointLightElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGFESpecularLightingElement.json
+++ b/api/SVGFESpecularLightingElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGFESpotLightElement.json
+++ b/api/SVGFESpotLightElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGFETileElement.json
+++ b/api/SVGFETileElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGFETurbulenceElement.json
+++ b/api/SVGFETurbulenceElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGFilterElement.json
+++ b/api/SVGFilterElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGForeignObjectElement.json
+++ b/api/SVGForeignObjectElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGGElement.json
+++ b/api/SVGGElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGGradientElement.json
+++ b/api/SVGGradientElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGGraphicsElement.json
+++ b/api/SVGGraphicsElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGImageElement.json
+++ b/api/SVGImageElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGLength.json
+++ b/api/SVGLength.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGLengthList.json
+++ b/api/SVGLengthList.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGLineElement.json
+++ b/api/SVGLineElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true
@@ -57,7 +57,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -104,7 +104,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -151,7 +151,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -198,7 +198,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true

--- a/api/SVGLinearGradientElement.json
+++ b/api/SVGLinearGradientElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGMPathElement.json
+++ b/api/SVGMPathElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGMaskElement.json
+++ b/api/SVGMaskElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGMatrix.json
+++ b/api/SVGMatrix.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGMetadataElement.json
+++ b/api/SVGMetadataElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGNumber.json
+++ b/api/SVGNumber.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGNumberList.json
+++ b/api/SVGNumberList.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGPathElement.json
+++ b/api/SVGPathElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGPatternElement.json
+++ b/api/SVGPatternElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGPoint.json
+++ b/api/SVGPoint.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGPolygonElement.json
+++ b/api/SVGPolygonElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true,

--- a/api/SVGPolylineElement.json
+++ b/api/SVGPolylineElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true,

--- a/api/SVGPreserveAspectRatio.json
+++ b/api/SVGPreserveAspectRatio.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGRadialGradientElement.json
+++ b/api/SVGRadialGradientElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGRect.json
+++ b/api/SVGRect.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1.5"

--- a/api/SVGRectElement.json
+++ b/api/SVGRectElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true,

--- a/api/SVGSVGElement.json
+++ b/api/SVGSVGElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGScriptElement.json
+++ b/api/SVGScriptElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGStopElement.json
+++ b/api/SVGStopElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGStringList.json
+++ b/api/SVGStringList.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "12",

--- a/api/SVGStylable.json
+++ b/api/SVGStylable.json
@@ -11,7 +11,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": null

--- a/api/SVGStyleElement.json
+++ b/api/SVGStyleElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGSwitchElement.json
+++ b/api/SVGSwitchElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGSymbolElement.json
+++ b/api/SVGSymbolElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGTSpanElement.json
+++ b/api/SVGTSpanElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGTests.json
+++ b/api/SVGTests.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "12"

--- a/api/SVGTextElement.json
+++ b/api/SVGTextElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGTextPathElement.json
+++ b/api/SVGTextPathElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGTitleElement.json
+++ b/api/SVGTitleElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGTransform.json
+++ b/api/SVGTransform.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGTransformList.json
+++ b/api/SVGTransformList.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGTransformable.json
+++ b/api/SVGTransformable.json
@@ -11,7 +11,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": null

--- a/api/SVGUnitTypes.json
+++ b/api/SVGUnitTypes.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGUseElement.json
+++ b/api/SVGUseElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/SVGViewElement.json
+++ b/api/SVGViewElement.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/Screen.json
+++ b/api/Screen.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true
@@ -352,7 +352,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -576,7 +576,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true,
+              "version_added": "≤18",
               "alternative_name": "onmsorientationchange"
             },
             "firefox": {
@@ -742,7 +742,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true

--- a/api/ScriptProcessorNode.json
+++ b/api/ScriptProcessorNode.json
@@ -12,7 +12,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "25"

--- a/api/SecurityPolicyViolationEvent.json
+++ b/api/SecurityPolicyViolationEvent.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {
@@ -83,7 +83,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -299,7 +299,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -731,7 +731,7 @@
               "version_added": "59"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -1019,7 +1019,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {

--- a/api/Selection.json
+++ b/api/Selection.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true,
@@ -1264,7 +1264,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true

--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -25,7 +25,7 @@
             }
           ],
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {

--- a/api/SourceBufferList.json
+++ b/api/SourceBufferList.json
@@ -18,7 +18,7 @@
             "version_added": "33"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {

--- a/api/SpeechSynthesis.json
+++ b/api/SpeechSynthesis.json
@@ -11,7 +11,7 @@
             "version_added": "33"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "49"

--- a/api/SpeechSynthesisErrorEvent.json
+++ b/api/SpeechSynthesisErrorEvent.json
@@ -11,7 +11,7 @@
             "version_added": "33"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "49"
@@ -71,7 +71,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "49"

--- a/api/SpeechSynthesisEvent.json
+++ b/api/SpeechSynthesisEvent.json
@@ -11,7 +11,7 @@
             "version_added": "33"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "49"

--- a/api/SpeechSynthesisUtterance.json
+++ b/api/SpeechSynthesisUtterance.json
@@ -11,7 +11,7 @@
             "version_added": "33"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "49"
@@ -72,7 +72,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "49"

--- a/api/SpeechSynthesisVoice.json
+++ b/api/SpeechSynthesisVoice.json
@@ -11,7 +11,7 @@
             "version_added": "33"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "49"

--- a/api/StereoPannerNode.json
+++ b/api/StereoPannerNode.json
@@ -11,7 +11,7 @@
             "version_added": "41"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "37"

--- a/api/StorageEvent.json
+++ b/api/StorageEvent.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/StyleSheet.json
+++ b/api/StyleSheet.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/StyleSheetList.json
+++ b/api/StyleSheetList.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "31"

--- a/api/Text.json
+++ b/api/Text.json
@@ -8,7 +8,7 @@
             "version_added": "1"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true
@@ -101,7 +101,7 @@
               "version_added": "53"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true

--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1.5"

--- a/api/TextTrackList.json
+++ b/api/TextTrackList.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true
@@ -204,7 +204,7 @@
               "version_added": "44"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true

--- a/api/TimeRanges.json
+++ b/api/TimeRanges.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/Touch.json
+++ b/api/Touch.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {
@@ -115,7 +115,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -171,7 +171,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -275,7 +275,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -331,7 +331,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -387,7 +387,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -587,7 +587,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -643,7 +643,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -699,7 +699,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {

--- a/api/TouchEvent.json
+++ b/api/TouchEvent.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true,
+            "version_added": "≤18",
             "flags": [
               {
                 "type": "preference",
@@ -125,7 +125,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -179,7 +179,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -233,7 +233,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -287,7 +287,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -341,7 +341,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -395,7 +395,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -449,7 +449,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {

--- a/api/TouchList.json
+++ b/api/TouchList.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {
@@ -112,7 +112,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -166,7 +166,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {

--- a/api/TrackDefault.json
+++ b/api/TrackDefault.json
@@ -11,7 +11,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": false
@@ -59,7 +59,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false
@@ -107,7 +107,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false
@@ -155,7 +155,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false
@@ -203,7 +203,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false
@@ -251,7 +251,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false
@@ -299,7 +299,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false

--- a/api/TrackDefaultList.json
+++ b/api/TrackDefaultList.json
@@ -11,7 +11,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": false
@@ -58,7 +58,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false
@@ -107,7 +107,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false
@@ -155,7 +155,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false

--- a/api/Transferable.json
+++ b/api/Transferable.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "4"

--- a/api/TransitionEvent.json
+++ b/api/TransitionEvent.json
@@ -25,7 +25,7 @@
             }
           ],
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "4"
@@ -135,7 +135,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "4"

--- a/api/TreeWalker.json
+++ b/api/TreeWalker.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "4"

--- a/api/UIEvent.json
+++ b/api/UIEvent.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true
@@ -59,7 +59,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "11"
@@ -107,7 +107,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -154,7 +154,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "53"
@@ -353,7 +353,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -401,7 +401,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true

--- a/api/VRDisplay.json
+++ b/api/VRDisplay.json
@@ -22,7 +22,7 @@
             ]
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {

--- a/api/VRDisplayCapabilities.json
+++ b/api/VRDisplayCapabilities.json
@@ -22,7 +22,7 @@
             ]
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {

--- a/api/VRDisplayEvent.json
+++ b/api/VRDisplayEvent.json
@@ -22,7 +22,7 @@
             ]
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {
@@ -83,7 +83,7 @@
               ]
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {

--- a/api/VREyeParameters.json
+++ b/api/VREyeParameters.json
@@ -22,7 +22,7 @@
             ]
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {

--- a/api/VRFieldOfView.json
+++ b/api/VRFieldOfView.json
@@ -22,7 +22,7 @@
             ]
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {

--- a/api/VRFrameData.json
+++ b/api/VRFrameData.json
@@ -22,7 +22,7 @@
             ]
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {
@@ -83,7 +83,7 @@
               ]
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {

--- a/api/VRLayerInit.json
+++ b/api/VRLayerInit.json
@@ -22,7 +22,7 @@
             ]
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {
@@ -82,7 +82,7 @@
               ]
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -143,7 +143,7 @@
               ]
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -204,7 +204,7 @@
               ]
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {

--- a/api/VRPose.json
+++ b/api/VRPose.json
@@ -22,7 +22,7 @@
             ]
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {

--- a/api/VRStageParameters.json
+++ b/api/VRStageParameters.json
@@ -22,7 +22,7 @@
             ]
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {
@@ -82,7 +82,7 @@
               ]
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -143,7 +143,7 @@
               ]
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -204,7 +204,7 @@
               ]
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {

--- a/api/VideoPlaybackQuality.json
+++ b/api/VideoPlaybackQuality.json
@@ -8,7 +8,7 @@
             "version_added": "23"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {

--- a/api/VideoTrack.json
+++ b/api/VideoTrack.json
@@ -11,7 +11,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": null

--- a/api/WEBGL_compressed_texture_s3tc.json
+++ b/api/WEBGL_compressed_texture_s3tc.json
@@ -23,7 +23,7 @@
             }
           ],
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {

--- a/api/WEBGL_debug_renderer_info.json
+++ b/api/WEBGL_debug_renderer_info.json
@@ -11,7 +11,7 @@
             "version_added": "33"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {

--- a/api/WEBGL_depth_texture.json
+++ b/api/WEBGL_depth_texture.json
@@ -23,7 +23,7 @@
             }
           ],
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {

--- a/api/WaveShaperNode.json
+++ b/api/WaveShaperNode.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "25"

--- a/api/WebGLObject.json
+++ b/api/WebGLObject.json
@@ -11,7 +11,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": null

--- a/api/WebKitCSSMatrix.json
+++ b/api/WebKitCSSMatrix.json
@@ -11,7 +11,7 @@
             "version_added": null
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": null

--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": [
             {
@@ -982,7 +982,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "37"

--- a/api/WheelEvent.json
+++ b/api/WheelEvent.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "17"
@@ -59,7 +59,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "17"

--- a/api/Window.json
+++ b/api/Window.json
@@ -59,7 +59,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "1"
@@ -156,7 +156,7 @@
               "version_added": "63"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "6"
@@ -527,7 +527,7 @@
               "version_added": "63"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "6"
@@ -576,7 +576,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "1"
@@ -680,7 +680,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": true
@@ -728,7 +728,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": true
@@ -776,7 +776,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "1"
@@ -874,7 +874,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -1276,7 +1276,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "6"
@@ -1341,7 +1341,7 @@
               }
             ],
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -1421,7 +1421,7 @@
               "version_added": "58"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -1467,7 +1467,7 @@
                 "version_added": "58"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "22"
@@ -1673,7 +1673,7 @@
               "version_added": "58"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -1719,7 +1719,7 @@
                 "version_added": "58"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "22"
@@ -1769,7 +1769,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "6"
@@ -1818,7 +1818,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -2277,7 +2277,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -2484,7 +2484,7 @@
               "version_added": "37"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "29"
@@ -2547,7 +2547,7 @@
               "version_added": "37"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "29"
@@ -2992,7 +2992,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.6"
@@ -3455,7 +3455,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -3600,7 +3600,7 @@
                 "version_added": "31"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "21"
@@ -4373,7 +4373,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -4787,7 +4787,7 @@
               }
             ],
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "29"
@@ -4870,7 +4870,7 @@
               }
             ],
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "29"
@@ -4940,7 +4940,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -6283,7 +6283,7 @@
               "version_added": "58"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -6329,7 +6329,7 @@
                 "version_added": "58"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "22"
@@ -6660,7 +6660,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "20"
@@ -7038,7 +7038,7 @@
                 "version_added": "25"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "11"
@@ -7089,7 +7089,7 @@
               "prefix": "webkit"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false
@@ -7206,7 +7206,7 @@
               "notes": "Chrome does not emit a <code>resize</code> event on page load."
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true,
@@ -8291,10 +8291,10 @@
             ],
             "edge": [
               {
-                "version_added": true
+                "version_added": "≤18"
               },
               {
-                "version_added": true,
+                "version_added": "≤18",
                 "alternative_name": "pageXOffset"
               }
             ],
@@ -8397,7 +8397,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "55"
@@ -8459,10 +8459,10 @@
             ],
             "edge": [
               {
-                "version_added": true
+                "version_added": "≤18"
               },
               {
-                "version_added": true,
+                "version_added": "≤18",
                 "alternative_name": "pageYOffset"
               }
             ],
@@ -8565,7 +8565,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "55"
@@ -9206,7 +9206,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "45"
@@ -9548,7 +9548,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -9616,7 +9616,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true

--- a/api/WindowClient.json
+++ b/api/WindowClient.json
@@ -11,7 +11,7 @@
             "version_added": "42"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "44",
@@ -107,7 +107,7 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "44",
@@ -156,7 +156,7 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "44",
@@ -205,7 +205,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "44",
@@ -254,7 +254,7 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "44",

--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true
@@ -58,7 +58,7 @@
               "version_added": "63"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "6"
@@ -106,7 +106,7 @@
               "version_added": "63"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "6"
@@ -154,7 +154,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "1"
@@ -259,7 +259,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.6"
@@ -640,7 +640,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "45"
@@ -781,7 +781,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true

--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -126,7 +126,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -246,7 +246,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -312,7 +312,7 @@
               "version_added": "45"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -929,7 +929,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -993,7 +993,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "37"
@@ -1189,7 +1189,7 @@
               "version_added": "30"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -1256,7 +1256,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": true
@@ -1308,7 +1308,7 @@
               "version_added": "30"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": [
               {
@@ -1375,7 +1375,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": true

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "3.5"
@@ -85,7 +85,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "3.5"

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "3.5"
@@ -252,7 +252,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true

--- a/api/WritableStreamDefaultController.json
+++ b/api/WritableStreamDefaultController.json
@@ -11,7 +11,7 @@
             "version_added": "58"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": false

--- a/api/XMLDocument.json
+++ b/api/XMLDocument.json
@@ -11,7 +11,7 @@
             "version_added": "45"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"

--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"
@@ -777,7 +777,7 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "9"
@@ -970,7 +970,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "6"
@@ -1018,7 +1018,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "6"
@@ -1066,7 +1066,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "11"
@@ -1414,7 +1414,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "9"
@@ -1512,7 +1512,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "2"
@@ -1561,7 +1561,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "2"
@@ -1926,7 +1926,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true

--- a/api/XMLHttpRequestEventTarget.json
+++ b/api/XMLHttpRequestEventTarget.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "1"
@@ -58,7 +58,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -106,7 +106,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -154,7 +154,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -202,7 +202,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -250,7 +250,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -298,7 +298,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -346,7 +346,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true

--- a/api/XMLHttpRequestUpload.json
+++ b/api/XMLHttpRequestUpload.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/XMLSerializer.json
+++ b/api/XMLSerializer.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/XPathExpression.json
+++ b/api/XPathExpression.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/XPathResult.json
+++ b/api/XPathResult.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/api/XSLTProcessor.json
+++ b/api/XSLTProcessor.json
@@ -11,7 +11,7 @@
             "version_added": true
           },
           "edge": {
-            "version_added": true
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": true

--- a/html/elements/audio.json
+++ b/html/elements/audio.json
@@ -107,7 +107,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "4"
@@ -295,7 +295,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "11"
@@ -510,7 +510,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": null

--- a/html/elements/data.json
+++ b/html/elements/data.json
@@ -12,7 +12,7 @@
               "version_added": "62"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -878,7 +878,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "28"

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -832,7 +832,7 @@
                 "version_added": "34"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": [
                 {

--- a/html/elements/keygen.json
+++ b/html/elements/keygen.json
@@ -14,7 +14,7 @@
               "version_removed": "57"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "1",

--- a/html/elements/marquee.json
+++ b/html/elements/marquee.json
@@ -260,7 +260,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "3"
@@ -307,7 +307,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "3"
@@ -495,7 +495,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "3"

--- a/html/elements/menu.json
+++ b/html/elements/menu.json
@@ -12,7 +12,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "8"
@@ -205,7 +205,7 @@
                   "version_added": false
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": "≤18"
                 },
                 "firefox": {
                   "version_added": "8"

--- a/html/elements/meter.json
+++ b/html/elements/meter.json
@@ -12,7 +12,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "16"
@@ -58,7 +58,7 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "16"
@@ -105,7 +105,7 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "16"
@@ -152,7 +152,7 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "16"
@@ -199,7 +199,7 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "16"
@@ -246,7 +246,7 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "16"
@@ -293,7 +293,7 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "16"
@@ -340,7 +340,7 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "16"

--- a/html/elements/output.json
+++ b/html/elements/output.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "4"
@@ -58,7 +58,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "4"
@@ -104,7 +104,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": "≤18"
                 },
                 "firefox": {
                   "version_added": "4"
@@ -150,7 +150,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": true
+                    "version_added": "≤18"
                   },
                   "firefox": {
                     "version_added": "4"

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -106,7 +106,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "13"

--- a/html/elements/source.json
+++ b/html/elements/source.json
@@ -107,7 +107,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": [
                 {
@@ -237,7 +237,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": [
                 {

--- a/html/elements/thead.json
+++ b/html/elements/thead.json
@@ -58,7 +58,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": false,

--- a/html/elements/time.json
+++ b/html/elements/time.json
@@ -12,7 +12,7 @@
               "version_added": "62"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "22"
@@ -70,7 +70,7 @@
                 "version_added": "62"
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "22"

--- a/html/elements/track.json
+++ b/html/elements/track.json
@@ -379,7 +379,7 @@
                   "version_added": null
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": "≤18"
                 },
                 "firefox": {
                   "version_added": "50",

--- a/html/elements/video.json
+++ b/html/elements/video.json
@@ -106,7 +106,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "4"
@@ -200,7 +200,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "12"
@@ -453,7 +453,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "15"

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -665,7 +665,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": true
+                  "version_added": "≤18"
                 },
                 "firefox": {
                   "version_added": "45"

--- a/http/headers/retry-after.json
+++ b/http/headers/retry-after.json
@@ -12,7 +12,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": false,

--- a/svg/elements/a.json
+++ b/svg/elements/a.json
@@ -152,7 +152,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "61"
@@ -199,7 +199,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "61"
@@ -293,7 +293,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "61"
@@ -387,7 +387,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "61"

--- a/svg/elements/altGlyph.json
+++ b/svg/elements/altGlyph.json
@@ -12,7 +12,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "4",

--- a/svg/elements/feComposite.json
+++ b/svg/elements/feComposite.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true
@@ -58,7 +58,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": true
@@ -105,7 +105,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": true
@@ -341,7 +341,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": true
@@ -388,7 +388,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": true

--- a/svg/elements/feDistantLight.json
+++ b/svg/elements/feDistantLight.json
@@ -12,7 +12,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": null

--- a/svg/elements/feGaussianBlur.json
+++ b/svg/elements/feGaussianBlur.json
@@ -12,7 +12,7 @@
               "version_added": null
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "4"
@@ -105,7 +105,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "4"
@@ -152,7 +152,7 @@
                 "version_added": null
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "4"

--- a/svg/elements/mpath.json
+++ b/svg/elements/mpath.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": true

--- a/svg/elements/use.json
+++ b/svg/elements/use.json
@@ -61,7 +61,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": true
+                "version_added": "≤18"
               },
               "firefox": {
                 "version_added": "4"

--- a/svg/elements/view.json
+++ b/svg/elements/view.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": true
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "15"


### PR DESCRIPTION
In preparation for mirroring Chromium data over to Edge, this PR sets all values set to `true` for Edge and replaces them with the new ranged value, `≤18`.  This will help us during mirroring of Chrome data to Edge.

(Note: with as many files as there are, this isn't really created by a dedicated script.  I had run `traverse` to find all the values set to "true", then set the values to `≤18` using a script I wrote to set a value for a specified identifier, following up with some manual updates.)