### PR TITLE
Firefox 73: MathML <mfenced> and <mo> removed

### DIFF
--- a/mathml/elements/mo.json
+++ b/mathml/elements/mo.json
@@ -15,7 +15,8 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "73"
             },
             "firefox_android": {
               "version_added": "4"
@@ -61,7 +62,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "73"
               },
               "firefox_android": {
                 "version_added": "4"
@@ -108,7 +110,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "12"
+                "version_added": "12",
+                "version_removed": "73"
               },
               "firefox_android": {
                 "version_added": "14"
@@ -202,7 +205,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "7"
+                "version_added": "7",
+                "version_removed": "73"
               },
               "firefox_android": {
                 "version_added": "7"
@@ -296,7 +300,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "73"
               },
               "firefox_android": {
                 "version_added": "4"
@@ -343,7 +348,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "73"
               },
               "firefox_android": {
                 "version_added": "4"
@@ -390,7 +396,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "28"
+                "version_added": "28",
+                "version_removed": "73"
               },
               "firefox_android": {
                 "version_added": "28"
@@ -437,7 +444,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "73"
               },
               "firefox_android": {
                 "version_added": "4"
@@ -484,7 +492,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "73"
               },
               "firefox_android": {
                 "version_added": "4"
@@ -531,7 +540,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "73"
               },
               "firefox_android": {
                 "version_added": "4"
@@ -578,7 +588,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "73"
               },
               "firefox_android": {
                 "version_added": "4"
@@ -625,7 +636,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "73"
               },
               "firefox_android": {
                 "version_added": "4"
@@ -672,7 +684,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "73"
               },
               "firefox_android": {
                 "version_added": "4"

--- a/mathml/elements/mrow.json
+++ b/mathml/elements/mrow.json
@@ -15,7 +15,8 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "73"
             },
             "firefox_android": {
               "version_added": "4"
@@ -61,7 +62,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "12"
+                "version_added": "12",
+                "version_removed": "73"
               },
               "firefox_android": {
                 "version_added": "14"
@@ -108,7 +110,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "7"
+                "version_added": "7",
+                "version_removed": "73"
               },
               "firefox_android": {
                 "version_added": "7"
@@ -155,7 +158,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "4"
+                "version_added": "4",
+                "version_removed": "73"
               },
               "firefox_android": {
                 "version_added": "4"
@@ -202,7 +206,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "4"
+                "version_added": "4",
+                "version_removed": "73"
               },
               "firefox_android": {
                 "version_added": "4"


### PR DESCRIPTION
# Data
[Firefox 73 release notes](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/73)

This is a part of #5713.