### PR TITLE
Add ConstrainULong/ULongRange; deprecate signed

### DIFF
--- a/api/ConstrainULong.json
+++ b/api/ConstrainULong.json
@@ -11,7 +11,7 @@
             "version_added": false
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
             "version_added": false

--- a/api/ConstrainULong.json
+++ b/api/ConstrainULong.json
@@ -5,40 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ConstrainULong",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": false
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": false
           },
           "edge": {
             "version_added": null
           },
           "firefox": {
-            "version_added": "50"
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": "50"
+            "version_added": false
           },
           "ie": {
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": false
           },
           "opera_android": {
-            "version_added": true
+            "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": false
           },
           "webview_android": {
-            "version_added": true
+            "version_added": false
           }
         },
         "status": {

--- a/api/ConstrainULong.json
+++ b/api/ConstrainULong.json
@@ -1,8 +1,8 @@
 {
   "api": {
-    "ConstrainLong": {
+    "ConstrainULong": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/ConstrainLong",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/ConstrainULong",
         "support": {
           "chrome": {
             "version_added": true
@@ -43,8 +43,8 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": false,
-          "deprecated": true
+          "standard_track": true,
+          "deprecated": false
         }
       }
     }

--- a/api/LongRange.json
+++ b/api/LongRange.json
@@ -43,8 +43,8 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": true,
-          "deprecated": false
+          "standard_track": false,
+          "deprecated": true
         }
       }
     }

--- a/api/ULongRange.json
+++ b/api/ULongRange.json
@@ -11,7 +11,7 @@
             "version_added": false
           },
           "edge": {
-            "version_added": null
+            "version_added": false
           },
           "firefox": {
             "version_added": false

--- a/api/ULongRange.json
+++ b/api/ULongRange.json
@@ -5,40 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ULongRange",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": false
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": false
           },
           "edge": {
             "version_added": null
           },
           "firefox": {
-            "version_added": "50"
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": "50"
+            "version_added": false
           },
           "ie": {
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": false
           },
           "opera_android": {
-            "version_added": true
+            "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": false
           },
           "webview_android": {
-            "version_added": true
+            "version_added": false
           }
         },
         "status": {

--- a/api/ULongRange.json
+++ b/api/ULongRange.json
@@ -1,8 +1,8 @@
 {
   "api": {
-    "ConstrainLong": {
+    "ULongRange": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/ConstrainLong",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/ULongRange",
         "support": {
           "chrome": {
             "version_added": true
@@ -43,8 +43,8 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": false,
-          "deprecated": true
+          "standard_track": true,
+          "deprecated": false
         }
       }
     }


### PR DESCRIPTION
https://github.com/w3c/mediacapture-main/commit/7f2c65d replaced the `MediaStreamTrack`-related dictionaries `ConstrainLong` and `LongRange` (signed) with `ConstrainULong` and `ULongRange` (unsigned) equivalents.