### PR TITLE
Update version numbers for console API

### DIFF
--- a/api/Console.json
+++ b/api/Console.json
@@ -5,13 +5,13 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console",
         "support": {
           "chrome": {
-            "version_added": "4"
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
-            "version_added": true
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "2"
@@ -21,26 +21,28 @@
           },
           "ie": {
             "version_added": "8",
-            "partial_implementation": true,
-            "notes": "Only functions when developer tools are opened. Otherwise, the 'console' object is undefined."
+            "notes": "In Internet Explorer 8 and 9, the <code>console</code> object is <code>undefined</code> when the developer tools are not open.  This behavior was fixed in Internet Explorer 10."
           },
           "nodejs": {
             "version_added": "0.1.100"
           },
           "opera": {
-            "version_added": "10.1"
+            "version_added": "10.5"
+          },
+          "opera_android": {
+            "version_added": "11"
           },
           "safari": {
-            "version_added": "3.1"
+            "version_added": "3"
           },
           "safari_ios": {
-            "version_added": "3.2"
+            "version_added": "1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -54,10 +56,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/assert",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -69,7 +71,7 @@
               "version_added": "28"
             },
             "ie": {
-              "version_added": true
+              "version_added": "8"
             },
             "nodejs": [
               {
@@ -82,19 +84,22 @@
               }
             ],
             "opera": {
-              "version_added": true
+              "version_added": "11"
+            },
+            "opera_android": {
+              "version_added": "11"
             },
             "safari": {
-              "version_added": true
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -363,10 +368,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/dir",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -384,19 +389,22 @@
               "version_added": "0.1.101"
             },
             "opera": {
-              "version_added": true
+              "version_added": "11"
+            },
+            "opera_android": {
+              "version_added": "11"
             },
             "safari": {
-              "version_added": true
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -466,10 +474,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/error",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -487,19 +495,22 @@
               "version_added": "0.1.100"
             },
             "opera": {
-              "version_added": true
+              "version_added": "10.5"
+            },
+            "opera_android": {
+              "version_added": "11"
             },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -660,7 +671,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/group",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -757,7 +768,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/groupEnd",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -904,10 +915,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/log",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -925,19 +936,22 @@
               "version_added": "0.1.100"
             },
             "opera": {
-              "version_added": true
+              "version_added": "10.5"
+            },
+            "opera_android": {
+              "version_added": "11"
             },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1113,10 +1127,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/table",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "27"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "27"
             },
             "edge": {
               "version_added": "13"
@@ -1134,19 +1148,22 @@
               "version_added": "10.0.0"
             },
             "opera": {
-              "version_added": true
+              "version_added": "11"
+            },
+            "opera_android": {
+              "version_added": "11"
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1161,7 +1178,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/time",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -1182,19 +1199,22 @@
               "version_added": "0.1.104"
             },
             "opera": {
-              "version_added": true
+              "version_added": "11"
+            },
+            "opera_android": {
+              "version_added": "11"
             },
             "safari": {
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "1"
             }
           },
           "status": {
@@ -1209,7 +1229,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/timeEnd",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -1242,7 +1262,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "1"
             }
           },
           "status": {
@@ -1360,10 +1380,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/trace",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1381,19 +1401,22 @@
               "version_added": "0.1.104"
             },
             "opera": {
-              "version_added": true
+              "version_added": "11"
+            },
+            "opera_android": {
+              "version_added": "11"
             },
             "safari": {
-              "version_added": true
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This PR sets and updates the version numbers for various portions of the console API based upon manual testing. The data is as follows:

	api.Console
		- Chrome - incorrect data, 1
		- IE - 8, but "undefined" when developer tools aren't open in IE 8 and 9
		- Opera - incorrect data, 10.5
		- Safari - incorrect data, 3
	api.Console.assert
		- Chrome - 1
		- IE - 8
		- Opera - 11
		- Safari - 4
	api.Console.dir
		- Chrome - 1
		- Opera - 11
		- Safari - 4
	api.Console.error
		- Chrome - 1
		- Opera - 10.5
		- Safari - 3
	api.Console.group
		- Chrome - incorrect data, 1
	api.Console.groupEnd
		- Chrome - incorrect data, 1
	api.Console.log
		- Chrome - 1
		- Opera - 10.5
		- Safari - 3
	api.Console.table
		- Chrome - 27
		- Opera - 11
		- Safari - 6.1
	api.Console.time
		- Chrome - incorrect data, 1
		- Opera - 11
	api.Console.timeEnd
		- Chrome - incorrect data, 1
	api.Console.trace
		- Chrome - 1
		- Opera - 11
		- Safari - 4