### PR TITLE
CSS flex-[basis/grow/shrink] supported since Chrome 22

### DIFF
--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -11,7 +11,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "21"
+                "version_added": "22"
               }
             ],
             "chrome_android": [
@@ -166,7 +166,7 @@
             "description": "<code>auto</code>",
             "support": {
               "chrome": {
-                "version_added": "21"
+                "version_added": "22"
               },
               "chrome_android": {
                 "version_added": "25"

--- a/css/properties/flex-grow.json
+++ b/css/properties/flex-grow.json
@@ -11,7 +11,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "21"
+                "version_added": "22"
               }
             ],
             "chrome_android": [

--- a/css/properties/flex-shrink.json
+++ b/css/properties/flex-shrink.json
@@ -11,7 +11,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "21"
+                "version_added": "22"
               }
             ],
             "chrome_android": [


### PR DESCRIPTION
This PR fixes #4839.  The prefixed versions of `flex-grow` and `flex-shrink` CSS properties have been supported since Chrome 22 rather than 21.