### PR TITLE
Add data for Chrome/Edge/WebView 80

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -553,19 +553,26 @@
         "79": {
           "release_date": "2019-12-10",
           "release_notes": "https://chromereleases.googleblog.com/2019/12/stable-channel-update-for-desktop.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "79"
         },
         "80": {
-          "status": "beta",
+          "release_date": "2020-02-04",
+          "release_notes": "https://chromereleases.googleblog.com/2020/02/stable-channel-update-for-desktop.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "80"
         },
         "81": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "81"
+        },
+        "82": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "82"
         }
       }
     }

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -390,19 +390,26 @@
         "79": {
           "release_date": "2019-12-17",
           "release_notes": "https://chromereleases.googleblog.com/2019/12/chrome-for-android-update_17.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "79"
         },
         "80": {
-          "status": "beta",
+          "release_date": "2020-02-04",
+          "release_notes": "https://chromereleases.googleblog.com/2020/02/chrome-for-android-update.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "80"
         },
         "81": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "81"
+        },
+        "82": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "82"
         }
       }
     }

--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -62,7 +62,6 @@
         },
         "80": {
           "release_date": "2020-02-07",
-          "release_notes": "https://twitter.com/MSEdgeDev/status/1225905079774937088",
           "status": "current",
           "engine": "Blink",
           "engine_version": "80"

--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -56,9 +56,26 @@
         "79": {
           "release_date": "2020-01-15",
           "release_notes": "https://blogs.windows.com/windowsexperience/2020/01/15/new-year-new-browser-the-new-microsoft-edge-is-out-of-preview-and-now-available-for-download/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "79"
+        },
+        "80": {
+          "release_date": "2020-02-07",
+          "release_notes": "https://twitter.com/MSEdgeDev/status/1225905079774937088",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "80"
+        },
+        "81": {
+          "status": "beta",
+          "engine": "Blink",
+          "engine_version": "81"
+        },
+        "82": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "82"
         }
       }
     }

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -381,19 +381,26 @@
         "79": {
           "release_date": "2019-12-17",
           "release_notes": "https://chromereleases.googleblog.com/2019/12/chrome-for-android-update_17.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "79"
         },
         "80": {
-          "status": "beta",
+          "release_date": "2020-02-04",
+          "release_notes": "https://chromereleases.googleblog.com/2020/02/chrome-for-android-update.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "80"
         },
         "81": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "81"
+        },
+        "82": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "82"
         }
       }
     }


### PR DESCRIPTION
Chrome 80 was released four days ago, and Edge 80 just yesterday.  This PR updates our Chromium and Edge data with the new releases, as well as adds beta and nightly versions to Edge.