### PR TITLE
Add documentation opening script

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "scripts": {
     "confluence": "node ./node_modules/mdn-confluence/main/generate.es6.js --output-dir=. --bcd-module=./index.js",
     "lint": "node test/lint",
+    "docs": "node scripts/docs",
     "fix": "node scripts/fix",
     "stats": "node scripts/statistics",
     "release-notes": "node scripts/release-notes",

--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -1,0 +1,54 @@
+'use strict';
+const { exec } = require('child_process');
+const chalk = require('chalk');
+const bcd = require('..');
+
+const start =
+  process.platform == 'darwin'
+    ? 'open'
+    : process.platform == 'win32'
+    ? 'start'
+    : 'xdg-open';
+
+const { argv } = require('yargs').command(
+  '$0 <feature>',
+  'Open the MDN documentation for a specified feature',
+  yargs => {
+    yargs.positional('feature', {
+      describe: 'The feature identifier',
+      type: 'string',
+    });
+  },
+);
+
+function openDocs(ident) {
+  let feature = ident.split('.');
+  let currentObj = bcd;
+
+  for (let depth = 0; depth < feature.length; depth++) {
+    currentObj = currentObj[feature[depth]];
+
+    if (!currentObj) {
+      console.error(chalk`{red Could not find {bold ${ident}}!}`);
+      return false;
+    }
+  }
+
+  if (!currentObj.__compat) {
+    console.error(
+      chalk`{red {bold ${ident}} has no compatibility data!  Maybe try its parent or a child?}`,
+    );
+    return false;
+  }
+
+  if (!currentObj.__compat.mdn_url) {
+    console.error(
+      chalk`{red {bold ${ident}} has no documentation!  Maybe try its parent?}`,
+    );
+    return false;
+  }
+
+  exec(`${start} ${currentObj.__compat.mdn_url}`);
+}
+
+openDocs(argv.feature);


### PR DESCRIPTION
This PR introduces a new script that opens the documentation of a specified feature (based upon identifier) in the system's default browser.  I've developed this script in Python for my own use, however I realize that it may be useful to other contributors.  As such, I've ported it over to NodeJS.