### PR TITLE
Add version numbers to Opera/Samsung Internet for HPKP removal

### DIFF
--- a/http/headers/public-key-pins.json
+++ b/http/headers/public-key-pins.json
@@ -40,11 +40,11 @@
             },
             "opera": {
               "version_added": true,
-              "version_removed": true
+              "version_removed": "59"
             },
             "opera_android": {
               "version_added": true,
-              "version_removed": true
+              "version_removed": "51"
             },
             "safari": {
               "version_added": false
@@ -53,7 +53,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "11.0"
             },
             "webview_android": {
               "version_added": false
@@ -92,7 +93,7 @@
               },
               "opera": {
                 "version_added": "33",
-                "version_removed": true
+                "version_removed": "59"
               },
               "opera_android": {
                 "version_added": "33",

--- a/http/headers/public-key-pins.json
+++ b/http/headers/public-key-pins.json
@@ -40,7 +40,7 @@
             },
             "opera": {
               "version_added": true,
-              "version_removed": "59"
+              "version_removed": "60"
             },
             "opera_android": {
               "version_added": true,
@@ -93,7 +93,7 @@
               },
               "opera": {
                 "version_added": "33",
-                "version_removed": "59"
+                "version_removed": "60"
               },
               "opera_android": {
                 "version_added": "33",
@@ -106,7 +106,8 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": true,
+                "version_removed": "11.0"
               },
               "webview_android": {
                 "version_added": false


### PR DESCRIPTION
Quick follow-up to #5650 that adds the specific version numbers for the removal of HTTP Public Key Pinning in Opera, Opera Android, and Samsung Internet.