### PR TITLE
Deprecate RTCPeerConnection: defaultIceServers

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -1147,8 +1147,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
https://github.com/w3c/webrtc-pc/commit/e9befd6 removed the `defaultIceServers` property from the `RTCPeerConnection` interface and replaced it with the `getDefaultIceServers()` method. So this change marks the `defaultIceServers` property as deprecated and non-standard-track.