### PR TITLE
Set versions for Opera for JavaScript Object builtin

### DIFF
--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -28,10 +28,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -80,10 +80,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -184,10 +184,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "4"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -342,10 +342,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "9.5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3"
@@ -503,10 +503,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "9.5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3"
@@ -1096,10 +1096,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3"
@@ -1148,10 +1148,10 @@
                 "version_added": "0.10"
               },
               "opera": {
-                "version_added": true
+                "version_added": "17"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "17"
               },
               "safari": {
                 "version_added": "9"
@@ -1304,10 +1304,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "4"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3"
@@ -1461,10 +1461,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "9.5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3"
@@ -1514,10 +1514,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "9.5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3"
@@ -1827,10 +1827,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "4"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3"
@@ -1880,10 +1880,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "10.5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "11"
               },
               "safari": {
                 "version_added": "3"
@@ -1984,10 +1984,10 @@
                 "version_added": "0.12"
               },
               "opera": {
-                "version_added": true
+                "version_added": "21"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "21"
               },
               "safari": {
                 "version_added": "9"
@@ -2036,10 +2036,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "4"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -2139,10 +2139,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -2296,10 +2296,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -1151,7 +1151,7 @@
                 "version_added": "17"
               },
               "opera_android": {
-                "version_added": "17"
+                "version_added": "18"
               },
               "safari": {
                 "version_added": "9"


### PR DESCRIPTION
This PR sets the version numbers for the generic JavaScript Object builtin for Opera and Opera Android, based upon manual testing. This is a part of a personal project to eliminate as many true/null values in Opera as we can.

The versions are as follows:

javascript.builtins.Object - 3
javascript.builtins.Object.Object - 3
javascript.builtins.Object.constructor - 4
javascript.builtins.Object.defineGetter - 9.5
javascript.builtins.Object.defineSetter - 9.5
javascript.builtins.Object.hasOwnProperty - 5
javascript.builtins.Object.is - Blink
javascript.builtins.Object.isPrototypeOf - 4
javascript.builtins.Object.lookupGetter - 9.5
javascript.builtins.Object.lookupSetter - 9.5
javascript.builtins.Object.propertyIsEnumerable - 4
javascript.builtins.Object.proto - 10.5
javascript.builtins.Object.setPrototypeOf - Blink
javascript.builtins.Object.toLocaleString - 4
javascript.builtins.Object.toString - 3
javascript.builtins.Object.valueOf - 3