### PR TITLE
Update firefox pref name for CSSPseudoElement

### DIFF
--- a/api/CSSPseudoElement.json
+++ b/api/CSSPseudoElement.json
@@ -15,7 +15,17 @@
           },
           "firefox": [
             {
+              "version_added": "75",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.css_pseudo_element.enabled"
+                }
+              ]
+            },
+            {
               "version_added": "63",
+              "version_removed": "75",
               "flags": [
                 {
                   "type": "preference",
@@ -98,7 +108,17 @@
             },
             "firefox": [
               {
+                "version_added": "75",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.css_pseudo_element.enabled"
+                  }
+                ]
+              },
+              {
                 "version_added": "67",
+                "version_removed": "75",
                 "flags": [
                   {
                     "type": "preference",
@@ -206,7 +226,17 @@
             },
             "firefox": [
               {
+                "version_added": "75",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.css_pseudo_element.enabled"
+                  }
+                ]
+              },
+              {
                 "version_added": "63",
+                "version_removed": "75",
                 "flags": [
                   {
                     "type": "preference",


### PR DESCRIPTION
To ship [`getAnimations()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getAnimations) as soon as possible, the CSSWG resolved to remove all references to [`CSSPseudoElement`](https://developer.mozilla.org/en-US/docs/Web/API/CSSPseudoElement) from the web animations specification, replaced instead with the `pseudoElement` parameter to compliment the now `Element`-only `target` parameter (compat data added in https://github.com/mdn/browser-compat-data/pull/5768). Please note that for now the interface itself remains defined in [CSS Pseudo-Elements Level 4](https://drafts.csswg.org/css-pseudo-4/#CSSPseudoElement-interface) and therefore on the standards track, however this is likely to change eventually: https://github.com/w3c/csswg-drafts/issues/4619.

Correspondingly, in Firefox 75, `CSSPseudoElement` is being split into its own preference, `dom.css_pseudo_element.enabled`. (No other browsers have implemented the interface yet.) This PR reflects that change.

- Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1610981
- Review: https://phabricator.services.mozilla.com/D63014

The new preference is definitely present for me in Nightly.