### PR TITLE
Firefox 74 updates for TextMetrics API

### DIFF
--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -49,6 +49,7 @@
       },
       "actualBoundingBoxAscent": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/actualBoundingBoxAscent",
           "support": {
             "chrome": [
               {
@@ -120,6 +121,7 @@
       },
       "actualBoundingBoxDescent": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/actualBoundingBoxDescent",
           "support": {
             "chrome": [
               {
@@ -191,6 +193,7 @@
       },
       "actualBoundingBoxLeft": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/actualBoundingBoxLeft",
           "support": {
             "chrome": [
               {
@@ -262,6 +265,7 @@
       },
       "actualBoundingBoxRight": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/actualBoundingBoxRight",
           "support": {
             "chrome": [
               {
@@ -333,6 +337,7 @@
       },
       "alphabeticBaseline": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/alphabeticBaseline",
           "support": {
             "chrome": {
               "version_added": true,
@@ -405,6 +410,7 @@
       },
       "emHeightAscent": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/emHeightAscent",
           "support": {
             "chrome": {
               "version_added": true,
@@ -477,6 +483,7 @@
       },
       "emHeightDescent": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/emHeightDescent",
           "support": {
             "chrome": {
               "version_added": true,
@@ -549,6 +556,7 @@
       },
       "fontBoundingBoxAscent": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/fontBoundingBoxAscent",
           "support": {
             "chrome": {
               "version_added": true,
@@ -621,6 +629,7 @@
       },
       "fontBoundingBoxDescent": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/fontBoundingBoxDescent",
           "support": {
             "chrome": {
               "version_added": true,
@@ -693,6 +702,7 @@
       },
       "hangingBaseline": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/hangingBaseline",
           "support": {
             "chrome": {
               "version_added": true,
@@ -765,6 +775,7 @@
       },
       "ideographicBaseline": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/ideographicBaseline",
           "support": {
             "chrome": {
               "version_added": true,

--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -84,12 +84,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false,
-              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+              "version_added": "74"
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -157,12 +155,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false,
-              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+              "version_added": "74"
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -230,12 +226,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false,
-              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+              "version_added": "74"
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -303,12 +297,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false,
-              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+              "version_added": "74"
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -370,12 +362,17 @@
               ]
             },
             "firefox": {
-              "version_added": false,
-              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+              "version_added": "74",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.textMetrics.baselines.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -437,12 +434,17 @@
               ]
             },
             "firefox": {
-              "version_added": false,
-              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+              "version_added": "74",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.textMetrics.emHeight.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -504,12 +506,17 @@
               ]
             },
             "firefox": {
-              "version_added": false,
-              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+              "version_added": "74",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.textMetrics.emHeight.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -571,12 +578,17 @@
               ]
             },
             "firefox": {
-              "version_added": false,
-              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+              "version_added": "74",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.textMetrics.fontBoundingBox.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -638,12 +650,17 @@
               ]
             },
             "firefox": {
-              "version_added": false,
-              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+              "version_added": "74",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.textMetrics.fontBoundingBox.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -705,12 +722,17 @@
               ]
             },
             "firefox": {
-              "version_added": false,
-              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+              "version_added": "74",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.textMetrics.baselines.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -772,12 +794,17 @@
               ]
             },
             "firefox": {
-              "version_added": false,
-              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+              "version_added": "74",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.textMetrics.baselines.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "Firefox does not implement this feature yet. See the related <a href='https://bugzil.la/1102584'>bug 1102584</a>."
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Bug https://bugzilla.mozilla.org/show_bug.cgi?id=1102584

Firefox 74 does

- enable by default:
  - actualBoundingBoxLeft
  - actualBoundingBoxRight
  - actualBoundingBoxAscent
  - actualBoundingBoxDescent
- ship behind "dom.textMetrics.fontBoundingBox.enabled" pref:
  - fontBoundingBoxAscent
  - fontBoundingBoxDescent
- ship behind "dom.textMetrics.emHeight.enabled" pref:
  - emHeightAscent
  - emHeightDescent
- ship behind "dom.textMetrics.baselines.enabled" pref:
  - hangingBaseline
  - alphabeticBaseline
  - ideographicBaseline

See also 
- https://dxr.mozilla.org/mozilla-central/source/dom/webidl/CanvasRenderingContext2D.webidl#356
- https://dxr.mozilla.org/mozilla-central/source/modules/libpref/init/StaticPrefList.yaml#2484

Edit: Also adds mdn_urls since these pages should be created.