### PR TITLE
CSS all: revert supported in Firefox 67

### DIFF
--- a/css/properties/all.json
+++ b/css/properties/all.json
@@ -62,10 +62,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": "67"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "67"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
This PR fixes #4939.  Data comes from the bug linked in the conversation on that issue.