### PR TITLE
Update SpeechRecognitionEvent: emma/interpretation

### DIFF
--- a/api/SpeechRecognitionEvent.json
+++ b/api/SpeechRecognitionEvent.json
@@ -106,8 +106,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -162,8 +162,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
https://github.com/WICG/speech-api/pull/55 removed the `emma` and `interpretation` members from the `SpeechRecognitionEvent` interface. https://github.com/WICG/speech-api/commit/223b91c