### PR TITLE
Safari iOS Supports ScrollToOptions

### DIFF
--- a/api/ScrollToOptions.json
+++ b/api/ScrollToOptions.json
@@ -32,7 +32,7 @@
             "version_added": true
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": "5.0"
@@ -80,7 +80,8 @@
               "notes": "Safari does not have support for the <code>smooth</code> scroll behavior."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Safari does not have support for the <code>smooth</code> scroll behavior."
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -128,7 +129,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -176,7 +177,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "5.0"


### PR DESCRIPTION
This PR sets Safari iOS to `true` for ScrollToOptions, effectively mirroring the data from Safari Desktop.  This fixes #5594.