### PR TITLE
No SourceBuffer.prototype.*Tracks support

### DIFF
--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -454,23 +454,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": false
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -1125,43 +1111,28 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SourceBuffer/textTracks",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "33"
+              "version_added": false
             },
             "edge": {
               "version_added": "18"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": false
+            },
             "firefox_android": {
               "version_added": false
             },
             "ie": {
-              "version_added": "11",
-              "notes": "Only works on Windows 8+."
+              "version_added": false
             },
             "opera": {
-              "version_added": "15"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": false
             },
             "safari": {
               "version_added": "8"
@@ -1170,10 +1141,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "3.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": false
             }
           },
           "status": {
@@ -1358,23 +1329,9 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.mediasource.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "Limited support to a whitelist of sites, for example YouTube, Netflix, and other popular streaming sites. The whitelist was removed when Media Source Extensions was enabled by default in Firefox 42."
-              }
-            ],
+            "firefox": {
+              "version_added": false
+            },
             "firefox_android": {
               "version_added": false
             },


### PR DESCRIPTION
Related to #5781 

This only removes unsupported features without fixing version numbers for supported ones as I'm not sure of them:

* Firefox never supported all *Tracks
* Chrome never supported textTracks
* IE11 does not support textTracks
