### PR TITLE
MediaSession not yet supported on Firefox

### DIFF
--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -14,7 +14,7 @@
             "version_added": "≤79"
           },
           "firefox": {
-            "version_added": "71"
+            "version_added": false
           },
           "firefox_android": {
             "version_added": null
@@ -61,7 +61,7 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "71"
+              "version_added": false
             },
             "firefox_android": {
               "version_added": null
@@ -158,7 +158,7 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "71"
+              "version_added": false
             },
             "firefox_android": {
               "version_added": null


### PR DESCRIPTION
Testing on Firefox 73 and the tests are negative:

```
>> 'mediaSession' in navigator
<- false
```

A checklist to help your pull request get merged faster:
- [ ] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
