### PR TITLE
CSS hanging-punctuation: Safari doesn't support force-end

### DIFF
--- a/css/properties/hanging-punctuation.json
+++ b/css/properties/hanging-punctuation.json
@@ -31,10 +31,12 @@
             },
             "safari": {
               "version_added": "10",
+              "partial_implementation": true,
               "notes": "The <code>force-end</code> keyword is recognized but has no effect."
             },
             "safari_ios": {
               "version_added": "10",
+              "partial_implementation": true,
               "notes": "The <code>force-end</code> keyword is recognized but has no effect."
             },
             "samsunginternet_android": {

--- a/css/properties/hanging-punctuation.json
+++ b/css/properties/hanging-punctuation.json
@@ -30,10 +30,12 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "10",
+              "notes": "The <code>force-end</code> keyword is recognized but has no effect."
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "10",
+              "notes": "The <code>force-end</code> keyword is recognized but has no effect."
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
This PR fixes #5541.  Safari doesn't have implementation for `force-end`, however it is recognized.  As such, this adds a note stating as such.