### PR TITLE
Optional chaining enabled by default in Chrome 80 / FF Nightly 74

### DIFF
--- a/javascript/operators/optional_chaining.json
+++ b/javascript/operators/optional_chaining.json
@@ -68,7 +68,7 @@
               }
             ],
             "opera_android": {
-              "version_added": "67"
+              "version_added": false
             },
             "safari": {
               "version_added": false

--- a/javascript/operators/optional_chaining.json
+++ b/javascript/operators/optional_chaining.json
@@ -41,7 +41,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "74"
             },
             "firefox_android": {
               "version_added": false
@@ -52,16 +52,21 @@
             "nodejs": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "65",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental JavaScript",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "opera": [
+              {
+                "version_added": "67"
+              },
+              {
+                "version_added": "65",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental JavaScript",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
               "version_added": false
             },

--- a/javascript/operators/optional_chaining.json
+++ b/javascript/operators/optional_chaining.json
@@ -68,7 +68,7 @@
               }
             ],
             "opera_android": {
-              "version_added": false
+              "version_added": "67"
             },
             "safari": {
               "version_added": false
@@ -80,7 +80,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "80"
             }
           },
           "status": {

--- a/javascript/operators/optional_chaining.json
+++ b/javascript/operators/optional_chaining.json
@@ -7,26 +7,36 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Optional_chaining",
           "spec_url": "https://tc39.es/proposal-optional-chaining/#top",
           "support": {
-            "chrome": {
-              "version_added": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental JavaScript",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental JavaScript",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "80"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental JavaScript",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "80"
+              },
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental JavaScript",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": false
             },


### PR DESCRIPTION
Optional chaining is now enabled by default in Chrome 80

See https://www.chromestatus.com/feature/5748330720133120
