### PR TITLE
Fix misuse of tag in IE notes

### DIFF
--- a/api/HTMLHyperlinkElementUtils.json
+++ b/api/HTMLHyperlinkElementUtils.json
@@ -138,7 +138,7 @@
             },
             "ie": {
               "version_added": "5",
-              "notes": "In Internet Explorer 9, the host of an <a href='https://developer.mozilla.org/docs/Web/HTML/Element/a'><code><a></code></a> always include the port (e.g. <code>developer.mozilla.org:443</code>), even if there is no explicit port in the <code>href</code> attribute value."
+              "notes": "In Internet Explorer 9, the host of an <a href='https://developer.mozilla.org/docs/Web/HTML/Element/a'><code>&lt;a&gt;</code></a> always include the port (e.g. <code>developer.mozilla.org:443</code>), even if there is no explicit port in the <code>href</code> attribute value."
             },
             "opera": {
               "version_added": false


### PR DESCRIPTION
This PR fixes a tag within a note that was meant to be used for display, by HTML-escaping the angle brackets.