### PR TITLE
Update Firefox support for RTCDataChannel features

### DIFF
--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -859,7 +859,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": "71"
             },
             "firefox_android": {
               "version_added": false

--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -274,10 +274,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": true
             },
             "ie": {
               "version_added": false
@@ -468,10 +468,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": true
             },
             "ie": {
               "version_added": false
@@ -763,10 +763,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": true
             },
             "ie": {
               "version_added": false
@@ -862,7 +862,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": true
             },
             "ie": {
               "version_added": false
@@ -907,10 +907,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": true
             },
             "ie": {
               "version_added": false
@@ -1004,10 +1004,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": true
             },
             "ie": {
               "version_added": false
@@ -1100,10 +1100,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": true
             },
             "ie": {
               "version_added": false
@@ -1148,10 +1148,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": true
             },
             "ie": {
               "version_added": false
@@ -1292,10 +1292,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": false
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": true
             },
             "ie": {
               "version_added": false

--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -859,7 +859,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "71"
+              "version_added": true
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
According to this MDN documentation page: https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel/onmessage#

The `RTCDataChannel.onmessage` property has no support in Firefox.  However, I've been experimenting with WebRTC and discovered that property works fine in Firefox-**72**.  I tried on 71 and also found it working so I'm submitting this change which says it was "added in **71**".  To be honest, I dunno if it was actually added in **71** or some earlier version, however that was as far as I was willing to spend time backtracking.  Perhaps someone knows when it was really added and can make a more correct change.