### PR TITLE
Set versions for Opera for misc. JavaScript builtins

### DIFF
--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -129,10 +129,10 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": true
+                  "version_added": "15"
                 },
                 "opera_android": {
-                  "version_added": true
+                  "version_added": "14"
                 },
                 "safari": {
                   "version_added": false
@@ -649,10 +649,12 @@
                   "version_added": true
                 },
                 "opera": {
-                  "version_added": true
+                  "version_added": "44",
+                  "notes": "Before version 58, <code>formatToParts()</code> returned an object with an incorrectly cased type key of <code>dayperiod</code>. Version 58 and later use the specification defined <code>dayPeriod</code>. See <a href='https://crbug.com/865351'>Chromium bug 865351</a>."
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "43",
+                  "notes": "Before version 50, <code>formatToParts()</code> returned an object with an incorrectly cased type key of <code>dayperiod</code>. Version 50 and later use the specification defined <code>dayPeriod</code>. See <a href='https://crbug.com/865351'>Chromium bug 865351</a>."
                 },
                 "safari": {
                   "version_added": "11"

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -191,7 +191,7 @@
                 "version_added": "12.9.0"
               },
               "opera": {
-                "version_added": null
+                "version_added": "63"
               },
               "opera_android": {
                 "version_added": "54"

--- a/javascript/builtins/Proxy.json
+++ b/javascript/builtins/Proxy.json
@@ -812,10 +812,10 @@
                 "version_added": "6.0.0"
               },
               "opera": {
-                "version_added": true
+                "version_added": "50"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "46"
               },
               "safari": {
                 "version_added": "10"

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -249,10 +249,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "27"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "27"
               },
               "safari": {
                 "version_added": "9"
@@ -312,10 +312,10 @@
                 }
               ],
               "opera": {
-                "version_added": true
+                "version_added": "37"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "37"
               },
               "safari": {
                 "version_added": "10"
@@ -364,10 +364,10 @@
                 "version_added": "6.0.0"
               },
               "opera": {
-                "version_added": true
+                "version_added": "35"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "35"
               },
               "safari": {
                 "version_added": "10"
@@ -468,10 +468,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "27"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "27"
               },
               "safari": {
                 "version_added": "9"
@@ -520,10 +520,10 @@
                 "version_added": "6.0.0"
               },
               "opera": {
-                "version_added": true
+                "version_added": "37"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "37"
               },
               "safari": {
                 "version_added": "10"
@@ -624,10 +624,10 @@
                 "version_added": "6.0.0"
               },
               "opera": {
-                "version_added": true
+                "version_added": "37"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "37"
               },
               "safari": {
                 "version_added": "10"
@@ -676,10 +676,10 @@
                 "version_added": "6.0.0"
               },
               "opera": {
-                "version_added": true
+                "version_added": "37"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "37"
               },
               "safari": {
                 "version_added": "10"
@@ -791,10 +791,10 @@
                 "version_added": "6.0.0"
               },
               "opera": {
-                "version_added": true
+                "version_added": "37"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "37"
               },
               "safari": {
                 "version_added": "10"
@@ -843,10 +843,10 @@
                 "version_added": "6.0.0"
               },
               "opera": {
-                "version_added": true
+                "version_added": "34"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "34"
               },
               "safari": {
                 "version_added": "10"
@@ -1009,10 +1009,10 @@
                 }
               ],
               "opera": {
-                "version_added": true
+                "version_added": "36"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "36"
               },
               "safari": {
                 "version_added": "10"
@@ -1061,10 +1061,10 @@
                 "version_added": "0.12"
               },
               "opera": {
-                "version_added": true
+                "version_added": "32"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "32"
               },
               "safari": {
                 "version_added": "9"


### PR DESCRIPTION
This PR sets the version numbers for various JavaScript builtins for Opera and Opera Android, based upon manual testing. This is a part of a personal project to eliminate as many true/null values in Opera as we can.

The versions are as follows:

javascript.builtins.Promise.allSettled - Blink
javascript.builtins.Proxy.revocable - Blink
javascript.builtins.Intl.Collator.caseFirst - Blink
javascript.builtins.Intl.DateTimeFormat.formatToParts - Blink
javascript.builtins.Symbol.for - Blink
javascript.builtins.Symbol.hasInstance - Blink
javascript.builtins.Symbol.isConcatSpreadable - Blink
javascript.builtins.Symbol.keyFor - Blink
javascript.builtins.Symbol.match - Blink
javascript.builtins.Symbol.replace - Blink
javascript.builtins.Symbol.search - Blink
javascript.builtins.Symbol.split - Blink
javascript.builtins.Symbol.toPrimitive - Blink
javascript.builtins.Symbol.toStringTag - Blink
javascript.builtins.Symbol.unscopables - Blink