### PR TITLE
Expose thirdParty state in WebRequest and proxy onRequest details

### DIFF
--- a/webextensions/api/proxy.json
+++ b/webextensions/api/proxy.json
@@ -101,6 +101,321 @@
                 "version_added": false
               }
             }
+          },
+          "cookieStoreId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "60"
+                },
+                "firefox_android": {
+                  "version_added": "60"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "documentUrl": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "60"
+                },
+                "firefox_android": {
+                  "version_added": "60"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "frameId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "60"
+                },
+                "firefox_android": {
+                  "version_added": "60"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "fromCache": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "60"
+                },
+                "firefox_android": {
+                  "version_added": "60"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "incognito": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "60"
+                },
+                "firefox_android": {
+                  "version_added": "60"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "method": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "60"
+                },
+                "firefox_android": {
+                  "version_added": "60"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "originUrl": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "60"
+                },
+                "firefox_android": {
+                  "version_added": "60"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "parentFrameId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "60"
+                },
+                "firefox_android": {
+                  "version_added": "60"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "requestHeaders": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "60"
+                },
+                "firefox_android": {
+                  "version_added": "60"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "requestId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "60"
+                },
+                "firefox_android": {
+                  "version_added": "60"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "tabId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "60"
+                },
+                "firefox_android": {
+                  "version_added": "60"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "thirdParty": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "72"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "timeStamp": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "60"
+                },
+                "firefox_android": {
+                  "version_added": "60"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "type": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "60"
+                },
+                "firefox_android": {
+                  "version_added": "60"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "url": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "60"
+                },
+                "firefox_android": {
+                  "version_added": "60"
+                },
+                "opera": {
+                  "version_added": false
+                }
+              }
+            }
           }
         },
         "register": {

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -1234,6 +1234,27 @@
                 }
               }
             },
+            "thirdParty": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "72"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
             "timeStamp": {
               "__compat": {
                 "support": {
@@ -1594,6 +1615,27 @@
                 }
               }
             },
+            "thirdParty": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "72"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
             "timeStamp": {
               "__compat": {
                 "support": {
@@ -1896,6 +1938,27 @@
                 }
               }
             },
+            "thirdParty": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "72"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
             "timeStamp": {
               "__compat": {
                 "support": {
@@ -2173,6 +2236,27 @@
                   },
                   "opera": {
                     "version_added": true
+                  }
+                }
+              }
+            },
+            "thirdParty": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "72"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
                   }
                 }
               }
@@ -2537,6 +2621,27 @@
                 }
               }
             },
+            "thirdParty": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "72"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
             "timeStamp": {
               "__compat": {
                 "support": {
@@ -2851,6 +2956,27 @@
                   },
                   "opera": {
                     "version_added": true
+                  }
+                }
+              }
+            },
+            "thirdParty": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "72"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
                   }
                 }
               }
@@ -3180,6 +3306,27 @@
                   },
                   "opera": {
                     "version_added": true
+                  }
+                }
+              }
+            },
+            "thirdParty": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "72"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
                   }
                 }
               }
@@ -3544,6 +3691,27 @@
                 }
               }
             },
+            "thirdParty": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "72"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
             "timeStamp": {
               "__compat": {
                 "support": {
@@ -3816,6 +3984,27 @@
                   },
                   "opera": {
                     "version_added": true
+                  }
+                }
+              }
+            },
+            "thirdParty": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "72"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
                   }
                 }
               }


### PR DESCRIPTION
This change adds the `thirdParty` property to:
* [`proxy.RequestDetails`](https://wiki.developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/proxy/RequestDetails), noting that the properties in this object (`cookieStoreId`, `documentUrl`, `frameId`, `fromCache`, `incognito`, `method`, `originUrl`, `parentFrameId`, `requestId`, `requestHeadersOptional`, `tabId`, `timeStamp`, `type`, and `url`) were not previously exemplified in the compatibility data and have now been added.
* the `details` property of `callback` for all of the events in [`webRequest`](https://wiki.developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest).

This property is a Firefox only feature.

Change made in support of bug [1591900](https://bugzilla.mozilla.org/show_bug.cgi?id=1591900) and detailed in  [proxy.json](https://hg.mozilla.org/integration/mozilla-inbound/diff/26616eb7c1749dcbcfd601966da08c6a48db46e5/toolkit/components/extensions/schemas/proxy.json) and [web_request.json](https://hg.mozilla.org/integration/mozilla-inbound/diff/26616eb7c1749dcbcfd601966da08c6a48db46e5/toolkit/components/extensions/schemas/web_request.json).

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)

Fixes #5539.
- [x] Link to related issues or pull requests, if any
