### PR TITLE
Add Safari support for text-underline-position

### DIFF
--- a/css/properties/text-underline-position.json
+++ b/css/properties/text-underline-position.json
@@ -30,7 +30,7 @@
               "version_added": "20"
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
               "version_added": false
@@ -271,7 +271,7 @@
                 "version_added": "20"
               },
               "safari": {
-                "version_added": false
+                "version_added": "12.1"
               },
               "safari_ios": {
                 "version_added": false

--- a/css/properties/text-underline-position.json
+++ b/css/properties/text-underline-position.json
@@ -29,9 +29,16 @@
             "opera_android": {
               "version_added": "20"
             },
-            "safari": {
-              "version_added": "12.1"
-            },
+            "safari": [
+                {
+                "version_added": "12.1"
+                },
+                {
+                "prefix": "-webkit",
+                "version_added": "9"
+                }
+            ]
+              
             "safari_ios": {
               "version_added": false
             },

--- a/css/properties/text-underline-position.json
+++ b/css/properties/text-underline-position.json
@@ -30,15 +30,14 @@
               "version_added": "20"
             },
             "safari": [
-                {
+              {
                 "version_added": "12.1"
-                },
-                {
+              },
+              {
                 "prefix": "-webkit",
                 "version_added": "9"
-                }
-            ]
-              
+              }
+            ],
             "safari_ios": {
               "version_added": false
             },


### PR DESCRIPTION
- [Webkit changeset](https://trac.webkit.org/changeset/237835/webkit); the comments for the changeset indicate it includes unprefixing text-underline-position, and that `left` and `right` are _not_ supported.
- That changeset was included in [STP 70](https://webkit.org/blog/8496/release-notes-for-safari-technology-preview-70/), which went into [Safari 12.1](https://webkit.org/blog/8718/new-webkit-features-in-safari-12-1/)
- The value of "9" for the prefixed feature is a little bit of a guess. It was implemented in [January 2016](https://trac.webkit.org/changeset/194500/webkit).
