### PR TITLE
Removed deprecated flag from requestSubmit()

### DIFF
--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -765,7 +765,7 @@
           "status": {
             "experimental": false,
             "standard_track": false,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },

--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -764,7 +764,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
Firefox & Chrome just implemented it (see links in original commit https://github.com/mdn/browser-compat-data/commit/7f9458baca8d78b5dc4f7a8cab55c7df315830f3), in https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement it is not marked as deprecated.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
