### PR TITLE
Create balance-all subfeature for column-fill

### DIFF
--- a/css/properties/column-fill.json
+++ b/css/properties/column-fill.json
@@ -68,6 +68,51 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "balance-all": {
+          "__compat": {
+            "description": "<code>balance-all</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "13"
+              },
+              "firefox_android": {
+                "version_added": "14"
+              },
+              "ie": {
+                "version_added": "10"
+              },
+              "opera": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "8"
+              },
+              "safari_ios": {
+                "version_added": "8"
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
This PR creates a subfeature for the `column-fill` CSS property regarding the `balance-all` keyword.  Fixes #5247.