### PR TITLE
Set versions for Opera for JavaScript Error builtins

### DIFF
--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -28,10 +28,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -80,10 +80,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "4"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -285,10 +285,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -337,10 +337,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "4"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -388,10 +388,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "10.5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "11"
               },
               "safari": {
                 "version_added": "6"
@@ -491,10 +491,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "4"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"

--- a/javascript/builtins/EvalError.json
+++ b/javascript/builtins/EvalError.json
@@ -28,10 +28,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/javascript/builtins/RangeError.json
+++ b/javascript/builtins/RangeError.json
@@ -28,10 +28,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/javascript/builtins/ReferenceError.json
+++ b/javascript/builtins/ReferenceError.json
@@ -28,10 +28,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/javascript/builtins/SyntaxError.json
+++ b/javascript/builtins/SyntaxError.json
@@ -28,10 +28,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/javascript/builtins/TypeError.json
+++ b/javascript/builtins/TypeError.json
@@ -28,10 +28,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/javascript/builtins/URIError.json
+++ b/javascript/builtins/URIError.json
@@ -28,10 +28,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"


### PR DESCRIPTION
This PR sets the version numbers for various JavaScript Error builtins for Opera and Opera Android, based upon manual testing. This is a part of a personal project to eliminate as many true/null values in Opera as we can.

The versions are as follows:

javascript.builtins.Error - 4
javascript.builtins.Error.Error - 4
javascript.builtins.Error.message - 5
javascript.builtins.Error.name - 4
javascript.builtins.Error.stack - 10.5
javascript.builtins.Error.toString - 4
javascript.builtins.EvalError - 5
javascript.builtins.RangeError - 5
javascript.builtins.ReferenceError - 5
javascript.builtins.SyntaxError - 5
javascript.builtins.TypeError - 5
javascript.builtins.URIError - 5