### PR TITLE
Update compatibility table for ES modules features in Node.js

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -556,16 +556,32 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": "8.5.0",
-                "flags": [
-                  {
-                    "name": "--experimental-modules",
-                    "type": "runtime_flag"
-                  }
-                ],
-                "notes": "Module file names must end with <code>.mjs</code>, not </code>.js</code>. See Node's <a href='https://nodejs.org/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
-              },
+              "nodejs": [
+                {
+                  "version_added": "13.2.0",
+                  "notes": "Modules must either have a filename ending in <code>.mjs</code>, or the nearest parent <code>package.json</code> file must contain <code>\"type\": \"module\"</code>. See Node's <a href='https://nodejs.org/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
+                },
+                {
+                  "version_added": "12.0.0",
+                  "flags": [
+                    {
+                      "name": "--experimental-modules",
+                      "type": "runtime_flag"
+                    }
+                  ],
+                  "notes": "Modules must either have a filename ending in <code>.mjs</code>, or the nearest parent <code>package.json</code> file must contain <code>\"type\": \"module\"</code>. See Node's <a href='https://nodejs.org/docs/latest-v12.x/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
+                },
+                {
+                  "version_added": "8.5.0",
+                  "flags": [
+                    {
+                      "name": "--experimental-modules",
+                      "type": "runtime_flag"
+                    }
+                  ],
+                  "notes": "Module filenames must end with <code>.mjs</code>, not </code>.js</code>. See Node's <a href='https://nodejs.org/docs/latest-v8.x/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
+                }
+              ],
               "opera": {
                 "version_added": "47"
               },
@@ -757,16 +773,32 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": {
-              "version_added": "8.5.0",
-              "flags": [
-                {
-                  "name": "--experimental-modules",
-                  "type": "runtime_flag"
-                }
-              ],
-              "notes": "Module file names must end with <code>.mjs</code>, not </code>.js</code>. See Node's <a href='https://nodejs.org/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
-            },
+            "nodejs": [
+              {
+                "version_added": "13.2.0",
+                "notes": "Modules must either have a filename ending in <code>.mjs</code>, or the nearest parent <code>package.json</code> file must contain <code>\"type\": \"module\"</code>. See Node's <a href='https://nodejs.org/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
+              },
+              {
+                "version_added": "12.0.0",
+                "flags": [
+                  {
+                    "name": "--experimental-modules",
+                    "type": "runtime_flag"
+                  }
+                ],
+                "notes": "Modules must either have a filename ending in <code>.mjs</code>, or the nearest parent <code>package.json</code> file must contain <code>\"type\": \"module\"</code>. See Node's <a href='https://nodejs.org/docs/latest-v12.x/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
+              },
+              {
+                "version_added": "8.5.0",
+                "flags": [
+                  {
+                    "name": "--experimental-modules",
+                    "type": "runtime_flag"
+                  }
+                ],
+                "notes": "Module filenames must end with <code>.mjs</code>, not </code>.js</code>. See Node's <a href='https://nodejs.org/docs/latest-v8.x/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
+              }
+            ],
             "opera": {
               "version_added": "47"
             },
@@ -1608,16 +1640,32 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": {
-              "version_added": "8.5.0",
-              "flags": [
-                {
-                  "name": "--experimental-modules",
-                  "type": "runtime_flag"
-                }
-              ],
-              "notes": "Module file names must end with <code>.mjs</code>, not </code>.js</code>. See Node's <a href='https://nodejs.org/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
-            },
+            "nodejs": [
+              {
+                "version_added": "13.2.0",
+                "notes": "Modules must either have a filename ending in <code>.mjs</code>, or the nearest parent <code>package.json</code> file must contain <code>\"type\": \"module\"</code>. See Node's <a href='https://nodejs.org/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
+              },
+              {
+                "version_added": "12.0.0",
+                "flags": [
+                  {
+                    "name": "--experimental-modules",
+                    "type": "runtime_flag"
+                  }
+                ],
+                "notes": "Modules must either have a filename ending in <code>.mjs</code>, or the nearest parent <code>package.json</code> file must contain <code>\"type\": \"module\"</code>. See Node's <a href='https://nodejs.org/docs/latest-v12.x/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
+              },
+              {
+                "version_added": "8.5.0",
+                "flags": [
+                  {
+                    "name": "--experimental-modules",
+                    "type": "runtime_flag"
+                  }
+                ],
+                "notes": "Module filenames must end with <code>.mjs</code>, not </code>.js</code>. See Node's <a href='https://nodejs.org/docs/latest-v8.x/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
+              }
+            ],
             "opera": {
               "version_added": "47"
             },
@@ -1692,16 +1740,22 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": "12.0.0",
-                "flags": [
-                  {
-                    "name": "--experimental-modules",
-                    "type": "runtime_flag"
-                  }
-                ],
-                "notes": "Module file names must end with <code>.mjs</code>, not </code>.js</code>. See Node's <a href='https://nodejs.org/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
-              },
+              "nodejs": [
+                {
+                  "version_added": "13.2.0",
+                  "notes": "Dynamic <code>import</code> can be used in either CommonJS or ES module files, to import either CommonJS or ES module files. See Node's <a href='https://nodejs.org/api/esm.html#esm_import_expressions'>ECMAScript Modules documentation</a> for more details."
+                },
+                {
+                  "version_added": "12.0.0",
+                  "flags": [
+                    {
+                      "name": "--experimental-modules",
+                      "type": "runtime_flag"
+                    }
+                  ],
+                  "notes": "Dynamic <code>import</code> can be used in either CommonJS or ES module files, to import either CommonJS or ES module files. See Node's <a href='https://nodejs.org/api/esm.html#esm_import_expressions'>ECMAScript Modules documentation</a> for more details."
+                }
+              ],
               "opera": {
                 "version_added": "50"
               },


### PR DESCRIPTION
This PR updates the compatibility table on https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#Browser_support for Node.js.

Specifically, [Node unflagged these module features in Node 13.2.0](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V13.md#13.2.0), and since 12.0.0 [`.mjs` is not required](https://nodejs.org/api/esm.html#esm_enabling).

Improves #5112.
