### PR TITLE
[Chrome] Bug 979041: Implement `@supports selector(…)`

### DIFF
--- a/css/at-rules/supports.json
+++ b/css/at-rules/supports.json
@@ -80,16 +80,13 @@
             "description": "<code>selector()</code>",
             "support": {
               "chrome": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/979041'>bug 979041</a>."
+                "version_added": "82"
               },
               "chrome_android": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/979041'>bug 979041</a>."
+                "version_added": "82"
               },
               "edge": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/979041'>bug 979041</a>."
+                "version_added": "82"
               },
               "firefox": [
                 {
@@ -128,18 +125,19 @@
                 "notes": "See <a href='https://crbug.com/979041'>bug 979041</a>."
               },
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/199237'>bug 199237</a>"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/199237'>bug 199237</a>"
               },
               "samsunginternet_android": {
                 "version_added": false,
                 "notes": "See <a href='https://crbug.com/979041'>bug 979041</a>."
               },
               "webview_android": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/979041'>bug 979041</a>."
+                "version_added": "82"
               }
             },
             "status": {


### PR DESCRIPTION
This has been implemented in [bug 979041](https://bugs.chromium.org/p/chromium/issues/detail?id=979041) and is shipping on by default, but [Chrome Platform Status](https://www.chromestatus.com/feature/5555643303854080) has yet to be updated.

---

review?(@jpmedley)