### PR TITLE
Update versions for Worker APIs

### DIFF
--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -151,7 +151,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -160,7 +160,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": "4"
@@ -169,19 +169,19 @@
               "version_added": "12"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12"
             },
             "safari": {
               "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -256,7 +256,7 @@
               "version_added": "5"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -283,10 +283,10 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -52,10 +52,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/atob",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -90,22 +90,22 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -120,10 +120,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/btoa",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -150,22 +150,22 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1236,7 +1236,7 @@
               "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -1355,7 +1355,7 @@
               "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4"
             }
           },
           "status": {

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -32,7 +32,7 @@
             "version_added": "4"
           },
           "safari_ios": {
-            "version_added": "5.1"
+            "version_added": "3.2"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -246,40 +246,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/importScripts",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "4"
             },
             "firefox_android": {
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "10.6"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
-              "version_added": true
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR sets and updates the version numbers for various portions of the worker APIs based upon manual testing. The data is as follows:

	api.WindowEventHandlers.onbeforeunload
		- Sufficient Data, Mirrored to Other Browsers
	api.WindowEventHandlers.onhashchange
		- Sufficient Data, Mirrored to Other Browsers
	api.WindowEventHandlers.onpopstate
		- Sufficient Data, No Change
	api.WindowOrWorkerGlobalScope.atob
		- Chrome - 4
		- Opera - 10.5
		- Safari - 3
	api.WindowOrWorkerGlobalScope.btoa
		- Chrome - 4
		- Opera - 10.5
		- Safari - 3
	api.WindowOrWorkerGlobalScope.clearInterval
		- Sufficient Data, No Change
	api.WindowOrWorkerGlobalScope.clearTimeout
		- Sufficient Data, No Change
	api.WindowOrWorkerGlobalScope.fetch
		- Sufficient Data, No Change
	api.WindowOrWorkerGlobalScope.setInterval
		- Sufficient Data, Mirrored to Other Browsers
	api.WindowOrWorkerGlobalScope.setTimeout
		- Sufficient Data, Mirrored to Other Browsers
	api.Worker
		- Sufficient Data, No Change
	api.WorkerGlobalScope.importScripts
		- Chrome - 4
		- Firefox - 4
		- IE - 10
		- Opera - 10.6
		- Safari - 4