### PR TITLE
Update data for Element.getAnimations()

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -3020,7 +3020,11 @@
             },
             "firefox": [
               {
+                "version_added": "75"
+              },
+              {
                 "version_added": "63",
+                "version_removed": "75",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/Element.json
+++ b/api/Element.json
@@ -3128,17 +3128,7 @@
             ],
             "opera_android": [
               {
-                "version_added": "66",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              },
-              {
-                "version_added": "54",
-                "version_removed": "66",
+                "version_added": "48",
                 "partial_implementation": true,
                 "notes": "Does not support the <code>subtree</code> option.",
                 "flags": [
@@ -3149,8 +3139,8 @@
                 ]
               },
               {
-                "version_added": "31",
-                "version_removed": "54",
+                "version_added": "32",
+                "version_removed": "48",
                 "partial_implementation": true,
                 "notes": "Does not return any animations added via CSS and does not support the <code>subtree</code> option.",
                 "flags": [
@@ -3163,7 +3153,7 @@
               {
                 "alternative_name": "getAnimationPlayers",
                 "version_added": "25",
-                "version_removed": "31",
+                "version_removed": "32",
                 "partial_implementation": true,
                 "notes": "Does not return any animations added via CSS and does not support the <code>subtree</code> option.",
                 "flags": [
@@ -3242,54 +3232,9 @@
                 ]
               }
             ],
-            "webview_android": [
-              {
-                "version_added": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              },
-              {
-                "version_added": "67",
-                "version_removed": "79",
-                "partial_implementation": true,
-                "notes": "Does not support the <code>subtree</code> option.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              },
-              {
-                "version_added": "44",
-                "version_removed": "67",
-                "partial_implementation": true,
-                "notes": "Does not return any animations added via CSS and does not support the <code>subtree</code> option.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              },
-              {
-                "alternative_name": "getAnimationPlayers",
-                "version_added": "38",
-                "version_removed": "44",
-                "partial_implementation": true,
-                "notes": "Does not return any animations added via CSS and does not support the <code>subtree</code> option.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ]
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": true,

--- a/api/Element.json
+++ b/api/Element.json
@@ -2913,42 +2913,383 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/getAnimations",
           "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome": [
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              {
+                "version_added": "67",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "Does not support the <code>subtree</code> option.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              {
+                "version_added": "44",
+                "version_removed": "67",
+                "partial_implementation": true,
+                "notes": "Does not return any animations added via CSS and does not support the <code>subtree</code> option.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              {
+                "alternative_name": "getAnimationPlayers",
+                "version_added": "38",
+                "version_removed": "44",
+                "partial_implementation": true,
+                "notes": "Does not return any animations added via CSS and does not support the <code>subtree</code> option.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              {
+                "version_added": "67",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "Does not support the <code>subtree</code> option.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              {
+                "version_added": "44",
+                "version_removed": "67",
+                "partial_implementation": true,
+                "notes": "Does not return any animations added via CSS and does not support the <code>subtree</code> option.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              {
+                "alternative_name": "getAnimationPlayers",
+                "version_added": "38",
+                "version_removed": "44",
+                "partial_implementation": true,
+                "notes": "Does not return any animations added via CSS and does not support the <code>subtree</code> option.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
             "edge": {
-              "version_added": false
+              "version_added": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.getAnimations.enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "48",
+                "version_removed": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.core.enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "40",
+                "version_removed": "48",
+                "partial_implementation": true,
+                "notes": "Does not support the <code>subtree</code> option.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.core.enabled"
+                  }
+                ]
+              },
+              {
+                "alternative_name": "getAnimationPlayers",
+                "version_added": "33",
+                "version_removed": "40",
+                "partial_implementation": true,
+                "notes": "Does not support the <code>subtree</code> option.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.animations-api.core.enabled"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Does not return any animations added via CSS.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.animations-api.getAnimations.enabled"
+                }
+              ]
             },
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": [
+              {
+                "version_added": "66",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              {
+                "version_added": "54",
+                "version_removed": "66",
+                "partial_implementation": true,
+                "notes": "Does not support the <code>subtree</code> option.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              {
+                "version_added": "31",
+                "version_removed": "54",
+                "partial_implementation": true,
+                "notes": "Does not return any animations added via CSS and does not support the <code>subtree</code> option.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              {
+                "alternative_name": "getAnimationPlayers",
+                "version_added": "25",
+                "version_removed": "31",
+                "partial_implementation": true,
+                "notes": "Does not return any animations added via CSS and does not support the <code>subtree</code> option.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "66",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              {
+                "version_added": "54",
+                "version_removed": "66",
+                "partial_implementation": true,
+                "notes": "Does not support the <code>subtree</code> option.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              {
+                "version_added": "31",
+                "version_removed": "54",
+                "partial_implementation": true,
+                "notes": "Does not return any animations added via CSS and does not support the <code>subtree</code> option.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              {
+                "alternative_name": "getAnimationPlayers",
+                "version_added": "25",
+                "version_removed": "31",
+                "partial_implementation": true,
+                "notes": "Does not return any animations added via CSS and does not support the <code>subtree</code> option.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
             "safari": {
-              "version_added": false
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Does not support the <code>subtree</code> option.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Web Animations"
+                },
+                {
+                  "type": "preference",
+                  "name": "CSS Animations via Web Animations"
+                }
+              ]
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Does not support the <code>subtree</code> option.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Web Animations"
+                },
+                {
+                  "type": "preference",
+                  "name": "CSS Animations via Web Animations"
+                }
+              ]
             },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "9.0",
+                "partial_implementation": true,
+                "notes": "Does not support the <code>subtree</code> option.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              {
+                "version_added": "4.0",
+                "version_removed": "9.0",
+                "partial_implementation": true,
+                "notes": "Does not return any animations added via CSS and does not support the <code>subtree</code> option.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              {
+                "alternative_name": "getAnimationPlayers",
+                "version_added": "3.0",
+                "version_removed": "4.0",
+                "partial_implementation": true,
+                "notes": "Does not return any animations added via CSS and does not support the <code>subtree</code> option.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              {
+                "version_added": "67",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "Does not support the <code>subtree</code> option.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              {
+                "version_added": "44",
+                "version_removed": "67",
+                "partial_implementation": true,
+                "notes": "Does not return any animations added via CSS and does not support the <code>subtree</code> option.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              {
+                "alternative_name": "getAnimationPlayers",
+                "version_added": "38",
+                "version_removed": "44",
+                "partial_implementation": true,
+                "notes": "Does not return any animations added via CSS and does not support the <code>subtree</code> option.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ]
           },
           "status": {
             "experimental": true,


### PR DESCRIPTION
This pull request updates the data for [Element.getAnimations()](https://developer.mozilla.org/en-US/docs/Web/API/Element/getAnimations). Please note that this is a different entry but similar function to [DocumentOrShadowRoot.getAnimations()](https://developer.mozilla.org/en-US/docs/Web/API/Document/getAnimations).

Tests used here are:

* Basic support: https://jsbin.com/hogequp/edit?html,css,js,console,output
* Returns css animations: https://jsbin.com/pojudek/edit?html,css,js,console,output
* Supports options.subtree: https://jsbin.com/mofeyuy/edit?html,css,js,console,output
* Returns animations on pseudoelements: https://jsbin.com/fubunuw/1/edit?html,css,js,console,output

### Firefox ###

Firefox data is mostly taken from the relevant bugs:

* Initial implementation: https://bugzilla.mozilla.org/show_bug.cgi?id=1032573
* Function rename: https://bugzilla.mozilla.org/show_bug.cgi?id=1145246
* Support options.subtree and pseudoelements: https://bugzilla.mozilla.org/show_bug.cgi?id=1254761 and https://bugzilla.mozilla.org/show_bug.cgi?id=1254418
* Rename pref: https://bugzilla.mozilla.org/show_bug.cgi?id=1471814

I verified basic support is present and css animations are returned with the necessary flags in Firefox 40 on Windows 7.

### Firefox for Android ###

Tested on a Samsung Galaxy S10e with Firefox for Android 68, the function does not appear to return any animations added via CSS. This is different to desktop support and I have no way of verifying support on previous versions, so the version is set to true.

### Chrome & Chrome for Android ###

Chrome data was tested using various desktop versions on Windows 7. The relevant bugs are below:

* Initial implementation: https://bugs.chromium.org/p/chromium/issues/detail?id=391364
* Function rename: https://bugs.chromium.org/p/chromium/issues/detail?id=483272
* Return css animations: https://bugs.chromium.org/p/chromium/issues/detail?id=813908
* Support options.subtree and pseudoelements: https://bugs.chromium.org/p/chromium/issues/detail?id=981898

Chrome for Android latest version appears to match the current desktop implementation, so I've mirrored the data.

### Android WebView ###

Android WebView data is mirrored from Chrome for Android data.

### Edge ###

Edge 18 does not support the web animations API at all so the Edge data is mirrored from Chrome.

### Opera & Opera for Android ###

Opera and Opera for Android data is mirrored by mapping the Chrome versions using their release notes: https://help.opera.com/en/opera-version-history/.

### Samsung Internet Browser ###

Samsung Internet Browser data is mirrored from Chrome for Android data using the engine version data in [browsers/samsunginternet_android.json](https://github.com/mdn/browser-compat-data/blob/master/browsers/samsunginternet_android.json).

### Safari & Safari for iOS ###

The Safari data should look like this:

* Safari 9.1: Does not support experimental features at all afaik? (Or in some different way I do not know of.)
* Safari 10-10.1: Function exists _with no preferences_ but always returns an empty array.
* Safari 11-11.1: Function exists behind "Web Animations" preference as an initial implementation.
* Safari 12-12.1: Returns css animations behind the "CSS Animations via Web Animations" preference.
* Safari 13: No change.
* Safari TP: [Release notes](https://developer.apple.com/safari/technology-preview/release-notes/) indicate that options.subtree will be supported.

Data (except for TP) is tested via browserstack. Unfortunately I have no idea how I can represent these ranges in the data format, so instead I have just added the Safari 12.1 data with version set to true.

Safari 13 for iOS appears to have the same support as regular Safari 13 on desktop, so I have mirrored the data.