### PR TITLE
Deprecate SVGZoomAndPan and zoomAndPan attribute

### DIFF
--- a/api/SVGZoomAndPan.json
+++ b/api/SVGZoomAndPan.json
@@ -43,8 +43,8 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": true,
-          "deprecated": false
+          "standard_track": false,
+          "deprecated": true
         }
       }
     }

--- a/svg/elements/svg.json
+++ b/svg/elements/svg.json
@@ -560,8 +560,8 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+              "standard_track": false,
+              "deprecated": true
             }
           }
         }

--- a/svg/elements/view.json
+++ b/svg/elements/view.json
@@ -231,8 +231,8 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+              "standard_track": false,
+              "deprecated": true
             }
           }
         }


### PR DESCRIPTION
https://github.com/w3c/svgwg/pull/724 removed the `zoomAndPan` attribute and underlying `SVGZoomAndPan` mixin from the SVG spec. https://github.com/w3c/svgwg/commit/c85c6b1