### PR TITLE
Set versions for Opera for JavaScript statements

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -146,10 +146,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -198,10 +198,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -314,10 +314,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "5.1"
@@ -366,10 +366,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -418,10 +418,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "5"
@@ -472,10 +472,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "4"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -621,10 +621,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -674,10 +674,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "5"
@@ -820,10 +820,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -1148,10 +1148,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "38"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "38"
               },
               "safari": {
                 "version_added": "7"
@@ -1201,10 +1201,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -1366,10 +1366,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "36"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "36"
               },
               "safari": {
                 "version_added": "10"
@@ -1522,10 +1522,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -1893,10 +1893,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -2071,10 +2071,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -2123,10 +2123,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -2175,10 +2175,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -2228,10 +2228,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -2384,10 +2384,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -2436,10 +2436,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -2488,10 +2488,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1151,7 +1151,7 @@
                 "version_added": "38"
               },
               "opera_android": {
-                "version_added": "38"
+                "version_added": "41"
               },
               "safari": {
                 "version_added": "7"


### PR DESCRIPTION
This PR sets the version numbers for various JavaScript statements for Opera and Opera Android, based upon manual testing. This is a part of a personal project to eliminate as many true/null values in Opera as we can.

The versions are as follows:

javascript.statements.block - 3
javascript.statements.break - 4
javascript.statements.const - 9
javascript.statements.continue - 4
javascript.statements.debugger - 10
javascript.statements.default.switch - 4
javascript.statements.do_while - 4
javascript.statements.empty - 3
javascript.statements.for - 3
javascript.statements.for_of.closing_iterators - Blink
javascript.statements.function - 3
javascript.statements.generator_function.IteratorResult_object - Blink
javascript.statements.if_else - 3
javascript.statements.label - 4
javascript.statements.return - 3
javascript.statements.switch - 4
javascript.statements.throw - 4
javascript.statements.try_catch - 4
javascript.statements.var - 3
javascript.statements.while - 3
javascript.statements.with - 4