### PR TITLE
Revert change to compatibility data for font-size-adjust in Chromium browsers

### DIFF
--- a/css/properties/font-size-adjust.json
+++ b/css/properties/font-size-adjust.json
@@ -15,7 +15,13 @@
               ]
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "43",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              ]
             },
             "edge": [
               {
@@ -60,7 +66,13 @@
               ]
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "30",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              ]
             },
             "safari": {
               "version_added": false

--- a/css/properties/font-size-adjust.json
+++ b/css/properties/font-size-adjust.json
@@ -23,20 +23,15 @@
                 }
               ]
             },
-            "edge": [
-              {
-                "version_added": "79"
-              },
-              {
-                "version_added": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "edge": {
+              "version_added": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              ]
+            },
             "firefox": [
               {
                 "version_added": "40"

--- a/css/properties/font-size-adjust.json
+++ b/css/properties/font-size-adjust.json
@@ -60,7 +60,7 @@
               ]
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -69,16 +69,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "43",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
-              ]
+              "version_added": false
             }
           },
           "status": {

--- a/css/properties/font-size-adjust.json
+++ b/css/properties/font-size-adjust.json
@@ -5,34 +5,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-size-adjust",
           "support": {
-            "chrome": [
-              {
-                "version_added": "54"
-              },
-              {
-                "version_added": "43",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "54"
-              },
-              {
-                "version_added": "43",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "43",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": [
               {
                 "version_added": "79"
@@ -66,34 +50,18 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "30",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "41"
-              },
-              {
-                "version_added": "30",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Enable experimental Web Platform features"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "30",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              ]
+            },
+            "opera_android": {
+              "version_added": null
+            },
             "safari": {
               "version_added": false
             },
@@ -101,10 +69,16 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": null
             },
             "webview_android": {
-              "version_added": "54"
+              "version_added": "43",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              ]
             }
           },
           "status": {


### PR DESCRIPTION
This reverts commit bc674e2a51cb0c3de4aea8a1cd7bce71bcd41dd2 (#4762), which was raised based on [a comment stating that `font-size-adjust` was enabled by default in Chrome 54](https://github.com/mdn/browser-compat-data/pull/4738#discussion_r320303396). I've not been able to find any evidence of this.

According to [Chrome Platform Status][1], [Chromium Issue 451346][2], [Can I Use][3] and [manual testing][4], `font-size-adjust` is still (as of Chrome 80) behind a flag.

[1]: https://www.chromestatus.com/features#font-size-adjust
[2]: https://bugs.chromium.org/p/chromium/issues/detail?id=451346
[3]: https://github.com/Fyrd/caniuse/blob/3588a7a15b4e5a3e7eab73eeb03ce22c5da68000/features-json/font-size-adjust.json#L165-L202
[4]: https://github.com/mdn/browser-compat-data/pull/4762#issuecomment-590781481