### PR TITLE
Update theme_experiment.json

### DIFF
--- a/webextensions/manifest/theme_experiment.json
+++ b/webextensions/manifest/theme_experiment.json
@@ -20,6 +20,11 @@
             "opera": {
               "version_added": false
             }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
           }
         },
         "colors": {
@@ -41,6 +46,11 @@
               "opera": {
                 "version_added": false
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
             }
           }
         },
@@ -63,6 +73,11 @@
               "opera": {
                 "version_added": false
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
             }
           }
         },
@@ -85,6 +100,11 @@
               "opera": {
                 "version_added": false
               }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
             }
           }
         }

--- a/webextensions/manifest/theme_experiment.json
+++ b/webextensions/manifest/theme_experiment.json
@@ -29,6 +29,7 @@
         },
         "colors": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme_experiment#Syntax",
             "support": {
               "chrome": {
                 "version_added": false
@@ -55,6 +56,7 @@
         },
         "images": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme_experiment#Syntax",
             "support": {
               "chrome": {
                 "version_added": false
@@ -81,6 +83,7 @@
         },
         "properties": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme_experiment#Syntax",
             "support": {
               "chrome": {
                 "version_added": false

--- a/webextensions/manifest/theme_experiment.json
+++ b/webextensions/manifest/theme_experiment.json
@@ -29,7 +29,6 @@
         },
         "colors": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme_experiment#Syntax",
             "support": {
               "chrome": {
                 "version_added": false
@@ -56,7 +55,6 @@
         },
         "images": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme_experiment#Syntax",
             "support": {
               "chrome": {
                 "version_added": false
@@ -83,7 +81,6 @@
         },
         "properties": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme_experiment#Syntax",
             "support": {
               "chrome": {
                 "version_added": false


### PR DESCRIPTION
## Changes
1. Mark WebExtension manifest key theme_experiment is experimental, non-standard. (See [the article](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme_experiment) for details).
2. Remove redundant MDN URLs

This is related to #5273, since removes MDN URLs that don't match the regular pattern. If these URLs should be kept, just tell me and I'll drop the second commit (and update #5273 accordingly).

A checklist to help your pull request get merged faster:
- [ ] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
