### PR TITLE
HPKP was removed from all browsers

### DIFF
--- a/http/headers/public-key-pins-report-only.json
+++ b/http/headers/public-key-pins-report-only.json
@@ -24,32 +24,34 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": "33"
+              "version_added": "33",
+              "version_removed": "60"
             },
             "opera_android": {
-              "version_added": "33"
+              "version_added": "33",
+              "version_removed": "51"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "version_removed": false
+              "version_added": "5.0",
+              "version_removed": "11.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": false
             }
           },
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/http/headers/public-key-pins.json
+++ b/http/headers/public-key-pins.json
@@ -39,10 +39,12 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": true
             },
             "opera_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": true
             },
             "safari": {
               "version_added": false
@@ -54,13 +56,13 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true
+              "version_added": false
             }
           },
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         },
         "report-uri": {
@@ -89,10 +91,12 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "33"
+                "version_added": "33",
+                "version_removed": true
               },
               "opera_android": {
-                "version_added": "33"
+                "version_added": "33",
+                "version_removed": "51"
               },
               "safari": {
                 "version_added": false
@@ -104,13 +108,13 @@
                 "version_added": true
               },
               "webview_android": {
-                "version_added": true
+                "version_added": false
               }
             },
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         }


### PR DESCRIPTION
## Summary

Browsers have removed [HTTP Public Key Pinning](https://developer.mozilla.org/en-US/docs/Web/HTTP/Public_Key_Pinning), which includes HTTP headers [`Public-Key-Pins`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Public-Key-Pins) and [`Public-Key-Pins-Report-Only`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Public-Key-Pins-Report-Only).

## Data

Edge never supported HPKP, officially HPKP was "under consideration" all the way until switch to Chromium, which already dropped HPKP by then. 

Google's documentation and communication about HPKP removal ([status](https://chromestatus.com/feature/5903385005916160), [bug](https://bugs.chromium.org/p/chromium/issues/detail?id=779166)) does not mention WebView, but modern WebView fails the test.

I used [this test](https://projects.dm.id.lv/Public-Key-Pins_test).

A checklist to help your pull request get merged faster:
- [ ] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
