### PR TITLE
Update fractional coordinates data for pointer events

### DIFF
--- a/api/PointerEvent.json
+++ b/api/PointerEvent.json
@@ -494,12 +494,12 @@
               "chrome": {
                 "version_added": "64",
                 "partial_implementation": true,
-                "notes": "<code>movementX</code> and <code>movementY</code> are not fractional."
+                "notes": "<code>movementX</code> and <code>movementY</code> are not fractional, see <a href='https://crbug.com/802067'>Chromium bug 802067</a>."
               },
               "chrome_android": {
                 "version_added": "64",
                 "partial_implementation": true,
-                "notes": "<code>movementX</code> and <code>movementY</code> are not fractional."
+                "notes": "<code>movementX</code> and <code>movementY</code> are not fractional, see <a href='https://crbug.com/802067'>Chromium bug 802067</a>."
               },
               "edge": [
                 {
@@ -528,12 +528,12 @@
               "opera": {
                 "version_added": "51",
                 "partial_implementation": true,
-                "notes": "<code>movementX</code> and <code>movementY</code> are not fractional, see <a href=\"https://crbug.com/802067\">Chromium bug 802067</a>"
+                "notes": "<code>movementX</code> and <code>movementY</code> are not fractional, see <a href='https://crbug.com/802067'>Chromium bug 802067</a>."
               },
               "opera_android": {
                 "version_added": "47",
                 "partial_implementation": true,
-                "notes": "<code>movementX</code> and <code>movementY</code> are not fractional, see <a href=\"https://crbug.com/802067\">Chromium bug 802067</a>"
+                "notes": "<code>movementX</code> and <code>movementY</code> are not fractional, see <a href='https://crbug.com/802067'>Chromium bug 802067</a>."
               },
               "safari": {
                 "version_added": null
@@ -544,12 +544,12 @@
               "samsunginternet_android": {
                 "version_added": "9.0",
                 "partial_implementation": true,
-                "notes": "<code>movementX</code> and <code>movementY</code> are not fractional, see <a href=\"https://crbug.com/802067\">Chromium bug 802067</a>"
+                "notes": "<code>movementX</code> and <code>movementY</code> are not fractional, see <a href='https://crbug.com/802067'>Chromium bug 802067</a>."
               },
               "webview_android": {
                 "version_added": "64",
                 "partial_implementation": true,
-                "notes": "<code>movementX</code> and <code>movementY</code> are not fractional, see <a href=\"https://crbug.com/802067\">Chromium bug 802067</a>"
+                "notes": "<code>movementX</code> and <code>movementY</code> are not fractional, see <a href='https://crbug.com/802067'>Chromium bug 802067</a>."
               }
             },
             "status": {

--- a/api/PointerEvent.json
+++ b/api/PointerEvent.json
@@ -518,7 +518,7 @@
                 "version_added": false
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": false
               },
               "ie": {
                 "version_added": true,
@@ -536,10 +536,10 @@
                 "notes": "<code>movementX</code> and <code>movementY</code> are not fractional, see <a href='https://crbug.com/802067'>Chromium bug 802067</a>."
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "9.0",

--- a/api/PointerEvent.json
+++ b/api/PointerEvent.json
@@ -492,28 +492,48 @@
             "description": "Fractional coordinates for <code>mouse</code>.",
             "support": {
               "chrome": {
-                "version_added": "64"
+                "version_added": "64",
+                "partial_implementation": true,
+                "notes": "<code>movementX</code> and <code>movementY</code> are not fractional."
               },
               "chrome_android": {
-                "version_added": "64"
+                "version_added": "64",
+                "partial_implementation": true,
+                "notes": "<code>movementX</code> and <code>movementY</code> are not fractional."
               },
-              "edge": {
-                "version_added": "≤79"
-              },
+              "edge": [
+                {
+                  "version_added": "79",
+                  "partial_implementation": true,
+                  "notes": "<code>movementX</code> and <code>movementY</code> are not fractional."
+                },
+                {
+                  "version_added": "12",
+                  "version_removed": "79",
+                  "partial_implementation": true,
+                  "notes": "Only <code>clientX</code>, <code>clientY</code>, <code>pageX</code> and <code>pageY</code> are fractional."
+                }
+              ],
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": null
               },
               "ie": {
-                "version_added": null
+                "version_added": true,
+                "partial_implementation": true,
+                "notes": "Only <code>clientX</code>, <code>clientY</code>, <code>pageX</code> and <code>pageY</code> are fractional."
               },
               "opera": {
-                "version_added": "51"
+                "version_added": "51",
+                "partial_implementation": true,
+                "notes": "<code>movementX</code> and <code>movementY</code> are not fractional, see <a href=\"https://crbug.com/802067\">Chromium bug 802067</a>"
               },
               "opera_android": {
-                "version_added": "47"
+                "version_added": "47",
+                "partial_implementation": true,
+                "notes": "<code>movementX</code> and <code>movementY</code> are not fractional, see <a href=\"https://crbug.com/802067\">Chromium bug 802067</a>"
               },
               "safari": {
                 "version_added": null
@@ -522,10 +542,14 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": "9.0"
+                "version_added": "9.0",
+                "partial_implementation": true,
+                "notes": "<code>movementX</code> and <code>movementY</code> are not fractional, see <a href=\"https://crbug.com/802067\">Chromium bug 802067</a>"
               },
               "webview_android": {
-                "version_added": "64"
+                "version_added": "64",
+                "partial_implementation": true,
+                "notes": "<code>movementX</code> and <code>movementY</code> are not fractional, see <a href=\"https://crbug.com/802067\">Chromium bug 802067</a>"
               }
             },
             "status": {

--- a/api/PointerEvent.json
+++ b/api/PointerEvent.json
@@ -505,7 +505,7 @@
                 {
                   "version_added": "79",
                   "partial_implementation": true,
-                  "notes": "<code>movementX</code> and <code>movementY</code> are not fractional."
+                  "notes": "<code>movementX</code> and <code>movementY</code> are not fractional, see <a href='https://crbug.com/802067'>Chromium bug 802067</a>."
                 },
                 {
                   "version_added": "12",


### PR DESCRIPTION
I have provided more data for the fractional coordiantes subfeature (where input type is `mouse`) of the pointer events API.

The test I used for this is here: https://output.jsbin.com/catajet/quiet

### Chromium Browsers ###

Chromium browsers are changed from full to partial implementation because `movementX` and `movementY` were omitted from the original patch, affecting only `screenX`, `screenY`, `pageX`, `pageY`, `clientX` and `clientY`. I can't see an obvious reason for this because both definitely existed at the time and are defined in the spec as the subtraction of two `screenX` and `screenY` values from different events. The relevant bug is here: https://bugs.chromium.org/p/chromium/issues/detail?id=802067. I tested this myself on a high dpi Windows laptop with a cheap usb mouse and reproduced this behaviour.

### Microsoft Browsers ###

On the same device as before, IE11 and Edge 18 both report `pageX`, `pageY`, `clientX` and `clientY` values fractionally. Edge reports `screenX`, `screenY`, `movementX` and `movementY` values as integers while IE 11 does the same except that it does not support `movementX` or `movementY`. This means both browsers have partial support. I do not know what the behaviour of IE10 was so I marked the version as simply `true` for IE.

### Firefox ###

The stable release of Firefox does not report fractional coordinates on my device and I cannot find a corresponding bug to change this behaviour. I do not have an Android tablet on which to test Firefox for Android with a mouse.