### PR TITLE
Add constructors, remove prototypes for wasm classes

### DIFF
--- a/javascript/builtins/webassembly/CompileError.json
+++ b/javascript/builtins/webassembly/CompileError.json
@@ -57,6 +57,64 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "CompileError": {
+            "__compat": {
+              "description": "<code>CompileError()</code> constructor",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/CompileError/CompileError",
+              "spec_url": [
+                "https://webassembly.github.io/spec/js-api/#exceptiondef-compileerror",
+                "https://tc39.es/ecma262/#sec-nativeerror-constructors"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "57"
+                },
+                "chrome_android": {
+                  "version_added": "57"
+                },
+                "edge": {
+                  "version_added": "16"
+                },
+                "firefox": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "firefox_android": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "8.0.0"
+                },
+                "opera": {
+                  "version_added": "44"
+                },
+                "opera_android": {
+                  "version_added": "43"
+                },
+                "safari": {
+                  "version_added": "11"
+                },
+                "safari_ios": {
+                  "version_added": "11"
+                },
+                "samsunginternet_android": {
+                  "version_added": "7.0"
+                },
+                "webview_android": {
+                  "version_added": "57"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }

--- a/javascript/builtins/webassembly/Global.json
+++ b/javascript/builtins/webassembly/Global.json
@@ -53,6 +53,59 @@
               "deprecated": false
             }
           },
+          "Global": {
+            "__compat": {
+              "description": "<code>Global()</code> constructor",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Global/Global",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#dom-global-global",
+              "support": {
+                "chrome": {
+                  "version_added": "69"
+                },
+                "chrome_android": {
+                  "version_added": "69"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "62"
+                },
+                "firefox_android": {
+                  "version_added": "62"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": "10.0"
+                },
+                "webview_android": {
+                  "version_added": "69"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "value": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Global/value",

--- a/javascript/builtins/webassembly/Instance.json
+++ b/javascript/builtins/webassembly/Instance.json
@@ -55,10 +55,11 @@
               "deprecated": false
             }
           },
-          "exports": {
+          "Instance": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance/exports",
-              "spec_url": "https://webassembly.github.io/spec/js-api/#dom-instance-exports",
+              "description": "<code>Instance()</code> constructor",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance/Instance",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#dom-instance-instance",
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -109,10 +110,10 @@
               }
             }
           },
-          "prototype": {
+          "exports": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance/prototype",
-              "spec_url": "https://webassembly.github.io/spec/js-api/#instance",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance/exports",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#dom-instance-exports",
               "support": {
                 "chrome": {
                   "version_added": "57"

--- a/javascript/builtins/webassembly/LinkError.json
+++ b/javascript/builtins/webassembly/LinkError.json
@@ -57,6 +57,64 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "LinkError": {
+            "__compat": {
+              "description": "<code>LinkError()</code> constructor",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/LinkError/LinkError",
+              "spec_url": [
+                "https://webassembly.github.io/spec/js-api/#exceptiondef-linkerror",
+                "https://tc39.es/ecma262/#sec-nativeerror-constructors"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "57"
+                },
+                "chrome_android": {
+                  "version_added": "57"
+                },
+                "edge": {
+                  "version_added": "16"
+                },
+                "firefox": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "firefox_android": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "8.0.0"
+                },
+                "opera": {
+                  "version_added": "44"
+                },
+                "opera_android": {
+                  "version_added": "43"
+                },
+                "safari": {
+                  "version_added": "11"
+                },
+                "safari_ios": {
+                  "version_added": "11"
+                },
+                "samsunginternet_android": {
+                  "version_added": "7.0"
+                },
+                "webview_android": {
+                  "version_added": "57"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }

--- a/javascript/builtins/webassembly/Memory.json
+++ b/javascript/builtins/webassembly/Memory.json
@@ -55,6 +55,61 @@
               "deprecated": false
             }
           },
+          "Memory": {
+            "__compat": {
+              "description": "<code>Memory()</code> constructor",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/Memory",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#dom-memory-memory",
+              "support": {
+                "chrome": {
+                  "version_added": "57"
+                },
+                "chrome_android": {
+                  "version_added": "57"
+                },
+                "edge": {
+                  "version_added": "16"
+                },
+                "firefox": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "firefox_android": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "8.0.0"
+                },
+                "opera": {
+                  "version_added": "44"
+                },
+                "opera_android": {
+                  "version_added": "43"
+                },
+                "safari": {
+                  "version_added": "11"
+                },
+                "safari_ios": {
+                  "version_added": "11"
+                },
+                "samsunginternet_android": {
+                  "version_added": "7.0"
+                },
+                "webview_android": {
+                  "version_added": "57"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "buffer": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/buffer",
@@ -113,60 +168,6 @@
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/grow",
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-memory-grow",
-              "support": {
-                "chrome": {
-                  "version_added": "57"
-                },
-                "chrome_android": {
-                  "version_added": "57"
-                },
-                "edge": {
-                  "version_added": "16"
-                },
-                "firefox": {
-                  "version_added": "52",
-                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
-                },
-                "firefox_android": {
-                  "version_added": "52",
-                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": "8.0.0"
-                },
-                "opera": {
-                  "version_added": "44"
-                },
-                "opera_android": {
-                  "version_added": "43"
-                },
-                "safari": {
-                  "version_added": "11"
-                },
-                "safari_ios": {
-                  "version_added": "11"
-                },
-                "samsunginternet_android": {
-                  "version_added": "7.0"
-                },
-                "webview_android": {
-                  "version_added": "57"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "prototype": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/prototype",
-              "spec_url": "https://webassembly.github.io/spec/js-api/#memory",
               "support": {
                 "chrome": {
                   "version_added": "57"

--- a/javascript/builtins/webassembly/Module.json
+++ b/javascript/builtins/webassembly/Module.json
@@ -55,6 +55,61 @@
               "deprecated": false
             }
           },
+          "Module": {
+            "__compat": {
+              "description": "<code>Module()</code> constructor",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/Module",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#dom-module-module",
+              "support": {
+                "chrome": {
+                  "version_added": "57"
+                },
+                "chrome_android": {
+                  "version_added": "57"
+                },
+                "edge": {
+                  "version_added": "16"
+                },
+                "firefox": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "firefox_android": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "8.0.0"
+                },
+                "opera": {
+                  "version_added": "44"
+                },
+                "opera_android": {
+                  "version_added": "43"
+                },
+                "safari": {
+                  "version_added": "11"
+                },
+                "safari_ios": {
+                  "version_added": "11"
+                },
+                "samsunginternet_android": {
+                  "version_added": "7.0"
+                },
+                "webview_android": {
+                  "version_added": "57"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "customSections": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/customSections",
@@ -167,60 +222,6 @@
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/imports",
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-module-imports",
-              "support": {
-                "chrome": {
-                  "version_added": "57"
-                },
-                "chrome_android": {
-                  "version_added": "57"
-                },
-                "edge": {
-                  "version_added": "16"
-                },
-                "firefox": {
-                  "version_added": "52",
-                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
-                },
-                "firefox_android": {
-                  "version_added": "52",
-                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": "8.0.0"
-                },
-                "opera": {
-                  "version_added": "44"
-                },
-                "opera_android": {
-                  "version_added": "43"
-                },
-                "safari": {
-                  "version_added": "11"
-                },
-                "safari_ios": {
-                  "version_added": "11"
-                },
-                "samsunginternet_android": {
-                  "version_added": "7.0"
-                },
-                "webview_android": {
-                  "version_added": "57"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "prototype": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/prototype",
-              "spec_url": "https://webassembly.github.io/spec/js-api/#module",
               "support": {
                 "chrome": {
                   "version_added": "57"

--- a/javascript/builtins/webassembly/RunTimeError.json
+++ b/javascript/builtins/webassembly/RunTimeError.json
@@ -57,6 +57,64 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "RuntimeError": {
+            "__compat": {
+              "description": "<code>RuntimeError()</code> constructor",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/RuntimeError/RuntimeError",
+              "spec_url": [
+                "https://webassembly.github.io/spec/js-api/#exceptiondef-runtimeerror",
+                "https://tc39.es/ecma262/#sec-nativeerror-constructors"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "57"
+                },
+                "chrome_android": {
+                  "version_added": "57"
+                },
+                "edge": {
+                  "version_added": "16"
+                },
+                "firefox": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "firefox_android": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "8.0.0"
+                },
+                "opera": {
+                  "version_added": "44"
+                },
+                "opera_android": {
+                  "version_added": "43"
+                },
+                "safari": {
+                  "version_added": "11"
+                },
+                "safari_ios": {
+                  "version_added": "11"
+                },
+                "samsunginternet_android": {
+                  "version_added": "7.0"
+                },
+                "webview_android": {
+                  "version_added": "57"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }

--- a/javascript/builtins/webassembly/Table.json
+++ b/javascript/builtins/webassembly/Table.json
@@ -55,6 +55,61 @@
               "deprecated": false
             }
           },
+          "Table": {
+            "__compat": {
+              "description": "<code>Table()</code> constructor",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/Table",
+              "spec_url": "https://webassembly.github.io/spec/js-api/#dom-table-table",
+              "support": {
+                "chrome": {
+                  "version_added": "57"
+                },
+                "chrome_android": {
+                  "version_added": "57"
+                },
+                "edge": {
+                  "version_added": "16"
+                },
+                "firefox": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "firefox_android": {
+                  "version_added": "52",
+                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "8.0.0"
+                },
+                "opera": {
+                  "version_added": "44"
+                },
+                "opera_android": {
+                  "version_added": "43"
+                },
+                "safari": {
+                  "version_added": "11"
+                },
+                "safari_ios": {
+                  "version_added": "11"
+                },
+                "samsunginternet_android": {
+                  "version_added": "7.0"
+                },
+                "webview_android": {
+                  "version_added": "57"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "get": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/get",
@@ -167,60 +222,6 @@
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/length",
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-table-length",
-              "support": {
-                "chrome": {
-                  "version_added": "57"
-                },
-                "chrome_android": {
-                  "version_added": "57"
-                },
-                "edge": {
-                  "version_added": "16"
-                },
-                "firefox": {
-                  "version_added": "52",
-                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
-                },
-                "firefox_android": {
-                  "version_added": "52",
-                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": "8.0.0"
-                },
-                "opera": {
-                  "version_added": "44"
-                },
-                "opera_android": {
-                  "version_added": "43"
-                },
-                "safari": {
-                  "version_added": "11"
-                },
-                "safari_ios": {
-                  "version_added": "11"
-                },
-                "samsunginternet_android": {
-                  "version_added": "7.0"
-                },
-                "webview_android": {
-                  "version_added": "57"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "prototype": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/prototype",
-              "spec_url": "https://webassembly.github.io/spec/js-api/#table",
               "support": {
                 "chrome": {
                   "version_added": "57"


### PR DESCRIPTION
Background: https://github.com/mdn/sprints/issues/2571

This adds constructor data and removes prototype data for WebAssembly classes. Once merged I will update the MDN pages and create constructor docs. The prototype pages will be redirected to the main object pages.