### PR TITLE
Update nullish coalescing compatibility for Safari

### DIFF
--- a/javascript/operators/nullish_coalescing.json
+++ b/javascript/operators/nullish_coalescing.json
@@ -38,7 +38,7 @@
               "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": "13.1"
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/javascript/operators/nullish_coalescing.json
+++ b/javascript/operators/nullish_coalescing.json
@@ -35,10 +35,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [X] Summarize your changes
Safari as of 13.1 supports the nullish coalescing operator
- [X] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
https://developer.apple.com/documentation/safari_release_notes/safari_13_1_beta_release_notes
- [X] Data: if you tested something, describe how you tested with details like browser and version
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_Coalescing_Operator
- [X] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [X] Link to related issues or pull requests, if any
