### PR TITLE
Set Opera Android value for CSS column-fill

### DIFF
--- a/css/properties/column-fill.json
+++ b/css/properties/column-fill.json
@@ -97,6 +97,9 @@
               "opera": {
                 "version_added": false
               },
+              "opera_android": {
+                "version_added": false
+              },
               "safari": {
                 "version_added": "8"
               },


### PR DESCRIPTION
This PR sets the Opera Android value for the CSS `column-fill` property, specifically the `balance-all` value, to get 100% completion of Opera Android CSS data.