### PR TITLE
BigInt ctors are also supported in Edge 79

### DIFF
--- a/javascript/builtins/BigInt64Array.json
+++ b/javascript/builtins/BigInt64Array.json
@@ -65,7 +65,7 @@
                 "version_added": "67"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "68"

--- a/javascript/builtins/BigUint64Array.json
+++ b/javascript/builtins/BigUint64Array.json
@@ -65,7 +65,7 @@
                 "version_added": "67"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "68"


### PR DESCRIPTION
I think my PR was still open when the big Edge 79 updates were merged and I forgot to add this here for the constructors.