### PR TITLE
Firefox 74: Feature Policy support enabled

### DIFF
--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -108,10 +108,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "74"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": null

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -112,8 +112,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1572461'>bug 1572461</a>."
+                "version_added": "74"
               },
               "firefox_android": {
                 "version_added": false

--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -14,16 +14,21 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "65",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.security.featurePolicy.header.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "74"
+              },
+              {
+                "version_added": "65",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.featurePolicy.header.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": "65",
               "flags": [


### PR DESCRIPTION
This marks the <iframe> element, HTMLIFrameElement interface,
and the Feature-Policy HTTP header as available by default
in Firefox 74.

Source:
* https://bugzilla.mozilla.org/show_bug.cgi?id=1617219
