### PR TITLE
Add Media Queries L5 features: `forced-colors`, `prefers-contrast`, `prefers-reduced-data`, `prefers-reduced-transparency`

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -590,6 +590,59 @@
             }
           }
         },
+        "forced-colors": {
+          "__compat": {
+            "description": "<code>forced-colors</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/forced-colors",
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/970285'>bug 970285</a>."
+              },
+              "chrome_android": {
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/970285'>bug 970285</a>."
+              },
+              "edge": {
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/970285'>bug 970285</a>."
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/970285'>bug 970285</a>."
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "grid": {
           "__compat": {
             "description": "<code>grid</code> media feature",
@@ -1275,6 +1328,55 @@
             }
           }
         },
+        "prefers-contrast": {
+          "__compat": {
+            "description": "<code>prefers-contrast</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/prefers-contrast",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "prefers-reduced-motion": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/prefers-reduced-motion",
@@ -1319,6 +1421,108 @@
             },
             "status": {
               "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "prefers-reduced-data": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/prefers-reduced-data",
+            "description": "<code>prefers-reduced-data</code> media feature",
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/1051189'>bug 1051189</a>."
+              },
+              "chrome_android": {
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/1051189'>bug 1051189</a>."
+              },
+              "edge": {
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/1051189'>bug 1051189</a>."
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "62"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/1051189'>bug 1051189</a>."
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "prefers-reduced-transparency": {
+          "__compat": {
+            "description": "<code>prefers-reduced-transparency</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/prefers-reduced-transparency",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1377,55 +1377,6 @@
             }
           }
         },
-        "prefers-reduced-motion": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/prefers-reduced-motion",
-            "description": "<code>prefers-reduced-motion</code> media feature",
-            "support": {
-              "chrome": {
-                "version_added": "74"
-              },
-              "chrome_android": {
-                "version_added": "74"
-              },
-              "edge": {
-                "version_added": "79"
-              },
-              "firefox": {
-                "version_added": "63"
-              },
-              "firefox_android": {
-                "version_added": "64"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "62"
-              },
-              "opera_android": {
-                "version_added": "53"
-              },
-              "safari": {
-                "version_added": "10.1"
-              },
-              "safari_ios": {
-                "version_added": "10.3"
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": "74"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "prefers-reduced-data": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/prefers-reduced-data",
@@ -1474,6 +1425,55 @@
             },
             "status": {
               "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "prefers-reduced-motion": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/prefers-reduced-motion",
+            "description": "<code>prefers-reduced-motion</code> media feature",
+            "support": {
+              "chrome": {
+                "version_added": "74"
+              },
+              "chrome_android": {
+                "version_added": "74"
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "63"
+              },
+              "firefox_android": {
+                "version_added": "64"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "62"
+              },
+              "opera_android": {
+                "version_added": "53"
+              },
+              "safari": {
+                "version_added": "10.1"
+              },
+              "safari_ios": {
+                "version_added": "10.3"
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "74"
+              }
+            },
+            "status": {
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
Add upcoming Media Queries Level 5 features:
 - `forced-colors`
    [MDN page](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors)
 - `prefers-contrast`
    [MDN page](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-contrast)
 - `prefers-reduced-data`
    [No MDN page](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-data)
 - `prefers-reduced-transparency`
    [MDN page](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-transparency)

FYI, no browser currently supports these features, but there are WPT tests and open bugs tracking their implementation.