### PR TITLE
Update PluralRules()/RelativeTimeFormat() MDN URLs

### DIFF
--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -2492,8 +2492,8 @@
           },
           "PluralRules": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/PluralRules",
-              "spec_url": "https://tc39.es/ecma402/#pluralrules-objects",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/PluralRules/PluralRules",
+              "spec_url": "https://tc39.es/ecma402/#sec-intl-pluralrules-constructor",
               "description": "<code>PluralRules()</code> constructor",
               "support": {
                 "chrome": {
@@ -2801,8 +2801,8 @@
           },
           "RelativeTimeFormat": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat",
-              "spec_url": "https://tc39.es/proposal-intl-relative-time/#relativetimeformat-objects",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/RelativeTimeFormat",
+              "spec_url": "https://tc39.es/proposal-intl-relative-time/#sec-intl-relativetimeformat-constructor",
               "description": "<code>RelativeTimeFormat()</code> constructor",
               "support": {
                 "chrome": {


### PR DESCRIPTION
The `Intl.PluralRules()` and `RelativeTimeFormat()` constructors now have their own MDN articles, so this change updates their MDN URLs (as well as (re)updating their spec URLs).

---

(I realize that per https://github.com/mdn/sprints/issues/2537, the MDN articles for these are destined to be moved, but I wanted to go ahead and do these now because they’re two particular ones that have been causing me some confusion for a while…)