### PR TITLE
Add chat link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ browser support for APIs. For example:
 
 Read how this project is [governed](https://github.com/mdn/browser-compat-data/blob/master/GOVERNANCE.md).
 
+Chat on [chat.mozilla.org#mdn](https://matrix.to/#/!cGYYDEJwjktUBMSTQT:mozilla.org).
+
 ## Installation
 
 You can install mdn-browser-compat-data as a node package.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ browser support for APIs. For example:
 
 Read how this project is [governed](https://github.com/mdn/browser-compat-data/blob/master/GOVERNANCE.md).
 
-Chat on [chat.mozilla.org#mdn](https://matrix.to/#/!cGYYDEJwjktUBMSTQT:mozilla.org).
+Chat on [chat.mozilla.org#mdn](https://chat.mozilla.org/#/room/#mdn:mozilla.org).
 
 ## Installation
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -67,4 +67,4 @@ If the feature you're interested in is a JavaScript API, you can cross-reference
 
 ## Getting help
 
-If you need help with this repository or have any questions, contact the MDN team on [chat.mozilla.org#mdn](https://matrix.to/#/!cGYYDEJwjktUBMSTQT:mozilla.org) or write us on [discourse](https://discourse.mozilla-community.org/c/mdn).
+If you need help with this repository or have any questions, contact the MDN team on [chat.mozilla.org#mdn](https://chat.mozilla.org/#/room/#mdn:mozilla.org) or write us on [discourse](https://discourse.mozilla-community.org/c/mdn).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -67,4 +67,4 @@ If the feature you're interested in is a JavaScript API, you can cross-reference
 
 ## Getting help
 
-If you need help with this repository or have any questions, contact the MDN team on [chat.mozilla.org#mdn](https://chat.mozilla.org/#/room/#mdn:mozilla.org) or write us on [discourse](https://discourse.mozilla-community.org/c/mdn).
+If you need help with this repository or have any questions, contact the MDN team on [chat.mozilla.org#mdn](https://chat.mozilla.org/#/room/#mdn:mozilla.org) or write to us on [Discourse](https://discourse.mozilla-community.org/c/mdn).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -67,5 +67,4 @@ If the feature you're interested in is a JavaScript API, you can cross-reference
 
 ## Getting help
 
-If you need help with this repository or have any questions, contact the MDN team
-in the [#mdn](irc://irc.mozilla.org/mdn) IRC channel on irc.mozilla.org or write us on [discourse](https://discourse.mozilla-community.org/c/mdn).
+If you need help with this repository or have any questions, contact the MDN team on [chat.mozilla.org#mdn](https://matrix.to/#/!cGYYDEJwjktUBMSTQT:mozilla.org) or write us on [discourse](https://discourse.mozilla-community.org/c/mdn).


### PR DESCRIPTION
I'd like to invite the BCD community to get closer to each other and closer to MDN folks. 
Mozilla has replaced its old IRC with matrix chat. We've created an MDN channel there. (I've used the "share room" functionality to get a link to the room).