### PR TITLE
Deprecate SourceBuffer: appendStream

### DIFF
--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -309,8 +309,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
https://github.com/w3c/media-source/pull/139 removed the `appendStream` member from the `SourceBuffer` interface. https://github.com/w3c/media-source/commit/e239e06