### PR TITLE
Mark copy/cut events as supported in IE 11

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2026,7 +2026,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
+              "version_added": true
             },
             "opera": {
               "version_added": "45"
@@ -2308,7 +2308,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "11"
+              "version_added": true
             },
             "opera": {
               "version_added": "45"

--- a/api/Element.json
+++ b/api/Element.json
@@ -2026,7 +2026,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
               "version_added": "45"
@@ -2308,7 +2308,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
               "version_added": "45"


### PR DESCRIPTION
Copy tested by opening [this jsbin](https://output.jsbin.com/dufokinire/1) in IE 11 and trying to copy some text (the second line should show the copied text)
Cut tested by opening [this jsbin](https://output.jsbin.com/tofemukimu/1) in IE 11 and trying to cut some text (the second line should show the cut text)