### PR TITLE
Refactor utils/regex tests into global test format

### DIFF
--- a/test/lint.js
+++ b/test/lint.js
@@ -19,6 +19,8 @@ const { IS_CI } = require('./utils.js');
 const testCompareFeatures = require('./test-compare-features');
 const testMigrations = require('./test-migrations');
 const testFormat = require('./test-format');
+const testRegexes = require('./test-regexes');
+const testUtils = require('./test-utils');
 
 /** @type {Map<string, string>} */
 const filesWithErrors = new Map();
@@ -161,6 +163,8 @@ var hasErrors = argv.files
 hasErrors = testCompareFeatures() || hasErrors;
 hasErrors = testMigrations() || hasErrors;
 hasErrors = testFormat() || hasErrors;
+hasErrors = testRegexes() || hasErrors;
+hasErrors = testUtils() || hasErrors;
 
 if (hasErrors) {
   console.warn('');

--- a/test/test-regexes.js
+++ b/test/test-regexes.js
@@ -1,3 +1,6 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
 'use strict';
 const assert = require('assert');
 const chalk = require('chalk');

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -1,45 +1,52 @@
 'use strict';
-const ora = require('ora');
 const chalk = require('chalk');
-const { IS_CI, escapeInvisibles } = require('./utils.js');
+const { escapeInvisibles } = require('./utils.js');
 
-it('`escapeInvisibles()` works correctly', () => {
-  const EXPECTED = [
-    /* ␀ */ ['\0', '\\0'],
-    /* ␁ */ '\x01',
-    /* ␂ */ '\x02',
-    /* ␃ */ '\x03',
-    /* ␄ */ '\x04',
-    /* ␅ */ '\x05',
-    /* ␆ */ '\x06',
-    /* ␇ */ '\x07',
-    /* ␈ */ ['\b', '\\b'],
-    /* ␉ */ ['\t', '\\t'],
-    /* ␊ */ ['\n', '\\n'],
-    /* ␋ */ ['\v', '\\v'],
-    /* ␌ */ ['\f', '\\f'],
-    /* ␍ */ ['\r', '\\r'],
-    /* ␏ */ '\x0F',
-    /* ␎ */ '\x0E',
-    /* ␐ */ '\x10',
-    /* ␑ */ '\x11',
-    /* ␒ */ '\x12',
-    /* ␓ */ '\x13',
-    /* ␔ */ '\x14',
-    /* ␕ */ '\x15',
-    /* ␖ */ '\x16',
-    /* ␗ */ '\x17',
-    /* ␘ */ '\x18',
-    /* ␙ */ '\x19',
-    /* ␚ */ '\x1A',
-    /* ␛ */ '\x1B',
-    /* ␜ */ '\x1C',
-    /* ␝ */ '\x1D',
-    /* ␞ */ '\x1E',
-    /* ␟ */ '\x1F',
-    /* ␠ */ ' ',
-    /* ␡ */ '\x7F',
-  ];
+const EXPECTED = [
+  /* ␀ */ ['\0', '\\0'],
+  /* ␁ */ '\x01',
+  /* ␂ */ '\x02',
+  /* ␃ */ '\x03',
+  /* ␄ */ '\x04',
+  /* ␅ */ '\x05',
+  /* ␆ */ '\x06',
+  /* ␇ */ '\x07',
+  /* ␈ */ ['\b', '\\b'],
+  /* ␉ */ ['\t', '\\t'],
+  /* ␊ */ ['\n', '\\n'],
+  /* ␋ */ ['\v', '\\v'],
+  /* ␌ */ ['\f', '\\f'],
+  /* ␍ */ ['\r', '\\r'],
+  /* ␏ */ '\x0F',
+  /* ␎ */ '\x0E',
+  /* ␐ */ '\x10',
+  /* ␑ */ '\x11',
+  /* ␒ */ '\x12',
+  /* ␓ */ '\x13',
+  /* ␔ */ '\x14',
+  /* ␕ */ '\x15',
+  /* ␖ */ '\x16',
+  /* ␗ */ '\x17',
+  /* ␘ */ '\x18',
+  /* ␙ */ '\x19',
+  /* ␚ */ '\x1A',
+  /* ␛ */ '\x1B',
+  /* ␜ */ '\x1C',
+  /* ␝ */ '\x1D',
+  /* ␞ */ '\x1E',
+  /* ␟ */ '\x1F',
+  /* ␠ */ ' ',
+  /* ␡ */ '\x7F',
+];
+
+/**
+ * @todo This test only tests the escapeInvisibles() function in the utilities file, nothing else.
+ *
+ * @returns {boolean} If the linter utilities aren't functioning properly
+ */
+const testUtils = () => {
+  /** @type {string[]} */
+  const errors = [];
 
   for (const data of EXPECTED) {
     let char, expected;
@@ -49,56 +56,25 @@ it('`escapeInvisibles()` works correctly', () => {
     } else {
       [char, expected = char] = data;
     }
-    console.assert(
-      escapeInvisibles(char) === expected,
-      chalk`{red Character ${escape(char)} does not get correctly escaped.}`,
+    if (escapeInvisibles(char) !== expected) {
+      errors.push(
+        chalk`Character {bold ${escape(char)}} does not get correctly escaped.`,
+      );
+    }
+  }
+
+  if (errors.length) {
+    console.error(
+      chalk`{red Linter utilities – {bold ${errors.length}} ${
+        errors.length === 1 ? 'error' : 'errors'
+      }:}`,
     );
+    for (let i in errors) {
+      console.error(chalk`{red   ${errors[i]}}`);
+    }
+    return true;
   }
-});
+  return false;
+};
 
-/**
- * TODO: Maybe use a real test suite for this?
- *
- * @param {string} message
- * @param {() => void | Promise<void>} testCase
- */
-function it(message, testCase) {
-  const spinner = ora({
-    stream: process.stdout,
-    text: message,
-  });
-
-  if (!IS_CI) {
-    // Continuous integration environments don't allow overwriting
-    // previous lines using VT escape sequences, which is how
-    // the spinner animation is implemented.
-    spinner.start();
-  }
-
-  let result;
-  let err;
-
-  try {
-    result = testCase();
-  } catch (e) {
-    err = e;
-  }
-  if (err) {
-    spinner.fail(chalk.red.bold(message));
-    console.error(err);
-    return;
-  }
-  if (result && typeof result.then === 'function') {
-    Promise.resolve(result).then(
-      () => {
-        spinner.succeed();
-      },
-      err => {
-        spinner.fail(chalk.red.bold(message));
-        console.error(err);
-      },
-    );
-    return;
-  }
-  spinner.succeed();
-}
+module.exports = testUtils;

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -1,3 +1,6 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
 'use strict';
 const chalk = require('chalk');
 const { escapeInvisibles } = require('./utils.js');

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,3 +1,6 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
 'use strict';
 const { platform } = require('os');
 const chalk = require('chalk');


### PR DESCRIPTION
This PR refactors two currently-unused tests (`test-utils` and `test-regex`) into the same format as our other global tests, allowing us to run them alongside our other tests.  This had come up as a part of the ESLint error fixing project I was working on.