### PR TITLE
Deprecate the SVG color-rendering property

### DIFF
--- a/svg/attributes/presentation.json
+++ b/svg/attributes/presentation.json
@@ -477,8 +477,8 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+              "standard_track": false,
+              "deprecated": true
             }
           }
         },


### PR DESCRIPTION
https://github.com/w3c/svgwg/pull/695 removed the `color-rendering` property from the SVG spec. https://github.com/w3c/svgwg/commit/fe13225