### PR TITLE
Deprecate SVG <solidcolor> & SVGSolidcolorElement

### DIFF
--- a/api/SVGSolidcolorElement.json
+++ b/api/SVGSolidcolorElement.json
@@ -43,8 +43,8 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": true,
-          "deprecated": false
+          "standard_track": false,
+          "deprecated": true
         }
       }
     }

--- a/svg/elements/solidcolor.json
+++ b/svg/elements/solidcolor.json
@@ -44,8 +44,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
https://github.com/w3c/svgwg/pull/450 removed the `<solidcolor>` element and `SVGSolidcolorElement` interface from the SVG spec. https://github.com/w3c/svgwg/commit/f05f02e