### PR TITLE
Deprecate RTCIceCandidateStats: networkType

### DIFF
--- a/api/RTCIceCandidateStats.json
+++ b/api/RTCIceCandidateStats.json
@@ -296,8 +296,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
https://github.com/w3c/webrtc-stats/pull/521 removed the `networkType` member from the `RTCIceCandidateStats` interface. https://github.com/w3c/webrtc-stats/commit/6bf1c53