### PR TITLE
Add HTTP Fetch Metadata Request Headers

### DIFF
--- a/http/headers/sec-fetch-dest.json
+++ b/http/headers/sec-fetch-dest.json
@@ -1,0 +1,54 @@
+{
+  "http": {
+    "headers": {
+      "Sec-Fetch-Dest": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-Fetch-Dest",
+          "support": {
+            "chrome": {
+              "version_added": "80"
+            },
+            "chrome_android": {
+              "version_added": "80"
+            },
+            "edge": {
+              "version_added": "80"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "67"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "80"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/http/headers/sec-fetch-mode.json
+++ b/http/headers/sec-fetch-mode.json
@@ -1,0 +1,54 @@
+{
+  "http": {
+    "headers": {
+      "Sec-Fetch-Mode": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-Fetch-Mode",
+          "support": {
+            "chrome": {
+              "version_added": "76"
+            },
+            "chrome_android": {
+              "version_added": "76"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "63"
+            },
+            "opera_android": {
+              "version_added": "54"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "76"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/http/headers/sec-fetch-site.json
+++ b/http/headers/sec-fetch-site.json
@@ -1,0 +1,54 @@
+{
+  "http": {
+    "headers": {
+      "Sec-Fetch-Site": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-Fetch-Site",
+          "support": {
+            "chrome": {
+              "version_added": "76"
+            },
+            "chrome_android": {
+              "version_added": "76"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "63"
+            },
+            "opera_android": {
+              "version_added": "54"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "76"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/http/headers/sec-fetch-user.json
+++ b/http/headers/sec-fetch-user.json
@@ -1,0 +1,54 @@
+{
+  "http": {
+    "headers": {
+      "Sec-Fetch-User": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-Fetch-User",
+          "support": {
+            "chrome": {
+              "version_added": "76"
+            },
+            "chrome_android": {
+              "version_added": "76"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "63"
+            },
+            "opera_android": {
+              "version_added": "54"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "76"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Add compatibility data for [Fetch Metadata Request Headers](https://w3c.github.io/webappsec-fetch-metadata/) already launched in Chrome 76 and 80.

## Data
The specification introduces four headers, `Sec-Fetch-Mode`, `Sec-Fetch-Site`, `Sec-Fetch-User` (all three launched in [Chrome 76](https://chromestatus.com/feature/5155867204780032
)) and `Sec-Fetch-Dest` (launched in [Chrome 80](https://chromestatus.com/feature/5206259592593408)) on all Chrome platforms (desktop, Android, WebView) and Chrome derivatives.

## Linter fail
This PR adds data about Edge 80, which is missing from BCD at this time. Therefore this PR is blocked on #5680, which adds Edge 80. For now, please add "not ready" label for now.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
