### PR TITLE
updating Fx support data for IDBTransaction.commit()

### DIFF
--- a/api/IDBTransaction.json
+++ b/api/IDBTransaction.json
@@ -222,7 +222,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "74"
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1497007

Support for `IDBTransaction.commit()` added to Fx 74.