### PR TITLE
Chromium adds support for color-scheme meta tag

### DIFF
--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -481,13 +481,13 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "81"
                 },
                 "chrome_android": {
-                  "version_added": false
+                  "version_added": "81"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "81"
                 },
                 "firefox": {
                   "version_added": false
@@ -499,7 +499,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": "68"
                 },
                 "opera_android": {
                   "version_added": false
@@ -514,7 +514,7 @@
                   "version_added": false
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "81"
                 }
               },
               "status": {


### PR DESCRIPTION
https://www.chromestatus.com/feature/5330651267989504 

Chrome, Chrome for Android and Android Webview is adding support in v81

That means Edge 81 and Opera 68 is almost certainly also adding support. Opera for Android is not out yet in that version.