### PR TITLE
Fix "[Array]" printing in consistency linter when data is "null"

### DIFF
--- a/test/linter/test-consistency.js
+++ b/test/linter/test-consistency.js
@@ -388,9 +388,9 @@ function testConsistency(filename) {
 
         subfeatures.forEach(subfeature => {
           console.error(
-            chalk`{red       → {bold ${path.join('.')}.${
-              subfeature[0]
-            }}: ${subfeature[1] || '[Array]'}}`,
+            chalk`{red       → {bold ${path.join('.')}.${subfeature[0]}}: ${
+              subfeature[1] === undefined ? '[Array]' : subfeature[1]
+            }}`,
           );
         });
       });


### PR DESCRIPTION
This fixes a slight error in the consistency linter's output that thinks data set to `null` is an array by checking if the data is specifically `undefined`.  This is purely in regards to the output of the logger and does not change the linter's internal code.