### PR TITLE
Remove constructor test from styling test file

### DIFF
--- a/test/linter/test-style.js
+++ b/test/linter/test-style.js
@@ -95,20 +95,6 @@ function processData(filename, logger) {
     );
   }
 
-  const constructorMatch = actual.match(
-    String.raw`"<code>([^)]*?)</code> constructor"`,
-  );
-  if (constructorMatch) {
-    logger.error(
-      chalk`{red → ${indexToPos(
-        actual,
-        constructorMatch.index,
-      )} – Use parentheses in constructor description ({yellow ${
-        constructorMatch[1]
-      }} → {green ${constructorMatch[1]}{bold ()}}).}`,
-    );
-  }
-
   const hrefDoubleQuoteIndex = actual.indexOf('href=\\"');
   if (hrefDoubleQuoteIndex >= 0) {
     logger.error(


### PR DESCRIPTION
This PR removes the constructor description test from the styling test file.  Since this is already tested by our descriptions test, we have no need for testing it twice.