### PR TITLE
Specification of scrollWidth/scrollHeight under Internet Explorer

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -6566,7 +6566,8 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "8"
+              "version_added": "5",
+              "notes": "In Internet Explorer 5 through 7, if padding is set, the value of <code>scrollHeight</code> is equal to the sum of the top and bottom padding. This behavior was fixed in Internet Explorer 8."
             },
             "opera": {
               "version_added": true
@@ -7076,7 +7077,8 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "5",
+              "notes": "In Internet Explorer 5 through 7, if padding is set, the value of <code>scrollWidth</code> is equal to the sum of the left and right padding. This behavior was fixed in Internet Explorer 8."
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes

> To specify that it is not unknown feature around `Element.scrollWidth` under Internet Explorer.

- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)

> There may be exception according to https://stackoverflow.com/questions/30900154/workaround-for-issue-with-ie-scrollwidth

- [x] Data: if you tested something, describe how you tested with details like browser and version

> I have tested from Internet Explorer 5 through 7 via a simualted environment under IE11.

- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any

> #5491
