### PR TITLE
Firefox 73 has released

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -532,28 +532,28 @@
         "72": {
           "release_date": "2020-01-07",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/72",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "72"
         },
         "73": {
           "release_date": "2020-02-11",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/73",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "73"
         },
         "74": {
           "release_date": "2020-03-10",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/74",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "74"
         },
         "75": {
           "release_date": "2020-04-07",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/75",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "75"
         },


### PR DESCRIPTION
Firefox 73 has released!  This PR updates BCD to indicate as such.
