### PR TITLE
Mark SourceBuffer: changeType non-standard

### DIFF
--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -648,7 +648,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }


### PR DESCRIPTION
The `changeType` method isn’t a member of the `SourceBuffer` interface in any published specification, neither any ED nor any W3C Rec/CR/WD — not in https://www.w3.org/TR/media-source/#idl-def-sourcebuffer (Rec) nor in any previously-published W3C Candidate Recommendation or Working Draft, nor in https://w3c.github.io/media-source/#idl-def-sourcebuffer nor https://wicg.github.io/media-source/#idl-def-sourcebuffer

---

The only place where `changeType` exists in a specification is in an unpublished branch of the MSE spec repo, added in https://github.com/WICG/media-source/commit/483dca4 through https://github.com/WICG/media-source/pull/2.