### PR TITLE
refactor: Avoid `require(…)` of JSON files

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function load() {
       extra = load(fp);
     } else if (path.extname(fp) === '.json') {
       try {
-        extra = require(fp);
+        extra = JSON.parse(fs.readFileSync(fp, 'utf-8'));
       } catch (e) {}
     }
 

--- a/test/linter/test-browsers.js
+++ b/test/linter/test-browsers.js
@@ -1,4 +1,5 @@
 'use strict';
+const fs = require('fs');
 const path = require('path');
 const chalk = require('chalk');
 
@@ -117,7 +118,7 @@ function testBrowsers(filename) {
   const category =
     relativePath.includes(path.sep) && relativePath.split(path.sep)[0];
   /** @type {Identifier} */
-  const data = require(filename);
+  const data = JSON.parse(fs.readFileSync(filename, 'UTF-8'));
 
   if (!category) {
     console.warn(chalk.blackBright('  Browsers – Unknown category'));

--- a/test/linter/test-consistency.js
+++ b/test/linter/test-consistency.js
@@ -1,5 +1,5 @@
 'use strict';
-const path = require('path');
+const fs = require('fs');
 const compareVersions = require('compare-versions');
 const chalk = require('chalk');
 
@@ -354,7 +354,7 @@ class ConsistencyChecker {
  */
 function testConsistency(filename) {
   /** @type {Identifier} */
-  let data = require(filename);
+  const data = JSON.parse(fs.readFileSync(filename, 'UTF-8'));
 
   const checker = new ConsistencyChecker();
   const errors = checker.check(data);

--- a/test/linter/test-descriptions.js
+++ b/test/linter/test-descriptions.js
@@ -1,4 +1,5 @@
 const chalk = require('chalk');
+const fs = require('fs');
 
 /**
  * @typedef {import('../../types').Identifier} Identifier
@@ -80,7 +81,7 @@ function hasCorrectWebWorkersDescription(apiData, apiName, logger) {
  */
 function testDescriptions(filename) {
   /** @type {Identifier} */
-  const data = require(filename);
+  const data = JSON.parse(fs.readFileSync(filename, 'UTF-8'));
 
   /** @type {string[]} */
   const errors = [];

--- a/test/linter/test-prefix.js
+++ b/test/linter/test-prefix.js
@@ -1,4 +1,5 @@
 'use strict';
+const fs = require('fs');
 const path = require('path');
 const chalk = require('chalk');
 
@@ -68,7 +69,8 @@ function testPrefix(filename) {
   );
   const category =
     relativePath.includes(path.sep) && relativePath.split(path.sep)[0];
-  const data = require(filename);
+  /** @type {Identifier} */
+  const data = JSON.parse(fs.readFileSync(filename, 'UTF-8'));
   const errors = processData(data, category);
 
   if (errors.length) {

--- a/test/linter/test-real-values.js
+++ b/test/linter/test-real-values.js
@@ -1,4 +1,5 @@
 'use strict';
+const fs = require('fs');
 const path = require('path');
 const chalk = require('chalk');
 
@@ -89,7 +90,7 @@ function testRealValues(filename) {
   const category =
     relativePath.includes(path.sep) && relativePath.split(path.sep)[0];
   /** @type {Identifier} */
-  const data = require(filename);
+  const data = JSON.parse(fs.readFileSync(filename, 'UTF-8'));
 
   /** @type {string[]} */
   const errors = [];

--- a/test/linter/test-schema.js
+++ b/test/linter/test-schema.js
@@ -1,10 +1,15 @@
 'use strict';
+const fs = require('fs');
 const Ajv = require('ajv');
 const betterAjvErrors = require('better-ajv-errors');
 const path = require('path');
 const chalk = require('chalk');
 
 const ajv = new Ajv({ jsonPointers: true, allErrors: true });
+
+/**
+ * @typedef {import('../../types').Identifier} Identifier
+ */
 
 /**
  * @param {string} dataFilename
@@ -14,8 +19,11 @@ function testSchema(
   dataFilename,
   schemaFilename = './../../schemas/compat-data.schema.json',
 ) {
-  const schema = require(schemaFilename);
-  const data = require(dataFilename);
+  const schema = JSON.parse(
+    fs.readFileSync(path.resolve(__dirname, schemaFilename), 'UTF-8'),
+  );
+  /** @type {Identifier} */
+  const data = JSON.parse(fs.readFileSync(dataFilename, 'UTF-8'));
 
   const valid = ajv.validate(schema, data);
 

--- a/test/linter/test-versions.js
+++ b/test/linter/test-versions.js
@@ -1,4 +1,5 @@
 'use strict';
+const fs = require('fs');
 const compareVersions = require('compare-versions');
 const chalk = require('chalk');
 
@@ -129,7 +130,7 @@ function checkVersions(supportData, relPath, logger) {
  */
 function testVersions(filename) {
   /** @type {Identifier} */
-  const data = require(filename);
+  const data = JSON.parse(fs.readFileSync(filename, 'UTF-8'));
 
   /** @type {string[]} */
   const errors = [];


### PR DESCRIPTION
This avoids having to go through **Node’s** `require(…)` resolution algorithm.

It will also make eventual migration of the test files to [**ECMAScript Modules**](https://nodejs.org/api/esm.html) easier.