### PR TITLE
Set versions for Opera for JavaScript Math builtins

### DIFF
--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -29,10 +29,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -81,10 +81,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -133,10 +133,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -185,10 +185,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -237,10 +237,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -289,10 +289,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -341,10 +341,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -393,10 +393,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -445,10 +445,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -497,10 +497,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -601,10 +601,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -705,10 +705,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -757,10 +757,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -913,10 +913,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -1017,10 +1017,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -1121,10 +1121,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -1225,10 +1225,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -1433,10 +1433,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -1641,10 +1641,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -1693,10 +1693,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -1745,10 +1745,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -1797,10 +1797,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -1849,10 +1849,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -1953,10 +1953,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -2057,10 +2057,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -2109,10 +2109,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"


### PR DESCRIPTION
This PR sets the version numbers for various JavaScript Math builtins for Opera and Opera Android, based upon manual testing. This is a part of a personal project to eliminate as many true/null values in Opera as we can.

The versions are as follows:

javascript.builtins.Math.E - 3
javascript.builtins.Math.LN2 - 3
javascript.builtins.Math.LN10 - 3
javascript.builtins.Math.LOG2E - 3
javascript.builtins.Math.LOG10E - 3
javascript.builtins.Math.PI - 3
javascript.builtins.Math.SQRT1_2 - 3
javascript.builtins.Math.SQRT2 - 3
javascript.builtins.Math.abs - 3
javascript.builtins.Math.acos - 3
javascript.builtins.Math.asin - 3
javascript.builtins.Math.atan - 3
javascript.builtins.Math.atan2 - 3
javascript.builtins.Math.ceil - 3
javascript.builtins.Math.cos - 3
javascript.builtins.Math.exp - 3
javascript.builtins.Math.floor - 3
javascript.builtins.Math.log - 3
javascript.builtins.Math.max - 3
javascript.builtins.Math.min - 3
javascript.builtins.Math.pow - 3
javascript.builtins.Math.random - 3
javascript.builtins.Math.round - 3
javascript.builtins.Math.sin - 3
javascript.builtins.Math.sqrt - 3
javascript.builtins.Math.tan - 3