### PR TITLE
Mark copy event as supported on iOS Safari

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2038,7 +2038,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "7.0"

--- a/api/Element.json
+++ b/api/Element.json
@@ -2084,7 +2084,7 @@
                 "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": true
               },
               "samsunginternet_android": {
                 "version_added": "7.0"


### PR DESCRIPTION
Tested by opening the [relevant MDN page](https://developer.mozilla.org/en-US/docs/Web/API/Element/copy_event) in iOS Safari 13 and trying the live example