### PR TITLE
Deprecate PaymentAddress: languageCode/regionCode

### DIFF
--- a/api/PaymentAddress.json
+++ b/api/PaymentAddress.json
@@ -474,8 +474,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -928,8 +928,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
https://github.com/w3c/payment-request/pull/765 and https://github.com/w3c/payment-request/pull/823 removed the `languageCode` and `regionCode` members from the `PaymentAddress` interface. https://github.com/w3c/payment-request/commit/3fb7e37 https://github.com/w3c/payment-request/commit/5906b72