### PR TITLE
Update compatibility of Element.getBoundingClientRect()

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -3361,7 +3361,7 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": false
+                "version_added": "11"
               },
               "safari_ios": {
                 "version_added": null
@@ -3410,7 +3410,7 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": false
+                "version_added": "11"
               },
               "safari_ios": {
                 "version_added": null

--- a/api/Element.json
+++ b/api/Element.json
@@ -3364,7 +3364,7 @@
                 "version_added": "11"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "11"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -3413,7 +3413,7 @@
                 "version_added": "11"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "11"
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
`Element.getBoundingClientRect().x` and `Element.getBoundingClientRect().y` are supported since Safari 11.

Details: issue [#5589 ](https://github.com/mdn/browser-compat-data/issues/5589)