### PR TITLE
Mark newer transition events as unsupported on Safari still

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -3194,10 +3194,10 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -3334,10 +3334,10 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -3383,10 +3383,10 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
The three new transition events added in the 2017 specification (`transitionrun`, `transitionstart`, `transitioncancel`) are still not supported on Safari.


Checked Apple's Developer Release Notes for Safari.

Then tested myself on macOS Safari (13.0.3) on MacBook and on an iPad with iOS Safari (12) on the MDN demo pages for the events.

Updating to iPadOS 13.3.1 to re-check in an hour, just in case.


A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
