### PR TITLE
Deprecate window.ondeviceproximity/onuserproximity

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -4757,8 +4757,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -5136,8 +5136,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
There `ondeviceproximity` and `onuserproximity` event handlers were once specified as members of the `Window` interface in a 2015 Working Draft:

https://www.w3.org/TR/2015/WD-proximity-20150903/#widl-Window-ondeviceproximity

...but they were dropped in the next published Working Draft:

https://www.w3.org/TR/2016/WD-proximity-20160719/

...and are not part of the current spec: https://w3c.github.io/proximity/