### PR TITLE
Change spec_url fragment in some ES spec proposals

### DIFF
--- a/javascript/operators/nullish_coalescing.json
+++ b/javascript/operators/nullish_coalescing.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Nullish coalescing operator (<code>??</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator",
-          "spec_url": "https://tc39.es/proposal-nullish-coalescing/#top",
+          "spec_url": "https://tc39.es/proposal-nullish-coalescing/#sec-intro",
           "support": {
             "chrome": {
               "version_added": "80"

--- a/javascript/operators/optional_chaining.json
+++ b/javascript/operators/optional_chaining.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Optional chaining operator (<code>?.</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Optional_chaining",
-          "spec_url": "https://tc39.es/proposal-optional-chaining/#top",
+          "spec_url": "https://tc39.es/proposal-optional-chaining/#sec-scope",
           "support": {
             "chrome": [
               {


### PR DESCRIPTION
This change replaces the fragment part of the `spec_url` for the proposed ECMAScript "Nullish coalescing" operator and proposed "Optional chaining" operator with more-useful fragment parts.