### PR TITLE
Deprecate BluetoothDevice: uuids

### DIFF
--- a/api/BluetoothDevice.json
+++ b/api/BluetoothDevice.json
@@ -618,8 +618,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
https://github.com/WebBluetoothCG/web-bluetooth/pull/292 removed the `uuids` member from the `BluetoothDevice` interface. https://github.com/WebBluetoothCG/web-bluetooth/commit/4860b2d