### PR TITLE
Update versions for HTML APIs

### DIFF
--- a/api/HTMLCollection.json
+++ b/api/HTMLCollection.json
@@ -5,40 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLCollection",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "8"
           },
           "opera": {
-            "version_added": true
+            "version_added": "8"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "10.1"
           },
           "safari": {
-            "version_added": true
+            "version_added": "4"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "3.2"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -20,25 +20,25 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "8"
           },
           "opera": {
-            "version_added": true
+            "version_added": "8"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "10.1"
           },
           "safari": {
-            "version_added": true
+            "version_added": "3"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -459,16 +459,16 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -507,28 +507,26 @@
               "version_added": "5"
             },
             "ie": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera": {
-              "version_added": true
+              "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
-              "version_added": "6",
-              "notes": "Before Safari 6, <code>click</code> is only defined on buttons and inputs."
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true,
-              "notes": "Before Safari 6, <code>click</code> is only defined on buttons and inputs."
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0",
               "notes": "Before Samsung Internet 1.5, <code>click</code> is only defined on buttons and inputs."
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "≤37",
               "notes": "Before Android WebView 4.4, <code>click</code> is only defined on buttons and inputs."
             }
           },
@@ -559,7 +557,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "5.5"
+              "version_added": "8"
             },
             "opera": {
               "version_added": "9"
@@ -666,13 +664,13 @@
               "version_added": "11"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "5.1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -860,16 +858,16 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1035,10 +1033,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/hidden",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1050,25 +1048,25 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "opera": {
-              "version_added": true
+              "version_added": "11.6"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12"
             },
             "safari": {
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1152,7 +1150,7 @@
               "version_added": "9.6"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"
@@ -1180,10 +1178,10 @@
           "description": "<code>input</code> event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": [
               {
@@ -1197,10 +1195,10 @@
               }
             ],
             "firefox": {
-              "version_added": true
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
               "version_added": "9",
@@ -1208,22 +1206,22 @@
               "notes": "Only supports <code>input</code> of type <code>text</code> and <code>password</code>."
             },
             "opera": {
-              "version_added": true
+              "version_added": "11.6"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari": {
-              "version_added": true
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1839,10 +1837,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetHeight",
           "support": {
             "chrome": {
-              "version_added": "47"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "47"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1854,25 +1852,25 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "47"
+              "version_added": "1"
             }
           },
           "status": {
@@ -1887,10 +1885,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetLeft",
           "support": {
             "chrome": {
-              "version_added": "47"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "47"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1902,25 +1900,25 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "47"
+              "version_added": "1"
             }
           },
           "status": {
@@ -1935,10 +1933,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetParent",
           "support": {
             "chrome": {
-              "version_added": "47"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "47"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1950,25 +1948,25 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "47"
+              "version_added": "1"
             }
           },
           "status": {
@@ -1983,10 +1981,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetTop",
           "support": {
             "chrome": {
-              "version_added": "47"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "47"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1998,25 +1996,25 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "47"
+              "version_added": "1"
             }
           },
           "status": {
@@ -2031,10 +2029,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetWidth",
           "support": {
             "chrome": {
-              "version_added": "47"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "47"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2046,25 +2044,25 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "47"
+              "version_added": "1"
             }
           },
           "status": {
@@ -3024,26 +3022,25 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true,
-              "notes": "Returns <code>CSS2Properties</code>, rather than <code>CSSStyleDeclaration</code>."
+              "version_added": "1"
             },
             "firefox_android": {
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -3086,7 +3083,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "7",
+              "version_added": "8",
               "partial_implementation": true,
               "notes": "Returns incorrect value for elements without an explicit tabindex attribute. See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/4365703/'>issue 4365703</a> for details."
             },
@@ -3224,7 +3221,7 @@
               },
               {
                 "alternative_name": "webkitTransitionEnd",
-                "version_added": true
+                "version_added": "1"
               }
             ],
             "chrome_android": [
@@ -3233,7 +3230,7 @@
               },
               {
                 "alternative_name": "webkitTransitionEnd",
-                "version_added": true
+                "version_added": "18"
               }
             ],
             "edge": [
@@ -3252,39 +3249,61 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": [
               {
-                "version_added": "15"
+                "version_added": "12.1"
               },
               {
                 "alternative_name": "webkitTransitionEnd",
-                "version_added": true
+                "version_added": "15"
+              },
+              {
+                "alternative_name": "oTransitionEnd",
+                "version_added": "11.6",
+                "version_removed": "15"
               }
             ],
             "opera_android": [
               {
-                "version_added": "14"
+                "version_added": "12.1"
               },
               {
                 "alternative_name": "webkitTransitionEnd",
-                "version_added": true
+                "version_added": "14"
+              },
+              {
+                "alternative_name": "oTransitionEnd",
+                "version_added": "12",
+                "version_removed": "14"
               }
             ],
-            "safari": {
-              "version_added": true
-            },
-            "safari_ios": {
-              "version_added": true
-            },
+            "safari": [
+              {
+                "version_added": "6.1"
+              },
+              {
+                "alternative_name": "webkitTransitionEnd",
+                "version_added": "4"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "7"
+              },
+              {
+                "alternative_name": "webkitTransitionEnd",
+                "version_added": "3.2"
+              }
+            ],
             "samsunginternet_android": [
               {
                 "version_added": "1.5"
               },
               {
                 "alternative_name": "webkitTransitionEnd",
-                "version_added": true
+                "version_added": "1.0"
               }
             ],
             "webview_android": [
@@ -3293,7 +3312,7 @@
               },
               {
                 "alternative_name": "webkitTransitionEnd",
-                "version_added": true
+                "version_added": "1"
               }
             ]
           },

--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFormElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -17,28 +17,28 @@
             "version_added": "1"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "9"
           },
           "opera": {
-            "version_added": true
+            "version_added": "8"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "10.1"
           },
           "safari": {
-            "version_added": true
+            "version_added": "3"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -244,40 +244,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFormElement/elements",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -774,40 +774,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFormElement/reset",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -920,40 +920,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFormElement/submit_event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -322,40 +322,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/contentWindow",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -8,7 +8,7 @@
             "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -20,25 +20,25 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "8"
           },
           "opera": {
-            "version_added": true
+            "version_added": "8"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "10.1"
           },
           "safari": {
-            "version_added": true
+            "version_added": "3"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -53,37 +53,37 @@
           "description": "<code>Image()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "31"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -248,7 +248,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "5",
+              "version_added": "8",
               "notes": "IE reports <code>false</code> for broken images."
             },
             "opera": {

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLInputElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -20,25 +20,25 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "8"
           },
           "opera": {
-            "version_added": true
+            "version_added": "8"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "10.1"
           },
           "safari": {
-            "version_added": true
+            "version_added": "3"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -1294,7 +1294,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1303,7 +1303,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -1312,19 +1312,19 @@
               "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "qq_android": {
               "version_added": null
             },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "uc_android": {
               "version_added": null
@@ -1333,7 +1333,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -4,24 +4,12 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement",
         "support": {
-          "chrome": [
-            {
-              "version_added": "42"
-            },
-            {
-              "version_added": "1",
-              "prefix": "webkit"
-            }
-          ],
-          "chrome_android": [
-            {
-              "version_added": "42"
-            },
-            {
-              "version_added": "18",
-              "prefix": "webkit"
-            }
-          ],
+          "chrome": {
+            "version_added": "1"
+          },
+          "chrome_android": {
+            "version_added": "18"
+          },
           "edge": {
             "version_added": "12"
           },
@@ -29,41 +17,29 @@
             "version_added": "3.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"
           },
           "opera": {
-            "version_added": true
+            "version_added": "10.5"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "11"
           },
           "safari": {
-            "version_added": true
+            "version_added": "3.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "2"
           },
-          "samsunginternet_android": [
-            {
-              "version_added": "4.0"
-            },
-            {
-              "prefix": "webkit",
-              "version_added": "1.0"
-            }
-          ],
-          "webview_android": [
-            {
-              "version_added": "42"
-            },
-            {
-              "version_added": true,
-              "prefix": "webkit"
-            }
-          ]
+          "samsunginternet_android": {
+            "version_added": "1.0"
+          },
+          "webview_android": {
+            "version_added": "1"
+          }
         },
         "status": {
           "experimental": false,
@@ -2466,10 +2442,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/play",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2478,28 +2454,28 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -3419,7 +3395,7 @@
             },
             "firefox": [
               {
-                "version_added": true,
+                "version_added": "42",
                 "partial_implementation": true,
                 "notes": "Currently only supports <code>MediaStream</code> objects."
               },
@@ -3431,7 +3407,7 @@
             ],
             "firefox_android": [
               {
-                "version_added": true,
+                "version_added": "42",
                 "partial_implementation": true,
                 "notes": "Currently only supports <code>MediaStream</code> objects."
               },
@@ -3442,7 +3418,7 @@
               }
             ],
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "39",
@@ -3455,7 +3431,10 @@
               "notes": "Currently only supports <code>MediaStream</code> objects."
             },
             "safari": {
-              "version_added": true
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
             },
             "samsunginternet_android": {
               "partial_implementation": true,

--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -33,7 +33,7 @@
             "version_added": "1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -293,10 +293,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/checkValidity",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -311,22 +311,22 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1015,40 +1015,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/selectedOptions",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "19"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "26"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "26"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/HTMLTableElement.json
+++ b/api/HTMLTableElement.json
@@ -678,6 +678,9 @@
             "chrome": {
               "version_added": "4"
             },
+            "chrome_android": {
+              "version_added": "18"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -696,16 +699,19 @@
               "version_added": "10"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3.2"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -5,40 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
-            "version_added": null
+            "version_added": "8"
           },
           "opera": {
-            "version_added": true
+            "version_added": "8"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "10.1"
           },
           "safari": {
-            "version_added": true
+            "version_added": "3"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {


### PR DESCRIPTION
This PR sets and updates the version numbers for various portions of the HTML APIs based upon manual testing. The data is as follows:

	api.HTMLCollection
		- Chrome - 1
		- Firefox - 1
		- IE - 8
		- Opera - 8
		- Safari - 4
	api.HTMLElement
		- IE - 8
		- Opera - 8
		- Safari - 3
	api.HTMLElement.blur
		- Opera - 8
		- Safari - incorrect data, 3
	api.HTMLElement.click
		- IE - 8
		- Opera - 10.5
	api.HTMLElement.dataset
		- Safari - incorrect data, 5.1
	api.HTMLElement.focus
		- Opera - incorrect data, 8
		- Safari - incorrect data, 3
	api.HTMLElement.hidden
		- Chrome - 6
		- IE - 11
		- Opera - 11.1
	api.HTMLElement.innerText
		- Sufficient Data, Mirrored to Other Browsers
	api.HTMLElement.input_event
		- Chrome - 1
		- Firefox - 6
		- Opera - 11.6
		- Safari - 3.1
	api.HTMLElement.offsetHeight
		- Chrome - incorrect data, 1
		- IE - 8
		- Opera - 8
		- Safari - incorrect data, 3
	api.HTMLElement.offsetLeft
		- Chrome - incorrect data, 1
		- IE - 8
		- Opera - 8
		- Safari - incorrect data, 3
	api.HTMLElement.offsetParent
		- Chrome - incorrect data, 1
		- IE - 8
		- Opera - 8
		- Safari - incorrect data, 3
	api.HTMLElement.offsetTop
		- Chrome - incorrect data, 1
		- IE - 8
		- Opera - 8
		- Safari - incorrect data, 3
	api.HTMLElement.offsetWidth
		- Chrome - incorrect data, 1
		- IE - 8
		- Opera - 8
		- Safari - incorrect data, 3
	api.HTMLElement.style
		- Firefox - 1 (existing note is not valid)
		- IE - 8
		- Opera - 8
	api.HTMLElement.transitionend_event
		- Chrome - 26 (1 as webkitTransitionEnd)
		- IE - 10
		- Opera - 12.1 (11.6 as oTransitionEnd)
		- Safari - 6.1 (4 as webkitTransitionEnd)
	api.HTMLFormElement
		- Chrome - 1
		- IE - 9
		- Opera - 8
		- Safari - 3
	api.HTMLFormElement.elements
		- Chrome - 1
		- Firefox - 1
		- IE - 9
		- Opera - 8
		- Safari - 3
	api.HTMLFormElement.reset
		- Chrome - 1
		- Firefox - 1
		- IE - 9
		- Opera - 8
		- Safari - 3
	api.HTMLFormElement.submit_event
		- Chrome - 1
		- Firefox - 1
		- IE - 9
		- Opera - 8
		- Safari - 3
	api.HTMLIFrameElement.contentWindow
		- Chrome - incorrect data, 1
		- Firefox - 1
		- IE - 8
		- Opera - 8
		- Safari - incorrect data, 3
	api.HTMLImageElement
		- IE - 8
		- Opera - 8
		- Safari - 3
	api.HTMLImageElement.Image
		- Chrome - incorrect data, 1
		- Firefox - 1
		- IE - 8
		- Opera - 8
		- Safari - 3
	api.HTMLInputElement
		- Chrome - 1
		- IE - 8
		- Opera - 8
		- Safari - 3
	api.HTMLInputElement.select
		- No BCD
	api.HTMLInputElement.setSelectionRange
		- Safari - 3
	api.HTMLMediaElement
		- Chrome - incorrect data, 1 (prefix not supported)
		- Opera - 10.5
		- Safari - 3.1
	api.HTMLMediaElement.play
		- Chrome - 1
		- Opera - 10.5
	api.HTMLMediaElement.srcObject
		- Firefox - 42
		- IE - false
		- Safari - false
	api.HTMLOptionElement.option
		- No BCD
	api.HTMLSelectElement
		- IE - incorrect data, 8
	api.HTMLSelectElement.checkValidity
		- Chrome - 4
		- Opera - 9
		- Safari - 5
	api.HTMLSelectElement.selectedOptions
		- Chrome - 19
		- Firefox - 26
		- Opera - 9
		- Safari - 6
	api.HTMLTableElement.insertRow
		- Sufficient Data, Mirrored to Other Browsers
	api.HTMLTextAreaElement
		- Chrome - 1
		- Firefox - 1
		- IE - 8
		- Opera - 8
		- Safari - 3

Note: I've seen references to element features in versions of Internet Explorer such as 5.5, before the `HTMLElement` API even existed, or from my research, any way to even get an element through JavaScript.  As such, I've bumped everything that was set to IE versions before `8`.  If anyone seeing this knows how I can test this in IE better, please let me know!