### PR TITLE
Opera for Android doesn't support x-xss-protection header

### DIFF
--- a/http/headers/x-xss-protection.json
+++ b/http/headers/x-xss-protection.json
@@ -32,7 +32,7 @@
             },
             "opera_android": {
               "version_added": true,
-              "version_removed": "65"
+              "version_removed": "56"
             },
             "safari": {
               "version_added": true

--- a/http/headers/x-xss-protection.json
+++ b/http/headers/x-xss-protection.json
@@ -31,7 +31,8 @@
               "version_removed": "65"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "65"
             },
             "safari": {
               "version_added": true


### PR DESCRIPTION
This follows the deprecation in Chrome and Opera

Original PR: #4958
