### PR TITLE
Add data for Opera 66, Opera Android 56

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -510,19 +510,26 @@
         "65": {
           "release_date": "2019-11-13",
           "release_notes": "https://blogs.opera.com/desktop/2019/11/opera-65-comes-with-an-improved-tracker-blocker-and-redesigned-address-bar/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "78"
         },
         "66": {
-          "status": "beta",
+          "release_date": "2020-01-07",
+          "release_notes": "https://blogs.opera.com/desktop/2020/01/opera-66-initial-release-makes-it-easier-to-reopen-closed-tabs-and-to-access-extensions/",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "79"
         },
         "67": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "80"
+        },
+        "68": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "81"
         }
       }
     }

--- a/browsers/opera_android.json
+++ b/browsers/opera_android.json
@@ -290,9 +290,16 @@
         "55": {
           "release_date": "2019-12-03",
           "release_notes": "https://forums.opera.com/topic/36858/opera-for-android-55",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "77"
+        },
+        "56": {
+          "release_date": "2020-02-06",
+          "release_notes": "https://blogs.opera.com/mobile/2020/02/easy-reading-in-opera-for-android/",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "78"
         }
       }
     }


### PR DESCRIPTION
Opera 66 and Opera Android 56 are now out.  This PR adds data for both of the browsers.