### PR TITLE
Optional chaining is no longer experimental

### DIFF
--- a/javascript/operators/optional_chaining.json
+++ b/javascript/operators/optional_chaining.json
@@ -69,7 +69,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
Optional chaining is now a stage 4 proposal, so it should no longer be marked `experimental`

https://github.com/tc39/proposal-optional-chaining

Chromium is also enabling this feature by default, but that is being handled in #5656