### PR TITLE
Deprecate SpeechRecognition: serviceURI

### DIFF
--- a/api/SpeechRecognition.json
+++ b/api/SpeechRecognition.json
@@ -1409,8 +1409,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
https://github.com/WICG/speech-api/pull/54 removed the `serviceURI` member from the `SpeechRecognition` interface. https://github.com/WICG/speech-api/commit/91ac89b