### PR TITLE
Update button.json, Safari now supports formaction

### DIFF
--- a/html/elements/button.json
+++ b/html/elements/button.json
@@ -264,7 +264,7 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": true
+                "version_added": "5.1"
               },
               "safari_ios": {
                 "version_added": true

--- a/html/elements/button.json
+++ b/html/elements/button.json
@@ -264,10 +264,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": true
               },
               "samsunginternet_android": {
                 "version_added": "1.0"

--- a/html/elements/button.json
+++ b/html/elements/button.json
@@ -267,7 +267,7 @@
                 "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "5"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"


### PR DESCRIPTION
Tested and works on Safari 13.0.5 on macOS and Safari 13 on iOS.  

Researched Apple's Developer Release Notes for Safari and was unable to find out exactly when the support was added.  There were some similar HTML5 changes in Safari 12, so it might have been supported earlier.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
