### PR TITLE
Fix a bug when comparing ranged version to non-ranged version

### DIFF
--- a/test/linter/test-versions.js
+++ b/test/linter/test-versions.js
@@ -41,6 +41,10 @@ function isValidVersion(browserIdentifier, version) {
   }
 }
 
+/**
+ * @param {SimpleSupportStatement} statement
+ * @returns {boolean}
+ */
 function removedAfterAdded(statement) {
   return compareVersions.compare(
     statement.version_added.startsWith('≤')

--- a/test/linter/test-versions.js
+++ b/test/linter/test-versions.js
@@ -41,6 +41,16 @@ function isValidVersion(browserIdentifier, version) {
   }
 }
 
+function removedAfterAdded(statement) {
+  return compareVersions.compare(
+    statement.version_added.startsWith('≤')
+      ? '0' // 0 was chosen as it's a number lower than any possible browser version
+      : statement.version_added,
+    statement.version_removed.replace('≤', ''),
+    '>=',
+  );
+}
+
 /**
  * @param {SupportBlock} supportData
  * @param {string} relPath
@@ -88,15 +98,7 @@ function checkVersions(supportData, relPath, logger) {
             typeof statement.version_added === 'string' &&
             typeof statement.version_removed === 'string'
           ) {
-            if (
-              compareVersions.compare(
-                statement.version_added.startsWith('≤')
-                  ? '0' // 0 was chosen as it's a number lower than any possible browser version
-                  : statement.version_added,
-                statement.version_removed.replace('≤', ''),
-                '>=',
-              )
-            ) {
+            if (removedAfterAdded(statement)) {
               logger.error(
                 chalk`{red → {bold ${relPath}} - {bold version_removed: "${statement.version_removed}"} must be greater than {bold version_added: "${statement.version_added}"}}`,
               );

--- a/test/linter/test-versions.js
+++ b/test/linter/test-versions.js
@@ -89,22 +89,13 @@ function checkVersions(supportData, relPath, logger) {
             typeof statement.version_removed === 'string'
           ) {
             if (
-              (statement.version_added.startsWith('≤') &&
-                statement.version_removed.startsWith('≤') &&
-                compareVersions.compare(
-                  statement.version_added.replace('≤', ''),
-                  statement.version_removed.replace('≤', ''),
-                  '<',
-                )) ||
-              ((!statement.version_added.startsWith('≤') ||
-                !statement.version_removed.startsWith('≤')) &&
-                compareVersions.compare(
-                  statement.version_added.startsWith('≤')
-                    ? '0'
-                    : statement.version_added,
-                  statement.version_removed.replace('≤', ''),
-                  '>=',
-                ))
+              compareVersions.compare(
+                statement.version_added.startsWith('≤')
+                  ? '0'
+                  : statement.version_added,
+                statement.version_removed.replace('≤', ''),
+                '>=',
+              )
             ) {
               logger.error(
                 chalk`{red → {bold ${relPath}} - {bold version_removed: "${statement.version_removed}"} must be greater than {bold version_added: "${statement.version_added}"}}`,

--- a/test/linter/test-versions.js
+++ b/test/linter/test-versions.js
@@ -99,7 +99,9 @@ function checkVersions(supportData, relPath, logger) {
               ((!statement.version_added.startsWith('≤') ||
                 !statement.version_removed.startsWith('≤')) &&
                 compareVersions.compare(
-                  statement.version_added.replace('≤', ''),
+                  statement.version_added.startsWith('≤')
+                    ? '0'
+                    : statement.version_added,
                   statement.version_removed.replace('≤', ''),
                   '>=',
                 ))

--- a/test/linter/test-versions.js
+++ b/test/linter/test-versions.js
@@ -91,7 +91,7 @@ function checkVersions(supportData, relPath, logger) {
             if (
               compareVersions.compare(
                 statement.version_added.startsWith('≤')
-                  ? '0'
+                  ? '0' // 0 was chosen as it's a number lower than any possible browser version
                   : statement.version_added,
                 statement.version_removed.replace('≤', ''),
                 '>=',


### PR DESCRIPTION
This PR intends to fix a bug that was discovered during #5246, when a ranged version in `version_added` has the same number as a non-ranged version in `version_removed`, or vice versa.  It was also found that because the linter just strips the `≤` when one is a ranged value, then if `version_added` was a ranged value and `version_removed` was a defined value within that range, the linter would fail.

This PR updates the logic so that a ranged value for `version_added` is equivalent to "0" (basically the lowest value), and a ranged value for `version_removed` is equivalent to whatever that version is.  (Example: `"version_added": "≤37", "version_removed": "≤37"` translates to `"version_added": "0", "version_removed": "37"` for the linter.)

As an additional step to reduce the complexity of the code, this removes the special case when both values are ranged.

(Note: There is also #5501, which fixes the first bug (when `version_added` is a ranged value with the number equivalent to `version_removed`), however the author of that PR showed no interest in updating that PR to include the fix for the second bug found (`version_removed` is less than the version number of `version_added`).  This fix, however, simplifies the code and makes the other PR's code completely redundant -- as such, this PR closes #5501.)