### PR TITLE
Revert "Feature Policy enabled by default on Firefox 73"

### DIFF
--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -108,7 +108,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "73"
+              "version_added": null
             },
             "firefox_android": {
               "version_added": null

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -112,7 +112,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "73"
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1572461'>bug 1572461</a>."
               },
               "firefox_android": {
                 "version_added": false

--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -14,21 +14,16 @@
             "edge": {
               "version_added": false
             },
-            "firefox": [
-              {
-                "version_added": "73"
-              },
-              {
-                "version_added": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.featurePolicy.header.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "65",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.featurePolicy.header.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": "65",
               "flags": [
@@ -236,21 +231,16 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "73"
-                },
-                {
-                  "version_added": "65",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.security.featurePolicy.header.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "65",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.featurePolicy.header.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
               "firefox_android": {
                 "version_added": "65",
                 "flags": [
@@ -353,21 +343,16 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "73"
-                },
-                {
-                  "version_added": "65",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.security.featurePolicy.header.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "65",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.featurePolicy.header.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
               "firefox_android": {
                 "version_added": "65",
                 "flags": [
@@ -420,21 +405,16 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "73"
-                },
-                {
-                  "version_added": "67",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.security.featurePolicy.header.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "67",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.featurePolicy.header.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
               "firefox_android": {
                 "version_added": "67",
                 "flags": [
@@ -487,21 +467,16 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "73"
-                },
-                {
-                  "version_added": "65",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.security.featurePolicy.header.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "65",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.featurePolicy.header.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
               "firefox_android": {
                 "version_added": "65",
                 "flags": [
@@ -554,21 +529,16 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "73"
-                },
-                {
-                  "version_added": "65",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.security.featurePolicy.header.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "65",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.featurePolicy.header.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
               "firefox_android": {
                 "version_added": "65",
                 "flags": [
@@ -621,21 +591,16 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "73"
-                },
-                {
-                  "version_added": "65",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.security.featurePolicy.header.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "65",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.featurePolicy.header.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
               "firefox_android": {
                 "version_added": "65",
                 "flags": [
@@ -688,21 +653,16 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "73"
-                },
-                {
-                  "version_added": "65",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.security.featurePolicy.header.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "65",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.featurePolicy.header.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
               "firefox_android": {
                 "version_added": "65",
                 "flags": [
@@ -1031,21 +991,16 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "73"
-                },
-                {
-                  "version_added": "65",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.security.featurePolicy.header.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "65",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.featurePolicy.header.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
               "firefox_android": {
                 "version_added": "65",
                 "flags": [
@@ -1098,21 +1053,16 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "73"
-                },
-                {
-                  "version_added": "65",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.security.featurePolicy.header.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "65",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.featurePolicy.header.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
               "firefox_android": {
                 "version_added": "65",
                 "flags": [
@@ -1241,21 +1191,16 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "73"
-                },
-                {
-                  "version_added": "65",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.security.featurePolicy.header.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "65",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.featurePolicy.header.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
               "firefox_android": {
                 "version_added": "65",
                 "flags": [


### PR DESCRIPTION
Reverts mdn/browser-compat-data#5502 as this feature was pulled from 73 nearly at the last minute. Should hit in 74 instead.