### PR TITLE
Fx74 - mozGetAsFile() removed

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -586,6 +586,7 @@
       "mozGetAsFile": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/mozGetAsFile",
+          "description": "<code>mozGetAsFile()</code>",
           "support": {
             "chrome": {
               "version_added": false
@@ -597,7 +598,9 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "4",
+              "version_removed": "74",
+              "notes": "<code>mozGetAsFile()</code> was deprecated in Firefox 26 (in 2013) and was removed entirely in Firefox 74."
             },
             "firefox_android": {
               "version_added": "4"

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -586,7 +586,6 @@
       "mozGetAsFile": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/mozGetAsFile",
-          "description": "<code>mozGetAsFile()</code>",
           "support": {
             "chrome": {
               "version_added": false
@@ -598,9 +597,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "4",
-              "version_removed": "74",
-              "notes": "<code>mozGetAsFile()</code> was deprecated in Firefox 26 (in 2013) and was removed entirely in Firefox 74."
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": "4"

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -597,7 +597,9 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "4",
+              "version_removed": "74",
+              "notes": "<code>mozGetAsFile()</code> was deprecated in Firefox 26 (in 2013) and was removed entirely in Firefox 74."
             },
             "firefox_android": {
               "version_added": "4"


### PR DESCRIPTION
Was deprecated in Firefox 26 and has been removed in 74.

Sources:
* https://bugzilla.mozilla.org/show_bug.cgi?id=1588980
* https://www.fxsitecompat.dev/en-CA/docs/2013/htmlcanvaselement-mozgetasfile-has-been-deprecated/