### PR TITLE
Rename api/XR to api/XRSystem

### DIFF
--- a/api/XRSystem.json
+++ b/api/XRSystem.json
@@ -1,13 +1,15 @@
 {
   "api": {
-    "XR": {
+    "XRSystem": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/XR",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSystem",
         "support": {
           "chrome": {
+            "alternative_name": "XR",
             "version_added": "79"
           },
           "chrome_android": {
+            "alternative_name": "XR",
             "version_added": "79"
           },
           "edge": {
@@ -49,7 +51,7 @@
       },
       "devicechange_event": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XR/devicechange_event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSystem/devicechange_event",
           "description": "<code>devicechange</code> event",
           "support": {
             "chrome": {
@@ -98,7 +100,7 @@
       },
       "isSessionSupported": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XR/isSessionSupported",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSystem/isSessionSupported",
           "description": "<code>isSessionSupported()</code>",
           "support": {
             "chrome": {
@@ -147,7 +149,7 @@
       },
       "ondevicechange": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XR/ondevicechange",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSystem/ondevicechange",
           "support": {
             "chrome": {
               "version_added": "79"
@@ -195,7 +197,7 @@
       },
       "requestSession": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XR/requestSession",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSystem/requestSession",
           "description": "<code>requestSession()</code>",
           "support": {
             "chrome": {


### PR DESCRIPTION
https://github.com/immersive-web/webxr/pull/948 renamed the `XR` interface to `XRSystem`. 
https://github.com/immersive-web/webxr/commit/af7d871