### PR TITLE
Intl.DTF: Move ctor features under ctor tree

### DIFF
--- a/javascript/builtins/intl/DateTimeFormat.json
+++ b/javascript/builtins/intl/DateTimeFormat.json
@@ -78,7 +78,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "opera": {
                   "version_added": "15"
@@ -96,7 +96,7 @@
                   "version_added": "1.5"
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "4.4"
                 }
               },
               "status": {
@@ -104,55 +104,206 @@
                 "standard_track": true,
                 "deprecated": false
               }
-            }
-          },
-          "dateStyle": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "76"
+            },
+            "dateStyle": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "76"
+                  },
+                  "chrome_android": {
+                    "version_added": "76"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": "63"
+                  },
+                  "opera_android": {
+                    "version_added": "54"
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  },
+                  "samsunginternet_android": {
+                    "version_added": false
+                  },
+                  "webview_android": {
+                    "version_added": "76"
+                  }
                 },
-                "chrome_android": {
-                  "version_added": "76"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": "63"
-                },
-                "opera_android": {
-                  "version_added": "54"
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "samsunginternet_android": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": "76"
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
                 }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+              }
+            },
+            "hourCycle": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "73"
+                  },
+                  "chrome_android": {
+                    "version_added": "73"
+                  },
+                  "edge": {
+                    "version_added": "18"
+                  },
+                  "firefox": {
+                    "version_added": "58"
+                  },
+                  "firefox_android": {
+                    "version_added": "58"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": "60"
+                  },
+                  "opera_android": {
+                    "version_added": "52"
+                  },
+                  "safari": {
+                    "version_added": "13"
+                  },
+                  "safari_ios": {
+                    "version_added": "13"
+                  },
+                  "samsunginternet_android": {
+                    "version_added": false
+                  },
+                  "webview_android": {
+                    "version_added": "73"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "iana_time_zone_names": {
+              "__compat": {
+                "description": "IANA time zone names in <code>timeZone</code> option",
+                "support": {
+                  "chrome": {
+                    "version_added": "24"
+                  },
+                  "chrome_android": {
+                    "version_added": "26"
+                  },
+                  "edge": {
+                    "version_added": "14"
+                  },
+                  "firefox": {
+                    "version_added": "52"
+                  },
+                  "firefox_android": {
+                    "version_added": "56"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": null
+                  },
+                  "opera": {
+                    "version_added": "15"
+                  },
+                  "opera_android": {
+                    "version_added": "14"
+                  },
+                  "safari": {
+                    "version_added": "10"
+                  },
+                  "safari_ios": {
+                    "version_added": "10"
+                  },
+                  "samsunginternet_android": {
+                    "version_added": "1.5"
+                  },
+                  "webview_android": {
+                    "version_added": "37"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "timeStyle": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "76"
+                  },
+                  "chrome_android": {
+                    "version_added": "76"
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": true
+                  },
+                  "opera": {
+                    "version_added": "63"
+                  },
+                  "opera_android": {
+                    "version_added": "54"
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  },
+                  "samsunginternet_android": {
+                    "version_added": false
+                  },
+                  "webview_android": {
+                    "version_added": "76"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
               }
             }
           },
@@ -370,107 +521,6 @@
               }
             }
           },
-          "hourCycle": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "73"
-                },
-                "chrome_android": {
-                  "version_added": "73"
-                },
-                "edge": {
-                  "version_added": "18"
-                },
-                "firefox": {
-                  "version_added": "58"
-                },
-                "firefox_android": {
-                  "version_added": "58"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": "60"
-                },
-                "opera_android": {
-                  "version_added": "52"
-                },
-                "safari": {
-                  "version_added": "13"
-                },
-                "safari_ios": {
-                  "version_added": "13"
-                },
-                "samsunginternet_android": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": "73"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "iana_time_zone_names": {
-            "__compat": {
-              "description": "IANA time zone names in <code>timeZone</code> option",
-              "support": {
-                "chrome": {
-                  "version_added": "24"
-                },
-                "chrome_android": {
-                  "version_added": "26"
-                },
-                "edge": {
-                  "version_added": "14"
-                },
-                "firefox": {
-                  "version_added": "52"
-                },
-                "firefox_android": {
-                  "version_added": "56"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": null
-                },
-                "opera": {
-                  "version_added": "15"
-                },
-                "opera_android": {
-                  "version_added": "14"
-                },
-                "safari": {
-                  "version_added": "10"
-                },
-                "safari_ios": {
-                  "version_added": "10"
-                },
-                "samsunginternet_android": {
-                  "version_added": "1.5"
-                },
-                "webview_android": {
-                  "version_added": "37"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
           "resolvedOptions": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/resolvedOptions",
@@ -617,56 +667,6 @@
                 },
                 "webview_android": {
                   "version_added": false
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "timeStyle": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "76"
-                },
-                "chrome_android": {
-                  "version_added": "76"
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": true
-                },
-                "opera": {
-                  "version_added": "63"
-                },
-                "opera_android": {
-                  "version_added": "54"
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "samsunginternet_android": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": "76"
                 }
               },
               "status": {

--- a/javascript/builtins/intl/DateTimeFormat.json
+++ b/javascript/builtins/intl/DateTimeFormat.json
@@ -11,7 +11,7 @@
                 "version_added": "24"
               },
               "chrome_android": {
-                "version_added": "26"
+                "version_added": "25"
               },
               "edge": {
                 "version_added": "12"
@@ -63,7 +63,7 @@
                   "version_added": "24"
                 },
                 "chrome_android": {
-                  "version_added": "26"
+                  "version_added": "25"
                 },
                 "edge": {
                   "version_added": "12"
@@ -316,7 +316,7 @@
                   "version_added": "24"
                 },
                 "chrome_android": {
-                  "version_added": "26"
+                  "version_added": "25"
                 },
                 "edge": {
                   "version_added": "12"
@@ -530,7 +530,7 @@
                   "version_added": "24"
                 },
                 "chrome_android": {
-                  "version_added": "26"
+                  "version_added": "25"
                 },
                 "edge": {
                   "version_added": "12"
@@ -633,7 +633,7 @@
                   "version_added": "24"
                 },
                 "chrome_android": {
-                  "version_added": "26"
+                  "version_added": "25"
                 },
                 "edge": {
                   "version_added": "12"

--- a/javascript/builtins/intl/DateTimeFormat.json
+++ b/javascript/builtins/intl/DateTimeFormat.json
@@ -213,7 +213,7 @@
                     "version_added": "24"
                   },
                   "chrome_android": {
-                    "version_added": "26"
+                    "version_added": "25"
                   },
                   "edge": {
                     "version_added": "14"


### PR DESCRIPTION
See https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat#Browser_compatibility.

There are a few random constructor arguments (like dateStyle, hourcylce, timeStyle) that should be under the constructor and not on the main object.