### PR TITLE
Added a feature for support of percentage values to text-underline-offset

### DIFF
--- a/css/properties/text-underline-offset.json
+++ b/css/properties/text-underline-offset.json
@@ -59,6 +59,54 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "percentage": {
+          "__compat": {
+            "description": "percentage values",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "74"
+              },
+              "firefox_android": {
+                "version_added": "74"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/text-underline-offset.json
+++ b/css/properties/text-underline-offset.json
@@ -77,7 +77,7 @@
                 "version_added": "74"
               },
               "firefox_android": {
-                "version_added": "74"
+                "version_added": false
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
- [Bugzilla bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1607534) for support in Firefox 74
- [Sprint issue](https://github.com/mdn/sprints/issues/2741) for adding to MDN

