### PR TITLE
Deprecate RTCPeerConnection: getLocalStreams(), getRemoteStreams(), getStreamById(), removeStream(), and addstream/removestream events

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -337,7 +337,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -1443,8 +1443,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -1553,8 +1553,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -1853,8 +1853,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -2395,7 +2395,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -3113,7 +3113,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -3600,8 +3600,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -3651,8 +3651,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
This change updates `deprecated` and `standard_track` flags in BCD to align with the changes made to the spec in https://github.com/w3c/webrtc-pc/commit/ce5794c, which revised the `RTCPeerConnection` interface to:

* drop the `getLocalStreams()` method [replaced with `getSenders()`]
* drop the `getRemoteStreams()` method [replaced with `getReceivers()`]
* drop the `removeStream()` method [replaced by `removeTrack()`]
* drop the `getStreamById()` method
* drop the `addstream` event [replaced with the `track` event]
* drop the `removestream` event [replaced with the `ended` event]
* drop the `onaddstream` and `onremovestream` event handlers