### PR TITLE
Set versions for Opera for JavaScript functions

### DIFF
--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -28,10 +28,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -80,10 +80,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -132,10 +132,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "4"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -182,10 +182,10 @@
                   "version_added": true
                 },
                 "opera": {
-                  "version_added": true
+                  "version_added": "5"
                 },
                 "opera_android": {
-                  "version_added": true
+                  "version_added": "10.1"
                 },
                 "safari": {
                   "version_added": "6"
@@ -234,10 +234,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -389,10 +389,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "4"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -440,10 +440,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "9.6"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3"
@@ -596,10 +596,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -699,10 +699,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "10.5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "11"
               },
               "safari": {
                 "version_added": "6"
@@ -906,10 +906,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "3"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"

--- a/javascript/builtins/Generator.json
+++ b/javascript/builtins/Generator.json
@@ -39,10 +39,10 @@
               }
             ],
             "opera": {
-              "version_added": true
+              "version_added": "26"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "26"
             },
             "safari": {
               "version_added": "10"
@@ -90,10 +90,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "26"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "26"
               },
               "safari": {
                 "version_added": "10"
@@ -205,10 +205,10 @@
                 }
               ],
               "opera": {
-                "version_added": true
+                "version_added": "26"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "26"
               },
               "safari": {
                 "version_added": "10"

--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -27,10 +27,10 @@
             "version_added": true
           },
           "opera": {
-            "version_added": true
+            "version_added": "3"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "10.1"
           },
           "safari": {
             "version_added": "1"
@@ -78,10 +78,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -129,10 +129,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "4"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -233,10 +233,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "4"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -288,10 +288,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "39"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "39"
               },
               "safari": {
                 "version_added": "9"

--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -291,7 +291,7 @@
                 "version_added": "39"
               },
               "opera_android": {
-                "version_added": "39"
+                "version_added": "41"
               },
               "safari": {
                 "version_added": "9"


### PR DESCRIPTION
This PR sets the version numbers for JavaScript functions for Opera and Opera Android, based upon manual testing. This is a part of a personal project to eliminate as many true/null values in Opera as we can.

The versions are as follows:

javascript.builtins.Function - 3
javascript.builtins.Function.Function - 3
javascript.builtins.Function.apply - 4
javascript.builtins.Function.apply.generic_arrays_as_arguments - 5
javascript.builtins.Function.arguments - 3
javascript.builtins.Function.call - 4
javascript.builtins.Function.caller - 9.6
javascript.builtins.Function.length - 3
javascript.builtins.Function.name - 10.5
javascript.builtins.Function.toString - 3
javascript.builtins.Generator - Blink
javascript.builtins.Generator.next - Blink
javascript.builtins.Generator.throw - Blink
javascript.functions - 3
javascript.functions.arguments - 3
javascript.functions.arguments.callee - 4
javascript.functions.arguments.length - 4
javascript.functions.arguments.@@iterator - Blink