### PR TITLE
Deprecate RTCIceCandidate: ip

### DIFF
--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -108,10 +108,16 @@
             "chrome_android": {
               "version_added": "74"
             },
-            "edge": {
-              "version_added": true,
-              "alternative_name": "ip"
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "≤18",
+                "version_removed": "79",
+                "alternative_name": "ip"
+              }
+            ],
             "firefox": {
               "version_added": null
             },

--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -109,7 +109,8 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": null
+              "version_added": true,
+              "alternative_name": "ip"
             },
             "firefox": {
               "version_added": null
@@ -287,54 +288,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        }
-      },
-      "ip": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidate/ip",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": true
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
           }
         }
       },

--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -333,8 +333,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
https://github.com/w3c/webrtc-pc/commit/35328b6 changed the name of the `ip` member of the `RTCIceCandidate` interface to `address`.