### PR TITLE
Mark img[loading] as supported in Firefox 75

### DIFF
--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -508,8 +508,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1542784'>bug 1542784</a>"
+                "version_added": "75"
               },
               "firefox_android": {
                 "version_added": false,


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1542784 was closed as *Resolved: Fixed* on 2020-02-12, with *Target Milestone: mozilla75*.