### PR TITLE
Add zoomSiteSpecific and zoomFullPage settings to browserSettings API

### DIFF
--- a/webextensions/api/browserSettings.json
+++ b/webextensions/api/browserSettings.json
@@ -332,6 +332,50 @@
               }
             }
           }
+        },
+        "zoomFullPage": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/zoomFullPage",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "75"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "zoomSiteSpecific": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/zoomSiteSpecific",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "75"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
As it says in the title, added `zoomSiteSpecific` and `zoomFullPage` settings to `browserSettings` API compatibility data. These changes are for [1286953](https://bugzilla.mozilla.org/show_bug.cgi?id=1286953) and reflect the changes documented in [browser_settings.json ](https://hg.mozilla.org/integration/autoland/diff/6c405454620d3edf5c3ee3745803545e19316da4/toolkit/components/extensions/schemas/browser_settings.json).

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
