### PR TITLE
Update EventSource compatibility for Edge browser

### DIFF
--- a/api/EventSource.json
+++ b/api/EventSource.json
@@ -11,7 +11,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": false
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "6"
@@ -59,7 +59,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "6"
@@ -106,7 +106,7 @@
                 "version_added": "26"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "11"
@@ -155,7 +155,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "6"
@@ -204,7 +204,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "6"
@@ -253,7 +253,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "6"
@@ -301,7 +301,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "6"
@@ -349,7 +349,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "6"
@@ -397,7 +397,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "6"
@@ -446,7 +446,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "6"
@@ -494,7 +494,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "6"
@@ -542,7 +542,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "6"
@@ -590,7 +590,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "6"
@@ -638,7 +638,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53"


### PR DESCRIPTION
This PR updates the `EventSource` compatibility for the Edge browser, in particular it adds support for `EventSource` for the all-new chromium-based Edge versions 79+. I verified the support in Edge 80 (see below), and I assume support in Edge 79 as well. This also aligns it with the current support for Server-sent events (see https://caniuse.com/#feat=eventsource).

---

Current support table:

![caniuse](https://user-images.githubusercontent.com/7271961/74237367-b4010e80-4cd3-11ea-97a4-7f3c53866d5b.PNG)

---

DevTools on an examplary website (here twitter.com) using EventSource in Edge 80:

![devtools](https://user-images.githubusercontent.com/7271961/74237423-d1ce7380-4cd3-11ea-82d3-9554ccebbf3e.PNG)

---

DevTools for checking on EventSource prototype in Edge 80:

![window](https://user-images.githubusercontent.com/7271961/74237462-e9a5f780-4cd3-11ea-8ab9-ed0c1fa50786.PNG)
