### PR TITLE
Correct removal version.

### DIFF
--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -56,7 +56,7 @@
               },
               {
                 "version_added": true,
-                "version_removed": "77",
+                "version_removed": "76",
                 "flags": [
                   {
                     "type": "preference",
@@ -71,7 +71,7 @@
               },
               {
                 "version_added": true,
-                "version_removed": "77",
+                "version_removed": "76",
                 "flags": [
                   {
                     "type": "preference",
@@ -129,7 +129,7 @@
               },
               {
                 "version_added": true,
-                "version_removed": "77",
+                "version_removed": "76",
                 "flags": [
                   {
                     "type": "preference",
@@ -144,7 +144,7 @@
               },
               {
                 "version_added": true,
-                "version_removed": "77",
+                "version_removed": "76",
                 "flags": [
                   {
                     "type": "preference",
@@ -202,7 +202,7 @@
               },
               {
                 "version_added": true,
-                "version_removed": "77",
+                "version_removed": "76",
                 "flags": [
                   {
                     "type": "preference",
@@ -217,7 +217,7 @@
               },
               {
                 "version_added": true,
-                "version_removed": "77",
+                "version_removed": "76",
                 "flags": [
                   {
                     "type": "preference",
@@ -275,7 +275,7 @@
               },
               {
                 "version_added": true,
-                "version_removed": "77",
+                "version_removed": "76",
                 "flags": [
                   {
                     "type": "preference",
@@ -290,7 +290,7 @@
               },
               {
                 "version_added": true,
-                "version_removed": "77",
+                "version_removed": "76",
                 "flags": [
                   {
                     "type": "preference",


### PR DESCRIPTION
Corrects #5659. If version 77 was the first version to have the feature on by default, then 76 was the last version to have the flag.

(We still don't endorse having Chrome flags on MDN.)