### PR TITLE
fix(package): Add `type` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "mdn-browser-compat-data",
   "version": "1.0.6",
   "description": "Browser compatibility data provided by MDN Web Docs",
+  "type": "commonjs",
   "main": "index.js",
   "types": "index.d.ts",
   "dependencies": {


### PR DESCRIPTION
**Node&nbsp;12** and&nbsp;newer&nbsp;supports [the&nbsp;`package.json` `"type"`&nbsp;field](https://nodejs.org/docs/latest-v12.x/api/esm.html#esm_code_package_json_code_code_type_code_field), which&nbsp;is&nbsp;similar to&nbsp;[the&nbsp;`type`&nbsp;attribute on&nbsp;the&nbsp;`<script>`&nbsp;element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-type), except&nbsp;that it&nbsp;only&nbsp;takes the&nbsp;`"module"` and&nbsp;`"commonjs"`&nbsp;values.

The&nbsp;**NodeJS** documentation&nbsp;recommends **CommonJS**&nbsp;packages to&nbsp;set&nbsp;this to&nbsp;`"commonjs"`, even&nbsp;though&nbsp;it’s&nbsp;not&nbsp;_currently_&nbsp;required.

---

review?(@Elchi3)