### PR TITLE
Update FontFace API: display for Chromium Edge

### DIFF
--- a/api/FontFace.json
+++ b/api/FontFace.json
@@ -107,7 +107,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "80"
             },
             "firefox": {
               "version_added": "58"


### PR DESCRIPTION
Fixes https://github.com/Fyrd/caniuse/issues/5301. See the issue and links there for discussion.

However this PR is probably incomplete. 
Looking at <https://caniuse.com/#search=FontFace%20API> and the various features of FontFace API or rather <https://developer.mozilla.org/en-US/docs/Web/API/FontFace#Browser_compatibility> shows most/all features are likely supported since the earliest version (79?) of Chromium Edge, so probably every entry in `api/FontFace.json` needs updating?

@zachleat did test FontFace API: display [on Twitter](https://twitter.com/zachleat/status/1232796784717639686), but tests for every entry and earlier versions of Edge would be needed to be sure?

Feel free to hijack this PR.