### PR TITLE
Remove obsolete typedarray move method

### DIFF
--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -1271,61 +1271,6 @@
             }
           }
         },
-        "move": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/move",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "16",
-                "version_removed": "34",
-                "notes": "Was available in Aurora and Nightly channels only."
-              },
-              "firefox_android": {
-                "version_added": "16",
-                "version_removed": "34",
-                "notes": "Was available in Aurora and Nightly channels only."
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": false,
-              "deprecated": true
-            }
-          }
-        },
         "name": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/name",


### PR DESCRIPTION
This method never saw the light in a release browser and has been removed from specs. I see no purpose for stuff like this to be around. The MDN page was deleted as well to avoid confusion when reading documentation.