### PR TITLE
Update KeyframeEffectOptions (ie Element.animate subfeatures)

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -696,45 +696,45 @@
             "deprecated": false
           }
         },
-        "composite_iterationcomposite_and_spacing_options": {
+        "composite_option": {
           "__compat": {
-            "description": "<code>composite</code>, <code>iterationComposite</code>, and <code>spacing</code> options",
+            "description": "<code>composite</code> option",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": null
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": null
               },
               "edge": {
-                "version_added": false
+                "version_added": null
               },
               "firefox": {
-                "version_added": false
+                "version_added": null
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": null
               },
               "ie": {
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": null
               },
               "opera_android": {
-                "version_added": false
+                "version_added": null
               },
               "safari": {
-                "version_added": false
+                "version_added": null
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": null
               },
               "webview_android": {
-                "version_added": false
+                "version_added": null
               }
             },
             "status": {
@@ -783,6 +783,54 @@
               },
               "webview_android": {
                 "version_added": "50"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "iterationcomposite_option": {
+          "__compat": {
+            "description": "<code>iterationComposite</code> option",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
               }
             },
             "status": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -711,40 +711,100 @@
             "description": "<code>composite</code> option",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
               },
               "edge": {
-                "version_added": null
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
               },
-              "firefox": {
-                "version_added": null
-              },
-              "firefox_android": {
-                "version_added": null
-              },
+              "firefox": [
+                {
+                  "version_added": "63",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.animations-api.compositing.enabled"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "53",
+                  "version_removed": "63",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.animations-api.core.enabled"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "63",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.animations-api.compositing.enabled"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "53",
+                  "version_removed": "63",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.animations-api.core.enabled"
+                    }
+                  ]
+                }
+              ],
               "ie": {
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": "66",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
-                "version_added": null
+                "version_added": false
               }
             },
             "status": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -678,7 +678,17 @@
               "version_added": "24"
             },
             "safari": {
-              "version_added": false
+              "version_added": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Web Animations"
+                },
+                {
+                  "type": "preference",
+                  "name": "CSS Animations via Web Animations"
+                }
+              ]
             },
             "safari_ios": {
               "version_added": null

--- a/api/Element.json
+++ b/api/Element.json
@@ -875,12 +875,48 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": null
-              },
-              "firefox_android": {
-                "version_added": null
-              },
+              "firefox": [
+                {
+                  "version_added": "63",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.animations-api.compositing.enabled"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "51",
+                  "version_removed": "63",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.animations-api.core.enabled"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "63",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.animations-api.compositing.enabled"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "51",
+                  "version_removed": "63",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.animations-api.core.enabled"
+                    }
+                  ]
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -891,10 +927,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
Update the [KeyframeEffectOptions dictionary](https://drafts.csswg.org/web-animations/#the-keyframeeffectoptions-dictionary) used in [`Element.animate()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/animate) and [`KeyframeEffect()`](https://wiki.developer.mozilla.org/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect).

## `composite` option ##

Test: https://jsbin.com/vojogol/edit?html,css,js,console,output
Spec: https://drafts.csswg.org/web-animations-1/#ref-for-dom-keyframeeffectoptions-composite

### Chromium ###

Tested present behind a flag in Chrome 79 and latest Chrome for Android, tested absent in Chrome 78. No idea what bug made this change. Mapped to equivalent other browsers (where they have engine 79 versions).

### Firefox ###

Tested present behind a flag in Firefox 53 and latest Firefox for Android, tested absent in Firefox 52. Relevant looking bugs:

* https://bugzilla.mozilla.org/show_bug.cgi?id=1216844
* https://bugzilla.mozilla.org/show_bug.cgi?id=1291468
* https://bugzilla.mozilla.org/show_bug.cgi?id=1471814

### Safari ###

Tested absent in Safari 13.

### IE & EdgeHTML ###

Has no support for the Web Animations API.

## `iterationComposite` option ##

Test: https://jsbin.com/kegurid/edit?html,css,js,console,output
Spec: https://drafts.csswg.org/web-animations-2/#ref-for-dom-keyframeeffect-iterationcomposite

### Chromium ###

Commented out in the source: https://chromium.googlesource.com/chromium/src/+/master/third_party/blink/renderer/core/animation/keyframe_effect_options.idl#8

### Firefox ###

Tested present behind a flag in Firefox 51 and latest Firefox for Android, tested absent in Firefox 50. Relevant looking bugs:

* https://bugzilla.mozilla.org/show_bug.cgi?id=1216843
* https://bugzilla.mozilla.org/show_bug.cgi?id=1294651
* https://bugzilla.mozilla.org/show_bug.cgi?id=1471814

### Safari ###

Tested absent in Safari 13.

### IE & EdgeHTML ###

Has no support for the Web Animations API.

## `spacing` option ##

The spacing option was removed from the spec in 2017 by https://github.com/w3c/web-animations/issues/180. It never had any meaningful support except for a long removed experimental implementation in Firefox that appeared somewhere between 45-55, before being fully removed in 56. It no longer appears in the editor's draft of the level 1 spec (even in the changelog section), the draft level 2 spec or on MDN, so I don't believe there's any purpose finding this data for BCD.