### PR TITLE
Added a feature to text-underline-position for from-font keyword

### DIFF
--- a/css/properties/text-underline-position.json
+++ b/css/properties/text-underline-position.json
@@ -146,6 +146,54 @@
             }
           }
         },
+        "from-font": {
+          "__compat": {
+            "description": "<code>from-font</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "74"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
         "left_right": {
           "__compat": {
             "description": "<code>left</code> and <code>right</code>",

--- a/css/properties/text-underline-position.json
+++ b/css/properties/text-underline-position.json
@@ -188,8 +188,8 @@
               }
             },
             "status": {
-              "experimental": true,
-              "standard_track": false,
+              "experimental": false,
+              "standard_track": true,
               "deprecated": false
             }
           }

--- a/css/properties/text-underline-position.json
+++ b/css/properties/text-underline-position.json
@@ -15,7 +15,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "74"
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
- [Bugzilla comment](https://bugzilla.mozilla.org/show_bug.cgi?id=1607308#c1)
- Per chat with jkew, only Firefox supports from-font, as far as he knows.
