### PR TITLE
Rename CSS <timing-function> to <easing-function>

### DIFF
--- a/css/types/easing-function.json
+++ b/css/types/easing-function.json
@@ -1,10 +1,10 @@
 {
   "css": {
     "types": {
-      "timing-function": {
+      "easing-function": {
         "__compat": {
-          "description": "<code>&lt;timing-function&gt;</code>",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/timing-function",
+          "description": "<code>&lt;easing-function&gt;</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/easing-function",
           "support": {
             "chrome": {
               "version_added": "4"


### PR DESCRIPTION
https://github.com/w3c/csswg-drafts/commit/322502c renamed the entire "CSS Timing Functions" spec to "CSS Easing Functions" (and in the spec internals, all instances of "timing" were changed to "easing").