### PR TITLE
Deprecate RTCIdentityErrorEvent, RTCIdentityEvent, onidentityresult, onpeeridentity, onidpassertionerror, and onidpvalidationerror

### DIFF
--- a/api/RTCIdentityErrorEvent.json
+++ b/api/RTCIdentityErrorEvent.json
@@ -44,8 +44,8 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": true,
-          "deprecated": false
+          "standard_track": false,
+          "deprecated": true
         }
       },
       "idp": {
@@ -91,8 +91,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -139,8 +139,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -187,8 +187,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }

--- a/api/RTCIdentityEvent.json
+++ b/api/RTCIdentityEvent.json
@@ -44,8 +44,8 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": true,
-          "deprecated": false
+          "standard_track": false,
+          "deprecated": true
         }
       },
       "assertion": {
@@ -91,8 +91,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -2801,8 +2801,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -2863,8 +2863,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -2925,8 +2925,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -3049,8 +3049,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
https://github.com/w3c/webrtc-pc/commit/f997b94 removed `RTCIdentityErrorEvent` and `RTCIdentityEvent` from the spec,  along with `onidentityresult`, `onpeeridentity`, `onidpassertionerror`, and `onidpvalidationerror`.

---

Note also that none of these were among the Identity-related parts of WebRTC that were moved to the _Identity for WebRTC_ spec.