### PR TITLE
Added Notes on Safari Scroll Anchoring Bugs

### DIFF
--- a/css/properties/scroll-margin-block-end.json
+++ b/css/properties/scroll-margin-block-end.json
@@ -34,7 +34,6 @@
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
               "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
-
             },
             "safari_ios": {
               "version_added": "11",

--- a/css/properties/scroll-margin-block-end.json
+++ b/css/properties/scroll-margin-block-end.json
@@ -33,14 +33,14 @@
               "version_added": "11",
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
 
             },
             "safari_ios": {
               "version_added": "11",
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-block-end.json
+++ b/css/properties/scroll-margin-block-end.json
@@ -31,13 +31,13 @@
             },
             "safari": {
               "version_added": "11",
-              "alternative_name": "scroll-snap-margin",
+              "alternative_name": "scroll-snap-margin-block-end",
               "partial_implementation": true,
               "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "safari_ios": {
               "version_added": "11",
-              "alternative_name": "scroll-snap-margin",
+              "alternative_name": "scroll-snap-margin-block-end",
               "partial_implementation": true,
               "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },

--- a/css/properties/scroll-margin-block-end.json
+++ b/css/properties/scroll-margin-block-end.json
@@ -33,13 +33,13 @@
               "version_added": "11",
               "alternative_name": "scroll-snap-margin-block-end",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "safari_ios": {
               "version_added": "11",
               "alternative_name": "scroll-snap-margin-block-end",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-block-end.json
+++ b/css/properties/scroll-margin-block-end.json
@@ -30,16 +30,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11",
-              "alternative_name": "scroll-snap-margin-block-end",
-              "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "11",
-              "alternative_name": "scroll-snap-margin-block-end",
-              "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-block-end.json
+++ b/css/properties/scroll-margin-block-end.json
@@ -30,10 +30,17 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11",
+              "alternative_name": "scroll-snap-margin",
+              "partial_implementation": true,
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
+
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11",
+              "alternative_name": "scroll-snap-margin",
+              "partial_implementation": true,
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-block-start.json
+++ b/css/properties/scroll-margin-block-start.json
@@ -34,7 +34,6 @@
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
               "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
-
             },
             "safari_ios": {
               "version_added": "11",

--- a/css/properties/scroll-margin-block-start.json
+++ b/css/properties/scroll-margin-block-start.json
@@ -33,13 +33,13 @@
               "version_added": "11",
               "alternative_name": "scroll-snap-margin-block-start",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "safari_ios": {
               "version_added": "11",
               "alternative_name": "scroll-snap-margin-block-start",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-block-start.json
+++ b/css/properties/scroll-margin-block-start.json
@@ -33,14 +33,14 @@
               "version_added": "11",
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
 
             },
             "safari_ios": {
               "version_added": "11",
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-block-start.json
+++ b/css/properties/scroll-margin-block-start.json
@@ -31,13 +31,13 @@
             },
             "safari": {
               "version_added": "11",
-              "alternative_name": "scroll-snap-margin",
+              "alternative_name": "scroll-snap-margin-block-start",
               "partial_implementation": true,
               "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "safari_ios": {
               "version_added": "11",
-              "alternative_name": "scroll-snap-margin",
+              "alternative_name": "scroll-snap-margin-block-start",
               "partial_implementation": true,
               "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },

--- a/css/properties/scroll-margin-block-start.json
+++ b/css/properties/scroll-margin-block-start.json
@@ -30,16 +30,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11",
-              "alternative_name": "scroll-snap-margin-block-start",
-              "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "11",
-              "alternative_name": "scroll-snap-margin-block-start",
-              "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-block-start.json
+++ b/css/properties/scroll-margin-block-start.json
@@ -30,10 +30,17 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11",
+              "alternative_name": "scroll-snap-margin",
+              "partial_implementation": true,
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
+
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11",
+              "alternative_name": "scroll-snap-margin",
+              "partial_implementation": true,
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-bottom.json
+++ b/css/properties/scroll-margin-bottom.json
@@ -33,13 +33,13 @@
               "version_added": "11",
               "alternative_name": "scroll-snap-margin-bottom",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "safari_ios": {
               "version_added": "11",
               "alternative_name": "scroll-snap-margin-bottom",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-bottom.json
+++ b/css/properties/scroll-margin-bottom.json
@@ -34,7 +34,6 @@
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
               "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
-
             },
             "safari_ios": {
               "version_added": "11",

--- a/css/properties/scroll-margin-bottom.json
+++ b/css/properties/scroll-margin-bottom.json
@@ -33,14 +33,14 @@
               "version_added": "11",
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
 
             },
             "safari_ios": {
               "version_added": "11",
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-bottom.json
+++ b/css/properties/scroll-margin-bottom.json
@@ -31,13 +31,13 @@
             },
             "safari": {
               "version_added": "11",
-              "alternative_name": "scroll-snap-margin",
+              "alternative_name": "scroll-snap-margin-bottom",
               "partial_implementation": true,
               "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "safari_ios": {
               "version_added": "11",
-              "alternative_name": "scroll-snap-margin",
+              "alternative_name": "scroll-snap-margin-bottom",
               "partial_implementation": true,
               "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },

--- a/css/properties/scroll-margin-bottom.json
+++ b/css/properties/scroll-margin-bottom.json
@@ -33,13 +33,13 @@
               "version_added": "11",
               "alternative_name": "scroll-snap-margin-bottom",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "safari_ios": {
               "version_added": "11",
               "alternative_name": "scroll-snap-margin-bottom",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-bottom.json
+++ b/css/properties/scroll-margin-bottom.json
@@ -30,10 +30,17 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11",
+              "alternative_name": "scroll-snap-margin",
+              "partial_implementation": true,
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
+
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11",
+              "alternative_name": "scroll-snap-margin",
+              "partial_implementation": true,
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-inline-end.json
+++ b/css/properties/scroll-margin-inline-end.json
@@ -34,7 +34,6 @@
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
               "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
-
             },
             "safari_ios": {
               "version_added": "11",

--- a/css/properties/scroll-margin-inline-end.json
+++ b/css/properties/scroll-margin-inline-end.json
@@ -33,14 +33,14 @@
               "version_added": "11",
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
 
             },
             "safari_ios": {
               "version_added": "11",
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-inline-end.json
+++ b/css/properties/scroll-margin-inline-end.json
@@ -33,13 +33,13 @@
               "version_added": "11",
               "alternative_name": "scroll-snap-margin-inline-end",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "safari_ios": {
               "version_added": "11",
               "alternative_name": "scroll-snap-margin-inline-end",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-inline-end.json
+++ b/css/properties/scroll-margin-inline-end.json
@@ -31,13 +31,13 @@
             },
             "safari": {
               "version_added": "11",
-              "alternative_name": "scroll-snap-margin",
+              "alternative_name": "scroll-snap-margin-inline-end",
               "partial_implementation": true,
               "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "safari_ios": {
               "version_added": "11",
-              "alternative_name": "scroll-snap-margin",
+              "alternative_name": "scroll-snap-margin-inline-end",
               "partial_implementation": true,
               "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },

--- a/css/properties/scroll-margin-inline-end.json
+++ b/css/properties/scroll-margin-inline-end.json
@@ -30,16 +30,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11",
-              "alternative_name": "scroll-snap-margin-inline-end",
-              "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "11",
-              "alternative_name": "scroll-snap-margin-inline-end",
-              "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-inline-end.json
+++ b/css/properties/scroll-margin-inline-end.json
@@ -30,10 +30,17 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11",
+              "alternative_name": "scroll-snap-margin",
+              "partial_implementation": true,
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
+
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11",
+              "alternative_name": "scroll-snap-margin",
+              "partial_implementation": true,
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-inline-start.json
+++ b/css/properties/scroll-margin-inline-start.json
@@ -34,7 +34,6 @@
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
               "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
-
             },
             "safari_ios": {
               "version_added": "11",

--- a/css/properties/scroll-margin-inline-start.json
+++ b/css/properties/scroll-margin-inline-start.json
@@ -33,14 +33,14 @@
               "version_added": "11",
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
 
             },
             "safari_ios": {
               "version_added": "11",
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-inline-start.json
+++ b/css/properties/scroll-margin-inline-start.json
@@ -30,16 +30,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11",
-              "alternative_name": "scroll-snap-margin-inline-start",
-              "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "11",
-              "alternative_name": "scroll-snap-margin-inline-start",
-              "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-inline-start.json
+++ b/css/properties/scroll-margin-inline-start.json
@@ -33,13 +33,13 @@
               "version_added": "11",
               "alternative_name": "scroll-snap-margin-inline-start",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "safari_ios": {
               "version_added": "11",
               "alternative_name": "scroll-snap-margin-inline-start",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-inline-start.json
+++ b/css/properties/scroll-margin-inline-start.json
@@ -31,13 +31,13 @@
             },
             "safari": {
               "version_added": "11",
-              "alternative_name": "scroll-snap-margin",
+              "alternative_name": "scroll-snap-margin-inline-start",
               "partial_implementation": true,
               "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "safari_ios": {
               "version_added": "11",
-              "alternative_name": "scroll-snap-margin",
+              "alternative_name": "scroll-snap-margin-inline-start",
               "partial_implementation": true,
               "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },

--- a/css/properties/scroll-margin-inline-start.json
+++ b/css/properties/scroll-margin-inline-start.json
@@ -30,10 +30,17 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11",
+              "alternative_name": "scroll-snap-margin",
+              "partial_implementation": true,
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
+
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11",
+              "alternative_name": "scroll-snap-margin",
+              "partial_implementation": true,
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-left.json
+++ b/css/properties/scroll-margin-left.json
@@ -34,7 +34,6 @@
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
               "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
-
             },
             "safari_ios": {
               "version_added": "11",

--- a/css/properties/scroll-margin-left.json
+++ b/css/properties/scroll-margin-left.json
@@ -33,14 +33,14 @@
               "version_added": "11",
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
 
             },
             "safari_ios": {
               "version_added": "11",
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-left.json
+++ b/css/properties/scroll-margin-left.json
@@ -33,13 +33,13 @@
               "version_added": "11",
               "alternative_name": "scroll-snap-margin-left",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "safari_ios": {
               "version_added": "11",
               "alternative_name": "scroll-snap-margin-left",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-left.json
+++ b/css/properties/scroll-margin-left.json
@@ -31,13 +31,13 @@
             },
             "safari": {
               "version_added": "11",
-              "alternative_name": "scroll-snap-margin",
+              "alternative_name": "scroll-snap-margin-left",
               "partial_implementation": true,
               "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "safari_ios": {
               "version_added": "11",
-              "alternative_name": "scroll-snap-margin",
+              "alternative_name": "scroll-snap-margin-left",
               "partial_implementation": true,
               "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },

--- a/css/properties/scroll-margin-left.json
+++ b/css/properties/scroll-margin-left.json
@@ -30,10 +30,17 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11",
+              "alternative_name": "scroll-snap-margin",
+              "partial_implementation": true,
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
+
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11",
+              "alternative_name": "scroll-snap-margin",
+              "partial_implementation": true,
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-left.json
+++ b/css/properties/scroll-margin-left.json
@@ -33,13 +33,13 @@
               "version_added": "11",
               "alternative_name": "scroll-snap-margin-left",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "safari_ios": {
               "version_added": "11",
               "alternative_name": "scroll-snap-margin-left",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-right.json
+++ b/css/properties/scroll-margin-right.json
@@ -33,13 +33,13 @@
               "version_added": "11",
               "alternative_name": "scroll-snap-margin-right",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "safari_ios": {
               "version_added": "11",
               "alternative_name": "scroll-snap-margin-right",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-right.json
+++ b/css/properties/scroll-margin-right.json
@@ -34,7 +34,6 @@
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
               "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
-
             },
             "safari_ios": {
               "version_added": "11",

--- a/css/properties/scroll-margin-right.json
+++ b/css/properties/scroll-margin-right.json
@@ -33,14 +33,14 @@
               "version_added": "11",
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
 
             },
             "safari_ios": {
               "version_added": "11",
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-right.json
+++ b/css/properties/scroll-margin-right.json
@@ -31,13 +31,13 @@
             },
             "safari": {
               "version_added": "11",
-              "alternative_name": "scroll-snap-margin",
+              "alternative_name": "scroll-snap-margin-right",
               "partial_implementation": true,
               "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "safari_ios": {
               "version_added": "11",
-              "alternative_name": "scroll-snap-margin",
+              "alternative_name": "scroll-snap-margin-right",
               "partial_implementation": true,
               "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },

--- a/css/properties/scroll-margin-right.json
+++ b/css/properties/scroll-margin-right.json
@@ -33,13 +33,13 @@
               "version_added": "11",
               "alternative_name": "scroll-snap-margin-right",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "safari_ios": {
               "version_added": "11",
               "alternative_name": "scroll-snap-margin-right",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-right.json
+++ b/css/properties/scroll-margin-right.json
@@ -30,10 +30,17 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11",
+              "alternative_name": "scroll-snap-margin",
+              "partial_implementation": true,
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
+
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11",
+              "alternative_name": "scroll-snap-margin",
+              "partial_implementation": true,
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-top.json
+++ b/css/properties/scroll-margin-top.json
@@ -34,7 +34,6 @@
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
               "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
-
             },
             "safari_ios": {
               "version_added": "11",

--- a/css/properties/scroll-margin-top.json
+++ b/css/properties/scroll-margin-top.json
@@ -33,14 +33,14 @@
               "version_added": "11",
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
 
             },
             "safari_ios": {
               "version_added": "11",
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-top.json
+++ b/css/properties/scroll-margin-top.json
@@ -33,13 +33,13 @@
               "version_added": "11",
               "alternative_name": "scroll-snap-margin-top",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "safari_ios": {
               "version_added": "11",
               "alternative_name": "scroll-snap-margin-top",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-top.json
+++ b/css/properties/scroll-margin-top.json
@@ -33,13 +33,13 @@
               "version_added": "11",
               "alternative_name": "scroll-snap-margin-top",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "safari_ios": {
               "version_added": "11",
               "alternative_name": "scroll-snap-margin-top",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-top.json
+++ b/css/properties/scroll-margin-top.json
@@ -30,10 +30,17 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11",
+              "alternative_name": "scroll-snap-margin",
+              "partial_implementation": true,
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
+
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11",
+              "alternative_name": "scroll-snap-margin",
+              "partial_implementation": true,
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin-top.json
+++ b/css/properties/scroll-margin-top.json
@@ -31,13 +31,13 @@
             },
             "safari": {
               "version_added": "11",
-              "alternative_name": "scroll-snap-margin",
+              "alternative_name": "scroll-snap-margin-top",
               "partial_implementation": true,
               "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "safari_ios": {
               "version_added": "11",
-              "alternative_name": "scroll-snap-margin",
+              "alternative_name": "scroll-snap-margin-top",
               "partial_implementation": true,
               "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },

--- a/css/properties/scroll-margin.json
+++ b/css/properties/scroll-margin.json
@@ -34,7 +34,6 @@
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
               "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
-
             },
             "safari_ios": {
               "version_added": "11",

--- a/css/properties/scroll-margin.json
+++ b/css/properties/scroll-margin.json
@@ -33,14 +33,14 @@
               "version_added": "11",
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
 
             },
             "safari_ios": {
               "version_added": "11",
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin.json
+++ b/css/properties/scroll-margin.json
@@ -33,13 +33,13 @@
               "version_added": "11",
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "safari_ios": {
               "version_added": "11",
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin.json
+++ b/css/properties/scroll-margin.json
@@ -33,13 +33,13 @@
               "version_added": "11",
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "safari_ios": {
               "version_added": "11",
               "alternative_name": "scroll-snap-margin",
               "partial_implementation": true,
-              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+              "notes": "Scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-margin.json
+++ b/css/properties/scroll-margin.json
@@ -30,10 +30,17 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11",
+              "alternative_name": "scroll-snap-margin",
+              "partial_implementation": true,
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
+
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11",
+              "alternative_name": "scroll-snap-margin",
+              "partial_implementation": true,
+              "notes": "Scroll margin is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=189265'>bug 189265</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-block-end.json
+++ b/css/properties/scroll-padding-block-end.json
@@ -33,7 +33,6 @@
               "version_added": "11",
               "partial_implementation": true,
               "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
-
             },
             "safari_ios": {
               "version_added": "11",

--- a/css/properties/scroll-padding-block-end.json
+++ b/css/properties/scroll-padding-block-end.json
@@ -30,14 +30,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11",
-              "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "11",
-              "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-block-end.json
+++ b/css/properties/scroll-padding-block-end.json
@@ -32,13 +32,13 @@
             "safari": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
 
             },
             "safari_ios": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-block-end.json
+++ b/css/properties/scroll-padding-block-end.json
@@ -32,12 +32,12 @@
             "safari": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "safari_ios": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-block-end.json
+++ b/css/properties/scroll-padding-block-end.json
@@ -30,10 +30,15 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11",
+              "partial_implementation": true,
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
+
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11",
+              "partial_implementation": true,
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-block-start.json
+++ b/css/properties/scroll-padding-block-start.json
@@ -33,7 +33,6 @@
               "version_added": "11",
               "partial_implementation": true,
               "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
-
             },
             "safari_ios": {
               "version_added": "11",

--- a/css/properties/scroll-padding-block-start.json
+++ b/css/properties/scroll-padding-block-start.json
@@ -30,14 +30,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11",
-              "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "11",
-              "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-block-start.json
+++ b/css/properties/scroll-padding-block-start.json
@@ -32,13 +32,13 @@
             "safari": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
 
             },
             "safari_ios": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-block-start.json
+++ b/css/properties/scroll-padding-block-start.json
@@ -32,12 +32,12 @@
             "safari": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "safari_ios": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-block-start.json
+++ b/css/properties/scroll-padding-block-start.json
@@ -30,10 +30,15 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11",
+              "partial_implementation": true,
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
+
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11",
+              "partial_implementation": true,
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-bottom.json
+++ b/css/properties/scroll-padding-bottom.json
@@ -33,7 +33,6 @@
               "version_added": "11",
               "partial_implementation": true,
               "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
-
             },
             "safari_ios": {
               "version_added": "11",

--- a/css/properties/scroll-padding-bottom.json
+++ b/css/properties/scroll-padding-bottom.json
@@ -32,12 +32,12 @@
             "safari": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "safari_ios": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-bottom.json
+++ b/css/properties/scroll-padding-bottom.json
@@ -32,13 +32,13 @@
             "safari": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
 
             },
             "safari_ios": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-bottom.json
+++ b/css/properties/scroll-padding-bottom.json
@@ -32,12 +32,12 @@
             "safari": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "safari_ios": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-bottom.json
+++ b/css/properties/scroll-padding-bottom.json
@@ -30,10 +30,15 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11",
+              "partial_implementation": true,
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
+
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11",
+              "partial_implementation": true,
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-inline-end.json
+++ b/css/properties/scroll-padding-inline-end.json
@@ -33,7 +33,6 @@
               "version_added": "11",
               "partial_implementation": true,
               "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
-
             },
             "safari_ios": {
               "version_added": "11",

--- a/css/properties/scroll-padding-inline-end.json
+++ b/css/properties/scroll-padding-inline-end.json
@@ -30,14 +30,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11",
-              "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "11",
-              "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-inline-end.json
+++ b/css/properties/scroll-padding-inline-end.json
@@ -32,13 +32,13 @@
             "safari": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
 
             },
             "safari_ios": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-inline-end.json
+++ b/css/properties/scroll-padding-inline-end.json
@@ -32,12 +32,12 @@
             "safari": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "safari_ios": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-inline-end.json
+++ b/css/properties/scroll-padding-inline-end.json
@@ -30,10 +30,15 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11",
+              "partial_implementation": true,
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
+
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11",
+              "partial_implementation": true,
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-inline-start.json
+++ b/css/properties/scroll-padding-inline-start.json
@@ -33,7 +33,6 @@
               "version_added": "11",
               "partial_implementation": true,
               "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
-
             },
             "safari_ios": {
               "version_added": "11",

--- a/css/properties/scroll-padding-inline-start.json
+++ b/css/properties/scroll-padding-inline-start.json
@@ -30,14 +30,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11",
-              "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "11",
-              "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-inline-start.json
+++ b/css/properties/scroll-padding-inline-start.json
@@ -32,13 +32,13 @@
             "safari": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
 
             },
             "safari_ios": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-inline-start.json
+++ b/css/properties/scroll-padding-inline-start.json
@@ -32,12 +32,12 @@
             "safari": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "safari_ios": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-inline-start.json
+++ b/css/properties/scroll-padding-inline-start.json
@@ -30,10 +30,15 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11",
+              "partial_implementation": true,
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
+
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11",
+              "partial_implementation": true,
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-left.json
+++ b/css/properties/scroll-padding-left.json
@@ -33,7 +33,6 @@
               "version_added": "11",
               "partial_implementation": true,
               "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
-
             },
             "safari_ios": {
               "version_added": "11",

--- a/css/properties/scroll-padding-left.json
+++ b/css/properties/scroll-padding-left.json
@@ -32,12 +32,12 @@
             "safari": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "safari_ios": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-left.json
+++ b/css/properties/scroll-padding-left.json
@@ -32,13 +32,13 @@
             "safari": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
 
             },
             "safari_ios": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-left.json
+++ b/css/properties/scroll-padding-left.json
@@ -32,12 +32,12 @@
             "safari": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "safari_ios": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-left.json
+++ b/css/properties/scroll-padding-left.json
@@ -30,10 +30,15 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11",
+              "partial_implementation": true,
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
+
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11",
+              "partial_implementation": true,
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-right.json
+++ b/css/properties/scroll-padding-right.json
@@ -33,7 +33,6 @@
               "version_added": "11",
               "partial_implementation": true,
               "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
-
             },
             "safari_ios": {
               "version_added": "11",

--- a/css/properties/scroll-padding-right.json
+++ b/css/properties/scroll-padding-right.json
@@ -32,12 +32,12 @@
             "safari": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "safari_ios": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-right.json
+++ b/css/properties/scroll-padding-right.json
@@ -32,13 +32,13 @@
             "safari": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
 
             },
             "safari_ios": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-right.json
+++ b/css/properties/scroll-padding-right.json
@@ -32,12 +32,12 @@
             "safari": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "safari_ios": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-right.json
+++ b/css/properties/scroll-padding-right.json
@@ -30,10 +30,15 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11",
+              "partial_implementation": true,
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
+
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11",
+              "partial_implementation": true,
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-top.json
+++ b/css/properties/scroll-padding-top.json
@@ -33,7 +33,6 @@
               "version_added": "11",
               "partial_implementation": true,
               "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
-
             },
             "safari_ios": {
               "version_added": "11",

--- a/css/properties/scroll-padding-top.json
+++ b/css/properties/scroll-padding-top.json
@@ -32,12 +32,12 @@
             "safari": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "safari_ios": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-top.json
+++ b/css/properties/scroll-padding-top.json
@@ -32,13 +32,13 @@
             "safari": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
 
             },
             "safari_ios": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-top.json
+++ b/css/properties/scroll-padding-top.json
@@ -32,12 +32,12 @@
             "safari": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "safari_ios": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding-top.json
+++ b/css/properties/scroll-padding-top.json
@@ -30,10 +30,15 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11",
+              "partial_implementation": true,
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
+
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11",
+              "partial_implementation": true,
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding.json
+++ b/css/properties/scroll-padding.json
@@ -33,7 +33,6 @@
               "version_added": "11",
               "partial_implementation": true,
               "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
-
             },
             "safari_ios": {
               "version_added": "11",

--- a/css/properties/scroll-padding.json
+++ b/css/properties/scroll-padding.json
@@ -32,12 +32,12 @@
             "safari": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "safari_ios": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding.json
+++ b/css/properties/scroll-padding.json
@@ -32,13 +32,13 @@
             "safari": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
 
             },
             "safari_ios": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding.json
+++ b/css/properties/scroll-padding.json
@@ -32,12 +32,12 @@
             "safari": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "safari_ios": {
               "version_added": "11",
               "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()`, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/css/properties/scroll-padding.json
+++ b/css/properties/scroll-padding.json
@@ -30,10 +30,15 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "11",
+              "partial_implementation": true,
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
+
             },
             "safari_ios": {
-              "version_added": "11"
+              "version_added": "11",
+              "partial_implementation": true,
+              "notes": "Scroll padding is not applied for scrolls to fragment target or `scrollIntoView()` when snapping is off, see <a href='https://bugs.webkit.org/show_bug.cgi?id=179379'>bug 179379</a>."
             },
             "samsunginternet_android": {
               "version_added": "10.0"


### PR DESCRIPTION
Safari 11-13 does not support the highlighted part of the Scroll Snap spec:

> If a page is navigated to a fragment that defines a target element (one that would be matched by :target, or the target of scrollIntoView()), the UA should use the element’s scroll snap area, rather than just its border box, to determine which area of the scrollable overflow region to bring into view, **even when snapping is off or not applied on this element**.
> https://drafts.csswg.org/css-scroll-snap-1/#scroll-snap-area

Related Safari bugs:
* https://bugs.webkit.org/show_bug.cgi?id=189265
* https://bugs.webkit.org/show_bug.cgi?id=179379

Here are codepens to verify that behavior:
* https://codepen.io/dakur/pen/bGNOZYw
* https://codepen.io/fabb64/pen/YzXYQPW

Also, [Safari did not yet rename `scroll-snap-margin-*` to `scroll-margin-*`](https://bugs.webkit.org/show_bug.cgi?id=189265), as [csswg decided here](https://github.com/w3c/csswg-drafts/issues/1954).

Fixes #4945.