### PR TITLE
Move a link test from styling to links

### DIFF
--- a/test/linter/test-links.js
+++ b/test/linter/test-links.js
@@ -1,5 +1,6 @@
 'use strict';
 const fs = require('fs');
+const url = require('url');
 const chalk = require('chalk');
 const { IS_WINDOWS, indexToPos, indexToPosRaw } = require('../utils.js');
 
@@ -176,11 +177,13 @@ function processData(filename) {
     actual,
     String.raw`<a href='([^'>]+)'>((?:.(?!</a>))*.)</a>`,
     match => {
-      return {
-        issue: 'Include hostname in URL',
-        actualLink: match[1],
-        expected: `https://developer.mozilla.org/${match[1]}`,
-      };
+      if (url.parse(match[1]).hostname === null) {
+        return {
+          issue: 'Include hostname in URL',
+          actualLink: match[1],
+          expected: `https://developer.mozilla.org/${match[1]}`,
+        };
+      }
     },
   );
 

--- a/test/linter/test-links.js
+++ b/test/linter/test-links.js
@@ -178,9 +178,8 @@ function processData(filename) {
     match => {
       return {
         issue: 'Include hostname in URL',
-        expected: `<a href='https://developer.mozilla.org/${match[1]}'>${
-          match[2]
-        }</a>.`,
+        actualLink: match[1],
+        expected: `https://developer.mozilla.org/${match[1]}`,
       };
     },
   );

--- a/test/linter/test-links.js
+++ b/test/linter/test-links.js
@@ -171,6 +171,20 @@ function processData(filename) {
     },
   );
 
+  processLink(
+    errors,
+    actual,
+    String.raw`<a href='([^'>]+)'>((?:.(?!</a>))*.)</a>`,
+    match => {
+      return {
+        issue: 'Include hostname in URL',
+        expected: `<a href='https://developer.mozilla.org/${match[1]}'>${
+          match[2]
+        }</a>.`,
+      };
+    },
+  );
+
   return errors;
 }
 

--- a/test/linter/test-style.js
+++ b/test/linter/test-style.js
@@ -1,6 +1,5 @@
 'use strict';
 const fs = require('fs');
-const url = require('url');
 const chalk = require('chalk');
 const { IS_WINDOWS, indexToPos, jsonDiff } = require('../utils.js');
 const compareFeatures = require('../../scripts/compare-features');

--- a/test/linter/test-style.js
+++ b/test/linter/test-style.js
@@ -118,25 +118,6 @@ function processData(filename, logger) {
       )} - Found {yellow \\"}, but expected {green \'} for <a href>.}`,
     );
   }
-
-  const regexp = new RegExp(
-    String.raw`<a href='([^'>]+)'>((?:.(?!</a>))*.)</a>`,
-    'g',
-  );
-  const match = regexp.exec(actual);
-  if (match) {
-    const a_url = url.parse(match[1]);
-    if (a_url.hostname === null) {
-      logger.error(
-        chalk`{red → ${indexToPos(
-          actual,
-          constructorMatch.index,
-        )} - Include hostname in URL ({yellow ${
-          match[1]
-        }} → {green {bold https://developer.mozilla.org/}${match[1]}}).}`,
-      );
-    }
-  }
 }
 
 function testStyle(filename) {


### PR DESCRIPTION
Apparently, a link-based test was included in the styling tests.  This PR moves the test from the styling test file to the links test file, helping keep everything in the right location.