### PR TITLE
Update version for HTMLFormElement API

### DIFF
--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -735,7 +735,7 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "75"
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
HTMLFormElement.requestSubmit() is available since version 75 of Firefox

[Firefox 75 Release Notes](https://developer.mozilla.org/fr/docs/Mozilla/Firefox/Releases/75#New_APIs)