### PR TITLE
RelativeTimeFormat now in ECMA402; update spec URLs

### DIFF
--- a/javascript/builtins/intl/RelativeTimeFormat.json
+++ b/javascript/builtins/intl/RelativeTimeFormat.json
@@ -5,7 +5,7 @@
         "RelativeTimeFormat": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat",
-            "spec_url": "https://tc39.es/proposal-intl-relative-time/#relativetimeformat-objects",
+            "spec_url": "https://tc39.es/ecma402/#relativetimeformat-objects",
             "support": {
               "chrome": {
                 "version_added": "71"
@@ -56,7 +56,7 @@
           "RelativeTimeFormat": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/RelativeTimeFormat",
-              "spec_url": "https://tc39.es/proposal-intl-relative-time/#sec-intl-relativetimeformat-constructor",
+              "spec_url": "https://tc39.es/ecma402/#sec-intl-relativetimeformat-constructor",
               "description": "<code>RelativeTimeFormat()</code> constructor",
               "support": {
                 "chrome": {
@@ -109,7 +109,7 @@
           "format": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/format",
-              "spec_url": "https://tc39.es/proposal-intl-relative-time/#sec-Intl.RelativeTimeFormat.prototype.format",
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat.prototype.format",
               "support": {
                 "chrome": {
                   "version_added": "71"
@@ -161,7 +161,7 @@
           "formatToParts": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/formatToParts",
-              "spec_url": "https://tc39.es/proposal-intl-relative-time/#sec-Intl.RelativeTimeFormat.prototype.formatToParts",
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat.prototype.formatToParts",
               "support": {
                 "chrome": {
                   "version_added": "71"
@@ -213,7 +213,7 @@
           "resolvedOptions": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/resolvedOptions",
-              "spec_url": "https://tc39.es/proposal-intl-relative-time/#sec-intl.relativetimeformat.prototype.resolvedoptions",
+              "spec_url": "https://tc39.es/ecma402/#sec-intl.relativetimeformat.prototype.resolvedoptions",
               "support": {
                 "chrome": {
                   "version_added": "71"
@@ -315,7 +315,7 @@
           "supportedLocalesOf": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat/supportedLocalesOf",
-              "spec_url": "https://tc39.es/proposal-intl-relative-time/#sec-Intl.RelativeTimeFormat.supportedLocalesOf",
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat.supportedLocalesOf",
               "support": {
                 "chrome": {
                   "version_added": "71"


### PR DESCRIPTION
https://github.com/tc39/ecma402/pull/391 moved `RelativeTimeFormat` into the ECMA402 spec. This change updates the associated BCD spec URLs. https://github.com/tc39/ecma402/commit/c5417aa