### PR TITLE
Set versions for Opera for JavaScript grammar

### DIFF
--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -28,10 +28,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -143,10 +143,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -195,10 +195,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -247,10 +247,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": null
+              "version_added": "61"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -299,10 +299,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -351,10 +351,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -403,10 +403,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -559,10 +559,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -611,10 +611,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -663,10 +663,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -922,10 +922,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "9.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -1023,10 +1023,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "9.5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3"

--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -247,7 +247,7 @@
               "version_added": true
             },
             "opera": {
-              "version_added": "61"
+              "version_added": "62"
             },
             "opera_android": {
               "version_added": "53"


### PR DESCRIPTION
This PR sets the version numbers for various JavaScript grammatics for Opera and Opera Android, based upon manual testing. This is a part of a personal project to eliminate as many true/null values in Opera as we can.

The versions are as follows:

javascript.grammar.array_literals - 4
javascript.grammar.boolean_literals - 3
javascript.grammar.decimal_numeric_literals - 3
javascript.grammar.hashbang_comments - Blink
javascript.grammar.hexadecimal_escape_sequences - 4
javascript.grammar.hexadecimal_numeric_literals - 3
javascript.grammar.null_literal - 3
javascript.grammar.regular_expression_literals - 5
javascript.grammar.string_literals - 3
javascript.grammar.unicode_escape_sequences - 4
javascript.grammar.trailing_commas - 9.5
javascript.grammar.trailing_commas.trailing_commas_in_object_literals - 9.5