### PR TITLE
Update versions for Event APIs

### DIFF
--- a/api/CloseEvent.json
+++ b/api/CloseEvent.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CloseEvent",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "13"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -27,22 +27,22 @@
             "version_added": "10"
           },
           "opera": {
-            "version_added": true
+            "version_added": "12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "12.1"
           },
           "safari": {
-            "version_added": true
+            "version_added": "6"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "6"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/CustomEvent.json
+++ b/api/CustomEvent.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomEvent",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "15"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -17,7 +17,7 @@
             "version_added": "6"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "6"
           },
           "ie": {
             "version_added": "9"
@@ -26,19 +26,19 @@
             "version_added": "11"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "11"
           },
           "safari": {
             "version_added": "5.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "6"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -56,7 +56,7 @@
               "version_added": "15"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "≤18"
@@ -65,7 +65,7 @@
               "version_added": "11"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "ie": {
               "version_added": false
@@ -74,7 +74,7 @@
               "version_added": "11.6"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12"
             },
             "safari": {
               "version_added": "6.1"
@@ -83,10 +83,10 @@
               "version_added": "6.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -101,7 +101,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomEvent/detail",
           "support": {
             "chrome": {
-              "version_added": "11"
+              "version_added": "15"
             },
             "chrome_android": {
               "version_added": true

--- a/api/Event.json
+++ b/api/Event.json
@@ -5,40 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Event",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "6"
           },
           "opera": {
-            "version_added": true
+            "version_added": "4"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "10.1"
           },
           "safari": {
-            "version_added": true
+            "version_added": "1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -86,7 +86,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -391,19 +391,19 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Event/currentTarget",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": [
               {
@@ -417,10 +417,10 @@
               }
             ],
             "opera": {
-              "version_added": true
+              "version_added": "7"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "10"
@@ -429,10 +429,10 @@
               "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -910,40 +910,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Event/preventDefault",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "7"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1089,7 +1089,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1104,40 +1104,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Event/stopPropagation",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "7"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1152,40 +1152,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Event/target",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "7"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1257,40 +1257,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Event/type",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "7"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "1"
             }
           },
           "status": {

--- a/api/EventSource.json
+++ b/api/EventSource.json
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "11"
           },
           "opera_android": {
-            "version_added": "12"
+            "version_added": "11"
           },
           "safari": {
             "version_added": "5"
@@ -38,7 +38,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -28,26 +28,14 @@
           "opera_android": {
             "version_added": "10.1"
           },
-          "safari": [
-            {
-              "version_added": "10.1"
-            },
-            {
-              "version_added": "1",
-              "version_removed": "10.1",
-              "notes": "<code>Window.EventTarget</code> did not exist on versions of Safari before 10.1."
-            }
-          ],
-          "safari_ios": [
-            {
-              "version_added": "10.3"
-            },
-            {
-              "version_added": "1",
-              "version_removed": "10.3",
-              "notes": "<code>Window.EventTarget</code> did not exist on versions of Safari iOS before 10.3."
-            }
-          ],
+          "safari": {
+            "version_added": "1",
+            "notes": "<code>window.EventTarget</code> did not exist on versions of Safari before 10.1."
+          },
+          "safari_ios": {
+            "version_added": "1",
+            "notes": "<code>window.EventTarget</code> did not exist on versions of Safari iOS before 10.3."
+          },
           "samsunginternet_android": {
             "version_added": "1.0"
           },
@@ -540,13 +528,13 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR sets and updates the version numbers for various portions of the event APIs based upon manual testing. The data is as follows:

	api.CloseEvent
		- Chrome - 13
		- Opera - 12.1
		- Safari - 6
	api.CustomEvent
		- Chrome - 15
	api.CustomEvent.CustomEvent
		- Sufficient Data, Mirrored to Other Browsers
	api.Event
		- Chrome - 1
		- Firefox - 1
		- IE - 6
		- Opera - 4
		- Safari - 1
	api.Event.currentTarget
		- Chrome - 1
		- Firefox - 1
		- Opera - 7
	api.Event.Event
		- Sufficient Data, Mirrored to Other Browsers
	api.Event.preventDefault
		- Chrome - 1
		- Firefox - 1
		- Opera - 7
		- Safari - 1
	api.Event.stopImmediatePropagation
		- Sufficient Data, Mirrored to Other Browsers
	api.Event.stopPropagation
		- Chrome - 1
		- Firefox - 1
		- Opera - 7
		- Safari - 1
	api.Event.target
		- Chrome - 1
		- Firefox - 1
		- IE - 9
		- Opera - 7
		- Safari - 1
	api.Event.type
		- Chrome - incorrect data, 1
		- Firefox - 1
		- IE - 9
		- Opera - incorrect data, 7
		- Safari - 1
	api.EventListener
		- Sufficient Data, No Changes
	api.EventSource
		- Opera - 11
	api.EventTarget
		- Sufficient Data, Mirrored to Other Browsers
	api.EventTarget.addEventlistener
		- Sufficient Data, No Changes
	api.EventTarget.dispatchEvent
		- Sufficient Data, Mirrored to Other Browsers
	api.EventTarget.removeEventListener
		- Sufficient Data, No Changes