### PR TITLE
Add Intl ctors; remove Intl prototypes

### DIFF
--- a/javascript/builtins/intl/Collator.json
+++ b/javascript/builtins/intl/Collator.json
@@ -53,6 +53,59 @@
               "deprecated": false
             }
           },
+          "Collator": {
+            "__compat": {
+              "description": "<code>Collator()</code> constructor",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Collator/Collator",
+              "spec_url": "https://tc39.es/ecma402/#sec-the-intl-collator-constructor",
+              "support": {
+                "chrome": {
+                  "version_added": "24"
+                },
+                "chrome_android": {
+                  "version_added": "26"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "29"
+                },
+                "firefox_android": {
+                  "version_added": "56"
+                },
+                "ie": {
+                  "version_added": "11"
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "15"
+                },
+                "opera_android": {
+                  "version_added": "14"
+                },
+                "safari": {
+                  "version_added": "10"
+                },
+                "safari_ios": {
+                  "version_added": "10"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.5"
+                },
+                "webview_android": {
+                  "version_added": false
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "caseFirst": {
             "__compat": {
               "description": "<code>caseFirst</code> option",
@@ -108,58 +161,6 @@
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Collator/compare",
               "spec_url": "https://tc39.es/ecma402/#sec-intl.collator.prototype.compare",
-              "support": {
-                "chrome": {
-                  "version_added": "24"
-                },
-                "chrome_android": {
-                  "version_added": "26"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "firefox": {
-                  "version_added": "29"
-                },
-                "firefox_android": {
-                  "version_added": "56"
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "nodejs": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": "15"
-                },
-                "opera_android": {
-                  "version_added": "14"
-                },
-                "safari": {
-                  "version_added": "10"
-                },
-                "safari_ios": {
-                  "version_added": "10"
-                },
-                "samsunginternet_android": {
-                  "version_added": "1.5"
-                },
-                "webview_android": {
-                  "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "prototype": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Collator/prototype",
-              "spec_url": "https://tc39.es/ecma402/#sec-intl.collator.prototype",
               "support": {
                 "chrome": {
                   "version_added": "24"

--- a/javascript/builtins/intl/DateTimeFormat.json
+++ b/javascript/builtins/intl/DateTimeFormat.json
@@ -55,7 +55,7 @@
           },
           "DateTimeFormat": {
             "__compat": {
-              "description": "<code>Collator()</code> constructor",
+              "description": "<code>DateTimeFormat()</code> constructor",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/DateTimeFormat",
               "spec_url": "https://tc39.es/ecma402/#sec-intl-datetimeformat-constructor",
               "support": {

--- a/javascript/builtins/intl/DateTimeFormat.json
+++ b/javascript/builtins/intl/DateTimeFormat.json
@@ -53,6 +53,59 @@
               "deprecated": false
             }
           },
+          "DateTimeFormat": {
+            "__compat": {
+              "description": "<code>Collator()</code> constructor",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/DateTimeFormat",
+              "spec_url": "https://tc39.es/ecma402/#sec-intl-datetimeformat-constructor",
+              "support": {
+                "chrome": {
+                  "version_added": "24"
+                },
+                "chrome_android": {
+                  "version_added": "26"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "29"
+                },
+                "firefox_android": {
+                  "version_added": "56"
+                },
+                "ie": {
+                  "version_added": "11"
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "15"
+                },
+                "opera_android": {
+                  "version_added": "14"
+                },
+                "safari": {
+                  "version_added": "10"
+                },
+                "safari_ios": {
+                  "version_added": "10"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.5"
+                },
+                "webview_android": {
+                  "version_added": false
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "dateStyle": {
             "__compat": {
               "support": {
@@ -409,58 +462,6 @@
                 },
                 "webview_android": {
                   "version_added": "37"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "prototype": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/prototype",
-              "spec_url": "https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype",
-              "support": {
-                "chrome": {
-                  "version_added": "24"
-                },
-                "chrome_android": {
-                  "version_added": "26"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "firefox": {
-                  "version_added": "29"
-                },
-                "firefox_android": {
-                  "version_added": "56"
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "nodejs": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": "15"
-                },
-                "opera_android": {
-                  "version_added": "14"
-                },
-                "safari": {
-                  "version_added": "10"
-                },
-                "safari_ios": {
-                  "version_added": "10"
-                },
-                "samsunginternet_android": {
-                  "version_added": "1.5"
-                },
-                "webview_android": {
-                  "version_added": false
                 }
               },
               "status": {

--- a/javascript/builtins/intl/ListFormat.json
+++ b/javascript/builtins/intl/ListFormat.json
@@ -53,6 +53,59 @@
               "deprecated": false
             }
           },
+          "ListFormat": {
+            "__compat": {
+              "description": "<code>ListFormat()</code> constructor",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ListFormat/ListFormat",
+              "spec_url": "https://tc39.es/proposal-intl-list-format/#sec-intl-listformat-constructor",
+              "support": {
+                "chrome": {
+                  "version_added": "72"
+                },
+                "chrome_android": {
+                  "version_added": "72"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "60"
+                },
+                "opera_android": {
+                  "version_added": "51"
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": "72"
+                }
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "format": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ListFormat/format",
@@ -109,58 +162,6 @@
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ListFormat/formatToParts",
               "spec_url": "https://tc39.es/proposal-intl-list-format/#sec-Intl.ListFormat.prototype.formatToParts",
-              "support": {
-                "chrome": {
-                  "version_added": "72"
-                },
-                "chrome_android": {
-                  "version_added": "72"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "60"
-                },
-                "opera_android": {
-                  "version_added": "51"
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "samsunginternet_android": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": "72"
-                }
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "prototype": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ListFormat/prototype",
-              "spec_url": "https://tc39.es/proposal-intl-list-format/#sec-Intl.ListFormat.prototype",
               "support": {
                 "chrome": {
                   "version_added": "72"

--- a/javascript/builtins/intl/Locale.json
+++ b/javascript/builtins/intl/Locale.json
@@ -53,6 +53,59 @@
               "experimental": false
             }
           },
+          "Locale": {
+            "__compat": {
+              "description": "<code>Locale()</code> constructor",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/Locale",
+              "spec_url": "https://tc39.es/proposal-intl-locale/#sec-intl-locale-constructor",
+              "support": {
+                "chrome": {
+                  "version_added": "74"
+                },
+                "chrome_android": {
+                  "version_added": "74"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": "74"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "deprecated": false,
+                "standard_track": true
+              }
+            }
+          },
           "baseName": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/baseName",
@@ -569,58 +622,6 @@
               "status": {
                 "deprecated": false,
                 "experimental": false,
-                "standard_track": true
-              }
-            }
-          },
-          "prototype": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/prototype",
-              "spec_url": "https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype",
-              "support": {
-                "chrome": {
-                  "version_added": "74"
-                },
-                "chrome_android": {
-                  "version_added": "74"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "samsunginternet_android": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": "74"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "deprecated": false,
                 "standard_track": true
               }
             }

--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -53,6 +53,59 @@
               "deprecated": false
             }
           },
+          "NumberFormat": {
+            "__compat": {
+              "description": "<code>NumberFormat()</code> constructor",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat/NumberFormat",
+              "spec_url": "https://tc39.es/ecma402/#sec-intl-numberformat-constructor",
+              "support": {
+                "chrome": {
+                  "version_added": "24"
+                },
+                "chrome_android": {
+                  "version_added": "26"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "29"
+                },
+                "firefox_android": {
+                  "version_added": "56"
+                },
+                "ie": {
+                  "version_added": "11"
+                },
+                "nodejs": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": "15"
+                },
+                "opera_android": {
+                  "version_added": "14"
+                },
+                "safari": {
+                  "version_added": "10"
+                },
+                "safari_ios": {
+                  "version_added": "10"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.5"
+                },
+                "webview_android": {
+                  "version_added": "≤37"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "format": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat/format",
@@ -152,58 +205,6 @@
               },
               "status": {
                 "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "prototype": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat/prototype",
-              "spec_url": "https://tc39.es/ecma402/#sec-intl.numberformat.prototype",
-              "support": {
-                "chrome": {
-                  "version_added": "24"
-                },
-                "chrome_android": {
-                  "version_added": "26"
-                },
-                "edge": {
-                  "version_added": "12"
-                },
-                "firefox": {
-                  "version_added": "29"
-                },
-                "firefox_android": {
-                  "version_added": "56"
-                },
-                "ie": {
-                  "version_added": "11"
-                },
-                "nodejs": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": "15"
-                },
-                "opera_android": {
-                  "version_added": "14"
-                },
-                "safari": {
-                  "version_added": "10"
-                },
-                "safari_ios": {
-                  "version_added": "10"
-                },
-                "samsunginternet_android": {
-                  "version_added": "1.5"
-                },
-                "webview_android": {
-                  "version_added": "≤37"
-                }
-              },
-              "status": {
-                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }

--- a/javascript/builtins/intl/PluralRules.json
+++ b/javascript/builtins/intl/PluralRules.json
@@ -106,57 +106,6 @@
               }
             }
           },
-          "prototype": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/PluralRules/prototype",
-              "support": {
-                "chrome": {
-                  "version_added": "63"
-                },
-                "chrome_android": {
-                  "version_added": "63"
-                },
-                "edge": {
-                  "version_added": "18"
-                },
-                "firefox": {
-                  "version_added": "58"
-                },
-                "firefox_android": {
-                  "version_added": "58"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": "10.0.0"
-                },
-                "opera": {
-                  "version_added": "50"
-                },
-                "opera_android": {
-                  "version_added": "46"
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "samsunginternet_android": {
-                  "version_added": "8.0"
-                },
-                "webview_android": {
-                  "version_added": "63"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
           "resolvedOptions": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/PluralRules/resolvedOptions",

--- a/javascript/builtins/intl/RelativeTimeFormat.json
+++ b/javascript/builtins/intl/RelativeTimeFormat.json
@@ -210,58 +210,6 @@
               }
             }
           },
-          "prototype": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/prototype",
-              "spec_url": "https://tc39.es/proposal-intl-relative-time/#sec-Intl.RelativeTimeFormat.prototype",
-              "support": {
-                "chrome": {
-                  "version_added": "71"
-                },
-                "chrome_android": {
-                  "version_added": "71"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "65"
-                },
-                "firefox_android": {
-                  "version_added": "65"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": "12.0.0"
-                },
-                "opera": {
-                  "version_added": "58"
-                },
-                "opera_android": {
-                  "version_added": "50"
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "samsunginternet_android": {
-                  "version_added": "10.0"
-                },
-                "webview_android": {
-                  "version_added": "71"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
           "resolvedOptions": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/resolvedOptions",


### PR DESCRIPTION
Background https://github.com/mdn/sprints/issues/2571

PluralRules and RelativeTimeFormat already have constructor data, so there I just removed the prototype entry.