### PR TITLE
Deprecate Web App Manifest serviceworker member

### DIFF
--- a/html/manifest/serviceworker.json
+++ b/html/manifest/serviceworker.json
@@ -44,8 +44,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
https://github.com/w3c/manifest/pull/825 removed the `serviceworker` member from the set of possible Web App Manifest members. https://github.com/w3c/manifest/commit/8923ba4