### PR TITLE
Mirror Chrome Android -> Samsung Internet for javascript/

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -144,7 +144,7 @@
                 "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"
@@ -196,7 +196,7 @@
                 "version_added": "9"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "45"
@@ -248,7 +248,7 @@
                 "version_added": "8"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
                 "version_added": "38"
@@ -363,7 +363,7 @@
                 "version_added": "8"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "45"
@@ -478,7 +478,7 @@
                 "version_added": "8"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "45"
@@ -541,7 +541,7 @@
                 "version_added": "8"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "45"
@@ -749,7 +749,7 @@
                 "version_added": "9"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "45"
@@ -812,7 +812,7 @@
                 "version_added": "9"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "47"
@@ -916,7 +916,7 @@
                 "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"
@@ -968,7 +968,7 @@
                 "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"
@@ -1020,7 +1020,7 @@
                 "version_added": "8"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
                 "version_added": "38"
@@ -1332,7 +1332,7 @@
                 "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"
@@ -1384,7 +1384,7 @@
                 "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"
@@ -1540,7 +1540,7 @@
                 "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"
@@ -1592,7 +1592,7 @@
                 "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"
@@ -1644,7 +1644,7 @@
                 "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"
@@ -1748,7 +1748,7 @@
                 "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"
@@ -1852,7 +1852,7 @@
                 "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"
@@ -2216,7 +2216,7 @@
                 "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"
@@ -2364,7 +2364,7 @@
                 "version_added": "10"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
                 "version_added": "38"

--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -40,7 +40,7 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4"
@@ -92,7 +92,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -144,7 +144,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"

--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -40,7 +40,7 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4"
@@ -92,7 +92,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -144,7 +144,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -249,7 +249,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -301,7 +301,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -457,7 +457,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -509,7 +509,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -561,7 +561,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -613,7 +613,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -665,7 +665,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -717,7 +717,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -769,7 +769,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -821,7 +821,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -1028,7 +1028,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -1080,7 +1080,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -1132,7 +1132,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -1184,7 +1184,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -1236,7 +1236,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -1288,7 +1288,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -1340,7 +1340,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -1392,7 +1392,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -1185,7 +1185,7 @@
                 "version_added": "4"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"

--- a/javascript/builtins/Float32Array.json
+++ b/javascript/builtins/Float32Array.json
@@ -40,7 +40,7 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4"

--- a/javascript/builtins/Float64Array.json
+++ b/javascript/builtins/Float64Array.json
@@ -40,7 +40,7 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4"

--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -711,7 +711,7 @@
                 "version_added": "6"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"

--- a/javascript/builtins/Generator.json
+++ b/javascript/builtins/Generator.json
@@ -51,7 +51,7 @@
               "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "39"
@@ -102,7 +102,7 @@
                 "version_added": "10"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "webview_android": {
                 "version_added": "39"
@@ -217,7 +217,7 @@
                 "version_added": "10"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "webview_android": {
                 "version_added": "39"

--- a/javascript/builtins/Int16Array.json
+++ b/javascript/builtins/Int16Array.json
@@ -40,7 +40,7 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4"

--- a/javascript/builtins/Int32Array.json
+++ b/javascript/builtins/Int32Array.json
@@ -40,7 +40,7 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4"

--- a/javascript/builtins/Int8Array.json
+++ b/javascript/builtins/Int8Array.json
@@ -40,7 +40,7 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4"

--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -920,7 +920,7 @@
                     "version_added": "10"
                   },
                   "samsunginternet_android": {
-                    "version_added": true
+                    "version_added": "3.0"
                   },
                   "webview_android": {
                     "version_added": false

--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -561,7 +561,7 @@
                 "version_added": "8"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
                 "version_added": "38"
@@ -665,7 +665,7 @@
                 "version_added": "8"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
                 "version_added": "38"
@@ -821,7 +821,7 @@
                 "version_added": "8"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
                 "version_added": "38"
@@ -873,7 +873,7 @@
                 "version_added": "8"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
                 "version_added": "38"
@@ -977,7 +977,7 @@
                 "version_added": "7"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
                 "version_added": "38"
@@ -1081,7 +1081,7 @@
                 "version_added": "8"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
                 "version_added": "38"
@@ -1185,7 +1185,7 @@
                 "version_added": "8"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
                 "version_added": "38"
@@ -1289,7 +1289,7 @@
                 "version_added": "8"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
                 "version_added": "38"
@@ -1341,7 +1341,7 @@
                 "version_added": "8"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
                 "version_added": "38"
@@ -1393,7 +1393,7 @@
                 "version_added": "7"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.5"
               },
               "webview_android": {
                 "version_added": "≤37"
@@ -1497,7 +1497,7 @@
                 "version_added": "8"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
                 "version_added": "38"
@@ -1549,7 +1549,7 @@
                 "version_added": "8"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
                 "version_added": "38"
@@ -1601,7 +1601,7 @@
                 "version_added": "8"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
                 "version_added": "38"
@@ -1913,7 +1913,7 @@
                 "version_added": "9"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
                 "version_added": "38"
@@ -2017,7 +2017,7 @@
                 "version_added": "8"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
                 "version_added": "38"
@@ -2173,7 +2173,7 @@
                 "version_added": "8"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
                 "version_added": "38"
@@ -2225,7 +2225,7 @@
                 "version_added": "8"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "3.0"
               },
               "webview_android": {
                 "version_added": "38"

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -143,7 +143,7 @@
                 "version_added": "9"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
                 "version_added": "≤37"
@@ -247,7 +247,7 @@
                 "version_added": "9"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
                 "version_added": "≤37"
@@ -560,7 +560,7 @@
                 "version_added": "9"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.5"
               },
               "webview_android": {
                 "version_added": "≤37"
@@ -664,7 +664,7 @@
                 "version_added": "9"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.5"
               },
               "webview_android": {
                 "version_added": "≤37"

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -300,7 +300,7 @@
                 "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"
@@ -406,7 +406,7 @@
                 "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"
@@ -467,7 +467,7 @@
                 "notes": "Also supported in Safari for iOS 4.2, but not on DOM objects."
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"
@@ -687,7 +687,7 @@
                 "version_added": "6"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"
@@ -850,7 +850,7 @@
                 "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"
@@ -965,7 +965,7 @@
                 "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"
@@ -1069,7 +1069,7 @@
                 "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"
@@ -1173,7 +1173,7 @@
                 "version_added": "9"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
                 "version_added": "≤37"
@@ -1225,7 +1225,7 @@
                 "version_added": "6"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"
@@ -1277,7 +1277,7 @@
                 "version_added": "6"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"
@@ -1381,7 +1381,7 @@
                 "version_added": "6"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"
@@ -1433,7 +1433,7 @@
                 "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"
@@ -1749,7 +1749,7 @@
                 "version_added": "6"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"
@@ -1799,7 +1799,7 @@
                   "version_added": "9"
                 },
                 "samsunginternet_android": {
-                  "version_added": true
+                  "version_added": "4.0"
                 },
                 "webview_android": {
                   "version_added": "44"
@@ -1957,7 +1957,7 @@
                 "version_added": "6"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"
@@ -2009,7 +2009,7 @@
                 "version_added": "9"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
                 "version_added": "37"

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -467,7 +467,7 @@
                 "version_added": "10"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "webview_android": {
                 "version_added": "41"
@@ -853,7 +853,7 @@
                 "version_added": "10"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "webview_android": {
                 "version_added": "41"
@@ -919,7 +919,7 @@
                 "version_added": "9"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "webview_android": {
                 "version_added": "41"

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -40,7 +40,7 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4"
@@ -91,7 +91,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -143,7 +143,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -195,7 +195,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -247,7 +247,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -402,7 +402,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": false
@@ -454,7 +454,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": false
@@ -506,7 +506,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": false
@@ -558,7 +558,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": false
@@ -1206,7 +1206,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -1365,7 +1365,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -1727,7 +1727,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"
@@ -1935,7 +1935,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "4"

--- a/javascript/builtins/Uint16Array.json
+++ b/javascript/builtins/Uint16Array.json
@@ -40,7 +40,7 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4"

--- a/javascript/builtins/Uint32Array.json
+++ b/javascript/builtins/Uint32Array.json
@@ -40,7 +40,7 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4"

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -40,7 +40,7 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4"

--- a/javascript/builtins/Uint8ClampedArray.json
+++ b/javascript/builtins/Uint8ClampedArray.json
@@ -40,7 +40,7 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4"

--- a/javascript/builtins/globals.json
+++ b/javascript/builtins/globals.json
@@ -766,7 +766,7 @@
                 "version_added": "6"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.5"
               },
               "webview_android": {
                 "version_added": "4.4"

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -140,7 +140,7 @@
               "version_added": "9"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49",
@@ -217,7 +217,7 @@
               "version_added": "9"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49",
@@ -400,7 +400,7 @@
               "version_added": "9"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": "49",

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -327,7 +327,7 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -1092,7 +1092,7 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
               "version_added": "38"
@@ -1193,7 +1193,7 @@
                 "version_added": "7"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "51"
@@ -1411,7 +1411,7 @@
                 "version_added": "10"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
                 "version_added": "49"


### PR DESCRIPTION
This PR mirrors the Chrome Android data over to Samsung Internet for the remaining data in `javascript/`.  We'll then be able to lock Samsung Internet data `javascript/` to only real values!