### PR TITLE
Fix used HTML tag in background-blend-mode

### DIFF
--- a/css/properties/background-blend-mode.json
+++ b/css/properties/background-blend-mode.json
@@ -13,7 +13,7 @@
             },
             "edge": {
               "version_added": false,
-              "notes": "EdgeHTML 18 has an <i>Enable CSS background-blend-mode property</i> flag, however the feature is an early prototype with no discernable end-user effect."
+              "notes": "EdgeHTML 18 has an <em>Enable CSS background-blend-mode property</em> flag, however the feature is an early prototype with no discernable end-user effect."
             },
             "firefox": {
               "version_added": "30"


### PR DESCRIPTION
`<i>` tags are not allowed in notes.  This PR replaces the `<i>` tag used in the notes for `background-blend-mode`.