### PR TITLE
Added required gfx.webrender.all flag for backdrop-filter in FF

### DIFF
--- a/css/properties/backdrop-filter.json
+++ b/css/properties/backdrop-filter.json
@@ -43,7 +43,8 @@
                   "type": "preference",
                   "name": "layout.css.backdrop-filter.enabled",
                   "value_to_set": "true"
-                },{
+                },
+                {
                   "type": "preference",
                   "name": "gfx.webrender.all",
                   "value_to_set": "true"

--- a/css/properties/backdrop-filter.json
+++ b/css/properties/backdrop-filter.json
@@ -43,6 +43,10 @@
                   "type": "preference",
                   "name": "layout.css.backdrop-filter.enabled",
                   "value_to_set": "true"
+                },{
+                  "type": "preference",
+                  "name": "gfx.webrender.all",
+                  "value_to_set": "true"
                 }
               ]
             },


### PR DESCRIPTION
Firefox needs to have `gfx.webrender.all` enabled in addition to `layout.css.backdrop-filter.enabled`. The table did not reflect that, so I have added that missing piece of information.

 This is described in [Bug 1591674](https://bugzilla.mozilla.org/show_bug.cgi?id=1591674) and I verified that the `gfx.webrender.all` is required in Firefox 73.0.1 (64-Bit).