### PR TITLE
Mirror Chrome -> Edge for webextensions/

### DIFF
--- a/webextensions/api/alarms.json
+++ b/webextensions/api/alarms.json
@@ -10,7 +10,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -32,7 +32,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -54,7 +54,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -76,7 +76,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": [
                 {
@@ -112,7 +112,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -134,7 +134,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -156,7 +156,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"

--- a/webextensions/api/bookmarks.json
+++ b/webextensions/api/bookmarks.json
@@ -10,7 +10,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -75,7 +75,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -97,7 +97,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -162,7 +162,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -184,7 +184,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -206,7 +206,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "47"
@@ -228,7 +228,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -294,7 +294,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "52"
@@ -316,7 +316,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -338,7 +338,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "52"
@@ -360,7 +360,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -382,7 +382,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -404,7 +404,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "52"
@@ -426,7 +426,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "52"
@@ -492,7 +492,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "47"

--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -210,7 +210,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -416,7 +416,14 @@
                 ]
               },
               "edge": {
-                "version_added": false
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#extension-apis",
+                    "value_to_set": "Enabled"
+                  }
+                ]
               },
               "firefox": {
                 "version_added": "57"
@@ -511,7 +518,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": true,
@@ -687,7 +694,7 @@
                   "version_added": "23"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "45"

--- a/webextensions/api/browsingData.json
+++ b/webextensions/api/browsingData.json
@@ -10,7 +10,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "53"
@@ -31,7 +31,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "53"
@@ -52,7 +52,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "53"
@@ -73,7 +73,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -94,7 +94,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "53"
@@ -115,7 +115,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "53"
@@ -136,7 +136,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "57"
@@ -157,7 +157,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "57"
@@ -178,7 +178,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "53"
@@ -199,7 +199,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "53"
@@ -220,7 +220,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -241,7 +241,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "53"
@@ -285,7 +285,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -305,7 +305,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": false
@@ -326,7 +326,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": false
@@ -348,7 +348,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "notes": "<code>since</code> is not supported with the following data types: <code>cache</code>, <code>indexedDB</code>, <code>localStorage</code>, and <code>serviceWorkers</code>.",
@@ -373,7 +373,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "notes": "Specifying <code>dataTypes.history</code> will also remove download history and service workers.",
@@ -397,7 +397,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "notes": "<code>removalOptions.since</code> is not supported.",
@@ -421,7 +421,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "53"
@@ -443,7 +443,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "53"
@@ -465,7 +465,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "53"
@@ -487,7 +487,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "notes": "This function also removes download history and service workers.",
@@ -511,7 +511,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "notes": "<code>removalOptions.since</code> is not supported.",
@@ -558,7 +558,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "53"
@@ -581,7 +581,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "53"
@@ -603,7 +603,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "53"

--- a/webextensions/api/commands.json
+++ b/webextensions/api/commands.json
@@ -10,7 +10,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "48"
@@ -32,7 +32,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "48"
@@ -54,7 +54,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "48",

--- a/webextensions/api/contentScripts.json
+++ b/webextensions/api/contentScripts.json
@@ -11,7 +11,8 @@
                 "notes": "There is a <a href='https://github.com/bfred-it/content-scripts-register-polyfill'>polyfill available</a>."
               },
               "edge": {
-                "version_added": false
+                "version_added": false,
+                "notes": "There is a <a href='https://github.com/bfred-it/content-scripts-register-polyfill'>polyfill available</a>."
               },
               "firefox": {
                 "version_added": "59"
@@ -33,7 +34,8 @@
                   "notes": "There is a <a href='https://github.com/bfred-it/content-scripts-register-polyfill'>polyfill available</a>."
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "There is a <a href='https://github.com/bfred-it/content-scripts-register-polyfill'>polyfill available</a>."
                 },
                 "firefox": {
                   "version_added": "59"
@@ -57,7 +59,8 @@
                 "notes": "There is a <a href='https://github.com/bfred-it/content-scripts-register-polyfill'>polyfill available</a>."
               },
               "edge": {
-                "version_added": false
+                "version_added": false,
+                "notes": "There is a <a href='https://github.com/bfred-it/content-scripts-register-polyfill'>polyfill available</a>."
               },
               "firefox": {
                 "version_added": "59"

--- a/webextensions/api/cookies.json
+++ b/webextensions/api/cookies.json
@@ -52,7 +52,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "63"
@@ -97,7 +97,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -232,7 +232,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -299,7 +299,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "63"
@@ -364,7 +364,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "63"

--- a/webextensions/api/devtools.json
+++ b/webextensions/api/devtools.json
@@ -11,7 +11,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "54"
@@ -31,7 +31,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": "55"
@@ -52,7 +52,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": false
@@ -73,7 +73,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": "55"
@@ -96,7 +96,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "54"
@@ -118,7 +118,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "54"
@@ -142,7 +142,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "notes": "The returned HAR log will be empty unless the user has previously activated the browser's network panel at least once.",
@@ -165,7 +165,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "54"
@@ -187,7 +187,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": [
                   {
@@ -219,7 +219,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": "57"
@@ -241,7 +241,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": "56"
@@ -264,7 +264,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": "54"
@@ -285,7 +285,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": false
@@ -306,7 +306,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": "54"
@@ -330,7 +330,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "notes": "This event is only fired when the user switches between sidebar panes, not when the user switches between devtools panels. See <a href='https://bugzil.la/1412317'>bug 1412317</a>.",
@@ -353,7 +353,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "notes": "This event is only fired when the user switches between sidebar panes, not when the user switches between devtools panels. See <a href='https://bugzil.la/1412317'>bug 1412317</a>.",
@@ -377,7 +377,8 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "notes": "The expression must evaluate to a JavaScript object or a DOM node, or nothing is shown in the sidebar.",
+                    "version_added": "79"
                   },
                   "firefox": {
                     "notes": "The expression must evaluate to an object that can be serialized to JSON, or nothing is shown in the sidebar. In particular, JavaScript cyclic objects and DOM nodes are not supported.  See <a href='https://bugzil.la/1403130'>bug 1403130</a>.",
@@ -401,7 +402,8 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "notes": "If the <code>jsonObject</code> parameter is a string, it is not displayed.",
+                    "version_added": "79"
                   },
                   "firefox": {
                     "notes": "If the <code>jsonObject</code> is a string, then <code>rootTitle</code> must also be given, or <code>jsonObject</code> will not be displayed. See <a href='https://bugzil.la/1412310'>bug 1412310</a>.",
@@ -425,7 +427,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "54"
@@ -447,7 +449,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "56"
@@ -491,7 +493,7 @@
                   "version_added": "54"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "55"

--- a/webextensions/api/downloads.json
+++ b/webextensions/api/downloads.json
@@ -10,7 +10,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "47"
@@ -32,7 +32,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "47"
@@ -54,7 +54,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "47"
@@ -76,7 +76,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "47"
@@ -97,7 +97,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "47"
@@ -118,7 +118,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "47"
@@ -139,7 +139,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "47"
@@ -160,7 +160,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "notes": "Always given as 'safe'.",
@@ -183,7 +183,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -204,7 +204,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "47"
@@ -225,7 +225,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "57"
@@ -246,7 +246,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "47"
@@ -267,7 +267,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "47"
@@ -288,7 +288,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "47"
@@ -309,7 +309,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "47"
@@ -330,7 +330,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "47"
@@ -351,7 +351,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "47"
@@ -372,7 +372,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "47"
@@ -393,7 +393,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "47"
@@ -414,7 +414,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "47"
@@ -435,7 +435,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "47"
@@ -456,7 +456,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "47"
@@ -477,7 +477,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "47"
@@ -500,7 +500,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "47"
@@ -522,7 +522,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "47"
@@ -544,7 +544,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "47"
@@ -564,7 +564,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -587,7 +587,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "47"
@@ -609,7 +609,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "47"
@@ -631,7 +631,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "47"
@@ -653,7 +653,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -675,7 +675,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "48"
@@ -697,7 +697,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "47"
@@ -738,7 +738,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "52"
@@ -759,7 +759,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "47"
@@ -780,7 +780,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "47"
@@ -801,7 +801,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "notes": "<code>Referer</code> headers supported from version 70.",
@@ -844,7 +844,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "notes": "POST is supported from version 52.",
@@ -867,7 +867,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "notes": "Before version 58, if this option was omitted, Firefox would never show the file chooser, regardless of the value of the browser's preference.",
@@ -891,7 +891,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -913,7 +913,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "48"
@@ -935,7 +935,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "48"
@@ -957,7 +957,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "47"
@@ -979,7 +979,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "48"
@@ -1001,7 +1001,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "48"
@@ -1023,7 +1023,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "48"
@@ -1045,7 +1045,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "48"
@@ -1067,7 +1067,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "48"
@@ -1089,7 +1089,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "48"
@@ -1111,7 +1111,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "47"
@@ -1133,7 +1133,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -1155,7 +1155,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "48"
@@ -1177,7 +1177,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "48"

--- a/webextensions/api/events.json
+++ b/webextensions/api/events.json
@@ -53,7 +53,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -74,7 +74,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -116,7 +116,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -158,7 +158,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -181,7 +181,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -203,7 +203,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "50"

--- a/webextensions/api/extension.json
+++ b/webextensions/api/extension.json
@@ -10,7 +10,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -75,7 +75,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -175,7 +175,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "48"
@@ -219,7 +219,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "47"
@@ -241,7 +241,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -268,7 +268,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -295,7 +295,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -322,7 +322,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false

--- a/webextensions/api/extensionTypes.json
+++ b/webextensions/api/extensionTypes.json
@@ -68,7 +68,9 @@
                 "notes": "This feature is supported but not exposed through the 'extensionTypes' object."
               },
               "edge": {
-                "version_added": false
+                "version_added": "79",
+                "partial_implementation": true,
+                "notes": "This feature is supported but not exposed through the 'extensionTypes' object."
               },
               "firefox": {
                 "version_added": "45"

--- a/webextensions/api/history.json
+++ b/webextensions/api/history.json
@@ -10,7 +10,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "49"
@@ -30,7 +30,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -53,7 +53,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "50"
@@ -75,7 +75,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "50"
@@ -97,7 +97,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "49"
@@ -182,7 +182,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "49"
@@ -204,7 +204,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "49"
@@ -226,7 +226,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "49"
@@ -248,7 +248,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "50"
@@ -292,7 +292,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "50"
@@ -314,7 +314,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "50",
@@ -337,7 +337,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "49"

--- a/webextensions/api/i18n.json
+++ b/webextensions/api/i18n.json
@@ -32,7 +32,7 @@
                 "version_added": "47"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "47"

--- a/webextensions/api/identity.json
+++ b/webextensions/api/identity.json
@@ -10,7 +10,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "53"
@@ -32,7 +32,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": [
                 {

--- a/webextensions/api/idle.json
+++ b/webextensions/api/idle.json
@@ -10,7 +10,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -32,7 +32,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "51"
@@ -52,7 +52,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -97,7 +97,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false

--- a/webextensions/api/management.json
+++ b/webextensions/api/management.json
@@ -10,7 +10,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "51"
@@ -30,7 +30,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -51,7 +51,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -72,7 +72,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "55"
@@ -93,7 +93,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -116,7 +116,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "56"
@@ -138,7 +138,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "55",
@@ -162,7 +162,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -184,7 +184,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -206,7 +206,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "51"
@@ -252,7 +252,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -274,7 +274,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -296,7 +296,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -318,7 +318,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -340,7 +340,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "55",
@@ -364,7 +364,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -386,7 +386,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "51"

--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -72,6 +72,7 @@
                   "version_added": false
                 },
                 "edge": {
+                  "notes": "See <a href='https://crbug.com/825443'>bug 825443</a>",
                   "version_added": false
                 },
                 "firefox": {
@@ -115,7 +116,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "48"
@@ -326,7 +327,8 @@
                   "version_added": "35"
                 },
                 "edge": {
-                  "version_added": null
+                  "alternative_name": "contextMenus.OnClickData.frameId",
+                  "version_added": "≤79"
                 },
                 "firefox": {
                   "version_added": "55"
@@ -447,7 +449,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": "≤79"
                 },
                 "firefox": {
                   "version_added": "63"
@@ -510,7 +512,7 @@
                   "version_added": "62"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "63"

--- a/webextensions/api/notifications.json
+++ b/webextensions/api/notifications.json
@@ -30,7 +30,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "notes": "Specifying this option doesn't throw an error, but its value is ignored.",
@@ -58,7 +58,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -80,7 +80,7 @@
                   "version_added": "31"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "notes": "Specifying this option doesn't throw an error, but its value is ignored.",
@@ -104,7 +104,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "notes": "Specifying this option doesn't throw an error, but its value is ignored.",
@@ -127,7 +127,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "notes": "Specifying this option doesn't throw an error, but its value is ignored.",
@@ -156,7 +156,7 @@
                   "version_added": "32"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "notes": "Specifying this option doesn't throw an error, but its value is ignored.",
@@ -181,7 +181,8 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "notes": "On macOS only the first item is shown.",
+                  "version_added": "79"
                 },
                 "firefox": {
                   "notes": "Specifying this option doesn't throw an error, but its value is ignored.",
@@ -205,7 +206,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "notes": "Specifying this option doesn't throw an error, but its value is ignored.",
@@ -228,7 +229,7 @@
                   "version_added": "30"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "notes": "Specifying this option doesn't throw an error, but its value is ignored.",
@@ -252,7 +253,7 @@
                   "version_added": "50"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -431,7 +432,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false

--- a/webextensions/api/omnibox.json
+++ b/webextensions/api/omnibox.json
@@ -10,7 +10,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "52"
@@ -32,7 +32,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "notes": "'description' is interpreted as plain text, and XML markup is not recognised.",
@@ -55,7 +55,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "52"
@@ -77,7 +77,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "52"
@@ -99,7 +99,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "52"
@@ -121,7 +121,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "52"
@@ -143,7 +143,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "notes": "'description' is interpreted as plain text, and XML markup is not recognised.",

--- a/webextensions/api/pageAction.json
+++ b/webextensions/api/pageAction.json
@@ -10,7 +10,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -229,7 +229,7 @@
                   "version_added": "23"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "45"

--- a/webextensions/api/permissions.json
+++ b/webextensions/api/permissions.json
@@ -10,7 +10,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "55"
@@ -32,7 +32,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "55"
@@ -54,7 +54,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false,
@@ -77,7 +77,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false,
@@ -100,7 +100,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "55"
@@ -122,7 +122,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "55"
@@ -144,7 +144,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": [
                 {

--- a/webextensions/api/privacy.json
+++ b/webextensions/api/privacy.json
@@ -10,7 +10,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "54"
@@ -52,7 +52,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "54",
@@ -76,7 +76,7 @@
                   "version_added": "70"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -97,7 +97,7 @@
                   "version_added": "70"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -123,7 +123,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -144,7 +144,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -165,7 +165,7 @@
                   "version_added": "38"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "56"
@@ -186,7 +186,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -207,7 +207,7 @@
                   "version_added": "42"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -228,7 +228,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -249,7 +249,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -270,7 +270,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -337,7 +337,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "54"
@@ -358,7 +358,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -379,7 +379,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "56"
@@ -421,7 +421,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -53,7 +53,7 @@
                   "version_added": "32"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "45"
@@ -123,7 +123,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -145,7 +145,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -167,7 +167,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -187,7 +187,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -210,7 +210,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -232,7 +232,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -297,7 +297,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -431,7 +431,7 @@
                 "version_added": "29"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -453,7 +453,7 @@
                 "version_added": "29"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -543,7 +543,7 @@
                 "version_added": "27"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -592,7 +592,7 @@
                 "version_added": "26"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "54"
@@ -768,7 +768,7 @@
                 "version_added": "26"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "54"
@@ -812,7 +812,7 @@
                 "version_added": "29"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -834,7 +834,7 @@
                 "version_added": "23"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "52"
@@ -856,7 +856,7 @@
                 "version_added": "22"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -878,7 +878,7 @@
                 "version_added": "22"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -900,7 +900,7 @@
                 "version_added": "25"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "51"
@@ -922,7 +922,7 @@
                 "version_added": "42"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "48"
@@ -966,7 +966,7 @@
                 "version_added": "25"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -1010,7 +1010,7 @@
                     "version_added": "32"
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": "45"

--- a/webextensions/api/sessions.json
+++ b/webextensions/api/sessions.json
@@ -10,7 +10,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "52"
@@ -32,7 +32,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "52"
@@ -54,7 +54,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "notes": "'Tab' objects in Sessions don't contain the 'url', 'title', or 'favIconUrl' properties.",
@@ -121,7 +121,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "52"
@@ -187,7 +187,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "53"
@@ -253,7 +253,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "52"

--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -188,7 +188,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "notes": [

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -10,7 +10,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "47"
@@ -32,7 +32,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "47"
@@ -203,7 +203,7 @@
                   "version_added": "45"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "45"
@@ -224,7 +224,7 @@
                   "version_added": "54"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -266,7 +266,7 @@
                   "version_added": "54"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "57"
@@ -308,7 +308,7 @@
                   "version_added": "31"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "45"
@@ -329,7 +329,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "45"
@@ -477,7 +477,7 @@
                   "version_added": "46"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "45"
@@ -498,7 +498,7 @@
                   "version_added": "18"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "57"
@@ -540,7 +540,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "45"
@@ -566,7 +566,7 @@
                   "version_added": "31"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": true
@@ -650,7 +650,7 @@
                   "version_added": "31"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "45"
@@ -738,7 +738,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -760,7 +760,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -782,7 +782,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -850,7 +850,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -871,7 +871,7 @@
                     "version_added": "41"
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": "45"
@@ -1021,7 +1021,7 @@
                     "version_added": "18"
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": "57"
@@ -1042,7 +1042,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": "45"
@@ -1063,7 +1063,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": false
@@ -1214,7 +1214,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "47"
@@ -1259,7 +1259,7 @@
                   "version_added": "39"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "43",
@@ -1303,7 +1303,7 @@
                   "version_added": "20"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "43"
@@ -1348,7 +1348,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -1397,7 +1397,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -1424,7 +1424,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -1446,7 +1446,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -1467,7 +1467,7 @@
                 "version_added": "72"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -1488,7 +1488,7 @@
                 "version_added": "72"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -1550,7 +1550,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "63"
@@ -1615,7 +1615,7 @@
                   "version_added": "39"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "53"
@@ -1678,7 +1678,7 @@
                   "version_added": "20"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "47"
@@ -1701,7 +1701,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "46"
@@ -1767,7 +1767,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -1860,7 +1860,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -1887,7 +1887,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": [
                 {
@@ -1917,7 +1917,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -1961,7 +1961,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -1983,7 +1983,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -2253,7 +2253,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -2362,7 +2362,7 @@
                     "version_added": "45"
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": "45"
@@ -2383,7 +2383,7 @@
                     "version_added": "54"
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": false
@@ -2446,7 +2446,7 @@
                     "version_added": "54"
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": "57"
@@ -2467,7 +2467,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "notes": "Treated as an alias for <code>queryInfo.active</code>.",
@@ -2539,7 +2539,7 @@
                     "version_added": "45"
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": "45"
@@ -2560,7 +2560,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": "57"
@@ -2581,7 +2581,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": "45"
@@ -2829,7 +2829,7 @@
                     "version_added": "41"
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": "45"
@@ -2853,7 +2853,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -2880,7 +2880,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -2902,7 +2902,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -3028,7 +3028,7 @@
                     "version_added": "54"
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": false
@@ -3049,7 +3049,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": "63"
@@ -3091,7 +3091,7 @@
                     "version_added": "45"
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": "45"
@@ -3112,7 +3112,7 @@
                     "version_added": "18"
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": "57"
@@ -3133,7 +3133,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": "45"
@@ -3154,7 +3154,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": false

--- a/webextensions/api/topSites.json
+++ b/webextensions/api/topSites.json
@@ -10,7 +10,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "52"
@@ -53,7 +53,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "52"

--- a/webextensions/api/types.json
+++ b/webextensions/api/types.json
@@ -10,7 +10,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "54"
@@ -31,7 +31,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "72"

--- a/webextensions/api/webNavigation.json
+++ b/webextensions/api/webNavigation.json
@@ -10,7 +10,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "notes": "'server_redirect' is limited to top-level frames and 'client_redirect' is not supplied when redirections are created by JavaScript.",
@@ -32,7 +32,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -55,7 +55,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "48"
@@ -75,7 +75,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -96,7 +96,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "48",
@@ -119,7 +119,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "48"
@@ -140,7 +140,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -161,7 +161,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -182,7 +182,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -203,7 +203,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "48",
@@ -226,7 +226,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -247,7 +247,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "48"
@@ -268,7 +268,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -289,7 +289,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -420,7 +420,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "48"
@@ -441,7 +441,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "48"
@@ -680,7 +680,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "48"
@@ -701,7 +701,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "48"
@@ -755,7 +755,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "48"
@@ -776,7 +776,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "48"

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -207,7 +207,7 @@
                 "version_added": "44"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -248,7 +248,7 @@
                   "version_added": "58"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "45"
@@ -269,7 +269,7 @@
                   "version_added": "49"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "45"
@@ -311,7 +311,7 @@
                   "version_added": "58"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "45"
@@ -356,7 +356,8 @@
                   "notes": "Requests sent by navigator.sendBeacon(), and CSP reports in Chrome 49-57 (Opera 36-44), are also labeled as `ping`."
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79",
+                  "notes": "Requests sent by navigator.sendBeacon(), and CSP reports in Edge 49-57 (Opera 36-44), are also labeled as `ping`."
                 },
                 "firefox": {
                   "version_added": "45"
@@ -420,7 +421,7 @@
                   "version_added": "58"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "45"
@@ -1840,7 +1841,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": "53"

--- a/webextensions/api/windows.json
+++ b/webextensions/api/windows.json
@@ -99,7 +99,7 @@
                   "version_added": "19"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "45"
@@ -226,7 +226,7 @@
                   "version_added": "31"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -395,7 +395,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -421,7 +421,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "45"
@@ -442,7 +442,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "45"
@@ -463,7 +463,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "45"
@@ -506,7 +506,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "45"
@@ -527,7 +527,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "45"
@@ -548,7 +548,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "45"
@@ -743,7 +743,7 @@
                     "version_added": true
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "79"
                   },
                   "firefox": {
                     "version_added": "45"
@@ -962,7 +962,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "45"
@@ -1188,7 +1188,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -1210,7 +1210,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "45"
@@ -1252,7 +1252,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "45"
@@ -1315,7 +1315,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "45"
@@ -1378,7 +1378,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "45"

--- a/webextensions/manifest/browser_action.json
+++ b/webextensions/manifest/browser_action.json
@@ -52,8 +52,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": false,
-                "notes": "Microsoft Edge instead uses the <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings#Microsoft_Edge_properties'><code>browser_action_next_to_addressbar</code> property</a> of the <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings'><code>browser_specific_settings</code> manifest key</a>"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "54"

--- a/webextensions/manifest/chrome_settings_overrides.json
+++ b/webextensions/manifest/chrome_settings_overrides.json
@@ -9,7 +9,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "55"
@@ -29,7 +29,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "55"
@@ -50,7 +50,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "55"
@@ -70,7 +70,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -91,7 +91,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "65"
@@ -112,7 +112,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "55"
@@ -133,7 +133,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -154,7 +154,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -175,7 +175,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -196,7 +196,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -217,7 +217,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "57",
@@ -239,7 +239,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "55"
@@ -260,7 +260,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "55"
@@ -281,7 +281,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -302,7 +302,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "55"
@@ -323,7 +323,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "64"
@@ -344,7 +344,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "64"
@@ -365,7 +365,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "64"
@@ -387,7 +387,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false

--- a/webextensions/manifest/chrome_url_overrides.json
+++ b/webextensions/manifest/chrome_url_overrides.json
@@ -9,7 +9,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "54"
@@ -29,7 +29,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -50,7 +50,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -72,7 +72,8 @@
                 "notes": "If two or more extensions both define a custom new tab page, then in Firefox the first extension to run wins. In Chrome the last extension wins."
               },
               "edge": {
-                "version_added": false
+                "version_added": "79",
+                "notes": "If two or more extensions both define a custom new tab page, then in Firefox the first extension to run wins. In Edge the last extension wins."
               },
               "firefox": {
                 "version_added": "54",

--- a/webextensions/manifest/commands.json
+++ b/webextensions/manifest/commands.json
@@ -9,7 +9,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "48"
@@ -29,7 +29,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "53"
@@ -50,7 +50,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "57",
@@ -75,7 +75,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "57",
@@ -100,7 +100,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "57",
@@ -125,7 +125,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "57",
@@ -172,7 +172,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false

--- a/webextensions/manifest/content_security_policy.json
+++ b/webextensions/manifest/content_security_policy.json
@@ -70,7 +70,8 @@
                 "notes": "Available in Canary builds."
               },
               "edge": {
-                "version_added": false
+                "version_added": false,
+                "notes": "Available in Canary builds."
               },
               "firefox": {
                 "version_added": "72",
@@ -131,7 +132,8 @@
                 "notes": "Available in Canary builds."
               },
               "edge": {
-                "version_added": false
+                "version_added": false,
+                "notes": "Available in Canary builds."
               },
               "firefox": {
                 "version_added": false,

--- a/webextensions/manifest/devtools_page.json
+++ b/webextensions/manifest/devtools_page.json
@@ -9,7 +9,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "54"

--- a/webextensions/manifest/externally_connectable.json
+++ b/webextensions/manifest/externally_connectable.json
@@ -9,7 +9,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false,

--- a/webextensions/manifest/homepage_url.json
+++ b/webextensions/manifest/homepage_url.json
@@ -9,7 +9,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "48"

--- a/webextensions/manifest/offline_enabled.json
+++ b/webextensions/manifest/offline_enabled.json
@@ -9,7 +9,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false

--- a/webextensions/manifest/omnibox.json
+++ b/webextensions/manifest/omnibox.json
@@ -9,7 +9,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "52"
@@ -29,7 +29,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "52"

--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -9,7 +9,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "55"
@@ -52,7 +52,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -74,7 +74,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "55"
@@ -118,7 +118,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "55"
@@ -140,7 +140,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "55"
@@ -162,7 +162,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -184,7 +184,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -206,7 +206,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "55"
@@ -228,7 +228,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -338,7 +338,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "55"
@@ -360,7 +360,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "55"
@@ -382,7 +382,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -404,7 +404,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "55"
@@ -426,7 +426,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -470,7 +470,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "55"
@@ -492,7 +492,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "55"
@@ -514,7 +514,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "55"
@@ -536,7 +536,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "55"
@@ -558,7 +558,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "55"

--- a/webextensions/manifest/options_ui.json
+++ b/webextensions/manifest/options_ui.json
@@ -9,7 +9,7 @@
               "version_added": "40"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "48"
@@ -30,7 +30,8 @@
                 "alternative_name": "chrome_style"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79",
+                "alternative_name": "chrome_style"
               },
               "firefox": {
                 "version_added": "55"
@@ -52,7 +53,7 @@
                 "version_added": "40"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "48"
@@ -74,7 +75,7 @@
                 "version_added": "40"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "48"

--- a/webextensions/manifest/permissions.json
+++ b/webextensions/manifest/permissions.json
@@ -30,7 +30,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "48"
@@ -52,7 +52,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "48"
@@ -74,7 +74,7 @@
                 "version_added": "10"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -140,7 +140,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "53"
@@ -184,7 +184,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "54"
@@ -206,7 +206,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "51"
@@ -228,7 +228,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -317,7 +317,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -361,7 +361,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "48"
@@ -383,7 +383,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "48"
@@ -449,7 +449,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "49"
@@ -471,7 +471,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "53"
@@ -515,7 +515,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "51"
@@ -581,7 +581,7 @@
                 "version_added": "5"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "48"
@@ -603,7 +603,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -647,7 +647,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "54"
@@ -669,7 +669,7 @@
                 "version_added": "33"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "55"
@@ -713,7 +713,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "52"
@@ -823,7 +823,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "52"

--- a/webextensions/manifest/theme.json
+++ b/webextensions/manifest/theme.json
@@ -9,7 +9,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "55"
@@ -30,7 +30,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "55"
@@ -83,7 +83,8 @@
                   "notes": "The CSS color form is not supported for this property."
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79",
+                  "notes": "The CSS color form is not supported for this property."
                 },
                 "firefox": {
                   "version_added": "58",
@@ -148,7 +149,8 @@
                   "notes": "The CSS color form is not supported for this property."
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79",
+                  "notes": "The CSS color form is not supported for this property."
                 },
                 "firefox": {
                   "version_added": "55",
@@ -171,7 +173,8 @@
                   "notes": "The CSS color form is not supported for this property."
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79",
+                  "notes": "The CSS color form is not supported for this property."
                 },
                 "firefox": {
                   "version_added": "60"
@@ -193,7 +196,8 @@
                   "notes": "The CSS color form is not supported for this property."
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79",
+                  "notes": "The CSS color form is not supported for this property."
                 },
                 "firefox": {
                   "version_added": false
@@ -215,7 +219,8 @@
                   "notes": "The CSS color form is not supported for this property."
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79",
+                  "notes": "The CSS color form is not supported for this property."
                 },
                 "firefox": {
                   "version_added": false
@@ -279,7 +284,8 @@
                   "notes": "The CSS color form is not supported for this property."
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79",
+                  "notes": "The CSS color form is not supported for this property."
                 },
                 "firefox": {
                   "version_added": "63"
@@ -301,7 +307,8 @@
                   "notes": "The CSS color form is not supported for this property."
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79",
+                  "notes": "The CSS color form is not supported for this property."
                 },
                 "firefox": {
                   "version_added": false
@@ -323,7 +330,8 @@
                   "notes": "The CSS color form is not supported for this property."
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79",
+                  "notes": "The CSS color form is not supported for this property."
                 },
                 "firefox": {
                   "version_added": false
@@ -345,7 +353,8 @@
                   "notes": "The CSS color form is not supported for this property."
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79",
+                  "notes": "The CSS color form is not supported for this property."
                 },
                 "firefox": {
                   "version_added": "63"
@@ -472,7 +481,8 @@
                   "notes": "The CSS color form is not supported for this property."
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79",
+                  "notes": "The CSS color form is not supported for this property."
                 },
                 "firefox": {
                   "version_added": "59"
@@ -557,7 +567,8 @@
                   "notes": "The CSS color form is not supported for this property."
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79",
+                  "notes": "The CSS color form is not supported for this property."
                 },
                 "firefox": {
                   "version_added": "55",
@@ -612,7 +623,8 @@
                   "notes": "The CSS color form is not supported for this property."
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79",
+                  "notes": "The CSS color form is not supported for this property."
                 },
                 "firefox": {
                   "version_added": "57",
@@ -936,7 +948,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "55",
@@ -1006,7 +1018,7 @@
                   "version_added": true
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "55"
@@ -1030,7 +1042,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "55"

--- a/webextensions/manifest/user_scripts.json
+++ b/webextensions/manifest/user_scripts.json
@@ -9,7 +9,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "68"
@@ -29,7 +29,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "68"

--- a/webextensions/manifest/version_name.json
+++ b/webextensions/manifest/version_name.json
@@ -9,7 +9,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false

--- a/webextensions/match_patterns.json
+++ b/webextensions/match_patterns.json
@@ -52,7 +52,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "55"
@@ -115,7 +115,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "55"
@@ -136,7 +136,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "55"
@@ -222,7 +222,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": "48",


### PR DESCRIPTION
This PR is a part of #5214, in mirroring Chromium data over to Edge as per the new Edge version.  This performs three tasks: setting the existing `true` values to `≤18`, mirroring the Chromium data to any entires marked as `null` whilst setting the version to `≤79`, and mirroring the Chromium data to entries marked as `false`.  The majority of this data has been generated by the mirroring script, however due to the nature of the migration, there's also a good portion modified manually (I do plan on upgrading the mirroring script to work better for this).