### PR TITLE
Add support data for KeyframeEffect.pseudoElement

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -869,6 +869,7 @@
               "deprecated": false
             }
           }
+        }
       },
       "attachShadow": {
         "__compat": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -798,6 +798,8 @@
             "support": {
               "chrome": {
                 "version_added": "81",
+                "partial_implementation": true,
+                "notes": "A valid animation object is returned but the targeted pseudoelement is not visually animated.",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/Element.json
+++ b/api/Element.json
@@ -791,7 +791,84 @@
               "deprecated": false
             }
           }
-        }
+        },
+        "pseudoElement_option": {
+          "__compat": {
+            "description": "<code>pseudoElement</code> option",
+            "support": {
+              "chrome": {
+                "version_added": "81",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              "chrome_android": {
+                "version_added": "81",
+                "partial_implementation": true,
+                "notes": "A valid animation object is returned but the targeted pseudoelement is not visually animated.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              "edge": {
+                "version_added": "81",
+                "partial_implementation": true,
+                "notes": "A valid animation object is returned but the targeted pseudoelement is not visually animated.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              "firefox": {
+                "version_added": "75"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "68",
+                "partial_implementation": true,
+                "notes": "A valid animation object is returned but the targeted pseudoelement is not visually animated.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
       },
       "attachShadow": {
         "__compat": {

--- a/api/KeyframeEffect.json
+++ b/api/KeyframeEffect.json
@@ -268,6 +268,78 @@
           }
         }
       },
+      "pseudoElement": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyframeEffect/pseudoElement",
+          "support": {
+            "chrome": {
+              "version_added": "81",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": "81",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
+            },
+            "edge": {
+              "version_added": "81",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
+            },
+            "firefox": {
+              "version_added": "75"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "68",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "setKeyframes": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyframeEffect/setKeyframes",

--- a/api/KeyframeEffect.json
+++ b/api/KeyframeEffect.json
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": true
           },
           "opera_android": {
-            "version_added": false
+            "version_added": true
           },
           "safari": {
             "version_added": false


### PR DESCRIPTION
I have added support data for the `KeyframeEffect.pseudoElement` property and its corresponding option in `Element.animate`. (These subfeatures are only relisted in this convenience method and not the object constructor.)

Spec: https://drafts.csswg.org/web-animations/#ref-for-dom-keyframeeffect-pseudoelement
Test: https://jsbin.com/pikusil/edit?html,css,js,console,output

### Firefox ###

Firefox adds support without a flag in version 75. See bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1610981. Tested in Nightly.

### Chrome Desktop ###

Chrome adds support behind the experimental web platform features flag in version 81. See bug: https://bugs.chromium.org/p/chromium/issues/detail?id=981894. Tested absent in 80, present in 81. In all present versions including Canary, a correct animation object is returned and the originating element is not animated as expected, however the pseudoelement is not visually animated either. The subfeature is therefore marked as a partial implementation.

### Other Chromium ###

Mirrored for Chrome for Android, Edge and Opera from the Chrome data. Note that because this subfeature is recent and behind a flag, non-false entries couldn't be added for browsers like Samsung Internet Browser, Opera for Android, etc.

### IE & EdgeHTML ###

IE and EdgeHTML do not support the web animations API at all.

### Safari ###

Tested absent in Safari 13 and I see no relevant entry in the TP release notes.