### PR TITLE
`ExtendableMessageEvent.origin` not in Firefox

### DIFF
--- a/api/ExtendableMessageEvent.json
+++ b/api/ExtendableMessageEvent.json
@@ -210,8 +210,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "45",
-              "notes": "Service workers (and Push) have been disabled in the Firefox 45 & 52 Extended Support Releases (ESR)."
+              "version_added": null,
             },
             "firefox_android": {
               "version_added": "45"

--- a/api/ExtendableMessageEvent.json
+++ b/api/ExtendableMessageEvent.json
@@ -210,7 +210,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null,
+              "version_added": null
             },
             "firefox_android": {
               "version_added": "45"

--- a/api/ExtendableMessageEvent.json
+++ b/api/ExtendableMessageEvent.json
@@ -210,10 +210,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "45"
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Seems like this isn't actually implemented in Firefox, see https://bugzilla.mozilla.org/show_bug.cgi?id=1348082

Testing in Firefox 72.0.2 reveals this still is set to empty string.
