### PR TITLE
Add versions for Safari wheel events

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -10575,7 +10575,7 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
               "version_added": true

--- a/api/Document.json
+++ b/api/Document.json
@@ -10578,7 +10578,7 @@
               "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "8.0"

--- a/api/Element.json
+++ b/api/Element.json
@@ -8265,7 +8265,7 @@
               "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "8.0"

--- a/api/Element.json
+++ b/api/Element.json
@@ -8262,7 +8262,7 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
               "version_added": true

--- a/api/WheelEvent.json
+++ b/api/WheelEvent.json
@@ -320,7 +320,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false

--- a/api/WheelEvent.json
+++ b/api/WheelEvent.json
@@ -29,7 +29,7 @@
             "version_added": true
           },
           "safari": {
-            "version_added": true
+            "version_added": "6.1"
           },
           "safari_ios": {
             "version_added": true
@@ -77,7 +77,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
               "version_added": null
@@ -125,7 +125,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
               "version_added": true
@@ -174,7 +174,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
               "version_added": true
@@ -223,7 +223,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
               "version_added": true
@@ -272,7 +272,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
               "version_added": true
@@ -320,7 +320,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": true
+              "version_added": null
             },
             "safari_ios": {
               "version_added": null

--- a/api/WheelEvent.json
+++ b/api/WheelEvent.json
@@ -32,7 +32,7 @@
             "version_added": "6.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": true
@@ -80,7 +80,7 @@
               "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true
@@ -128,7 +128,7 @@
               "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true
@@ -177,7 +177,7 @@
               "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true
@@ -226,7 +226,7 @@
               "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true
@@ -275,7 +275,7 @@
               "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true
@@ -323,7 +323,7 @@
               "version_added": null
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
Also remove pinch to zoom support, since I could not get it to work
I used https://www.quirksmode.org/dom/events/tests/scroll.html and browserstack to test wheel event support
