### PR TITLE
prefixed multicol properties removed in 74

### DIFF
--- a/css/properties/column-count.json
+++ b/css/properties/column-count.json
@@ -39,6 +39,7 @@
               {
                 "prefix": "-moz-",
                 "version_added": "1.5",
+                "version_removed": "74",
                 "notes": "Prior to version 37, multiple columns didn't work with <code>display: table-caption</code> elements."
               }
             ],

--- a/css/properties/column-fill.json
+++ b/css/properties/column-fill.json
@@ -20,7 +20,8 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "13"
+                "version_added": "13",
+                "version_removed": "74"
               }
             ],
             "firefox_android": [

--- a/css/properties/column-gap.json
+++ b/css/properties/column-gap.json
@@ -279,6 +279,7 @@
                 {
                   "prefix": "-moz-",
                   "version_added": "1.5",
+                  "version_removed": "74",
                   "notes": "Before Firefox 3, the default value for the <code>normal</code> keyword was <code>0</code> and not <code>1em</code>."
                 }
               ],

--- a/css/properties/column-rule-color.json
+++ b/css/properties/column-rule-color.json
@@ -38,7 +38,8 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "3.5"
+                "version_added": "3.5",
+                "version_removed": "74"
               }
             ],
             "firefox_android": [

--- a/css/properties/column-rule-style.json
+++ b/css/properties/column-rule-style.json
@@ -38,7 +38,8 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "3.5"
+                "version_added": "3.5",
+                "version_removed": "74"
               }
             ],
             "firefox_android": [

--- a/css/properties/column-rule-width.json
+++ b/css/properties/column-rule-width.json
@@ -38,7 +38,8 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "3.5"
+                "version_added": "3.5",
+                "version_removed": "74"
               }
             ],
             "firefox_android": [

--- a/css/properties/column-rule.json
+++ b/css/properties/column-rule.json
@@ -39,6 +39,7 @@
               {
                 "prefix": "-moz-",
                 "version_added": "3.5",
+                "version_removed": "74",
                 "notes": "Before Firefox 3, the default value for the <code>normal</code> keyword was <code>0</code> and not <code>1em</code>."
               }
             ],

--- a/css/properties/column-width.json
+++ b/css/properties/column-width.json
@@ -39,6 +39,7 @@
               {
                 "prefix": "-moz-",
                 "version_added": "1.5",
+                "version_removed": "74",
                 "notes": "Prior to version 37, multiple columns didn't work with <code>display: table-caption</code> elements."
               }
             ],

--- a/css/properties/columns.json
+++ b/css/properties/columns.json
@@ -33,6 +33,7 @@
               {
                 "prefix": "-moz-",
                 "version_added": "9",
+                "version_removed": "74",
                 "notes": "Prior to version 37, multiple columns didn't work with <code>display: table-caption</code> elements."
               }
             ],


### PR DESCRIPTION
The `-moz` prefixed Multicol properties are being removed in Firefox 74. https://bugzilla.mozilla.org/show_bug.cgi?id=1308636

This PR updates the data to indicate that removal.