### PR TITLE
Allow commands.update() to un-set a shortcut

### DIFF
--- a/webextensions/api/commands.json
+++ b/webextensions/api/commands.json
@@ -111,6 +111,72 @@
                 "version_added": false
               }
             }
+          },
+          "details": {
+            "description": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "60"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
+            "name": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "60"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
+            "shortcut": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "60",
+                    "notes": "From Firefox 74 can be set as an empty string to clear the shortcut assignment."
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
Adding the `details` properties to `update` so a note can be added to `shortcut` about the ability to set it to an empty string in Firefox 74 and after to clear a shortcut assignment.

Details of the change to `shortcut` are in bug [1475043](https://bugzilla.mozilla.org/show_bug.cgi?id=1475043)

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
