### PR TITLE
Add constructors to typed arrays

### DIFF
--- a/javascript/builtins/BigInt64Array.json
+++ b/javascript/builtins/BigInt64Array.json
@@ -51,6 +51,59 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "BigInt64Array": {
+          "__compat": {
+            "description": "<code>BigInt64Array()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt64Array/BigInt64Array",
+            "spec_url": "https://tc39.es/ecma262/#sec-typedarray-constructors",
+            "support": {
+              "chrome": {
+                "version_added": "67"
+              },
+              "chrome_android": {
+                "version_added": "67"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "68"
+              },
+              "firefox_android": {
+                "version_added": "68"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "10.4.0"
+              },
+              "opera": {
+                "version_added": "54"
+              },
+              "opera_android": {
+                "version_added": "48"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "9.0"
+              },
+              "webview_android": {
+                "version_added": "67"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/javascript/builtins/BigUint64Array.json
+++ b/javascript/builtins/BigUint64Array.json
@@ -51,6 +51,59 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "BigUint64Array": {
+          "__compat": {
+            "description": "<code>BigUint64Array()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigUint64Array/BigUint64Array",
+            "spec_url": "https://tc39.es/ecma262/#sec-typedarray-constructors",
+            "support": {
+              "chrome": {
+                "version_added": "67"
+              },
+              "chrome_android": {
+                "version_added": "67"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "68"
+              },
+              "firefox_android": {
+                "version_added": "68"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "10.4.0"
+              },
+              "opera": {
+                "version_added": "54"
+              },
+              "opera_android": {
+                "version_added": "48"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "9.0"
+              },
+              "webview_android": {
+                "version_added": "67"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/javascript/builtins/Float32Array.json
+++ b/javascript/builtins/Float32Array.json
@@ -52,9 +52,11 @@
             "deprecated": false
           }
         },
-        "constructor_without_arguments": {
+        "Float32Array": {
           "__compat": {
-            "description": "Constructor without arguments",
+            "description": "<code>Float32Array()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float32Array/Float32Array",
+            "spec_url": "https://tc39.es/ecma262/#sec-typedarray-constructors",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -66,16 +68,16 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "55"
+                "version_added": "4"
               },
               "firefox_android": {
-                "version_added": "55"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "0.10"
               },
               "opera": {
                 "version_added": "11.6"
@@ -87,13 +89,13 @@
                 "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": "5"
+                "version_added": "4.2"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "4"
               }
             },
             "status": {
@@ -101,107 +103,158 @@
               "standard_track": true,
               "deprecated": false
             }
-          }
-        },
-        "iterable_in_constructor": {
-          "__compat": {
-            "description": "Iterable in constructor",
-            "support": {
-              "chrome": {
-                "version_added": "39"
+          },
+          "constructor_without_arguments": {
+            "__compat": {
+              "description": "Constructor without arguments",
+              "support": {
+                "chrome": {
+                  "version_added": "7"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "55"
+                },
+                "firefox_android": {
+                  "version_added": "55"
+                },
+                "ie": {
+                  "version_added": "10"
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "11.6"
+                },
+                "opera_android": {
+                  "version_added": "12"
+                },
+                "safari": {
+                  "version_added": "5.1"
+                },
+                "safari_ios": {
+                  "version_added": "5"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "≤37"
+                }
               },
-              "chrome_android": {
-                "version_added": "39"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "firefox": {
-                "version_added": "52"
-              },
-              "firefox_android": {
-                "version_added": "52"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "4.0.0"
-              },
-              "opera": {
-                "version_added": "26"
-              },
-              "opera_android": {
-                "version_added": "26"
-              },
-              "safari": {
-                "version_added": "10"
-              },
-              "safari_ios": {
-                "version_added": "10"
-              },
-              "samsunginternet_android": {
-                "version_added": "4.0"
-              },
-              "webview_android": {
-                "version_added": "39"
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
             }
-          }
-        },
-        "new_required": {
-          "__compat": {
-            "description": "<code>Float32Array()</code> without <code>new</code> throws",
-            "support": {
-              "chrome": {
-                "version_added": "7"
+          },
+          "iterable_allowed": {
+            "__compat": {
+              "description": "<code>new Float32Array(iterable)</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "39"
+                },
+                "chrome_android": {
+                  "version_added": "39"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": {
+                  "version_added": "52"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "4.0.0"
+                },
+                "opera": {
+                  "version_added": "26"
+                },
+                "opera_android": {
+                  "version_added": "26"
+                },
+                "safari": {
+                  "version_added": "10"
+                },
+                "safari_ios": {
+                  "version_added": "10"
+                },
+                "samsunginternet_android": {
+                  "version_added": "4.0"
+                },
+                "webview_android": {
+                  "version_added": "39"
+                }
               },
-              "chrome_android": {
-                "version_added": "18"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "firefox": {
-                "version_added": "44"
-              },
-              "firefox_android": {
-                "version_added": "44"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "0.12"
-              },
-              "opera": {
-                "version_added": "15"
-              },
-              "opera_android": {
-                "version_added": "14"
-              },
-              "safari": {
-                "version_added": "5.1"
-              },
-              "safari_ios": {
-                "version_added": "5"
-              },
-              "samsunginternet_android": {
-                "version_added": "1.0"
-              },
-              "webview_android": {
-                "version_added": "≤37"
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+            }
+          },
+          "new_required": {
+            "__compat": {
+              "description": "<code>Float32Array()</code> without <code>new</code> throws",
+              "support": {
+                "chrome": {
+                  "version_added": "7"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "44"
+                },
+                "firefox_android": {
+                  "version_added": "44"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "0.12"
+                },
+                "opera": {
+                  "version_added": "15"
+                },
+                "opera_android": {
+                  "version_added": "14"
+                },
+                "safari": {
+                  "version_added": "5.1"
+                },
+                "safari_ios": {
+                  "version_added": "5"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "≤37"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         }

--- a/javascript/builtins/Float64Array.json
+++ b/javascript/builtins/Float64Array.json
@@ -52,9 +52,11 @@
             "deprecated": false
           }
         },
-        "constructor_without_arguments": {
+        "Float64Array": {
           "__compat": {
-            "description": "Constructor without arguments",
+            "description": "<code>Float64Array()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float64Array/Float64Array",
+            "spec_url": "https://tc39.es/ecma262/#sec-typedarray-constructors",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -66,16 +68,16 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "55"
+                "version_added": "4"
               },
               "firefox_android": {
-                "version_added": "55"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "0.10"
               },
               "opera": {
                 "version_added": "11.6"
@@ -87,13 +89,13 @@
                 "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": "5"
+                "version_added": "4.2"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "4"
               }
             },
             "status": {
@@ -101,107 +103,158 @@
               "standard_track": true,
               "deprecated": false
             }
-          }
-        },
-        "iterable_in_constructor": {
-          "__compat": {
-            "description": "Iterable in constructor",
-            "support": {
-              "chrome": {
-                "version_added": "39"
+          },
+          "constructor_without_arguments": {
+            "__compat": {
+              "description": "Constructor without arguments",
+              "support": {
+                "chrome": {
+                  "version_added": "7"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "55"
+                },
+                "firefox_android": {
+                  "version_added": "55"
+                },
+                "ie": {
+                  "version_added": "10"
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "11.6"
+                },
+                "opera_android": {
+                  "version_added": "12"
+                },
+                "safari": {
+                  "version_added": "5.1"
+                },
+                "safari_ios": {
+                  "version_added": "5"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "≤37"
+                }
               },
-              "chrome_android": {
-                "version_added": "39"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "firefox": {
-                "version_added": "52"
-              },
-              "firefox_android": {
-                "version_added": "52"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "4.0.0"
-              },
-              "opera": {
-                "version_added": "26"
-              },
-              "opera_android": {
-                "version_added": "26"
-              },
-              "safari": {
-                "version_added": "10"
-              },
-              "safari_ios": {
-                "version_added": "10"
-              },
-              "samsunginternet_android": {
-                "version_added": "4.0"
-              },
-              "webview_android": {
-                "version_added": "39"
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
             }
-          }
-        },
-        "new_required": {
-          "__compat": {
-            "description": "<code>Float64Array()</code> without <code>new</code> throws",
-            "support": {
-              "chrome": {
-                "version_added": "7"
+          },
+          "iterable_allowed": {
+            "__compat": {
+              "description": "<code>new Float64Array(iterable)</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "39"
+                },
+                "chrome_android": {
+                  "version_added": "39"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": {
+                  "version_added": "52"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "4.0.0"
+                },
+                "opera": {
+                  "version_added": "26"
+                },
+                "opera_android": {
+                  "version_added": "26"
+                },
+                "safari": {
+                  "version_added": "10"
+                },
+                "safari_ios": {
+                  "version_added": "10"
+                },
+                "samsunginternet_android": {
+                  "version_added": "4.0"
+                },
+                "webview_android": {
+                  "version_added": "39"
+                }
               },
-              "chrome_android": {
-                "version_added": "18"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "firefox": {
-                "version_added": "44"
-              },
-              "firefox_android": {
-                "version_added": "44"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "0.12"
-              },
-              "opera": {
-                "version_added": "15"
-              },
-              "opera_android": {
-                "version_added": "14"
-              },
-              "safari": {
-                "version_added": "5.1"
-              },
-              "safari_ios": {
-                "version_added": "5"
-              },
-              "samsunginternet_android": {
-                "version_added": "1.0"
-              },
-              "webview_android": {
-                "version_added": "≤37"
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+            }
+          },
+          "new_required": {
+            "__compat": {
+              "description": "<code>Float64Array()</code> without <code>new</code> throws",
+              "support": {
+                "chrome": {
+                  "version_added": "7"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "44"
+                },
+                "firefox_android": {
+                  "version_added": "44"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "0.12"
+                },
+                "opera": {
+                  "version_added": "15"
+                },
+                "opera_android": {
+                  "version_added": "14"
+                },
+                "safari": {
+                  "version_added": "5.1"
+                },
+                "safari_ios": {
+                  "version_added": "5"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "≤37"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         }

--- a/javascript/builtins/Int16Array.json
+++ b/javascript/builtins/Int16Array.json
@@ -52,9 +52,11 @@
             "deprecated": false
           }
         },
-        "constructor_without_arguments": {
+        "Int16Array": {
           "__compat": {
-            "description": "Constructor without arguments",
+            "description": "<code>Int16Array()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int16Array/Int16Array",
+            "spec_url": "https://tc39.es/ecma262/#sec-typedarray-constructors",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -66,16 +68,16 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "55"
+                "version_added": "4"
               },
               "firefox_android": {
-                "version_added": "55"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "0.10"
               },
               "opera": {
                 "version_added": "11.6"
@@ -87,13 +89,13 @@
                 "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": "5"
+                "version_added": "4.2"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "4"
               }
             },
             "status": {
@@ -101,107 +103,158 @@
               "standard_track": true,
               "deprecated": false
             }
-          }
-        },
-        "iterable_in_constructor": {
-          "__compat": {
-            "description": "Iterable in constructor",
-            "support": {
-              "chrome": {
-                "version_added": "39"
+          },
+          "constructor_without_arguments": {
+            "__compat": {
+              "description": "Constructor without arguments",
+              "support": {
+                "chrome": {
+                  "version_added": "7"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "55"
+                },
+                "firefox_android": {
+                  "version_added": "55"
+                },
+                "ie": {
+                  "version_added": "10"
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "11.6"
+                },
+                "opera_android": {
+                  "version_added": "12"
+                },
+                "safari": {
+                  "version_added": "5.1"
+                },
+                "safari_ios": {
+                  "version_added": "5"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "≤37"
+                }
               },
-              "chrome_android": {
-                "version_added": "39"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "firefox": {
-                "version_added": "52"
-              },
-              "firefox_android": {
-                "version_added": "52"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "4.0.0"
-              },
-              "opera": {
-                "version_added": "26"
-              },
-              "opera_android": {
-                "version_added": "26"
-              },
-              "safari": {
-                "version_added": "10"
-              },
-              "safari_ios": {
-                "version_added": "10"
-              },
-              "samsunginternet_android": {
-                "version_added": "4.0"
-              },
-              "webview_android": {
-                "version_added": "39"
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
             }
-          }
-        },
-        "new_required": {
-          "__compat": {
-            "description": "<code>Int16Array()</code> without <code>new</code> throws",
-            "support": {
-              "chrome": {
-                "version_added": "7"
+          },
+          "iterable_allowed": {
+            "__compat": {
+              "description": "<code>new Int16Array(iterable)</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "39"
+                },
+                "chrome_android": {
+                  "version_added": "39"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": {
+                  "version_added": "52"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "4.0.0"
+                },
+                "opera": {
+                  "version_added": "26"
+                },
+                "opera_android": {
+                  "version_added": "26"
+                },
+                "safari": {
+                  "version_added": "10"
+                },
+                "safari_ios": {
+                  "version_added": "10"
+                },
+                "samsunginternet_android": {
+                  "version_added": "4.0"
+                },
+                "webview_android": {
+                  "version_added": "39"
+                }
               },
-              "chrome_android": {
-                "version_added": "18"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "firefox": {
-                "version_added": "44"
-              },
-              "firefox_android": {
-                "version_added": "44"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "0.12"
-              },
-              "opera": {
-                "version_added": "15"
-              },
-              "opera_android": {
-                "version_added": "14"
-              },
-              "safari": {
-                "version_added": "5.1"
-              },
-              "safari_ios": {
-                "version_added": "5"
-              },
-              "samsunginternet_android": {
-                "version_added": "1.0"
-              },
-              "webview_android": {
-                "version_added": "≤37"
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+            }
+          },
+          "new_required": {
+            "__compat": {
+              "description": "<code>Int16Array()</code> without <code>new</code> throws",
+              "support": {
+                "chrome": {
+                  "version_added": "7"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "44"
+                },
+                "firefox_android": {
+                  "version_added": "44"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "0.12"
+                },
+                "opera": {
+                  "version_added": "15"
+                },
+                "opera_android": {
+                  "version_added": "14"
+                },
+                "safari": {
+                  "version_added": "5.1"
+                },
+                "safari_ios": {
+                  "version_added": "5"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "≤37"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         }

--- a/javascript/builtins/Int32Array.json
+++ b/javascript/builtins/Int32Array.json
@@ -52,9 +52,11 @@
             "deprecated": false
           }
         },
-        "constructor_without_arguments": {
+        "Int32Array": {
           "__compat": {
-            "description": "Constructor without arguments",
+            "description": "<code>Int32Array()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int32Array/Int32Array",
+            "spec_url": "https://tc39.es/ecma262/#sec-typedarray-constructors",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -66,16 +68,16 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "55"
+                "version_added": "4"
               },
               "firefox_android": {
-                "version_added": "55"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "0.10"
               },
               "opera": {
                 "version_added": "11.6"
@@ -87,13 +89,13 @@
                 "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": "5"
+                "version_added": "4.2"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "4"
               }
             },
             "status": {
@@ -101,107 +103,158 @@
               "standard_track": true,
               "deprecated": false
             }
-          }
-        },
-        "iterable_in_constructor": {
-          "__compat": {
-            "description": "Iterable in constructor",
-            "support": {
-              "chrome": {
-                "version_added": "39"
+          },
+          "constructor_without_arguments": {
+            "__compat": {
+              "description": "Constructor without arguments",
+              "support": {
+                "chrome": {
+                  "version_added": "7"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "55"
+                },
+                "firefox_android": {
+                  "version_added": "55"
+                },
+                "ie": {
+                  "version_added": "10"
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "11.6"
+                },
+                "opera_android": {
+                  "version_added": "12"
+                },
+                "safari": {
+                  "version_added": "5.1"
+                },
+                "safari_ios": {
+                  "version_added": "5"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "≤37"
+                }
               },
-              "chrome_android": {
-                "version_added": "39"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "firefox": {
-                "version_added": "52"
-              },
-              "firefox_android": {
-                "version_added": "52"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "4.0.0"
-              },
-              "opera": {
-                "version_added": "26"
-              },
-              "opera_android": {
-                "version_added": "26"
-              },
-              "safari": {
-                "version_added": "10"
-              },
-              "safari_ios": {
-                "version_added": "10"
-              },
-              "samsunginternet_android": {
-                "version_added": "4.0"
-              },
-              "webview_android": {
-                "version_added": "39"
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
             }
-          }
-        },
-        "new_required": {
-          "__compat": {
-            "description": "<code>Int32Array()</code> without <code>new</code> throws",
-            "support": {
-              "chrome": {
-                "version_added": "7"
+          },
+          "iterable_allowed": {
+            "__compat": {
+              "description": "<code>new Int32Array(iterable)</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "39"
+                },
+                "chrome_android": {
+                  "version_added": "39"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": {
+                  "version_added": "52"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "4.0.0"
+                },
+                "opera": {
+                  "version_added": "26"
+                },
+                "opera_android": {
+                  "version_added": "26"
+                },
+                "safari": {
+                  "version_added": "10"
+                },
+                "safari_ios": {
+                  "version_added": "10"
+                },
+                "samsunginternet_android": {
+                  "version_added": "4.0"
+                },
+                "webview_android": {
+                  "version_added": "39"
+                }
               },
-              "chrome_android": {
-                "version_added": "18"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "firefox": {
-                "version_added": "44"
-              },
-              "firefox_android": {
-                "version_added": "44"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "0.12"
-              },
-              "opera": {
-                "version_added": "15"
-              },
-              "opera_android": {
-                "version_added": "14"
-              },
-              "safari": {
-                "version_added": "5.1"
-              },
-              "safari_ios": {
-                "version_added": "5"
-              },
-              "samsunginternet_android": {
-                "version_added": "1.0"
-              },
-              "webview_android": {
-                "version_added": "≤37"
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+            }
+          },
+          "new_required": {
+            "__compat": {
+              "description": "<code>Int32Array()</code> without <code>new</code> throws",
+              "support": {
+                "chrome": {
+                  "version_added": "7"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "44"
+                },
+                "firefox_android": {
+                  "version_added": "44"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "0.12"
+                },
+                "opera": {
+                  "version_added": "15"
+                },
+                "opera_android": {
+                  "version_added": "14"
+                },
+                "safari": {
+                  "version_added": "5.1"
+                },
+                "safari_ios": {
+                  "version_added": "5"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "≤37"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         }

--- a/javascript/builtins/Int8Array.json
+++ b/javascript/builtins/Int8Array.json
@@ -52,9 +52,11 @@
             "deprecated": false
           }
         },
-        "constructor_without_arguments": {
+        "Int8Array": {
           "__compat": {
-            "description": "Constructor without arguments",
+            "description": "<code>Int8Array()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int8Array/Int8Array",
+            "spec_url": "https://tc39.es/ecma262/#sec-typedarray-constructors",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -66,16 +68,16 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "55"
+                "version_added": "4"
               },
               "firefox_android": {
-                "version_added": "55"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "0.10"
               },
               "opera": {
                 "version_added": "11.6"
@@ -87,13 +89,13 @@
                 "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": "5"
+                "version_added": "4.2"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "4"
               }
             },
             "status": {
@@ -101,107 +103,158 @@
               "standard_track": true,
               "deprecated": false
             }
-          }
-        },
-        "iterable_in_constructor": {
-          "__compat": {
-            "description": "Iterable in constructor",
-            "support": {
-              "chrome": {
-                "version_added": "39"
+          },
+          "constructor_without_arguments": {
+            "__compat": {
+              "description": "Constructor without arguments",
+              "support": {
+                "chrome": {
+                  "version_added": "7"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "55"
+                },
+                "firefox_android": {
+                  "version_added": "55"
+                },
+                "ie": {
+                  "version_added": "10"
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "11.6"
+                },
+                "opera_android": {
+                  "version_added": "12"
+                },
+                "safari": {
+                  "version_added": "5.1"
+                },
+                "safari_ios": {
+                  "version_added": "5"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "≤37"
+                }
               },
-              "chrome_android": {
-                "version_added": "39"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "firefox": {
-                "version_added": "52"
-              },
-              "firefox_android": {
-                "version_added": "52"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "4.0.0"
-              },
-              "opera": {
-                "version_added": "26"
-              },
-              "opera_android": {
-                "version_added": "26"
-              },
-              "safari": {
-                "version_added": "10"
-              },
-              "safari_ios": {
-                "version_added": "10"
-              },
-              "samsunginternet_android": {
-                "version_added": "4.0"
-              },
-              "webview_android": {
-                "version_added": "39"
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
             }
-          }
-        },
-        "new_required": {
-          "__compat": {
-            "description": "<code>Int8Array()</code> without <code>new</code> throws",
-            "support": {
-              "chrome": {
-                "version_added": "7"
+          },
+          "iterable_allowed": {
+            "__compat": {
+              "description": "<code>new Int8Array(iterable)</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "39"
+                },
+                "chrome_android": {
+                  "version_added": "39"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": {
+                  "version_added": "52"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "4.0.0"
+                },
+                "opera": {
+                  "version_added": "26"
+                },
+                "opera_android": {
+                  "version_added": "26"
+                },
+                "safari": {
+                  "version_added": "10"
+                },
+                "safari_ios": {
+                  "version_added": "10"
+                },
+                "samsunginternet_android": {
+                  "version_added": "4.0"
+                },
+                "webview_android": {
+                  "version_added": "39"
+                }
               },
-              "chrome_android": {
-                "version_added": "18"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "firefox": {
-                "version_added": "44"
-              },
-              "firefox_android": {
-                "version_added": "44"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "0.12"
-              },
-              "opera": {
-                "version_added": "15"
-              },
-              "opera_android": {
-                "version_added": "14"
-              },
-              "safari": {
-                "version_added": "5.1"
-              },
-              "safari_ios": {
-                "version_added": "5"
-              },
-              "samsunginternet_android": {
-                "version_added": "1.0"
-              },
-              "webview_android": {
-                "version_added": "≤37"
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+            }
+          },
+          "new_required": {
+            "__compat": {
+              "description": "<code>Int8Array()</code> without <code>new</code> throws",
+              "support": {
+                "chrome": {
+                  "version_added": "7"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "44"
+                },
+                "firefox_android": {
+                  "version_added": "44"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "0.12"
+                },
+                "opera": {
+                  "version_added": "15"
+                },
+                "opera_android": {
+                  "version_added": "14"
+                },
+                "safari": {
+                  "version_added": "5.1"
+                },
+                "safari_ios": {
+                  "version_added": "5"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "≤37"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         }

--- a/javascript/builtins/Uint16Array.json
+++ b/javascript/builtins/Uint16Array.json
@@ -52,9 +52,11 @@
             "deprecated": false
           }
         },
-        "constructor_without_arguments": {
+        "Uint16Array": {
           "__compat": {
-            "description": "Constructor without arguments",
+            "description": "<code>Uint16Array()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint16Array/Uint16Array",
+            "spec_url": "https://tc39.es/ecma262/#sec-typedarray-constructors",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -66,16 +68,16 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "55"
+                "version_added": "4"
               },
               "firefox_android": {
-                "version_added": "55"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "0.10"
               },
               "opera": {
                 "version_added": "11.6"
@@ -87,13 +89,13 @@
                 "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": "5"
+                "version_added": "4.2"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "4"
               }
             },
             "status": {
@@ -101,107 +103,158 @@
               "standard_track": true,
               "deprecated": false
             }
-          }
-        },
-        "iterable_in_constructor": {
-          "__compat": {
-            "description": "Iterable in constructor",
-            "support": {
-              "chrome": {
-                "version_added": "39"
+          },
+          "constructor_without_arguments": {
+            "__compat": {
+              "description": "Constructor without arguments",
+              "support": {
+                "chrome": {
+                  "version_added": "7"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "55"
+                },
+                "firefox_android": {
+                  "version_added": "55"
+                },
+                "ie": {
+                  "version_added": "10"
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "11.6"
+                },
+                "opera_android": {
+                  "version_added": "12"
+                },
+                "safari": {
+                  "version_added": "5.1"
+                },
+                "safari_ios": {
+                  "version_added": "5"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "≤37"
+                }
               },
-              "chrome_android": {
-                "version_added": "39"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "firefox": {
-                "version_added": "52"
-              },
-              "firefox_android": {
-                "version_added": "52"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "4.0.0"
-              },
-              "opera": {
-                "version_added": "26"
-              },
-              "opera_android": {
-                "version_added": "26"
-              },
-              "safari": {
-                "version_added": "10"
-              },
-              "safari_ios": {
-                "version_added": "10"
-              },
-              "samsunginternet_android": {
-                "version_added": "4.0"
-              },
-              "webview_android": {
-                "version_added": "39"
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
             }
-          }
-        },
-        "new_required": {
-          "__compat": {
-            "description": "<code>Uint16Array()</code> without <code>new</code> throws",
-            "support": {
-              "chrome": {
-                "version_added": "7"
+          },
+          "iterable_allowed": {
+            "__compat": {
+              "description": "<code>new Uint16Array(iterable)</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "39"
+                },
+                "chrome_android": {
+                  "version_added": "39"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": {
+                  "version_added": "52"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "4.0.0"
+                },
+                "opera": {
+                  "version_added": "26"
+                },
+                "opera_android": {
+                  "version_added": "26"
+                },
+                "safari": {
+                  "version_added": "10"
+                },
+                "safari_ios": {
+                  "version_added": "10"
+                },
+                "samsunginternet_android": {
+                  "version_added": "4.0"
+                },
+                "webview_android": {
+                  "version_added": "39"
+                }
               },
-              "chrome_android": {
-                "version_added": "18"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "firefox": {
-                "version_added": "44"
-              },
-              "firefox_android": {
-                "version_added": "44"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "0.12"
-              },
-              "opera": {
-                "version_added": "15"
-              },
-              "opera_android": {
-                "version_added": "14"
-              },
-              "safari": {
-                "version_added": "5.1"
-              },
-              "safari_ios": {
-                "version_added": "5"
-              },
-              "samsunginternet_android": {
-                "version_added": "1.0"
-              },
-              "webview_android": {
-                "version_added": "≤37"
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+            }
+          },
+          "new_required": {
+            "__compat": {
+              "description": "<code>Uint16Array()</code> without <code>new</code> throws",
+              "support": {
+                "chrome": {
+                  "version_added": "7"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "44"
+                },
+                "firefox_android": {
+                  "version_added": "44"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "0.12"
+                },
+                "opera": {
+                  "version_added": "15"
+                },
+                "opera_android": {
+                  "version_added": "14"
+                },
+                "safari": {
+                  "version_added": "5.1"
+                },
+                "safari_ios": {
+                  "version_added": "5"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "≤37"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         }

--- a/javascript/builtins/Uint32Array.json
+++ b/javascript/builtins/Uint32Array.json
@@ -52,9 +52,11 @@
             "deprecated": false
           }
         },
-        "constructor_without_arguments": {
+        "Uint32Array": {
           "__compat": {
-            "description": "Constructor without arguments",
+            "description": "<code>Uint32Array()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint32Array/Uint32Array",
+            "spec_url": "https://tc39.es/ecma262/#sec-typedarray-constructors",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -66,16 +68,16 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "55"
+                "version_added": "4"
               },
               "firefox_android": {
-                "version_added": "55"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "0.10"
               },
               "opera": {
                 "version_added": "11.6"
@@ -87,13 +89,13 @@
                 "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": "5"
+                "version_added": "4.2"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "4"
               }
             },
             "status": {
@@ -101,107 +103,158 @@
               "standard_track": true,
               "deprecated": false
             }
-          }
-        },
-        "iterable_in_constructor": {
-          "__compat": {
-            "description": "Iterable in constructor",
-            "support": {
-              "chrome": {
-                "version_added": "39"
+          },
+          "constructor_without_arguments": {
+            "__compat": {
+              "description": "Constructor without arguments",
+              "support": {
+                "chrome": {
+                  "version_added": "7"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "55"
+                },
+                "firefox_android": {
+                  "version_added": "55"
+                },
+                "ie": {
+                  "version_added": "10"
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "11.6"
+                },
+                "opera_android": {
+                  "version_added": "12"
+                },
+                "safari": {
+                  "version_added": "5.1"
+                },
+                "safari_ios": {
+                  "version_added": "5"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "≤37"
+                }
               },
-              "chrome_android": {
-                "version_added": "39"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "firefox": {
-                "version_added": "52"
-              },
-              "firefox_android": {
-                "version_added": "52"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "4.0.0"
-              },
-              "opera": {
-                "version_added": "26"
-              },
-              "opera_android": {
-                "version_added": "26"
-              },
-              "safari": {
-                "version_added": "10"
-              },
-              "safari_ios": {
-                "version_added": "10"
-              },
-              "samsunginternet_android": {
-                "version_added": "4.0"
-              },
-              "webview_android": {
-                "version_added": "39"
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
             }
-          }
-        },
-        "new_required": {
-          "__compat": {
-            "description": "<code>Uint32Array()</code> without <code>new</code> throws",
-            "support": {
-              "chrome": {
-                "version_added": "7"
+          },
+          "iterable_allowed": {
+            "__compat": {
+              "description": "<code>new Uint32Array(iterable)</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "39"
+                },
+                "chrome_android": {
+                  "version_added": "39"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": {
+                  "version_added": "52"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "4.0.0"
+                },
+                "opera": {
+                  "version_added": "26"
+                },
+                "opera_android": {
+                  "version_added": "26"
+                },
+                "safari": {
+                  "version_added": "10"
+                },
+                "safari_ios": {
+                  "version_added": "10"
+                },
+                "samsunginternet_android": {
+                  "version_added": "4.0"
+                },
+                "webview_android": {
+                  "version_added": "39"
+                }
               },
-              "chrome_android": {
-                "version_added": "18"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "firefox": {
-                "version_added": "44"
-              },
-              "firefox_android": {
-                "version_added": "44"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "0.12"
-              },
-              "opera": {
-                "version_added": "15"
-              },
-              "opera_android": {
-                "version_added": "14"
-              },
-              "safari": {
-                "version_added": "5.1"
-              },
-              "safari_ios": {
-                "version_added": "5"
-              },
-              "samsunginternet_android": {
-                "version_added": "1.0"
-              },
-              "webview_android": {
-                "version_added": "≤37"
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+            }
+          },
+          "new_required": {
+            "__compat": {
+              "description": "<code>Uint32Array()</code> without <code>new</code> throws",
+              "support": {
+                "chrome": {
+                  "version_added": "7"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "44"
+                },
+                "firefox_android": {
+                  "version_added": "44"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "0.12"
+                },
+                "opera": {
+                  "version_added": "15"
+                },
+                "opera_android": {
+                  "version_added": "14"
+                },
+                "safari": {
+                  "version_added": "5.1"
+                },
+                "safari_ios": {
+                  "version_added": "5"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "≤37"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         }

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -52,9 +52,11 @@
             "deprecated": false
           }
         },
-        "constructor_without_arguments": {
+        "Uint8Array": {
           "__compat": {
-            "description": "Constructor without arguments",
+            "description": "<code>Uint8Array()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/Uint8Array",
+            "spec_url": "https://tc39.es/ecma262/#sec-typedarray-constructors",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -66,16 +68,16 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "55"
+                "version_added": "4"
               },
               "firefox_android": {
-                "version_added": "55"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "0.10"
               },
               "opera": {
                 "version_added": "11.6"
@@ -87,13 +89,13 @@
                 "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": "5"
+                "version_added": "4.2"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "4"
               }
             },
             "status": {
@@ -101,107 +103,158 @@
               "standard_track": true,
               "deprecated": false
             }
-          }
-        },
-        "iterable_in_constructor": {
-          "__compat": {
-            "description": "Iterable in constructor",
-            "support": {
-              "chrome": {
-                "version_added": "39"
+          },
+          "constructor_without_arguments": {
+            "__compat": {
+              "description": "Constructor without arguments",
+              "support": {
+                "chrome": {
+                  "version_added": "7"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "55"
+                },
+                "firefox_android": {
+                  "version_added": "55"
+                },
+                "ie": {
+                  "version_added": "10"
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "11.6"
+                },
+                "opera_android": {
+                  "version_added": "12"
+                },
+                "safari": {
+                  "version_added": "5.1"
+                },
+                "safari_ios": {
+                  "version_added": "5"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "≤37"
+                }
               },
-              "chrome_android": {
-                "version_added": "39"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "firefox": {
-                "version_added": "52"
-              },
-              "firefox_android": {
-                "version_added": "52"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "4.0.0"
-              },
-              "opera": {
-                "version_added": "26"
-              },
-              "opera_android": {
-                "version_added": "26"
-              },
-              "safari": {
-                "version_added": "10"
-              },
-              "safari_ios": {
-                "version_added": "10"
-              },
-              "samsunginternet_android": {
-                "version_added": "4.0"
-              },
-              "webview_android": {
-                "version_added": "39"
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
             }
-          }
-        },
-        "new_required": {
-          "__compat": {
-            "description": "<code>Uint8Array()</code> without <code>new</code> throws",
-            "support": {
-              "chrome": {
-                "version_added": "7"
+          },
+          "iterable_allowed": {
+            "__compat": {
+              "description": "<code>new Uint8Array(iterable)</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "39"
+                },
+                "chrome_android": {
+                  "version_added": "39"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": {
+                  "version_added": "52"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "4.0.0"
+                },
+                "opera": {
+                  "version_added": "26"
+                },
+                "opera_android": {
+                  "version_added": "26"
+                },
+                "safari": {
+                  "version_added": "10"
+                },
+                "safari_ios": {
+                  "version_added": "10"
+                },
+                "samsunginternet_android": {
+                  "version_added": "4.0"
+                },
+                "webview_android": {
+                  "version_added": "39"
+                }
               },
-              "chrome_android": {
-                "version_added": "18"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "firefox": {
-                "version_added": "44"
-              },
-              "firefox_android": {
-                "version_added": "44"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "0.12"
-              },
-              "opera": {
-                "version_added": "15"
-              },
-              "opera_android": {
-                "version_added": "14"
-              },
-              "safari": {
-                "version_added": "5.1"
-              },
-              "safari_ios": {
-                "version_added": "5"
-              },
-              "samsunginternet_android": {
-                "version_added": "1.0"
-              },
-              "webview_android": {
-                "version_added": "≤37"
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+            }
+          },
+          "new_required": {
+            "__compat": {
+              "description": "<code>Uint8Array()</code> without <code>new</code> throws",
+              "support": {
+                "chrome": {
+                  "version_added": "7"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "44"
+                },
+                "firefox_android": {
+                  "version_added": "44"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "0.12"
+                },
+                "opera": {
+                  "version_added": "15"
+                },
+                "opera_android": {
+                  "version_added": "14"
+                },
+                "safari": {
+                  "version_added": "5.1"
+                },
+                "safari_ios": {
+                  "version_added": "5"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "≤37"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         }

--- a/javascript/builtins/Uint8ClampedArray.json
+++ b/javascript/builtins/Uint8ClampedArray.json
@@ -52,9 +52,11 @@
             "deprecated": false
           }
         },
-        "constructor_without_arguments": {
+        "Uint8ClampedArray": {
           "__compat": {
-            "description": "Constructor without arguments",
+            "description": "<code>Uint8ClampedArray()</code> constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray/Uint8ClampedArray",
+            "spec_url": "https://tc39.es/ecma262/#sec-typedarray-constructors",
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -66,16 +68,16 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "55"
+                "version_added": "4"
               },
               "firefox_android": {
-                "version_added": "55"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "10"
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "0.10"
               },
               "opera": {
                 "version_added": "11.6"
@@ -87,13 +89,13 @@
                 "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": "5"
+                "version_added": "4.2"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "4"
               }
             },
             "status": {
@@ -101,107 +103,158 @@
               "standard_track": true,
               "deprecated": false
             }
-          }
-        },
-        "iterable_in_constructor": {
-          "__compat": {
-            "description": "Iterable in constructor",
-            "support": {
-              "chrome": {
-                "version_added": "39"
+          },
+          "constructor_without_arguments": {
+            "__compat": {
+              "description": "Constructor without arguments",
+              "support": {
+                "chrome": {
+                  "version_added": "7"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "55"
+                },
+                "firefox_android": {
+                  "version_added": "55"
+                },
+                "ie": {
+                  "version_added": "10"
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "11.6"
+                },
+                "opera_android": {
+                  "version_added": "12"
+                },
+                "safari": {
+                  "version_added": "5.1"
+                },
+                "safari_ios": {
+                  "version_added": "5"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "≤37"
+                }
               },
-              "chrome_android": {
-                "version_added": "39"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "firefox": {
-                "version_added": "52"
-              },
-              "firefox_android": {
-                "version_added": "52"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "4.0.0"
-              },
-              "opera": {
-                "version_added": "26"
-              },
-              "opera_android": {
-                "version_added": "26"
-              },
-              "safari": {
-                "version_added": "10"
-              },
-              "safari_ios": {
-                "version_added": "10"
-              },
-              "samsunginternet_android": {
-                "version_added": "4.0"
-              },
-              "webview_android": {
-                "version_added": "39"
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
             }
-          }
-        },
-        "new_required": {
-          "__compat": {
-            "description": "<code>Uint8ClampedArray()</code> without <code>new</code> throws",
-            "support": {
-              "chrome": {
-                "version_added": "7"
+          },
+          "iterable_allowed": {
+            "__compat": {
+              "description": "<code>new Uint8ClampedArray(iterable)</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "39"
+                },
+                "chrome_android": {
+                  "version_added": "39"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": {
+                  "version_added": "52"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "4.0.0"
+                },
+                "opera": {
+                  "version_added": "26"
+                },
+                "opera_android": {
+                  "version_added": "26"
+                },
+                "safari": {
+                  "version_added": "10"
+                },
+                "safari_ios": {
+                  "version_added": "10"
+                },
+                "samsunginternet_android": {
+                  "version_added": "4.0"
+                },
+                "webview_android": {
+                  "version_added": "39"
+                }
               },
-              "chrome_android": {
-                "version_added": "18"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "firefox": {
-                "version_added": "44"
-              },
-              "firefox_android": {
-                "version_added": "44"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "0.12"
-              },
-              "opera": {
-                "version_added": "15"
-              },
-              "opera_android": {
-                "version_added": "14"
-              },
-              "safari": {
-                "version_added": "5.1"
-              },
-              "safari_ios": {
-                "version_added": "5"
-              },
-              "samsunginternet_android": {
-                "version_added": "1.0"
-              },
-              "webview_android": {
-                "version_added": "≤37"
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+            }
+          },
+          "new_required": {
+            "__compat": {
+              "description": "<code>Uint8ClampedArray()</code> without <code>new</code> throws",
+              "support": {
+                "chrome": {
+                  "version_added": "7"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "44"
+                },
+                "firefox_android": {
+                  "version_added": "44"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "0.12"
+                },
+                "opera": {
+                  "version_added": "15"
+                },
+                "opera_android": {
+                  "version_added": "14"
+                },
+                "safari": {
+                  "version_added": "5.1"
+                },
+                "safari_ios": {
+                  "version_added": "5"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "≤37"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         }


### PR DESCRIPTION
This adds constructor data for typed arrays. See https://github.com/mdn/sprints/issues/2571 for background.

I've also moved data that belongs to the constructor under that tree, like done in https://github.com/mdn/browser-compat-data/pull/5608

Can you review this @bershanskiy?