### PR TITLE
Add Chrome support for `overflow-wrap: anywhere` value

### DIFF
--- a/css/properties/overflow-wrap.json
+++ b/css/properties/overflow-wrap.json
@@ -120,13 +120,13 @@
             "description": "<code>anywhere</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "80"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "80"
               },
               "edge": {
-                "version_added": false
+                "version_added": "80"
               },
               "firefox": {
                 "version_added": "65"
@@ -138,7 +138,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "67"
               },
               "opera_android": {
                 "version_added": false
@@ -153,7 +153,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "80"
               }
             },
             "status": {


### PR DESCRIPTION
It was released in Chrome 80, according to https://www.chromestatus.com/feature/5126089347170304.