### PR TITLE
Add RTCDataChannel.onclosing

### DIFF
--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -799,6 +799,54 @@
           }
         }
       },
+      "onclosing": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDataChannel/onclosing",
+          "support": {
+            "chrome": {
+              "version_added": "81"
+            },
+            "chrome_android": {
+              "version_added": "81"
+            },
+            "edge": {
+              "version_added": "81"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "68"
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": "81"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "onerror": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDataChannel/onerror",


### PR DESCRIPTION
## Summary
Chrome 81 introduces new RTC event, `RTCDataChannel.onclosing`.

## Data
 - [Chrome Platform Status](https://chromestatus.com/feature/5733328181264384)
 - [Specification draft](https://w3c.github.io/webrtc-pc/#dom-rtcdatachannel-onclosing)

I could not add Opera for Android and Samsung Internet data because BCD does not have info about these releases so linter fails.

Also, see [MDN article draft](https://wiki.developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel/onclosing).

### Test
The simplest test is to open a console online (e.g., [jsconsole.com](https://jsconsole.com/)) and try this out:
```
// Create new connection and a channel
var pc = new RTCPeerConnection()
var ch = pc.createDataChannel("ch")
// Expected: undefined

// Example of event handler that "exists" 
ch.onclose
// Expected: null

// Example of event handler that does not exist 
ch.nonexistent
// Expected: undefined

// Check whether onclosing exists
ch.onclosing
// Expected in Chrome 81 and later: null
// Expected in Firefox: undefined
```

## Related PRs
This PR might merge conflict with #5818, so we probably should wait for #5818 to merge and then rebase it.

Note: 
A checklist to help your pull request get merged faster:
- [ ] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
