### PR TITLE
Mark CSSPseudoElement unsupported by Safari

### DIFF
--- a/api/CSSPseudoElement.json
+++ b/api/CSSPseudoElement.json
@@ -65,7 +65,7 @@
             "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
             "version_added": false
@@ -172,7 +172,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false
@@ -256,7 +256,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
This PR follows on from https://github.com/mdn/browser-compat-data/pull/4284

I retested in Safari 13 on Mac OS Catalina (via Browserstack) and even with both `Web Animations` and `CSS Animations via Web Animations` experimental features enabled, `CSSPseudoElement` was not present.

The tests:
* https://output.jsbin.com/casodi/1
* https://jsbin.com/fubunuw/1/edit?html,css,js,console,output