### PR TITLE
Add onlanguagechange to workers

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -586,6 +586,7 @@
       "mozGetAsFile": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/mozGetAsFile",
+          "description": "<code>mozGetAsFile()</code>",
           "support": {
             "chrome": {
               "version_added": false
@@ -597,7 +598,9 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "4",
+              "version_removed": "74",
+              "notes": "<code>mozGetAsFile()</code> was deprecated in Firefox 26 (in 2013) and was removed entirely in Firefox 74."
             },
             "firefox_android": {
               "version_added": "4"

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -586,7 +586,6 @@
       "mozGetAsFile": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/mozGetAsFile",
-          "description": "<code>mozGetAsFile()</code>",
           "support": {
             "chrome": {
               "version_added": false
@@ -598,9 +597,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "4",
-              "version_removed": "74",
-              "notes": "<code>mozGetAsFile()</code> was deprecated in Firefox 26 (in 2013) and was removed entirely in Firefox 74."
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": "4"

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -352,10 +352,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "74"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": false
             },
             "ie": {
               "version_added": true
@@ -594,10 +594,10 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "74"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": false
             },
             "ie": {
               "version_added": true


### PR DESCRIPTION
    Firefox 74: Support languagechange event on workers
    This was already supported on windows, so this just adds it to
    `WorkerGlobalScope.
    
    Note that this was previously labeled in BCD as having been implemented
    in Firefox 3.5, but that was not accurate.
    
    Source:
    * https://bugzilla.mozilla.org/show_bug.cgi?id=1154779