### PR TITLE
Update RTCOfferAnswerOptions: voiceActivityDetection

### DIFF
--- a/api/RTCOfferAnswerOptions.json
+++ b/api/RTCOfferAnswerOptions.json
@@ -90,8 +90,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
https://github.com/w3c/webrtc-pc/pull/2352 removed the `voiceActivityDetection` member from the `RTCOfferAnswerOptions` interface. https://github.com/w3c/webrtc-pc/commit/467fa36

So, this change marks `voiceActivityDetection` as deprecated and non-standard-track.