### PR TITLE
Remove javascript.builtins.ArrayBuffer.transfer

### DIFF
--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -314,58 +314,6 @@
             }
           }
         },
-        "transfer": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/transfer",
-            "spec_url": "https://github.com/domenic/proposal-arraybuffer-transfer/#arraybufferprototypetransfer",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": false,
-              "deprecated": false
-            }
-          }
-        },
         "@@species": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/@@species",


### PR DESCRIPTION
Removes `ArrayBuffer.transfer()` that is not standardized yet, and not implemented anywhere.

## Details
As discussed in [#5694](https://github.com/mdn/browser-compat-data/pull/5694#issuecomment-585292378):
> > ArrayBuffer.transfer() is just a Stage 2 proposal and is not (yet) available on any platform. Is there any point in keeping a documentation page about a feature that no platform committed to implement and might change during the implementation?
>
> Yes, premature features in documentation are confusing. People might search for "arraybuffer transfer" then find this page and be disappointed is not present in reality. We should avoid this. Lets remove this in a separate PR.