### PR TITLE
Firefox supports -webkit-appearance since 64

### DIFF
--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -27,6 +27,11 @@
                 "prefix": "-moz-"
               },
               {
+                "version_added": "64",
+                "partial_implementation": true,
+                "prefix": "-webkit-"
+              },
+              {
                 "version_added": "62",
                 "partial_implementation": true,
                 "prefix": "-webkit-",
@@ -44,6 +49,11 @@
                 "version_added": "4",
                 "partial_implementation": true,
                 "prefix": "-moz-"
+              },
+              {
+                "version_added": "64",
+                "partial_implementation": true,
+                "prefix": "-webkit-"
               },
               {
                 "version_added": "62",


### PR DESCRIPTION
This PR fixes #4873 by adding a new support statement indicating Firefox's support for the WebKit-prefixed value since Firefox 64.