### PR TITLE
Firefox does not support MediaSession by default

### DIFF
--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -18,8 +18,7 @@
             "flags": [
               {
                 "type": "preference",
-                "name": "dom.media.mediasession.enabled",
-                "value_to_set": "true"
+                "name": "dom.media.mediasession.enabled"
               }
             ]
           },
@@ -72,8 +71,7 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "dom.media.mediasession.enabled",
-                  "value_to_set": "true"
+                  "name": "dom.media.mediasession.enabled"
                 }
               ]
             },
@@ -176,8 +174,7 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "dom.media.mediasession.enabled",
-                  "value_to_set": "true"
+                  "name": "dom.media.mediasession.enabled"
                 }
               ]
             },

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1405,7 +1405,13 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "71"
+              "version_added": "71",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.media.mediasession.enabled"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": null


### PR DESCRIPTION
#5767 added the flag data but (maybe accidentally) set the value to `true`, which is not true.

Related PR: https://phabricator.services.mozilla.com/D45456#change-snxvCxzhFNv0
Current code: https://searchfox.org/mozilla-central/source/modules/libpref/init/StaticPrefList.yaml#2001-2005