### PR TITLE
Element contextmenu_event supported on Chromium/Firefox for Android

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -1956,7 +1956,7 @@
               "version_added": true
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -1965,7 +1965,7 @@
               "version_added": true
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": true
             },
             "ie": {
               "version_added": "9"
@@ -1974,7 +1974,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": "3"
@@ -1983,7 +1983,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": true
             },
             "webview_android": {
               "version_added": false

--- a/api/Element.json
+++ b/api/Element.json
@@ -1986,7 +1986,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": false
+              "version_added": true
             }
           },
           "status": {


### PR DESCRIPTION
I don't know when this was introduced, but I've been using it on my personal site for some time. 

I tested in latest _edit: *mobile*_ Chrome, Samsung Internet, Opera, and Firefox using this codepen: https://codepen.io/AshKyd/pen/LYVPaqG

Also tested latest Safari on iOS, but it still doesn't work.

Edit: tested this works as a long-press on mobile.