### PR TITLE
WWW-Authenticate, One of the oldest auth methods, goes back to 1997-ish

### DIFF
--- a/http/headers/www-authenticate.json
+++ b/http/headers/www-authenticate.json
@@ -12,7 +12,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"

--- a/http/headers/www-authenticate.json
+++ b/http/headers/www-authenticate.json
@@ -21,7 +21,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "1"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This is one of the oldest auth methods and goes very far back -- probably version 1 or 2 of IE going back to RFC 2617 in 1997. Every version of IE that I ever came across (unfortunately, too many) supported it.
