### PR TITLE
getDisplayMedia not supported on Opera Mobile

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -276,7 +276,7 @@
                 "version_added": null
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": false

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -225,7 +225,7 @@
               "version_added": null
             },
             "opera_android": {
-              "version_added": true
+              "version_added": false
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
Wasn't able to find an official resource confirming the lack of support for this, but I tried it and it doesn't work (the promise rejects right away like Chrome), Chromium itself doesn't have support for this API on android, and I found a user complaining on [stackoverflow](https://stackoverflow.com/a/58879212/5253155) about the same thing, so I believe that the data stating that getDisplayMedia is supported on Opera Android is a mistake.

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
