### PR TITLE
Set versions for Opera for CSS color type

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -25,10 +25,10 @@
               "version_added": "3"
             },
             "opera": {
-              "version_added": true
+              "version_added": "3.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1"
@@ -76,7 +76,7 @@
                 "version_added": "10"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3.1"
@@ -317,7 +317,7 @@
                 "version_added": "9.5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3.1"
@@ -415,7 +415,7 @@
                 "version_added": "3.5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -560,7 +560,7 @@
                 "version_added": "3.5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -609,7 +609,7 @@
                 "version_added": "3.5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"
@@ -706,7 +706,7 @@
                 "version_added": "10"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3.1"


### PR DESCRIPTION
This PR sets the Opera and Opera Android versions for the CSS color type, letting us return to 100% real values for Opera in CSS once again.