### PR TITLE
Deprecate IDBEnvironment mixin

### DIFF
--- a/api/IDBEnvironment.json
+++ b/api/IDBEnvironment.json
@@ -58,8 +58,8 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": true,
-          "deprecated": false
+          "standard_track": false,
+          "deprecated": true
         }
       },
       "worker_support": {
@@ -105,8 +105,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
https://github.com/w3c/IndexedDB/commit/8c2196a and https://github.com/w3c/IndexedDB/commit/44d82bf completely removed the `IDBEnvironment` mixin from the Indexed DB spec. The `indexedDB` property it had provided was moved to the `WindowOrWorkerGlobalScope` mixin. https://github.com/w3c/IndexedDB/pull/95

---

Is this a case where we should just completely remove this item from BCD? It’s not something that was ever exposed to developers to begin with. 