### PR TITLE
Move constructors compat data under constructors

### DIFF
--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -114,6 +114,170 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "iterable_allowed": {
+            "__compat": {
+              "description": "<code>new Map(iterable)</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "38"
+                },
+                "chrome_android": {
+                  "version_added": "38"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "13"
+                },
+                "firefox_android": {
+                  "version_added": "14"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "0.12"
+                },
+                "opera": {
+                  "version_added": "25"
+                },
+                "opera_android": {
+                  "version_added": "25"
+                },
+                "safari": {
+                  "version_added": "9"
+                },
+                "safari_ios": {
+                  "version_added": "9"
+                },
+                "samsunginternet_android": {
+                  "version_added": "3.0"
+                },
+                "webview_android": {
+                  "version_added": "38"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "new_required": {
+            "__compat": {
+              "description": "<code>Map()</code> without <code>new</code> throws",
+              "support": {
+                "chrome": {
+                  "version_added": "38"
+                },
+                "chrome_android": {
+                  "version_added": "38"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "42"
+                },
+                "firefox_android": {
+                  "version_added": "42"
+                },
+                "ie": {
+                  "version_added": "11"
+                },
+                "nodejs": {
+                  "version_added": "0.12"
+                },
+                "opera": {
+                  "version_added": "25"
+                },
+                "opera_android": {
+                  "version_added": "25"
+                },
+                "safari": {
+                  "version_added": "9"
+                },
+                "safari_ios": {
+                  "version_added": "9"
+                },
+                "samsunginternet_android": {
+                  "version_added": "3.0"
+                },
+                "webview_android": {
+                  "version_added": "38"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "null_allowed": {
+            "__compat": {
+              "description": "<code>new Map(null)</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "38"
+                },
+                "chrome_android": {
+                  "version_added": "38"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "37"
+                },
+                "firefox_android": {
+                  "version_added": "37"
+                },
+                "ie": {
+                  "version_added": "11"
+                },
+                "nodejs": [
+                  {
+                    "version_added": "0.12"
+                  },
+                  {
+                    "version_added": "0.10",
+                    "flags": [
+                      {
+                        "type": "runtime_flag",
+                        "name": "--harmony"
+                      }
+                    ]
+                  }
+                ],
+                "opera": {
+                  "version_added": "25"
+                },
+                "opera_android": {
+                  "version_added": "25"
+                },
+                "safari": {
+                  "version_added": "9"
+                },
+                "safari_ios": {
+                  "version_added": "9"
+                },
+                "samsunginternet_android": {
+                  "version_added": "3.0"
+                },
+                "webview_android": {
+                  "version_added": "38"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         },
         "clear": {
@@ -527,170 +691,6 @@
               },
               "safari_ios": {
                 "version_added": "8"
-              },
-              "samsunginternet_android": {
-                "version_added": "3.0"
-              },
-              "webview_android": {
-                "version_added": "38"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "map_iterable": {
-          "__compat": {
-            "description": "<code>new Map(iterable)</code>",
-            "support": {
-              "chrome": {
-                "version_added": "38"
-              },
-              "chrome_android": {
-                "version_added": "38"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "13"
-              },
-              "firefox_android": {
-                "version_added": "14"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "0.12"
-              },
-              "opera": {
-                "version_added": "25"
-              },
-              "opera_android": {
-                "version_added": "25"
-              },
-              "safari": {
-                "version_added": "9"
-              },
-              "safari_ios": {
-                "version_added": "9"
-              },
-              "samsunginternet_android": {
-                "version_added": "3.0"
-              },
-              "webview_android": {
-                "version_added": "38"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "map_null": {
-          "__compat": {
-            "description": "<code>new Map(null)</code>",
-            "support": {
-              "chrome": {
-                "version_added": "38"
-              },
-              "chrome_android": {
-                "version_added": "38"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "37"
-              },
-              "firefox_android": {
-                "version_added": "37"
-              },
-              "ie": {
-                "version_added": "11"
-              },
-              "nodejs": [
-                {
-                  "version_added": "0.12"
-                },
-                {
-                  "version_added": "0.10",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
-              "opera": {
-                "version_added": "25"
-              },
-              "opera_android": {
-                "version_added": "25"
-              },
-              "safari": {
-                "version_added": "9"
-              },
-              "safari_ios": {
-                "version_added": "9"
-              },
-              "samsunginternet_android": {
-                "version_added": "3.0"
-              },
-              "webview_android": {
-                "version_added": "38"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "map_without_new_throws": {
-          "__compat": {
-            "description": "<code>Map()</code> without <code>new</code> throws",
-            "support": {
-              "chrome": {
-                "version_added": "38"
-              },
-              "chrome_android": {
-                "version_added": "38"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "42"
-              },
-              "firefox_android": {
-                "version_added": "42"
-              },
-              "ie": {
-                "version_added": "11"
-              },
-              "nodejs": {
-                "version_added": "0.12"
-              },
-              "opera": {
-                "version_added": "25"
-              },
-              "opera_android": {
-                "version_added": "25"
-              },
-              "safari": {
-                "version_added": "9"
-              },
-              "safari_ios": {
-                "version_added": "9"
               },
               "samsunginternet_android": {
                 "version_added": "3.0"

--- a/javascript/builtins/Set.json
+++ b/javascript/builtins/Set.json
@@ -114,6 +114,170 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "iterable_allowed": {
+            "__compat": {
+              "description": "<code>new Set(iterable)</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "38"
+                },
+                "chrome_android": {
+                  "version_added": "38"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "13"
+                },
+                "firefox_android": {
+                  "version_added": "14"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "0.12"
+                },
+                "opera": {
+                  "version_added": "25"
+                },
+                "opera_android": {
+                  "version_added": "25"
+                },
+                "safari": {
+                  "version_added": "9"
+                },
+                "safari_ios": {
+                  "version_added": "9"
+                },
+                "samsunginternet_android": {
+                  "version_added": "3.0"
+                },
+                "webview_android": {
+                  "version_added": "38"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "new_required": {
+            "__compat": {
+              "description": "<code>Set()</code> without <code>new</code> throws",
+              "support": {
+                "chrome": {
+                  "version_added": "38"
+                },
+                "chrome_android": {
+                  "version_added": "38"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "42"
+                },
+                "firefox_android": {
+                  "version_added": "42"
+                },
+                "ie": {
+                  "version_added": "11"
+                },
+                "nodejs": {
+                  "version_added": "0.12"
+                },
+                "opera": {
+                  "version_added": "25"
+                },
+                "opera_android": {
+                  "version_added": "25"
+                },
+                "safari": {
+                  "version_added": "9"
+                },
+                "safari_ios": {
+                  "version_added": "9"
+                },
+                "samsunginternet_android": {
+                  "version_added": "3.0"
+                },
+                "webview_android": {
+                  "version_added": "38"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "null_allowed": {
+            "__compat": {
+              "description": "<code>new Set(null)</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "38"
+                },
+                "chrome_android": {
+                  "version_added": "38"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "37"
+                },
+                "firefox_android": {
+                  "version_added": "37"
+                },
+                "ie": {
+                  "version_added": "11"
+                },
+                "nodejs": [
+                  {
+                    "version_added": "0.12"
+                  },
+                  {
+                    "version_added": "0.10",
+                    "flags": [
+                      {
+                        "type": "runtime_flag",
+                        "name": "--harmony"
+                      }
+                    ]
+                  }
+                ],
+                "opera": {
+                  "version_added": "25"
+                },
+                "opera_android": {
+                  "version_added": "25"
+                },
+                "safari": {
+                  "version_added": "9"
+                },
+                "safari_ios": {
+                  "version_added": "9"
+                },
+                "samsunginternet_android": {
+                  "version_added": "3.0"
+                },
+                "webview_android": {
+                  "version_added": "38"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         },
         "add": {
@@ -465,170 +629,6 @@
               },
               "nodejs": {
                 "version_added": "4.0.0"
-              },
-              "opera": {
-                "version_added": "25"
-              },
-              "opera_android": {
-                "version_added": "25"
-              },
-              "safari": {
-                "version_added": "9"
-              },
-              "safari_ios": {
-                "version_added": "9"
-              },
-              "samsunginternet_android": {
-                "version_added": "3.0"
-              },
-              "webview_android": {
-                "version_added": "38"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "set_iterable": {
-          "__compat": {
-            "description": "<code>new Set(iterable)</code>",
-            "support": {
-              "chrome": {
-                "version_added": "38"
-              },
-              "chrome_android": {
-                "version_added": "38"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "13"
-              },
-              "firefox_android": {
-                "version_added": "14"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "0.12"
-              },
-              "opera": {
-                "version_added": "25"
-              },
-              "opera_android": {
-                "version_added": "25"
-              },
-              "safari": {
-                "version_added": "9"
-              },
-              "safari_ios": {
-                "version_added": "9"
-              },
-              "samsunginternet_android": {
-                "version_added": "3.0"
-              },
-              "webview_android": {
-                "version_added": "38"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "set_null": {
-          "__compat": {
-            "description": "<code>new Set(null)</code>",
-            "support": {
-              "chrome": {
-                "version_added": "38"
-              },
-              "chrome_android": {
-                "version_added": "38"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "37"
-              },
-              "firefox_android": {
-                "version_added": "37"
-              },
-              "ie": {
-                "version_added": "11"
-              },
-              "nodejs": [
-                {
-                  "version_added": "0.12"
-                },
-                {
-                  "version_added": "0.10",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
-              "opera": {
-                "version_added": "25"
-              },
-              "opera_android": {
-                "version_added": "25"
-              },
-              "safari": {
-                "version_added": "9"
-              },
-              "safari_ios": {
-                "version_added": "9"
-              },
-              "samsunginternet_android": {
-                "version_added": "3.0"
-              },
-              "webview_android": {
-                "version_added": "38"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "set_without_new_throws": {
-          "__compat": {
-            "description": "<code>Set()</code> without <code>new</code> throws",
-            "support": {
-              "chrome": {
-                "version_added": "38"
-              },
-              "chrome_android": {
-                "version_added": "38"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "42"
-              },
-              "firefox_android": {
-                "version_added": "42"
-              },
-              "ie": {
-                "version_added": "11"
-              },
-              "nodejs": {
-                "version_added": "0.12"
               },
               "opera": {
                 "version_added": "25"

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -125,6 +125,170 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "iterable_allowed": {
+            "__compat": {
+              "description": "<code>new WeakMap(iterable)</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "38"
+                },
+                "chrome_android": {
+                  "version_added": "38"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "36"
+                },
+                "firefox_android": {
+                  "version_added": "36"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "0.12"
+                },
+                "opera": {
+                  "version_added": "25"
+                },
+                "opera_android": {
+                  "version_added": "25"
+                },
+                "safari": {
+                  "version_added": "9"
+                },
+                "safari_ios": {
+                  "version_added": "9"
+                },
+                "samsunginternet_android": {
+                  "version_added": "3.0"
+                },
+                "webview_android": {
+                  "version_added": "38"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "new_required": {
+            "__compat": {
+              "description": "<code>WeakMap()</code> without <code>new</code> throws",
+              "support": {
+                "chrome": {
+                  "version_added": "36"
+                },
+                "chrome_android": {
+                  "version_added": "36"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "42"
+                },
+                "firefox_android": {
+                  "version_added": "42"
+                },
+                "ie": {
+                  "version_added": "11"
+                },
+                "nodejs": {
+                  "version_added": "0.12"
+                },
+                "opera": {
+                  "version_added": "23"
+                },
+                "opera_android": {
+                  "version_added": "24"
+                },
+                "safari": {
+                  "version_added": "9"
+                },
+                "safari_ios": {
+                  "version_added": "9"
+                },
+                "samsunginternet_android": {
+                  "version_added": "3.0"
+                },
+                "webview_android": {
+                  "version_added": "37"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "null_allowed": {
+            "__compat": {
+              "description": "<code>new WeakMap(null)</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "36"
+                },
+                "chrome_android": {
+                  "version_added": "36"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "37"
+                },
+                "firefox_android": {
+                  "version_added": "37"
+                },
+                "ie": {
+                  "version_added": "11"
+                },
+                "nodejs": [
+                  {
+                    "version_added": "0.12"
+                  },
+                  {
+                    "version_added": "0.10",
+                    "flags": [
+                      {
+                        "type": "runtime_flag",
+                        "name": "--harmony"
+                      }
+                    ]
+                  }
+                ],
+                "opera": {
+                  "version_added": "23"
+                },
+                "opera_android": {
+                  "version_added": "24"
+                },
+                "safari": {
+                  "version_added": "8"
+                },
+                "safari_ios": {
+                  "version_added": "8"
+                },
+                "samsunginternet_android": {
+                  "version_added": "3.0"
+                },
+                "webview_android": {
+                  "version_added": "37"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         },
         "clear": {
@@ -435,170 +599,6 @@
               },
               "safari_ios": {
                 "version_added": "8"
-              },
-              "samsunginternet_android": {
-                "version_added": "3.0"
-              },
-              "webview_android": {
-                "version_added": "37"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "weakmap_iterable": {
-          "__compat": {
-            "description": "<code>new WeakMap(iterable)</code>",
-            "support": {
-              "chrome": {
-                "version_added": "38"
-              },
-              "chrome_android": {
-                "version_added": "38"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "36"
-              },
-              "firefox_android": {
-                "version_added": "36"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "0.12"
-              },
-              "opera": {
-                "version_added": "25"
-              },
-              "opera_android": {
-                "version_added": "25"
-              },
-              "safari": {
-                "version_added": "9"
-              },
-              "safari_ios": {
-                "version_added": "9"
-              },
-              "samsunginternet_android": {
-                "version_added": "3.0"
-              },
-              "webview_android": {
-                "version_added": "38"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "weakmap_null": {
-          "__compat": {
-            "description": "<code>new WeakMap(null)</code>",
-            "support": {
-              "chrome": {
-                "version_added": "36"
-              },
-              "chrome_android": {
-                "version_added": "36"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "37"
-              },
-              "firefox_android": {
-                "version_added": "37"
-              },
-              "ie": {
-                "version_added": "11"
-              },
-              "nodejs": [
-                {
-                  "version_added": "0.12"
-                },
-                {
-                  "version_added": "0.10",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
-              "opera": {
-                "version_added": "23"
-              },
-              "opera_android": {
-                "version_added": "24"
-              },
-              "safari": {
-                "version_added": "8"
-              },
-              "safari_ios": {
-                "version_added": "8"
-              },
-              "samsunginternet_android": {
-                "version_added": "3.0"
-              },
-              "webview_android": {
-                "version_added": "37"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "weakmap_without_new_throws": {
-          "__compat": {
-            "description": "<code>WeakMap()</code> without <code>new</code> throws",
-            "support": {
-              "chrome": {
-                "version_added": "36"
-              },
-              "chrome_android": {
-                "version_added": "36"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "42"
-              },
-              "firefox_android": {
-                "version_added": "42"
-              },
-              "ie": {
-                "version_added": "11"
-              },
-              "nodejs": {
-                "version_added": "0.12"
-              },
-              "opera": {
-                "version_added": "23"
-              },
-              "opera_android": {
-                "version_added": "24"
-              },
-              "safari": {
-                "version_added": "9"
-              },
-              "safari_ios": {
-                "version_added": "9"
               },
               "samsunginternet_android": {
                 "version_added": "3.0"

--- a/javascript/builtins/WeakSet.json
+++ b/javascript/builtins/WeakSet.json
@@ -103,6 +103,108 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "iterable_allowed": {
+            "__compat": {
+              "description": "<code>new WeakSet(iterable)</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "38"
+                },
+                "chrome_android": {
+                  "version_added": "38"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "34"
+                },
+                "firefox_android": {
+                  "version_added": "34"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "0.12"
+                },
+                "opera": {
+                  "version_added": "25"
+                },
+                "opera_android": {
+                  "version_added": "25"
+                },
+                "safari": {
+                  "version_added": "9"
+                },
+                "safari_ios": {
+                  "version_added": "9"
+                },
+                "samsunginternet_android": {
+                  "version_added": "3.0"
+                },
+                "webview_android": {
+                  "version_added": "38"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "null_allowed": {
+            "__compat": {
+              "description": "<code>new WeakSet(null)</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "36"
+                },
+                "chrome_android": {
+                  "version_added": "36"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "37"
+                },
+                "firefox_android": {
+                  "version_added": "37"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "0.12"
+                },
+                "opera": {
+                  "version_added": "23"
+                },
+                "opera_android": {
+                  "version_added": "24"
+                },
+                "safari": {
+                  "version_added": "9"
+                },
+                "safari_ios": {
+                  "version_added": "9"
+                },
+                "samsunginternet_android": {
+                  "version_added": "3.0"
+                },
+                "webview_android": {
+                  "version_added": "37"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         },
         "add": {
@@ -287,108 +389,6 @@
               },
               "firefox_android": {
                 "version_added": "34"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "0.12"
-              },
-              "opera": {
-                "version_added": "23"
-              },
-              "opera_android": {
-                "version_added": "24"
-              },
-              "safari": {
-                "version_added": "9"
-              },
-              "safari_ios": {
-                "version_added": "9"
-              },
-              "samsunginternet_android": {
-                "version_added": "3.0"
-              },
-              "webview_android": {
-                "version_added": "37"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "weakset_iterable": {
-          "__compat": {
-            "description": "<code>new WeakSet(iterable)</code>",
-            "support": {
-              "chrome": {
-                "version_added": "38"
-              },
-              "chrome_android": {
-                "version_added": "38"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "34"
-              },
-              "firefox_android": {
-                "version_added": "34"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "0.12"
-              },
-              "opera": {
-                "version_added": "25"
-              },
-              "opera_android": {
-                "version_added": "25"
-              },
-              "safari": {
-                "version_added": "9"
-              },
-              "safari_ios": {
-                "version_added": "9"
-              },
-              "samsunginternet_android": {
-                "version_added": "3.0"
-              },
-              "webview_android": {
-                "version_added": "38"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "weakset_null": {
-          "__compat": {
-            "description": "<code>new WeakSet(null)</code>",
-            "support": {
-              "chrome": {
-                "version_added": "36"
-              },
-              "chrome_android": {
-                "version_added": "36"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "37"
-              },
-              "firefox_android": {
-                "version_added": "37"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
## Summary

Move some constructor information under the constructor object in BCD:
 - `Map.map_iterable` to `Map.Map.iterable_allowed`
 - `Map.map_null` to `Map.Map.null_allowed`
 - `Map.map_without_new_throws` to `Map.Map.new_required`
 - `Set.set_iterable` to `Set.Set.iterable_allowed`
 - `Set.set_null` to `Set.Set.null_allowed`
 - `Set.set_without_new_throws` to `Set.Set.new_required`
 - `WakMap.weakmap_null` to `WakMap.WakMap.null_allowed`
 - `WakMap.weakmap_iterable` to `WakMap.WakMap.iterable_allowed`
 - `WakMap.weakmap_without_new_throws` to `WakMap.WakMap.new_required`
 - `WeakSet.weakset_null` to `WeakSet.WeakSet.null_allowed`
 - `WeakSet.weakset_iterable` to `WeakSet.WeakSet.iterable_allowed`

FYI, some `*Array` use `*Array.iterable_in_constructor` to denote equivalent of `[name].[name].iterable_allowed`.

## TODO
Will be in a separate PR.
 - `*Array`, see comments in https://github.com/mdn/sprints/issues/2571
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#Browser_compatibility
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView#Browser_compatibility
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer#Browser_compatibility

## Related issues
https://github.com/mdn/sprints/issues/2571

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
