### PR TITLE
Update versions for Window API

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -20,25 +20,25 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "4"
           },
           "opera": {
-            "version_added": true
+            "version_added": "3"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "10.1"
           },
           "safari": {
-            "version_added": true
+            "version_added": "1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -56,7 +56,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -74,19 +74,19 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -198,46 +198,46 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/alert",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Starting with Chrome 46, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "notes": "Starting with Chrome 46, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera": {
-              "version_added": true,
-              "notes": "Starting with Opera 53, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
+              "version_added": "3",
+              "notes": "Starting with Opera 33, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
             },
             "opera_android": {
-              "version_added": true,
-              "notes": "Starting with Opera 53, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
+              "version_added": "10.1",
+              "notes": "Starting with Opera 33, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "notes": "Starting with Samsung Internet 5.0, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "Starting with Chrome 46, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
+              "version_added": "1",
+              "notes": "Starting with WebView 46, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
             }
           },
           "status": {
@@ -591,7 +591,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -609,19 +609,19 @@
               "version_added": "12"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12"
             },
             "safari": {
               "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1195,33 +1195,33 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Starting in Firefox 46.0.1, <code>Window.close()</code> can no longer close windows that weren't opened by the same script. This is a security precaution."
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "4",
               "notes": "Starting in Firefox 46.0.1, <code>Window.close()</code> can no longer close windows that weren't opened by the same script. This is a security precaution."
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1236,45 +1236,45 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/confirm",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Starting with Chrome 46, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "notes": "Starting with Chrome 46, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera": {
-              "version_added": true,
-              "notes": "In Opera, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
+              "version_added": "3",
+              "notes": "Starting with Opera 33, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
             },
             "opera_android": {
-              "version_added": true,
-              "notes": "In Opera, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
+              "version_added": "10.1",
+              "notes": "Starting with Opera 33, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "notes": "Starting with Samsung Internet 5.0, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Starting with Chrome 46, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
             }
           },
@@ -1893,40 +1893,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/devicePixelRatio",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "49"
+              "version_added": "18"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "ie": {
               "version_added": "11"
             },
             "opera": {
-              "version_added": "41"
+              "version_added": "11.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari": {
-              "version_added": "9.1"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "9.3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -2086,10 +2086,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2117,25 +2117,25 @@
               ]
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera": {
-              "version_added": true
+              "version_added": "7"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -2711,42 +2711,42 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/getComputedStyle",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Before version 62 this function returned <code>null</code> when called on a Window with no presentation (e.g. an iframe with <code>display: none;</code> set). Since 62 it returns a <code>CSSStyleDeclaration</code> object with <code>length</code> 0, containing empty strings (<a href='https://bugzil.la/1467722'>bug 1467722</a>; also see <a href='https://bugzil.la/1471231'>bug 1471231</a> for further work)."
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "4",
               "notes": "Before version 62 this function returned <code>null</code> when called on a Window with no presentation (e.g. an iframe with <code>display: none;</code> set). Since 62 it returns a <code>CSSStyleDeclaration</code> object with <code>length</code> 0, containing empty strings (<a href='https://bugzil.la/1467722'>bug 1467722</a>; also see <a href='https://bugzil.la/1471231'>bug 1471231</a> for further work)."
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "7.2"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -2905,42 +2905,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/getSelection",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "55",
-              "notes": "No support for selection events."
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera_android": {
-              "version_added": "37"
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "5.1",
-              "notes": "No support for selection start."
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -3053,40 +3051,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/history",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "4"
             },
             "opera": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -3153,7 +3151,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -3191,13 +3189,13 @@
               "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -3215,7 +3213,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -3253,13 +3251,13 @@
               "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -3468,40 +3466,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/load_event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -3519,7 +3517,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -3528,7 +3526,7 @@
               "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "8"
@@ -3546,10 +3544,10 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -3564,42 +3562,42 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/location",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Before Firefox 57, single quotes contained in URLs were escaped when accessed via URL APIs. See <a href='https://bugzil.la/1386683'>bug 1386683</a>."
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "4",
               "notes": "Before Firefox 57, single quotes contained in URLs were escaped when accessed via URL APIs. See <a href='https://bugzil.la/1386683'>bug 1386683</a>."
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -3713,7 +3711,7 @@
               "version_added": "9"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -3740,10 +3738,10 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -4337,40 +4335,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/navigator",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -5675,40 +5673,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/open",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -5819,40 +5817,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/opener",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -6206,40 +6204,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/pageYOffset",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -6254,40 +6252,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/parent",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -6546,11 +6544,11 @@
           "support": {
             "chrome": {
               "version_added": "5",
-              "notes": "Chrome used to emit a <code>popstate</code> event on page load, but since version 34 no longer does."
+              "notes": "Before version 34, Chrome would fire a <code>popstate</code> event on page load."
             },
             "chrome_android": {
               "version_added": "18",
-              "notes": "Chrome used to emit a <code>popstate</code> event on page load, but since version 34 no longer does."
+              "notes": "Before version 34, Chrome would fire a <code>popstate</code> event on page load."
             },
             "edge": {
               "version_added": "12"
@@ -6574,18 +6572,19 @@
             },
             "safari": {
               "version_added": "6",
-              "notes": "Safari used to emit a <code>popstate</code> event on page load, but since version 10.0 no longer does."
+              "notes": "Before version 10, Safari would fire a <code>popstate</code> event on page load."
             },
             "safari_ios": {
               "version_added": "5.1",
-              "notes": "Safari used to emit a <code>popstate</code> event on page load, but since version 10.0 no longer does."
+              "notes": "Before version 10, Safari would fire a <code>popstate</code> event on page load."
             },
             "samsunginternet_android": {
               "version_added": "1.0",
-              "notes": "Samsung Internet used to emit a <code>popstate</code> event on page load, but since Samsung Internet 2.0 no longer does."
+              "notes": "Before version 2.0, Samsung Internet would fire a <code>popstate</code> event on page load."
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37",
+              "notes": "Before version 37, WebView would fire a <code>popstate</code> event on page load."
             }
           },
           "status": {
@@ -6603,7 +6602,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -6618,7 +6617,7 @@
                 "notes": "The <code>message</code> parameter is serialized using the <a href='https://developer.mozilla.org/docs/Web/API/Web_Workers_API/Structured_clone_algorithm'>structured clone algorithm</a>. This means you can pass a broad variety of data objects safely to the destination window without having to serialize them yourself."
               },
               {
-                "version_added": true,
+                "version_added": "3",
                 "version_removed": "6",
                 "notes": "The <code>message</code> parameter must be a string."
               }
@@ -6633,7 +6632,7 @@
                 "notes": "The <code>message</code> parameter is serialized using the <a href='https://developer.mozilla.org/docs/Web/API/Web_Workers_API/Structured_clone_algorithm'>structured clone algorithm</a>. This means you can pass a broad variety of data objects safely to the destination window without having to serialize them yourself."
               },
               {
-                "version_added": true,
+                "version_added": "4",
                 "version_removed": "6",
                 "notes": "The <code>message</code> parameter must be a string."
               }
@@ -6653,20 +6652,19 @@
               "version_added": "9.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": true,
-              "notes": "For security reasons, to work properly on Safari, construct using <code>document.getElementById('your-frame').contentWindow</code>."
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -6729,17 +6727,18 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/print",
           "support": {
             "chrome": {
-              "version_added": true,
-              "notes": "Starting with Chrome 46.0 this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
+              "version_added": "1",
+              "notes": "Starting with Chrome 46, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18",
+              "notes": "Starting with Chrome 46, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
               "version_added": false,
@@ -6749,22 +6748,26 @@
               "version_added": "5"
             },
             "opera": {
-              "version_added": true
+              "version_added": "6",
+              "notes": "Starting with Opera 33, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1",
+              "notes": "Starting with Opera 33, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
             },
             "safari": {
-              "version_added": true
+              "version_added": "1.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0",
+              "notes": "Starting with Samsung Internet 5.0, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1",
+              "notes": "Starting with WebView 46, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
             }
           },
           "status": {
@@ -6779,42 +6782,47 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/prompt",
           "support": {
             "chrome": {
-              "version_added": true,
-              "notes": "Starting with Chrome 46.0 this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
+              "version_added": "1",
+              "notes": "Starting with Chrome 46, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18",
+              "notes": "Starting with Chrome 46, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": true,
+              "version_added": "4",
               "notes": "This function has no effect in the Modern UI/Metro version of Internet Explorer for Windows 8. It does not display a prompt to the user, and always returns <code>undefined</code>. It is not clear whether this is a bug or intended behavior. Desktop versions of IE do implement this function."
             },
             "opera": {
-              "version_added": true
+              "version_added": "3",
+              "notes": "Starting with Opera 33, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1",
+              "notes": "Starting with Opera 33, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0",
+              "notes": "Starting with Samsung Internet 5.0, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1",
+              "notes": "Starting with WebView 46, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
             }
           },
           "status": {
@@ -7001,9 +7009,8 @@
                 "version_added": "15"
               },
               {
-                "version_added": true,
-                "version_removed": "15",
-                "prefix": "o"
+                "version_added": "15",
+                "prefix": "webkit"
               }
             ],
             "opera_android": [
@@ -7011,9 +7018,8 @@
                 "version_added": "14"
               },
               {
-                "version_added": true,
-                "version_removed": "14",
-                "prefix": "o"
+                "version_added": "14",
+                "prefix": "webkit"
               }
             ],
             "safari": [
@@ -7043,9 +7049,15 @@
                 "version_added": "1.0"
               }
             ],
-            "webview_android": {
-              "version_added": true
-            }
+            "webview_android": [
+              {
+                "version_added": "≤37"
+              },
+              {
+                "version_added": "≤37",
+                "prefix": "webkit"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -7196,7 +7208,7 @@
               "version_added": "34"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "34"
             },
             "safari": {
               "version_added": false
@@ -7224,48 +7236,48 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/resize_event",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "1",
               "notes": "Chrome does not emit a <code>resize</code> event on page load."
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "18",
               "notes": "Chrome does not emit a <code>resize</code> event on page load."
             },
             "edge": {
               "version_added": "12",
-              "notes": "Edge does not emit a <code>resize</code> event on page load since Edge 79."
+              "notes": "Prior to Edge 79, Edge emitted a <code>resize</code> event on page load. This is no longer the case."
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Prior to Firefox 68, Firefox emitted a <code>resize</code> event on page load. This is no longer the case."
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "4",
               "notes": "Prior to Firefox 68, Firefox emitted a <code>resize</code> event on page load. This is no longer the case."
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera": {
-              "version_added": "32",
+              "version_added": "7",
               "notes": "Opera does not emit a <code>resize</code> event on page load."
             },
             "opera_android": {
-              "version_added": "32",
+              "version_added": "10.1",
               "notes": "Opera does not emit a <code>resize</code> event on page load."
             },
             "safari": {
-              "version_added": true
+              "version_added": "1.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "5.0",
+              "version_added": "1.0",
               "notes": "Samsung Internet does not emit a <code>resize</code> event on page load."
             },
             "webview_android": {
-              "version_added": "45",
+              "version_added": "1",
               "notes": "Webview does not emit a <code>resize</code> event on page load."
             }
           },
@@ -7767,40 +7779,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/scroll",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "4"
             },
             "opera": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -7911,21 +7923,27 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/scrollBy",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
-            "edge": {
-              "version_added": "12",
-              "partial_implementation": true,
-              "notes": "Only <code>scrollBy(x-coord, y-coord)</code> is supported."
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "Only <code>scrollBy(x-coord, y-coord)</code> is supported."
+              }
+            ],
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11",
@@ -7933,22 +7951,22 @@
               "notes": "Only <code>scrollBy(x-coord, y-coord)</code> is supported."
             },
             "opera": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -8203,40 +8221,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/scrollTo",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -8468,19 +8486,19 @@
           "support": {
             "chrome": [
               {
-                "version_added": true
+                "version_added": "1"
               },
               {
-                "version_added": true,
+                "version_added": "1",
                 "alternative_name": "pageYOffset"
               }
             ],
             "chrome_android": [
               {
-                "version_added": true
+                "version_added": "18"
               },
               {
-                "version_added": true,
+                "version_added": "18",
                 "alternative_name": "pageYOffset"
               }
             ],
@@ -8495,82 +8513,77 @@
             ],
             "firefox": [
               {
-                "version_added": true
+                "version_added": "1"
               },
               {
-                "version_added": true,
+                "version_added": "1",
                 "alternative_name": "pageYOffset"
               }
             ],
             "firefox_android": [
               {
-                "version_added": true
+                "version_added": "4"
               },
               {
-                "version_added": true,
+                "version_added": "4",
                 "alternative_name": "pageYOffset"
               }
             ],
-            "ie": [
-              {
-                "version_added": false
-              },
-              {
-                "version_added": "9",
-                "alternative_name": "pageYOffset"
-              }
-            ],
+            "ie": {
+              "version_added": "9",
+              "alternative_name": "pageYOffset"
+            },
             "opera": [
               {
-                "version_added": true
+                "version_added": "9.6"
               },
               {
-                "version_added": true,
+                "version_added": "4",
                 "alternative_name": "pageYOffset"
               }
             ],
             "opera_android": [
               {
-                "version_added": true
+                "version_added": "10.1"
               },
               {
-                "version_added": null,
+                "version_added": "10.1",
                 "alternative_name": "pageYOffset"
               }
             ],
             "safari": [
               {
-                "version_added": true
+                "version_added": "1"
               },
               {
-                "version_added": true,
+                "version_added": "1",
                 "alternative_name": "pageYOffset"
               }
             ],
             "safari_ios": [
               {
-                "version_added": true
+                "version_added": "1"
               },
               {
-                "version_added": null,
+                "version_added": "1",
                 "alternative_name": "pageYOffset"
               }
             ],
             "samsunginternet_android": [
               {
-                "version_added": true
+                "version_added": "1.0"
               },
               {
-                "version_added": true,
+                "version_added": "1.0",
                 "alternative_name": "pageYOffset"
               }
             ],
             "webview_android": [
               {
-                "version_added": true
+                "version_added": "1"
               },
               {
-                "version_added": true,
+                "version_added": "1",
                 "alternative_name": "pageYOffset"
               }
             ]
@@ -8686,7 +8699,7 @@
               "version_added": "5"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -8695,7 +8708,7 @@
               "version_added": "2"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "8"
@@ -8713,10 +8726,10 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -9638,40 +9651,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/unload_event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This PR sets and updates the version numbers for various portions of the window API based upon manual testing. The data is as follows:

	api.Window
		- IE - 4
		- Opera - 3
		- Safari - 1
	api.Window.alert
		- Chrome - 1
		- Firefox - 1
		- IE - 4
		- Opera - 3
		- Safari - 1
	api.Window.beforeunload_event
		- Sufficient Data, Mirrered to Other Browsers
	api.Window.close
		- Firefox - 1
		- IE - 4
		- Opera - 3
		- Safari - 1
	api.Window.confirm
		- Chrome - 1
		- Firefox - 1
		- IE - 4
		- Opera - 3
		- Safari - 1
	api.Window.devicePixelRatio
		- Chrome - 1
		- Firefox - incorrect data, 18
		- Opera - incorrect data, 11.1
		- Safari - incorrect data, 3
	api.Window.DOMContentLoaded_event
		- Sufficient Data, Mirrored to Other Browsers
	api.Window.event
		- Chrome - 1
		- IE - 4
		- Opera - 7
		- Safari - 1.1
	api.Window.getComputedStyle
		- Chrome - 1
		- Firefox - 1
		- Opera - 7.2
		- Safari - 3
	api.Window.getSelection
		- Chrome - 1
		- Firefox - 1
		- Opera - 9
		- Safari - 1
	api.Window.history
		- Chrome - 1
		- Firefox - 1
		- Opera - 3
		- Safari - 1
	api.Window.innerHeight
		- Sufficient Data, Mirrored to Other Browsers
	api.Window.innerWidth
		- Sufficient Data, Mirrored to Other Browsers
	api.Window.load_event
		- Chrome - 1
		- Firefox - 1
		- IE - 4
		- Opera - 4
		- Safari - 1.3
	api.Window.localStorage
		- Sufficient Data, Mirrored to Other Browsers
	api.Window.location
		- Chrome - 1
		- Firefox - 1
		- IE - 4
		- Opera - 3
		- Safari - 1
	api.Window.matchMedia
		- Sufficient Data, Mirrored to Other Browsers
	api.Window.navigator
		- Chrome - 1
		- Firefox - 1
		- IE - 4
		- Opera - 3
		- Safari - 1
	api.Window.open
		- Chrome - 1
		- Firefox - 1
		- IE - 4
		- Opera - 3
		- Safari - 1
	api.Window.opener
		- Chrome - 1
		- Firefox - 1
		- IE - false
		- Opera - 3
		- Safari - 1
	api.Window.orientationchange_event
		- Chrome (Android) - not sure how I can get the version number for this
		- Opera (Android) - not sure how I can get the version number for this
		- Safari (iOS) - not sure how I can get the version number for this
	api.Window.pageYOffset
		- Chrome - 1
		- Firefox - 1
		- Opera - 3
		- Safari - 1
	api.Window.parent
		- Chrome - 1
		- Firefox - 1
		- Opera - 3
		- Safari - 1.3
	api.Window.popstate_event
		- Sufficient Data, Mirrored to Other Browsers
	api.Window.postMessage
		- Firefox - 3
		- Safari - 4 (note on Safari iOS was invalid)
	api.Window.print
		- Chrome - 1
		- Firefox - 1
		- Opera - 6
		- Safari - 1.1
	api.Window.prompt
		- Chrome - 1
		- Firefox - 1
		- IE - 4
		- Opera - 3
		- Safari - 1
	api.Window.requestAnimationFrame
		- Opera - Blink (not supported with "o" prefix as initially indicated)
	api.Window.requestIdleCallback
		- Sufficient Data, Mirrored to Other Browsers
	api.Window.resize_event
		- Chrome - incorrect data, 1
		- Firefox - 1
		- IE - 4
		- Opera - incorrect data, 7
		- Safari - 1.1
	api.Window.scroll
		- Chrome - 1
		- Firefox - 1
		- IE - 4
		- Opera - 3
		- Safari - 1
	api.Window.scrollBy
		- Chrome - 1
		- Firefox - 1
		- Opera - 3
		- Safari - 1
	api.Window.scrollTo
		- Chrome - 1
		- Firefox - 1
		- IE - 4
		- Opera - 4
		- Safari - 1
	api.Window.scrollY
		- Chrome - 1 (1 as pageYOffset)
		- Firefox - 1 (1 as pageYOffset)
		- Edge - 12 (12 as pageYOffset)
		- IE - false (9 as pageYOffset)
		- Opera - 9.6 (4 as pageYOffset)
		- Safari - 1 (1 as pageYOffset)
	api.Window.sessionStorage
		- Sufficient Data, Mirrored to Other Browsers
	api.Window.setImmediate
		- Sufficient Data, No Change
	api.Window.unload_event
		- Chrome - 1
		- Firefox - 1
		- IE - 4
		- Opera - 4
		- Safari - 3