### PR TITLE
Samsung Internet does not support Web Auth yet

### DIFF
--- a/api/AuthenticatorAssertionResponse.json
+++ b/api/AuthenticatorAssertionResponse.json
@@ -50,7 +50,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "10.0"
+            "version_added": false
           },
           "webview_android": {
             "version_added": "70"
@@ -112,7 +112,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": "70"
@@ -175,7 +175,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": "70"
@@ -238,7 +238,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": "70"

--- a/api/AuthenticatorResponse.json
+++ b/api/AuthenticatorResponse.json
@@ -50,7 +50,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "10.0"
+            "version_added": false
           },
           "webview_android": {
             "version_added": "70"
@@ -112,7 +112,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": "70"

--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -50,7 +50,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "10.0"
+            "version_added": false
           },
           "webview_android": {
             "version_added": "70"
@@ -112,7 +112,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": "70"
@@ -175,7 +175,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": "70"
@@ -238,7 +238,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": "70"
@@ -301,7 +301,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": "70"

--- a/api/PublicKeyCredentialCreationOptions.json
+++ b/api/PublicKeyCredentialCreationOptions.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": "9.0"
+            "version_added": false
           },
           "webview_android": {
             "version_added": false
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "9.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "9.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -178,7 +178,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "9.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -226,7 +226,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "9.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -274,7 +274,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "9.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -322,7 +322,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "9.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -370,7 +370,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "9.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -418,7 +418,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "9.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -466,7 +466,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "9.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/PublicKeyCredentialRequestOptions.json
+++ b/api/PublicKeyCredentialRequestOptions.json
@@ -35,7 +35,7 @@
             "version_added": null
           },
           "samsunginternet_android": {
-            "version_added": "9.0"
+            "version_added": false
           },
           "webview_android": {
             "version_added": "67"
@@ -82,7 +82,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "9.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": "67"
@@ -130,7 +130,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "9.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": "67"
@@ -178,7 +178,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "9.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": "67"
@@ -226,7 +226,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "9.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": "67"
@@ -274,7 +274,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "9.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": "67"
@@ -322,7 +322,7 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": "9.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": "67"


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [ ] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any

Samsung Internet does not support Web Authentication yet, we're working on it.

Tested in the latest version of Samsung Internet on https://webauthn.bin.coffee/
