### PR TITLE
Update api.TextMetrics compatibility for Chrome and Edge

### DIFF
--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -81,7 +81,7 @@
               }
             ],
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false,
@@ -154,7 +154,7 @@
               }
             ],
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false,
@@ -227,7 +227,7 @@
               }
             ],
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false,
@@ -300,7 +300,7 @@
               }
             ],
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false,

--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -51,22 +51,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
+              "version_added": "77"
             },
             "chrome_android": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
+              "version_added": "77"
             },
             "edge": {
               "version_added": false
@@ -98,7 +86,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "77"
             }
           },
           "status": {
@@ -112,22 +100,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
+              "version_added": "77"
             },
             "chrome_android": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
+              "version_added": "77"
             },
             "edge": {
               "version_added": false
@@ -159,7 +135,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "77"
             }
           },
           "status": {
@@ -173,22 +149,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
+              "version_added": "77"
             },
             "chrome_android": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
+              "version_added": "77"
             },
             "edge": {
               "version_added": false
@@ -220,7 +184,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "77"
             }
           },
           "status": {
@@ -234,22 +198,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
+              "version_added": "77"
             },
             "chrome_android": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
+              "version_added": "77"
             },
             "edge": {
               "version_added": false
@@ -281,7 +233,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "77"
             }
           },
           "status": {

--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -708,20 +708,15 @@
       "ideographicBaseline": {
         "__compat": {
           "support": {
-            "chrome": [
-              {
-                "version_added": "77"
-              },
-              {
-                "version_added": true,
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
+            },
             "chrome_android": {
               "version_added": true,
               "flags": [

--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -50,12 +50,36 @@
       "actualBoundingBoxAscent": {
         "__compat": {
           "support": {
-            "chrome": {
-              "version_added": "77"
-            },
-            "chrome_android": {
-              "version_added": "77"
-            },
+            "chrome": [
+              {
+                "version_added": "77"
+              },
+              {
+                "version_added": true,
+                "version_removed": "77",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "77"
+              },
+              {
+                "version_added": true,
+                "version_removed": "77",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": false
             },
@@ -99,12 +123,36 @@
       "actualBoundingBoxDescent": {
         "__compat": {
           "support": {
-            "chrome": {
-              "version_added": "77"
-            },
-            "chrome_android": {
-              "version_added": "77"
-            },
+            "chrome": [
+              {
+                "version_added": "77"
+              },
+              {
+                "version_added": true,
+                "version_removed": "77",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "77"
+              },
+              {
+                "version_added": true,
+                "version_removed": "77",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": false
             },
@@ -148,12 +196,36 @@
       "actualBoundingBoxLeft": {
         "__compat": {
           "support": {
-            "chrome": {
-              "version_added": "77"
-            },
-            "chrome_android": {
-              "version_added": "77"
-            },
+            "chrome": [
+              {
+                "version_added": "77"
+              },
+              {
+                "version_added": true,
+                "version_removed": "77",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "77"
+              },
+              {
+                "version_added": true,
+                "version_removed": "77",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": false
             },
@@ -197,12 +269,36 @@
       "actualBoundingBoxRight": {
         "__compat": {
           "support": {
-            "chrome": {
-              "version_added": "77"
-            },
-            "chrome_android": {
-              "version_added": "77"
-            },
+            "chrome": [
+              {
+                "version_added": "77"
+              },
+              {
+                "version_added": true,
+                "version_removed": "77",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "77"
+              },
+              {
+                "version_added": true,
+                "version_removed": "77",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": false
             },
@@ -612,15 +708,20 @@
       "ideographicBaseline": {
         "__compat": {
           "support": {
-            "chrome": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "77"
+              },
+              {
+                "version_added": true,
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
             "chrome_android": {
               "version_added": true,
               "flags": [


### PR DESCRIPTION
- [x] Summarize your changes: Chrome has four more properties from TextMetrics enabled by default since release 77 of desktop, Android, and Webview browsers.

- [x] Data: link to resources that verify support information: [Chrome Platform Status: New TextMetrics object in canvas](https://www.chromestatus.com/feature/5307344997056512) says that `actualBoundingBoxLeft`, `actualBoundingBoxRight`, `actualBoundingBoxAscent` and `actualBoundingBoxDescent` are enabled by default since release 77.

- [x] Data: if you tested something, describe how you tested with details like browser and version:
I made a quick test on Chrome 79 desktop:
```javascript
document.createElement('canvas').getContext('2d').measureText('testing metrics')
```
It gives an object with the following properties:
```
width: 64.462890625
actualBoundingBoxLeft: -0.1123046875
actualBoundingBoxRight: 64.1015625
actualBoundingBoxAscent: 7.1728515625
actualBoundingBoxDescent: 2.2119140625
```

- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!): done, all green.

- [x] Link to related issues or pull requests, if any: haven't found anything related to TextMetrics in Chrome 77.