### PR TITLE
Safari supports scroll-margin with alt. name

### DIFF
--- a/css/properties/scroll-margin-bottom.json
+++ b/css/properties/scroll-margin-bottom.json
@@ -30,10 +30,12 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11",
+              "alternative_name": "scroll-snap-margin-bottom"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11",
+              "alternative_name": "scroll-snap-margin-bottom"
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-left.json
+++ b/css/properties/scroll-margin-left.json
@@ -30,10 +30,12 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11",
+              "alternative_name": "scroll-snap-margin-left"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11",
+              "alternative_name": "scroll-snap-margin-left"
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-right.json
+++ b/css/properties/scroll-margin-right.json
@@ -30,10 +30,12 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11",
+              "alternative_name": "scroll-snap-margin-right"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11",
+              "alternative_name": "scroll-snap-margin-right"
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-top.json
+++ b/css/properties/scroll-margin-top.json
@@ -30,10 +30,12 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11",
+              "alternative_name": "scroll-snap-margin-top"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11",
+              "alternative_name": "scroll-snap-margin-top"
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin.json
+++ b/css/properties/scroll-margin.json
@@ -30,10 +30,12 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11",
+              "alternative_name": "scroll-snap-margin"
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11",
+              "alternative_name": "scroll-snap-margin"
             },
             "samsunginternet_android": {
               "version_added": "10.0"


### PR DESCRIPTION
This PR fixes #4945 by defining the alternative name Safari uses for `scroll-margin-*`.