### PR TITLE
Set Safari versions for ReadableStream API

### DIFF
--- a/api/ReadableStream.json
+++ b/api/ReadableStream.json
@@ -63,10 +63,10 @@
             "version_added": "30"
           },
           "safari": {
-            "version_added": null
+            "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "10.3"
           },
           "samsunginternet_android": {
             "version_added": "4.0"
@@ -145,10 +145,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -227,10 +227,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -309,10 +309,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -391,10 +391,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -439,10 +439,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -487,10 +487,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -569,10 +569,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"


### PR DESCRIPTION
Supersedes #5424.  This PR adds the version numbers for the ReadableStream API for Safari.  Hadn't heard from the original author after requested changes, so this PR was opened up.