### PR TITLE
webrequest urlclassification now part of the public API

### DIFF
--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -1297,6 +1297,48 @@
                   }
                 }
               }
+            },
+            "url": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": true
+                  },
+                  "edge": {
+                    "version_added": "14"
+                  },
+                  "firefox": {
+                    "version_added": "46"
+                  },
+                  "firefox_android": {
+                    "version_added": "48"
+                  },
+                  "opera": {
+                    "version_added": true
+                  }
+                }
+              }
+            },
+            "urlClassification": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "74"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
             }
           }
         },
@@ -1699,6 +1741,27 @@
                   }
                 }
               }
+            },
+            "urlClassification": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "74"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
             }
           }
         },
@@ -2022,6 +2085,27 @@
                   }
                 }
               }
+            },
+            "urlClassification": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "74"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
             }
           }
         },
@@ -2321,6 +2405,27 @@
                   },
                   "opera": {
                     "version_added": true
+                  }
+                }
+              }
+            },
+            "urlClassification": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "74"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
                   }
                 }
               }
@@ -2705,6 +2810,27 @@
                   }
                 }
               }
+            },
+            "urlClassification": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "74"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
             }
           }
         },
@@ -3041,6 +3167,27 @@
                   },
                   "opera": {
                     "version_added": true
+                  }
+                }
+              }
+            },
+            "urlClassification": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "74"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
                   }
                 }
               }
@@ -3391,6 +3538,27 @@
                   },
                   "opera": {
                     "version_added": true
+                  }
+                }
+              }
+            },
+            "urlClassification": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "74"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
                   }
                 }
               }
@@ -3775,6 +3943,27 @@
                   }
                 }
               }
+            },
+            "urlClassification": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "74"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  }
+                }
+              }
             }
           }
         },
@@ -4069,6 +4258,27 @@
                   },
                   "opera": {
                     "version_added": true
+                  }
+                }
+              }
+            },
+            "urlClassification": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "74"
+                  },
+                  "firefox_android": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
                   }
                 }
               }

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -1308,10 +1308,10 @@
                     "version_added": "14"
                   },
                   "firefox": {
-                    "version_added": "46"
+                    "version_added": "54"
                   },
                   "firefox_android": {
-                    "version_added": "48"
+                    "version_added": "54"
                   },
                   "opera": {
                     "version_added": true


### PR DESCRIPTION
webrequest `urlclassification` was originally released as a property available only to privileged extensions. As per [1589494](https://bugzilla.mozilla.org/show_bug.cgi?id=1589494) it is now public and, therefore, has been added to the `details` object of all of the webrequest events. In addition, it was noted that onAuthRequired was missing the `url` property from its compatibility information, so that has been added to.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
