### PR TITLE
Opera supports CSS font-optical-sizing

### DIFF
--- a/css/properties/font-optical-sizing.json
+++ b/css/properties/font-optical-sizing.json
@@ -50,7 +50,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "66"
             },
             "opera_android": {
               "version_added": false


### PR DESCRIPTION
This was added in Chrome 79 which corresponds with Opera 66.

Tested to be supported by default in Opera 66+ by going into the developer tools and checking if `font-optical-sizing: auto` was recognized when set on the body element.

Original PR: #4960 