### PR TITLE
isReload removed from Fetch events

### DIFF
--- a/api/FetchEvent.json
+++ b/api/FetchEvent.json
@@ -210,7 +210,8 @@
             },
             "firefox": {
               "version_added": "44",
-              "notes": "Service workers (and <a href='https://developer.mozilla.org/docs/Web/API/Push_API'>Push</a>) have been disabled in the <a href='https://www.mozilla.org/en-US/firefox/organizations/'>Firefox 45 and 52 Extended Support Releases</a> (ESR.)"
+              "version_removed": "74",
+              "notes": "Service workers (and <a href='https://developer.mozilla.org/docs/Web/API/Push_API'>Push</a>) have been disabled in the <a href='https://www.mozilla.org/en-US/firefox/organizations/'>Firefox 45 and 52 Extended Support Releases</a> (ESR)."
             },
             "firefox_android": {
               "version_added": "44"
@@ -240,7 +241,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
This is effective in Firefox 74.

Source:
* https://bugzilla.mozilla.org/show_bug.cgi?id=1264175
* https://github.com/slightlyoff/ServiceWorker/issues/873
