### PR TITLE
Deprecate Window: ondevicelight

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -4564,8 +4564,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
https://github.com/anssiko/ambient-light/commit/05969be removed the `ondevicelight` event handler from `Window`.