### PR TITLE
Bump supported Node.js version to v10

### DIFF
--- a/.github/compat-data-helper/package.json
+++ b/.github/compat-data-helper/package.json
@@ -31,7 +31,7 @@
     "standard": "^14.1.0"
   },
   "engines": {
-    "node": ">= 8.3.0"
+    "node": ">=10.0.0"
   },
   "standard": {
     "env": [

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: stable
+node_js: 'lts/dubnium'
 sudo: false
 notifications:
   email: false

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "extend": "3.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
While reviewing #5624, I looked at `package.json` and was reminded that we decided [we should not support Node.js versions older than that supported by the Node project itself](https://github.com/mdn/browser-compat-data/issues/3509#issuecomment-467476914). This PR increments `package.json` and `.travis.yml`'s Node version to the current oldest supported LTS release ("Dubnium").

For semver purposes, I don't think this is a breaking change, but I'm not certain about it. It might be non-breaking because we're not changing our support policy, but it might be breaking because we're explicitly moving the pointer from v8 to v10. This is a philosophical question I'd like @Elchi3 to consider.

The next version change (from v10 to v12) will take place April 30 2021, when [v10 reaches end of life](https://github.com/nodejs/Release/blob/master/schedule.json#L50).