### PR TITLE
Added Firefox support in 74 for text-underline-position

### DIFF
--- a/css/properties/text-underline-position.json
+++ b/css/properties/text-underline-position.json
@@ -15,7 +15,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "74"
             },
             "firefox_android": {
               "version_added": false
@@ -63,7 +63,7 @@
                 "version_removed": "79"
               },
               "firefox": {
-                "version_added": false
+                "version_added": "74"
               },
               "firefox_android": {
                 "version_added": false
@@ -160,7 +160,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": false
+                "version_added": "74"
               },
               "firefox_android": {
                 "version_added": false
@@ -208,7 +208,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": false
+                "version_added": "74"
               },
               "firefox_android": {
                 "version_added": false


### PR DESCRIPTION
Bugzilla bugs:
- [Implement CSS3 text module text-underline-position](https://bugzilla.mozilla.org/show_bug.cgi?id=770780)
- [Let CSS text-underline-position property ride the train to release](https://bugzilla.mozilla.org/show_bug.cgi?id=1606997)

GitHub
- [Corresponding sprint issue](https://github.com/mdn/sprints/issues/2741)

