### PR TITLE
Add support for 'all' keyword in Fx 75

### DIFF
--- a/css/properties/text-decoration-skip-ink.json
+++ b/css/properties/text-decoration-skip-ink.json
@@ -47,6 +47,54 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "all": {
+          "__compat": {
+            "description": "<code>all</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "75"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
- [Bugzilla bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1611965)
- [Content sprint issue](https://github.com/mdn/sprints/issues/2926)
- CSS WG has decided to use `all`, not `always` per [this comment](https://bugzilla.mozilla.org/show_bug.cgi?id=1611965#c4)
