### PR TITLE
Update versions for Element API

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -20,25 +20,25 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "4"
           },
           "opera": {
-            "version_added": true
+            "version_added": "8"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "10.1"
           },
           "safari": {
-            "version_added": true
+            "version_added": "3"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -681,7 +681,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "3.0"
@@ -776,7 +776,7 @@
                 "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -923,7 +923,7 @@
               "version_added": "26"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "26"
             },
             "edge": {
               "version_added": "16"
@@ -935,25 +935,25 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1116,7 +1116,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/blur_event",
           "support": {
             "chrome": {
-              "version_added": "5"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -1126,37 +1126,44 @@
             },
             "firefox": [
               {
-                "version_added": true
+                "version_added": "24"
               },
               {
-                "version_added": true,
+                "version_added": "6",
                 "version_removed": "24",
                 "notes": "The interface for this event is <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/FocusEvent'><code>FocusEvent</code></a>."
               }
             ],
-            "firefox_android": {
-              "version_added": true
-            },
+            "firefox_android": [
+              {
+                "version_added": "24"
+              },
+              {
+                "version_added": "6",
+                "version_removed": "24",
+                "notes": "The interface for this event is <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/FocusEvent'><code>FocusEvent</code></a>."
+              }
+            ],
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
-              "version_added": "12.1"
+              "version_added": "11.6"
             },
             "opera_android": {
               "version_added": "12.1"
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "5.1"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1174,7 +1181,7 @@
               "version_added": "8"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": [
               {
@@ -1182,6 +1189,7 @@
               },
               {
                 "version_added": "12",
+                "version_removed": "16",
                 "notes": "Not supported for SVG elements.",
                 "partial_implementation": true
               }
@@ -1190,7 +1198,7 @@
               "version_added": "3.6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10",
@@ -1198,10 +1206,10 @@
               "partial_implementation": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "11.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11.5"
             },
             "safari": {
               "version_added": "6"
@@ -1210,10 +1218,10 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1378,28 +1386,28 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": "13"
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -1421,41 +1429,41 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/click_event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "6",
               "notes": "Beginning in Firefox 68, Firefox no longer incorrectly sends a <code>click</code> event for buttons other than the primary mouse button; previouly, there were circumstances in which this would occur. One example: middle-clicking a link would send a <code>click</code> to the document's <code>&lt;html&gt;</code> element."
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "11.6"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1535,25 +1543,25 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "6"
             },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -1679,25 +1687,25 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "6"
             },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -1739,7 +1747,7 @@
               "version_added": "28"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "28"
             },
             "safari": {
               "version_added": "6"
@@ -1962,19 +1970,19 @@
           "description": "<code>contextmenu</code> event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
               "version_added": "9"
@@ -1983,19 +1991,19 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari": {
               "version_added": "3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -2389,7 +2397,7 @@
           "description": "<code>dblclick</code> event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": false
@@ -2398,26 +2406,26 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "6",
               "notes": "Starting in Firefox 68, <code>dblclick</code> events are only sent for the primary mouse button, per the specification."
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "6"
             },
             "ie": {
               "version_added": "11"
             },
             "opera": {
-              "version_added": null
+              "version_added": "11.6"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "safari": {
-              "version_added": null
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -2488,47 +2496,54 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/focus_event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": [
               {
-                "version_added": true
+                "version_added": "24"
               },
               {
-                "version_added": true,
+                "version_added": "6",
                 "version_removed": "24",
                 "notes": "The interface for this event is <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/FocusEvent'><code>FocusEvent</code></a>."
               }
             ],
-            "firefox_android": {
-              "version_added": true
-            },
+            "firefox_android": [
+              {
+                "version_added": "24"
+              },
+              {
+                "version_added": "6",
+                "version_removed": "24",
+                "notes": "The interface for this event is <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/FocusEvent'><code>FocusEvent</code></a>."
+              }
+            ],
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "11.6"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -2544,10 +2559,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/focusin_event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2559,25 +2574,25 @@
               "version_added": "52"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "11.6"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -2593,10 +2608,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/focusout_event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2608,25 +2623,25 @@
               "version_added": "52"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "11.6"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -2965,7 +2980,7 @@
               "version_added": "29"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "29"
             },
             "edge": {
               "version_added": "12"
@@ -2977,25 +2992,25 @@
               "version_added": "23"
             },
             "ie": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -3203,10 +3218,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/getBoundingClientRect",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "2"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -3221,10 +3236,10 @@
               "version_added": "4"
             },
             "opera": {
-              "version_added": true
+              "version_added": "9.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "6"
@@ -3234,10 +3249,10 @@
               "notes": "Safari for iOS will modify the effective viewport based on the user zoom. This results in incorrect values whenever the user has zoomed."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -3442,40 +3457,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/getClientRects",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "2"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "8"
             },
             "opera": {
-              "version_added": true
+              "version_added": "9.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -3490,10 +3505,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/getElementsByClassName",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": [
               {
@@ -3501,38 +3516,38 @@
               },
               {
                 "version_added": "12",
+                "version_removed": "18",
                 "notes": "This function is implemented in the <code>HTMLElement</code> API, meaning non-HTML elements (like SVG elements) cannot use this function."
               }
             ],
             "firefox": {
-              "version_added": true,
+              "version_added": "3",
               "notes": "Prior to Firefox 19, this method was returning a <code>NodeList</code>; it was then changed to reflect the change in the spec."
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9",
               "notes": "This function is implemented in the <code>HTMLElement</code> API, meaning non-HTML elements (like SVG elements) cannot use this function."
             },
             "opera": {
-              "version_added": true
+              "version_added": "9.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": "6",
-              "notes": "Safari on iOS 8 and OS X 10.10 returns a <code>NodeList</code>."
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -3551,41 +3566,45 @@
               "notes": "Initially, this method was returning a <code>NodeList</code>; it was then changed to reflect the spec change."
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18",
+              "notes": "Initially, this method was returning a <code>NodeList</code>; it was then changed to reflect the spec change."
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Prior to Firefox 19, this method was returning a <code>NodeList</code>; it was then changed to reflect the change in the spec."
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "4",
               "notes": "Prior to Firefox 19, this method was returning a <code>NodeList</code>; it was then changed to reflect the change in the spec."
             },
             "ie": {
               "version_added": "5.5"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "8",
               "notes": "Initially, this method was returning a <code>NodeList</code>; it was then changed to reflect the spec change."
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "6",
               "notes": "Initially, this method was returning a <code>NodeList</code>; it was then changed to reflect the spec change."
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6",
+              "notes": "Initially, this method was returning a <code>NodeList</code>; it was then changed to reflect the spec change."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0",
+              "notes": "Initially, this method was returning a <code>NodeList</code>; it was then changed to reflect the spec change."
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1",
+              "notes": "Initially, this method was returning a <code>NodeList</code>; it was then changed to reflect the spec change."
             }
           },
           "status": {
@@ -3760,40 +3779,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/hasAttribute",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -4033,7 +4052,7 @@
               "notes": "This API was previously available on the <code>Node</code> API."
             },
             "edge": {
-              "version_added": "14"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -4045,23 +4064,23 @@
               "version_added": "4"
             },
             "opera": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "9"
             },
             "safari_ios": {
-              "version_added": "1"
+              "version_added": "9"
             },
             "samsunginternet_android": {
-              "version_added": "1.0",
+              "version_added": "2.0",
               "notes": "This API was previously available on the <code>Node</code> API."
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "4.4",
               "notes": "This API was previously available on the <code>Node</code> API."
             }
           },
@@ -4088,6 +4107,7 @@
               },
               {
                 "version_added": "12",
+                "version_removed": "18",
                 "notes": "This function is implemented in the <code>HTMLElement</code> API, meaning non-HTML elements (like SVG elements) cannot use this function."
               }
             ],
@@ -4098,26 +4118,26 @@
               "version_added": "48"
             },
             "ie": {
-              "version_added": true,
+              "version_added": "8",
               "notes": "This function is implemented in the <code>HTMLElement</code> API, meaning non-HTML elements (like SVG elements) cannot use this function."
             },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "2.3"
+              "version_added": "1"
             }
           },
           "status": {
@@ -4143,6 +4163,7 @@
               },
               {
                 "version_added": "12",
+                "version_removed": "18",
                 "notes": "This function is implemented in the <code>HTMLElement</code> API, meaning non-HTML elements (like SVG elements) cannot use this function."
               }
             ],
@@ -4160,10 +4181,10 @@
               ]
             },
             "opera": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "10"
@@ -4175,7 +4196,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "2.3"
+              "version_added": "1"
             }
           },
           "status": {
@@ -4453,19 +4474,19 @@
           "support": {
             "chrome": [
               {
-                "version_added": "34"
+                "version_added": "33"
               },
               {
-                "version_added": true,
+                "version_added": "4",
                 "alternative_name": "webkitMatchesSelector"
               }
             ],
             "chrome_android": [
               {
-                "version_added": "34"
+                "version_added": "33"
               },
               {
-                "version_added": true,
+                "version_added": "18",
                 "alternative_name": "webkitMatchesSelector"
               }
             ],
@@ -4559,7 +4580,7 @@
                 "version_added": "8"
               },
               {
-                "version_added": true,
+                "version_added": "4.2",
                 "alternative_name": "webkitMatchesSelector"
               }
             ],
@@ -4568,16 +4589,16 @@
                 "version_added": "2.0"
               },
               {
-                "version_added": true,
+                "version_added": "1.0",
                 "alternative_name": "webkitMatchesSelector"
               }
             ],
             "webview_android": [
               {
-                "version_added": true
+                "version_added": "4.4"
               },
               {
-                "version_added": true,
+                "version_added": "≤37",
                 "alternative_name": "webkitMatchesSelector"
               }
             ]
@@ -4595,40 +4616,40 @@
           "description": "<code>mousedown</code> event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "2"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "11.6"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -4647,7 +4668,7 @@
               "version_added": "30"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "30"
             },
             "edge": {
               "version_added": "12"
@@ -4668,16 +4689,16 @@
               "version_added": "18"
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -4696,7 +4717,7 @@
               "version_added": "30"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "30"
             },
             "edge": {
               "version_added": "12"
@@ -4717,16 +4738,16 @@
               "version_added": "18"
             },
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -4742,40 +4763,40 @@
           "description": "<code>mousemove</code> event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "2"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "11.6"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -4840,40 +4861,40 @@
           "description": "<code>mouseover</code> event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "2"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "9.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -4889,40 +4910,40 @@
           "description": "<code>mouseup</code> event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "2"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "11.6"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -5320,35 +5341,35 @@
               "notes": "This API was previously available on the <code>Node</code> API."
             },
             "edge": {
-              "version_added": "14"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "11"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "ie": {
               "version_added": "4"
             },
             "opera": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "9"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "9"
             },
             "samsunginternet_android": {
               "version_added": "2.0",
               "notes": "This API was previously available on the <code>Node</code> API."
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "4.4",
               "notes": "This API was previously available on the <code>Node</code> API."
             }
           },
@@ -5478,10 +5499,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "22"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "22"
             },
             "ie": {
               "version_added": "11"
@@ -5493,10 +5514,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": true
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -5620,7 +5641,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -5629,7 +5650,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": [
               {
@@ -5642,22 +5663,22 @@
               }
             ],
             "opera": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -5675,7 +5696,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -5684,7 +5705,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": [
               {
@@ -5700,19 +5721,19 @@
               "version_added": "10"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -5805,41 +5826,41 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/removeAttribute",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12",
               "notes": "This function doesn't respect boolean attributes' default values.  See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/12087679/'>bug 12087679</a>."
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "8"
             },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -5963,7 +5984,7 @@
                 "version_added": "69"
               },
               {
-                "version_added": true,
+                "version_added": "18",
                 "prefix": "webkit"
               }
             ],
@@ -6058,11 +6079,11 @@
               }
             ],
             "safari": {
-              "version_added": true,
+              "version_added": "6",
               "prefix": "webkit"
             },
             "safari_ios": {
-              "version_added": true,
+              "version_added": "6",
               "prefix": "webkit",
               "notes": "Only available on iPad, not on iPhone. Shows an overlay button which can not be disabled."
             },
@@ -6072,7 +6093,7 @@
               },
               {
                 "prefix": "webkit",
-                "version_added": true
+                "version_added": "1.0"
               }
             ],
             "webview_android": [
@@ -6080,7 +6101,7 @@
                 "version_added": "69"
               },
               {
-                "version_added": true,
+                "version_added": "≤37",
                 "prefix": "webkit"
               }
             ]
@@ -6328,10 +6349,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "36"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "36"
             },
             "ie": {
               "version_added": false
@@ -6563,7 +6584,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -6579,30 +6600,38 @@
                 "notes": "In Firefox versions prior to 21, when an element's content does not generate a vertical scrollbar, then its <code>scrollHeight</code> property is equal to its <code>clientHeight</code> property. This can mean either the content is too short to require a scrollbar or that the element has a CSS style <code>overflow</code> value of <code>visible</code> (non-scrollable)."
               }
             ],
-            "firefox_android": {
-              "version_added": true
-            },
+            "firefox_android": [
+              {
+                "version_added": "21"
+              },
+              {
+                "version_added": "4",
+                "version_removed": "21",
+                "partial_implementation": true,
+                "notes": "In Firefox versions prior to 21, when an element's content does not generate a vertical scrollbar, then its <code>scrollHeight</code> property is equal to its <code>clientHeight</code> property. This can mean either the content is too short to require a scrollbar or that the element has a CSS style <code>overflow</code> value of <code>visible</code> (non-scrollable)."
+              }
+            ],
             "ie": {
               "version_added": "5",
               "notes": "In Internet Explorer 5 through 7, if padding is set, the value of <code>scrollHeight</code> is equal to the sum of the top and bottom padding. This behavior was fixed in Internet Explorer 8."
             },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "4"
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -6620,7 +6649,7 @@
               "version_added": "29"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "29"
             },
             "edge": [
               {
@@ -6629,6 +6658,7 @@
               },
               {
                 "version_added": "12",
+                "version_removed": "18",
                 "notes": [
                   "This function is implemented in the <code>HTMLElement</code> API, meaning non-HTML elements (like SVG elements) cannot use this function.",
                   "No support for <code>smooth</code> behavior."
@@ -6652,7 +6682,7 @@
               "version_added": "38"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": "6",
@@ -6663,10 +6693,10 @@
               "notes": "No support for <code>smooth</code> behavior or <code>center</code> options."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -6744,10 +6774,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/scrollIntoViewIfNeeded",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "79"
@@ -6762,22 +6792,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -6801,25 +6831,25 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -6897,10 +6927,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "36"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "36"
             },
             "ie": {
               "version_added": false
@@ -6993,31 +7023,31 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -7178,41 +7208,41 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/setAttribute",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "5",
               "notes": "In Internet Explorer 7 and earlier, <code>setAttribute</code> doesn't set styles and removes events when you try to set them."
             },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -7730,25 +7760,25 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -8268,14 +8298,14 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "17"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "17"
             },
             "ie": {
               "version_added": "9",
-              "notes": " Internet Explorer exposes the wheel event only via addEventListener, there is no onwheel attribute on DOM objects. <a href='https://connect.microsoft.com/IE/feedback/details/782835/missing-onwheel-attribute-for-the-wheel-event-although-its-supported-via-addeventlistener'>Bug report</a>."
+              "notes": "Internet Explorer only exposes the wheel event via <code>addEventListener</code>; there is no <code>onwheel</code> attribute on DOM objects. See <a href='https://connect.microsoft.com/IE/feedback/details/782835/missing-onwheel-attribute-for-the-wheel-event-although-its-supported-via-addeventlistener'>IE bug 782835</a>."
             },
             "opera": {
               "version_added": "48"
@@ -8284,10 +8314,10 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": "8.0"


### PR DESCRIPTION
This PR sets and updates the version numbers for various portions of the element API based upon manual testing. The data is as follows:

	api.Element
		- IE - 4
		- Opera - 8
		- Safari - 3
	api.Element.animate
		- Sufficient Data, Mirrored to Other Browsers
	api.Element.attributes
		- Opera - 8
	api.Element.blur_event
		- Chrome - incorrect data, 1
		- Firefox - 6
		- IE - 9
		- Opera - incorrect data, 11.6
		- Safari - incorrect data, 3.1
	api.Element.classList
		- Opera - 11.5
	api.Element.className
		- Firefox - 1
		- IE - 8
		- Opera - 8
	api.Element.click_event
		- Chrome - 1
		- Firefox - 6
		- IE - 9
		- Opera - 11.6
		- Safari - 3
	api.Element.clientHeight
		- Firefox - 1
		- Opera - 8
	api.Element.clientWidth
		- Firefox - 1
		- Opera - 8
	api.Element.closest
		- Sufficient Data, Mirrored to Other Browsers
	api.Element.contextmenu_event
		- Chrome - 1
		- Firefox - 6
	api.Element.dblclick_event
		- Chrome - 1
		- Firefox - 6
		- Opera - 11.6
		- Safari - 3
	api.Element.focus_event
		- Chrome - 1
		- Firefox - 6
		- IE - 9
		- Opera - 11.6
		- Safari - 3.1
	api.Element.focusin_event
		- Chrome - 5
		- IE - 9
		- Opera - 11.6
		- Safari - 5
	api.Element.focusout_event
		- Chrome - 5
		- IE - 9
		- Opera - 11.6
		- Safari - 5
	api.Element.getAttribute
		- IE - 8
		- Opera - 8
	api.Element.getBoundingClientRect
		- Chrome - 2
		- Opera - 9.5
	api.Element.getClientRects
		- Chrome - 2
		- Firefox - 3
		- IE - 8
		- Opera - 9.5
	api.Element.getElementsByClassName
		- Chrome - 1
		- Firefox - 3
		- Opera - 9.5
	api.Element.getElementsByTagName
		- Firefox - 1
		- Opera - 8
	api.Element.hasAttribute
		- Chrome - 1
		- Firefox - 1
		- IE - 8
		- Opera - 8
	api.Element.innerHTML
		- Sufficient Data, Mirrored to Other Browsers
	api.Element.insertAdjacentElement
		- IE - 8
		- Opera - 8
	api.Element.insertAdjacentHTML
		- Sufficient Data, Mirrored to Other Browsers
	api.Element.matches
		- Chrome - 33 (4 as webkitMatchesSelector)
	api.Element.mousedown_event
		- Chrome - 2
		- Firefox - 6
		- IE - 9
		- Opera - 11.6
		- Safari - 4
	api.Element.mouseenter_event
		- Safari - 6.1
	api.Element.mouseleave_event
		- Safari - 6.1
	api.Element.mousemove_event
		- Chrome - 2
		- Firefox - 6
		- IE - 9
		- Opera - 11.6
		- Safari - 4
	api.Element.mouseover_event
		- Chrome - 2
		- Firefox - 6
		- IE - 9
		- Opera - 9.5
		- Safari - 4
	api.Element.mouseup_event
		- Chrome - 2
		- Firefox - 6
		- IE - 9
		- Opera - 11.6
		- Safari - 4
	api.Element.outerHTML
		- Sufficient Data, Mirrored to Other Browsers
	api.Element.paste_event
		- Firefox - 22
		- Safari - 5
	api.Element.querySelector
		- Safari - incorrect data, 3.1
		- Opera - 10
	api.Element.querySelectorAll
		- Safari - incorrect data, 3.1
	api.Element.removeAttribute
		- Chrome - 1
		- Firefox - 1
		- IE - 8
		- Safari - incorrect data, 3
		- Opera - 8
	api.Element.requestFullscreen
		- Safari - 6 (with webkit prefix)
	api.Element.scroll
		- Firefox - 36
	api.Element.scrollHeight
		- Opera - 8
	api.Element.scrollIntoView
		- Sufficient Data, Mirrored to Other Browsers
	api.Element.scrollIntoViewIfNeeded
		- Chrome - 1
		- Opera - Blink
		- Safari - incorrect data, 3
	api.Element.scrollLeft
		- Firefox - 1
		- IE - 8
		- Opera - 8
	api.Element.scrollTo
		- Firefox - 36
	api.Element.scrollTop
		- Firefox - 1
		- IE - 8
		- Opera - 8
	api.Element.setAttribute
		- Chrome - 1
		- Firefox - 1
		- Opera - 8
		- Safari - incorrect data, 3
	api.Element.tagName
		- Firefox - 1
		- IE - 8
		- Opera - 8
	api.Element.wheel_event
		- Firefox - 17
		- IE - 9 (through addEventListener); done by #5687
		- Safari - 7