### PR TITLE
Set versions for Opera for JavaScript RegExp builtin

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -28,10 +28,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -80,10 +80,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -132,10 +132,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "6"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3.1"
@@ -246,10 +246,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -350,10 +350,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -453,10 +453,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -556,10 +556,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "3"
@@ -608,10 +608,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -660,10 +660,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "10.5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "11"
               },
               "safari": {
                 "version_added": "3"
@@ -712,10 +712,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "10.5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "11"
               },
               "safari": {
                 "version_added": "3"
@@ -764,10 +764,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "8"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3"
@@ -869,10 +869,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -972,10 +972,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -1149,10 +1149,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "8"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3"
@@ -1201,10 +1201,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -1560,10 +1560,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -1663,10 +1663,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"


### PR DESCRIPTION
This PR sets the version numbers for the JavaScript RegExp builtin for Opera and Opera Android, based upon manual testing. This is a part of a personal project to eliminate as many true/null values in Opera as we can.

The versions are as follows:

javascript.builtins.RegExp - 5
javascript.builtins.RegExp.RegExp - 5
javascript.builtins.RegExp.compile - 6
javascript.builtins.RegExp.exec - 5
javascript.builtins.RegExp.global - 5
javascript.builtins.RegExp.ignoreCase - 5
javascript.builtins.RegExp.input - Blink
javascript.builtins.RegExp.lastIndex - 5
javascript.builtins.RegExp.lastMatch - 10.5
javascript.builtins.RegExp.lastParen - 10.5
javascript.builtins.RegExp.leftContext - 8
javascript.builtins.RegExp.multiline - 5
javascript.builtins.RegExp.n - 5
javascript.builtins.RegExp.rightContext - 8
javascript.builtins.RegExp.source - 5
javascript.builtins.RegExp.test - 5
javascript.builtins.RegExp.toString - 5