### PR TITLE
Fx74 remove toSource()/uneval()

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -586,6 +586,7 @@
       "mozGetAsFile": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/mozGetAsFile",
+          "description": "<code>mozGetAsFile()</code>",
           "support": {
             "chrome": {
               "version_added": false
@@ -597,7 +598,9 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "4",
+              "version_removed": "74",
+              "notes": "<code>mozGetAsFile()</code> was deprecated in Firefox 26 (in 2013) and was removed entirely in Firefox 74."
             },
             "firefox_android": {
               "version_added": "4"

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -586,7 +586,6 @@
       "mozGetAsFile": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/mozGetAsFile",
-          "description": "<code>mozGetAsFile()</code>",
           "support": {
             "chrome": {
               "version_added": false
@@ -598,9 +597,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "4",
-              "version_removed": "74",
-              "notes": "<code>mozGetAsFile()</code> was deprecated in Firefox 26 (in 2013) and was removed entirely in Firefox 74."
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": "4"

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -2030,7 +2030,9 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "74",
+                "notes": "Starting in Firefox 74, <code>toSource()</code> is no longer available for use by web content. It is still allowed for internal and privileged code."
               },
               "firefox_android": {
                 "version_added": "4"

--- a/javascript/builtins/Boolean.json
+++ b/javascript/builtins/Boolean.json
@@ -119,7 +119,9 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "74",
+                "notes": "Starting in Firefox 74, <code>toSource()</code> is no longer available for use by web content. It is still allowed for internal and privileged code."
               },
               "firefox_android": {
                 "version_added": "4"

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -3029,7 +3029,9 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "74",
+                "notes": "Starting in Firefox 74, <code>toSource()</code> is no longer available for use by web content. It is still allowed for internal and privileged code."
               },
               "firefox_android": {
                 "version_added": "4"

--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -427,7 +427,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "notes": "Starting in Firefox 74, <code>toSource()</code> is no longer available for use by web content. It is still allowed for internal and privileged code."
               },
               "firefox_android": {
                 "version_added": "4"

--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -842,7 +842,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "notes": "Starting in Firefox 74, <code>toSource()</code> is no longer available for use by web content. It is still allowed for internal and privileged code."
               },
               "firefox_android": {
                 "version_added": "4"

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -1211,7 +1211,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "notes": "Starting in Firefox 74, <code>toSource()</code> is no longer available for use by web content. It is still allowed for internal and privileged code."
               },
               "firefox_android": {
                 "version_added": "4"

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -2075,7 +2075,8 @@
               },
               "firefox": {
                 "version_added": "1",
-                "version_removed": "74"
+                "version_removed": "74",
+                "notes": "Starting in Firefox 74, <code>toSource()</code> is no longer available for use by web content. It is still allowed for internal and privileged code."
               },
               "firefox_android": {
                 "version_added": "4"
@@ -2128,8 +2129,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "1",
-                "notes": "Starting in Firefox 74, <code>toString()</code> is no longer available for use by web content. It is still allowed for internal and privileged code."
+                "version_added": "1"
               },
               "firefox_android": {
                 "version_added": "4"

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -2074,7 +2074,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "74"
               },
               "firefox_android": {
                 "version_added": "4"
@@ -2115,6 +2116,7 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/toString",
             "spec_url": "https://tc39.es/ecma262/#sec-object.prototype.tostring",
+            "description": "<code>toString()</code>",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2126,7 +2128,8 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "notes": "Starting in Firefox 74, <code>toString()</code> is no longer available for use by web content. It is still allowed for internal and privileged code."
               },
               "firefox_android": {
                 "version_added": "4"

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -1599,7 +1599,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "notes": "Starting in Firefox 74, <code>toSource()</code> is no longer available for use by web content. It is still allowed for internal and privileged code."
               },
               "firefox_android": {
                 "version_added": "4"

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -2812,7 +2812,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "notes": "Starting in Firefox 74, <code>toSource()</code> is no longer available for use by web content. It is still allowed for internal and privileged code."
               },
               "firefox_android": {
                 "version_added": "4"

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -882,7 +882,8 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "36"
+                "version_added": "36",
+                "notes": "Starting in Firefox 74, <code>toSource()</code> is no longer available for use by web content. It is still allowed for internal and privileged code."
               },
               "firefox_android": {
                 "version_added": "36"

--- a/javascript/builtins/globals.json
+++ b/javascript/builtins/globals.json
@@ -887,6 +887,7 @@
       "uneval": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/uneval",
+          "description": "<code>uneval()</code>",
           "support": {
             "chrome": {
               "version_added": false
@@ -898,7 +899,9 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "74",
+              "notes": "Starting in Firefox 74, <code>uneval()</code> is no longer available for use by web content. It is still allowed for internal and privileged code."
             },
             "firefox_android": {
               "version_added": "4"


### PR DESCRIPTION
Remove Object.toSource() and uneval()
Firefox 74 no longer supports these in non-chrome code.

Source:
* https://bugzilla.mozilla.org/show_bug.cgi?id=1565170