### PR TITLE
Locale object now in ECMA402; update spec URLs

### DIFF
--- a/javascript/builtins/intl/Locale.json
+++ b/javascript/builtins/intl/Locale.json
@@ -5,7 +5,7 @@
         "Locale": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale",
-            "spec_url": "https://tc39.es/proposal-intl-locale/#locale-objects",
+            "spec_url": "https://tc39.es/ecma402/#locale-objects",
             "support": {
               "chrome": {
                 "version_added": "74"
@@ -57,7 +57,7 @@
             "__compat": {
               "description": "<code>Locale()</code> constructor",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/Locale",
-              "spec_url": "https://tc39.es/proposal-intl-locale/#sec-intl-locale-constructor",
+              "spec_url": "https://tc39.es/ecma402/#sec-intl-locale-constructor",
               "support": {
                 "chrome": {
                   "version_added": "74"
@@ -109,7 +109,7 @@
           "baseName": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/baseName",
-              "spec_url": "https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.baseName",
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.Locale.prototype.baseName",
               "support": {
                 "chrome": {
                   "version_added": "74"
@@ -161,7 +161,7 @@
           "calendar": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/calendar",
-              "spec_url": "https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.calendar",
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.Locale.prototype.calendar",
               "support": {
                 "chrome": {
                   "version_added": "74"
@@ -213,7 +213,7 @@
           "caseFirst": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/caseFirst",
-              "spec_url": "https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.caseFirst",
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.Locale.prototype.caseFirst",
               "support": {
                 "chrome": {
                   "version_added": "74"
@@ -265,7 +265,7 @@
           "collation": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/collation",
-              "spec_url": "https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.collation",
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.Locale.prototype.collation",
               "support": {
                 "chrome": {
                   "version_added": "74"
@@ -317,7 +317,7 @@
           "hourCycle": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/hourCycle",
-              "spec_url": "https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.hourCycle",
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.Locale.prototype.hourCycle",
               "support": {
                 "chrome": {
                   "version_added": "74"
@@ -369,7 +369,7 @@
           "language": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/language",
-              "spec_url": "https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.language",
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.Locale.prototype.language",
               "support": {
                 "chrome": {
                   "version_added": "74"
@@ -421,7 +421,7 @@
           "maximize": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/maximize",
-              "spec_url": "https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.maximize",
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.Locale.prototype.maximize",
               "support": {
                 "chrome": {
                   "version_added": "74"
@@ -473,7 +473,7 @@
           "minimize": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/minimize",
-              "spec_url": "https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.minimize",
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.Locale.prototype.minimize",
               "support": {
                 "chrome": {
                   "version_added": "74"
@@ -525,7 +525,7 @@
           "numberingSystem": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/numberingSystem",
-              "spec_url": "https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.numberingSystem",
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.Locale.prototype.numberingSystem",
               "support": {
                 "chrome": {
                   "version_added": "74"
@@ -577,7 +577,7 @@
           "numeric": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/numeric",
-              "spec_url": "https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.numeric",
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.Locale.prototype.numeric",
               "support": {
                 "chrome": {
                   "version_added": "74"
@@ -629,7 +629,7 @@
           "region": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/region",
-              "spec_url": "https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.region",
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.Locale.prototype.region",
               "support": {
                 "chrome": {
                   "version_added": "74"
@@ -681,7 +681,7 @@
           "script": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/script",
-              "spec_url": "https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.script",
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.Locale.prototype.script",
               "support": {
                 "chrome": {
                   "version_added": "74"
@@ -733,7 +733,7 @@
           "toString": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Locale/toString",
-              "spec_url": "https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.toString",
+              "spec_url": "https://tc39.es/ecma402/#sec-Intl.Locale.prototype.toString",
               "support": {
                 "chrome": {
                   "version_added": "74"


### PR DESCRIPTION
https://github.com/tc39/ecma402/pull/406 moved the `Locale` object into the ECMA402 spec. This change updates the associated BCD spec URLs. https://github.com/tc39/ecma402/commit/4d1a24a
