### PR TITLE
Deprecate SourceBuffer: trackDefaults

### DIFF
--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -1276,8 +1276,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
https://github.com/w3c/media-source/pull/138 removed the `trackDefaults` member from the `SourceBuffer` interface. https://github.com/w3c/media-source/commit/ed76bbd