### PR TITLE
Update Intl.Locale compat data

### DIFF
--- a/javascript/builtins/intl/Locale.json
+++ b/javascript/builtins/intl/Locale.json
@@ -14,10 +14,10 @@
                 "version_added": "74"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
-                "version_added": false
+                "version_added": "75"
               },
               "firefox_android": {
                 "version_added": false
@@ -29,10 +29,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "62"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "53"
               },
               "safari": {
                 "version_added": false
@@ -41,7 +41,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "11.0"
               },
               "webview_android": {
                 "version_added": "74"
@@ -66,10 +66,10 @@
                   "version_added": "74"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": "75"
                 },
                 "firefox_android": {
                   "version_added": false
@@ -81,10 +81,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": "62"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "53"
                 },
                 "safari": {
                   "version_added": false
@@ -93,7 +93,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "11.0"
                 },
                 "webview_android": {
                   "version_added": "74"
@@ -118,10 +118,10 @@
                   "version_added": "74"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": "75"
                 },
                 "firefox_android": {
                   "version_added": false
@@ -133,10 +133,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": "62"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "53"
                 },
                 "safari": {
                   "version_added": false
@@ -145,7 +145,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "11.0"
                 },
                 "webview_android": {
                   "version_added": "74"
@@ -170,10 +170,10 @@
                   "version_added": "74"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": "75"
                 },
                 "firefox_android": {
                   "version_added": false
@@ -185,10 +185,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": "62"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "53"
                 },
                 "safari": {
                   "version_added": false
@@ -197,7 +197,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "11.0"
                 },
                 "webview_android": {
                   "version_added": "74"
@@ -222,10 +222,10 @@
                   "version_added": "74"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": "75"
                 },
                 "firefox_android": {
                   "version_added": false
@@ -237,10 +237,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": "62"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "53"
                 },
                 "safari": {
                   "version_added": false
@@ -249,7 +249,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "11.0"
                 },
                 "webview_android": {
                   "version_added": "74"
@@ -274,10 +274,10 @@
                   "version_added": "74"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": "75"
                 },
                 "firefox_android": {
                   "version_added": false
@@ -289,10 +289,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": "62"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "53"
                 },
                 "safari": {
                   "version_added": false
@@ -301,7 +301,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "11.0"
                 },
                 "webview_android": {
                   "version_added": "74"
@@ -326,10 +326,10 @@
                   "version_added": "74"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": "75"
                 },
                 "firefox_android": {
                   "version_added": false
@@ -341,10 +341,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": "62"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "53"
                 },
                 "safari": {
                   "version_added": false
@@ -353,7 +353,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "11.0"
                 },
                 "webview_android": {
                   "version_added": "74"
@@ -378,10 +378,10 @@
                   "version_added": "74"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": "75"
                 },
                 "firefox_android": {
                   "version_added": false
@@ -393,10 +393,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": "62"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "53"
                 },
                 "safari": {
                   "version_added": false
@@ -405,7 +405,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "11.0"
                 },
                 "webview_android": {
                   "version_added": "74"
@@ -430,10 +430,10 @@
                   "version_added": "74"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": "75"
                 },
                 "firefox_android": {
                   "version_added": false
@@ -445,10 +445,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": "62"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "53"
                 },
                 "safari": {
                   "version_added": false
@@ -457,7 +457,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "11.0"
                 },
                 "webview_android": {
                   "version_added": "74"
@@ -482,10 +482,10 @@
                   "version_added": "74"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": "75"
                 },
                 "firefox_android": {
                   "version_added": false
@@ -497,10 +497,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": "62"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "53"
                 },
                 "safari": {
                   "version_added": false
@@ -509,7 +509,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "11.0"
                 },
                 "webview_android": {
                   "version_added": "74"
@@ -534,10 +534,10 @@
                   "version_added": "74"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": "75"
                 },
                 "firefox_android": {
                   "version_added": false
@@ -549,10 +549,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": "62"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "53"
                 },
                 "safari": {
                   "version_added": false
@@ -561,7 +561,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "11.0"
                 },
                 "webview_android": {
                   "version_added": "74"
@@ -586,10 +586,10 @@
                   "version_added": "74"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": "75"
                 },
                 "firefox_android": {
                   "version_added": false
@@ -601,10 +601,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": "62"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "53"
                 },
                 "safari": {
                   "version_added": false
@@ -613,7 +613,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "11.0"
                 },
                 "webview_android": {
                   "version_added": "74"
@@ -638,10 +638,10 @@
                   "version_added": "74"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": "75"
                 },
                 "firefox_android": {
                   "version_added": false
@@ -653,10 +653,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": "62"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "53"
                 },
                 "safari": {
                   "version_added": false
@@ -665,7 +665,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "11.0"
                 },
                 "webview_android": {
                   "version_added": "74"
@@ -690,10 +690,10 @@
                   "version_added": "74"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": "75"
                 },
                 "firefox_android": {
                   "version_added": false
@@ -705,10 +705,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": "62"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "53"
                 },
                 "safari": {
                   "version_added": false
@@ -717,7 +717,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "11.0"
                 },
                 "webview_android": {
                   "version_added": "74"
@@ -742,10 +742,10 @@
                   "version_added": "74"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": "75"
                 },
                 "firefox_android": {
                   "version_added": false
@@ -757,10 +757,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": "62"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "53"
                 },
                 "safari": {
                   "version_added": false
@@ -769,7 +769,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "11.0"
                 },
                 "webview_android": {
                   "version_added": "74"


### PR DESCRIPTION
Ships in Firefox 75: https://bugzilla.mozilla.org/show_bug.cgi?id=1613713

Also updated the chromium based browsers based on the Chrome version number.