### PR TITLE
Update versions for XHR API

### DIFF
--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -17,7 +17,7 @@
             {
               "version_added": "12",
               "version_removed": "79",
-              "notes": "Implemented via <code>ActiveXObject</code>"
+              "notes": "Implemented via <code>ActiveXObject('Microsoft.XMLHTTP')</code>"
             }
           ],
           "firefox": {
@@ -32,26 +32,26 @@
             },
             {
               "version_added": "5",
-              "notes": "Implemented via <code>ActiveXObject</code>"
+              "notes": "Implemented via <code>ActiveXObject('Microsoft.XMLHTTP')</code>"
             }
           ],
           "opera": {
-            "version_added": true
+            "version_added": "8"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "10.1"
           },
           "safari": {
             "version_added": "1.2"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -79,15 +79,9 @@
             "firefox_android": {
               "version_added": true
             },
-            "ie": [
-              {
-                "version_added": "7"
-              },
-              {
-                "version_added": "5",
-                "notes": "Implemented via <code>ActiveXObject</code>"
-              }
-            ],
+            "ie": {
+              "version_added": "5"
+            },
             "opera": {
               "version_added": true
             },
@@ -233,15 +227,9 @@
               "version_added": "4",
               "notes": "Starting from Firefox 49, empty headers are returned as empty strings in case the preference <code>network.http.keep_empty_response_headers_as_empty_string</code> is set to <code>true</code>, defaulting to <code>false</code>. Before Firefox 49 empty headers had been ignored. Since Firefox 50 the preference defaults to <code>true</code>."
             },
-            "ie": [
-              {
-                "version_added": "7"
-              },
-              {
-                "version_added": "5",
-                "notes": "Implemented via <code>ActiveXObject</code>"
-              }
-            ],
+            "ie": {
+              "version_added": "5"
+            },
             "opera": {
               "version_added": true
             },
@@ -330,39 +318,33 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Starting from Firefox 49, empty headers are returned as empty strings in case the preference <code>network.http.keep_empty_response_headers_as_empty_string</code> is set to <code>true</code>, defaulting to <code>false</code>. Before Firefox 49 empty headers had been ignored. Since Firefox 50 the preference defaults to <code>true</code>."
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "4",
               "notes": "Starting from Firefox 49, empty headers are returned as empty strings in case the preference <code>network.http.keep_empty_response_headers_as_empty_string</code> is set to <code>true</code>, defaulting to <code>false</code>. Before Firefox 49 empty headers had been ignored. Since Firefox 50 the preference defaults to <code>true</code>."
             },
-            "ie": [
-              {
-                "version_added": "7"
-              },
-              {
-                "version_added": "5",
-                "notes": "Implemented via <code>ActiveXObject</code>"
-              }
-            ],
+            "ie": {
+              "version_added": "5"
+            },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -539,20 +521,19 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "7",
-              "notes": "Internet Explorer version 5 and 6 supported ajax calls using <code>ActiveXObject()</code>"
+              "version_added": "5"
             },
             "opera": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -582,39 +563,33 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Starting in Firefox 30, synchronous requests on the main thread have been deprecated due to their negative impact on performance and the user experience. Therefore, the <code>async</code> parameter may not be <code>false</code> except in a <code>Worker</code>."
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "4",
               "notes": "Starting in Firefox 30, synchronous requests on the main thread have been deprecated due to their negative impact on performance and the user experience. Therefore, the <code>async</code> parameter may not be <code>false</code> except in a <code>Worker</code>."
             },
-            "ie": [
-              {
-                "version_added": "7"
-              },
-              {
-                "version_added": "5",
-                "notes": "Implemented via <code>ActiveXObject</code>"
-              }
-            ],
+            "ie": {
+              "version_added": "5"
+            },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -750,22 +725,22 @@
               "version_added": "7"
             },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -827,40 +802,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/response",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "9"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "11.6"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12"
             },
             "safari": {
-              "version_added": true
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -875,41 +850,41 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/responseText",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": true,
-              "notes": "Before IE 10, the value of <code>XMLHttpRequest.responseText</code> could be read only once the request was complete."
+              "version_added": "5",
+              "notes": "Before Internet Explorer 10, the value of <code>XMLHttpRequest.responseText</code> could be read only once the request was complete."
             },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -945,13 +920,13 @@
               "version_added": "18"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "42"
             },
             "safari": {
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -1375,32 +1350,26 @@
             "firefox_android": {
               "version_added": "4"
             },
-            "ie": [
-              {
-                "version_added": "7"
-              },
-              {
-                "version_added": "5",
-                "notes": "Implemented via <code>ActiveXObject</code>"
-              }
-            ],
+            "ie": {
+              "version_added": "5"
+            },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1724,37 +1693,31 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
-            "ie": [
-              {
-                "version_added": "7"
-              },
-              {
-                "version_added": "5",
-                "notes": "Implemented via <code>ActiveXObject</code>"
-              }
-            ],
+            "ie": {
+              "version_added": "5"
+            },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1772,7 +1735,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1788,22 +1751,22 @@
               "notes": "Internet Explorer version 5 and 6 supported ajax calls using <code>ActiveXObject()</code>"
             },
             "opera": {
-              "version_added": true
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1870,7 +1833,7 @@
               "version_added": "29"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "29"
             },
             "edge": {
               "version_added": "12"
@@ -1879,7 +1842,7 @@
               "version_added": "12"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "ie": {
               "version_added": "8"
@@ -1903,16 +1866,16 @@
               }
             ],
             "safari": {
-              "version_added": true
+              "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -2024,10 +1987,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/withCredentials",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "3"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2048,19 +2011,19 @@
               "version_added": "12"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12"
             },
             "safari": {
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR sets and updates the version numbers for various portions of the XMLHttpRequest (XHR) API based upon manual testing. The data is as follows:

	api.XMLHttpRequest
		- IE - 7 (5 with ActiveXObject as Microsoft.XMLHTTP)
		- Opera - 8
	api.XMLHttpRequest.getResponseHeader
		- Firefox - 1
		- Opera - 8
	api.XMLHttpRequest.onreadystatechange
		- IE - marked as 7, but notes indicate support since 5 via ActiveXObject
		- Opera - 9
	api.XMLHttpRequest.open
		- Firefox - 1
		- Opera - 8
	api.XMLHttpRequest.readyState
		- Opera - 8
	api.XMLHttpRequest.response
		- Chrome - 9
		- Firefox - 6
		- Opera - 11.6
		- Safari - 5.1
	api.XMLHttpRequest.responseText
		- Chrome - 1
		- Firefox - 1
		- IE - 5
		- Safari - incorrect data, 1.2
		- Opera - 8
	api.XMLHttpRequest.responseType
		- Sufficient Data, Mirrored to Other Browsers
	api.XMLHttpRequest.send
		- Opera - 8
	api.XMLHttpRequest.setRequestHeader
		- Firefox - 1
		- Opera - 8
	api.XMLHttpRequest.status
		- Opera - 8
	api.XMLHttpRequest.timeout
		- Safari - 6.1
	api.XMLHttpRequest.withCredentials
		- Chrome - 3