### PR TITLE
Update versions for misc. APIs (A-G)

### DIFF
--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -61,7 +61,7 @@
             "prefix": "webkit"
           },
           "safari_ios": {
-            "version_added": true,
+            "version_added": "6",
             "prefix": "webkit"
           },
           "samsunginternet_android": [

--- a/api/Blob.json
+++ b/api/Blob.json
@@ -26,19 +26,19 @@
             "version_added": "11"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "11"
           },
           "safari": {
             "version_added": "5.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "6"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -76,13 +76,13 @@
               "version_added": "12"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari": {
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": "1.5"

--- a/api/Body.json
+++ b/api/Body.json
@@ -73,7 +73,7 @@
             "version_added": "10"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "10"
           },
           "samsunginternet_android": {
             "version_added": "4.0"
@@ -256,7 +256,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -581,7 +581,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -673,7 +673,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/CSSStyleDeclaration.json
+++ b/api/CSSStyleDeclaration.json
@@ -515,19 +515,19 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/CacheStorage.json
+++ b/api/CacheStorage.json
@@ -41,7 +41,7 @@
             "version_added": "11.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "11.3"
           },
           "samsunginternet_android": {
             "version_added": "4.0",

--- a/api/ChildNode.json
+++ b/api/ChildNode.json
@@ -151,7 +151,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -178,10 +178,10 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/Crypto.json
+++ b/api/Crypto.json
@@ -85,7 +85,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/DOMParser.json
+++ b/api/DOMParser.json
@@ -8,7 +8,7 @@
             "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -17,7 +17,7 @@
             "version_added": "1"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"
@@ -26,19 +26,19 @@
             "version_added": "8"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "10.1"
           },
           "safari": {
             "version_added": "3.2"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "2"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -8,25 +8,25 @@
             "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"
           },
           "opera": {
-            "version_added": true
+            "version_added": "11.5"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "11.5"
           },
           "safari": {
             "version_added": "5.1"
@@ -35,10 +35,10 @@
             "version_added": "5.1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {

--- a/api/DataTransfer.json
+++ b/api/DataTransfer.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DataTransfer",
         "support": {
           "chrome": {
-            "version_added": "4"
+            "version_added": "3"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -18,7 +18,8 @@
             "notes": "As of Firefox 52, the <a href='https://developer.mozilla.org/docs/Web/API/DataTransfer/types'><code>DataTransfer.types</code></a> property returns a frozen array of <a href='https://developer.mozilla.org/docs/Web/API/DOMString'><code>DOMString</code></a>s as per spec, rather than a <a href='https://developer.mozilla.org/docs/Web/API/DOMStringList'><code>DOMStringList</code></a>."
           },
           "firefox_android": {
-            "version_added": "52"
+            "version_added": "4",
+            "notes": "As of Firefox 52, the <a href='https://developer.mozilla.org/docs/Web/API/DataTransfer/types'><code>DataTransfer.types</code></a> property returns a frozen array of <a href='https://developer.mozilla.org/docs/Web/API/DOMString'><code>DOMString</code></a>s as per spec, rather than a <a href='https://developer.mozilla.org/docs/Web/API/DOMStringList'><code>DOMStringList</code></a>."
           },
           "ie": {
             "version_added": "10"
@@ -27,19 +28,19 @@
             "version_added": "12"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "12"
           },
           "safari": {
             "version_added": "3.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "2"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -827,40 +828,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DataTransfer/setData",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "3"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "10"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "10"
             },
             "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": true
-            },
-            "safari_ios": {
               "version_added": false
             },
+            "opera": {
+              "version_added": "12"
+            },
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5"
+            },
+            "safari_ios": {
+              "version_added": "5"
+            },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/DeviceMotionEvent.json
+++ b/api/DeviceMotionEvent.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceMotionEvent",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "11"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "≤18"
@@ -20,25 +20,25 @@
             "version_added": "6"
           },
           "ie": {
-            "version_added": null
-          },
-          "opera": {
-            "version_added": true
-          },
-          "opera_android": {
             "version_added": false
           },
+          "opera": {
+            "version_added": "15"
+          },
+          "opera_android": {
+            "version_added": "14"
+          },
           "safari": {
-            "version_added": null
+            "version_added": "5"
           },
           "safari_ios": {
             "version_added": "4.2"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -68,13 +68,13 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
             },
             "opera_android": {
-              "version_added": false
+              "version_added": null
             },
             "safari": {
               "version_added": null
@@ -116,13 +116,13 @@
               "version_added": "6"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": null
             },
             "safari": {
               "version_added": null
@@ -164,13 +164,13 @@
               "version_added": "6"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -212,13 +212,13 @@
               "version_added": "6"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -260,13 +260,13 @@
               "version_added": "6"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": null

--- a/api/DeviceOrientationEvent.json
+++ b/api/DeviceOrientationEvent.json
@@ -9,7 +9,7 @@
             "notes": "Before version 50, Chrome provided absolute values instead of relative values for this event. Developers still needing absolute values may use the <code>ondeviceorientationabsolute</code> event."
           },
           "chrome_android": {
-            "version_added": true,
+            "version_added": "18",
             "notes": "Before version 50, Chrome provided absolute values instead of relative values for this event. Developers still needing absolute values may use the <code>ondeviceorientationabsolute</code> event."
           },
           "edge": {
@@ -24,26 +24,26 @@
             "notes": "Firefox 3.6, 4, and 5 supported <code>mozOrientation</code> instead of the standard DeviceOrientationEvent interface."
           },
           "ie": {
-            "version_added": null
-          },
-          "opera": {
-            "version_added": true
-          },
-          "opera_android": {
             "version_added": false
           },
+          "opera": {
+            "version_added": "15"
+          },
+          "opera_android": {
+            "version_added": "14"
+          },
           "safari": {
-            "version_added": null
+            "version_added": "5"
           },
           "safari_ios": {
             "version_added": "4.2"
           },
           "samsunginternet_android": {
-            "version_added": true,
+            "version_added": "1.0",
             "notes": "Before Samsung Internet 5.0, Samsung Internet provided absolute values instead of relative values for this event. Developers still needing absolute values may use the <code>ondeviceorientationabsolute</code> event."
           },
           "webview_android": {
-            "version_added": true,
+            "version_added": "≤37",
             "notes": "Before version 50, Chrome provided absolute values instead of relative values for this event. Developers still needing absolute values may use the <code>ondeviceorientationabsolute</code> event."
           }
         },
@@ -74,13 +74,13 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
             },
             "opera_android": {
-              "version_added": false
+              "version_added": null
             },
             "safari": {
               "version_added": null
@@ -122,13 +122,13 @@
               "version_added": "6"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -170,13 +170,13 @@
               "version_added": "6"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -218,13 +218,13 @@
               "version_added": "6"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": null
@@ -266,13 +266,13 @@
               "version_added": "6"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
             },
             "opera_android": {
-              "version_added": false
+              "version_added": true
             },
             "safari": {
               "version_added": null

--- a/api/Document.json
+++ b/api/Document.json
@@ -4769,7 +4769,7 @@
               }
             ],
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": [
               {
@@ -4790,11 +4790,12 @@
               }
             ],
             "safari": {
-              "alternative_name": "webkitIsFullScreen",
-              "version_added": true
+              "version_added": "6",
+              "alternative_name": "webkitIsFullScreen"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "6",
+              "alternative_name": "webkitIsFullScreen"
             },
             "samsunginternet_android": [
               {

--- a/api/DragEvent.json
+++ b/api/DragEvent.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DragEvent",
         "support": {
           "chrome": {
-            "version_added": "46"
+            "version_added": "3"
           },
           "chrome_android": {
             "version_added": false
@@ -17,13 +17,13 @@
             "version_added": "3.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"
           },
           "opera": {
-            "version_added": true
+            "version_added": "12"
           },
           "opera_android": {
             "version_added": false

--- a/api/File.json
+++ b/api/File.json
@@ -8,7 +8,7 @@
             "version_added": "13"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -49,10 +49,10 @@
             "version_added": "6"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -70,7 +70,7 @@
               "version_added": "13"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "79"
@@ -88,7 +88,7 @@
               "version_added": "11.5"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "11.5"
             },
             "safari": {
               "version_added": "10.1"
@@ -97,10 +97,10 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/FileList.json
+++ b/api/FileList.json
@@ -5,40 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileList",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
-            "version_added": null
+            "version_added": "10"
           },
           "opera": {
-            "version_added": true
+            "version_added": "11.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "11.1"
           },
           "safari": {
-            "version_added": true
+            "version_added": "4"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "3.2"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {

--- a/api/FileReader.json
+++ b/api/FileReader.json
@@ -8,7 +8,7 @@
             "version_added": "7"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -36,10 +36,10 @@
             "version_added": "6.1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -505,7 +505,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -532,10 +532,10 @@
               "version_added": "6.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -698,7 +698,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -725,10 +725,10 @@
               "version_added": "6.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -746,7 +746,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -773,10 +773,10 @@
               "version_added": "6.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -794,7 +794,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -822,10 +822,10 @@
               "version_added": "6.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -843,7 +843,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -870,10 +870,10 @@
               "version_added": "6.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/FileSystemSync.json
+++ b/api/FileSystemSync.json
@@ -9,7 +9,7 @@
             "prefix": "webkit"
           },
           "chrome_android": {
-            "version_added": true,
+            "version_added": "18",
             "prefix": "webkit"
           },
           "edge": {
@@ -26,23 +26,27 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "15",
+            "prefix": "webkit"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "14",
+            "prefix": "webkit"
           },
           "safari": {
-            "version_added": false
+            "version_added": "6",
+            "prefix": "webkit"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "6",
+            "prefix": "webkit"
           },
           "samsunginternet_android": {
             "prefix": "webkit",
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true,
+            "version_added": "≤37",
             "prefix": "webkit"
           }
         },
@@ -59,7 +63,7 @@
               "version_added": "13"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "≤79"
@@ -74,22 +78,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari": {
-              "version_added": false
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -106,7 +110,7 @@
               "version_added": "13"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "≤79"
@@ -121,22 +125,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari": {
-              "version_added": false
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/FormData.json
+++ b/api/FormData.json
@@ -8,7 +8,7 @@
             "version_added": "7"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -18,7 +18,8 @@
             "notes": "Prior to Firefox 7, specifying a <a href='https://developer.mozilla.org/docs/Web/API/Blob'><code>Blob</code></a> as the data to append to the object, the filename reported in the <code>Content-Disposition</code> HTTP header was an empty string, resulting in errors on some servers. Starting with Firefox 7, the filename <code>blob</code> is sent."
           },
           "firefox_android": {
-            "version_added": "4"
+            "version_added": "4",
+            "notes": "Prior to Firefox 7, specifying a <a href='https://developer.mozilla.org/docs/Web/API/Blob'><code>Blob</code></a> as the data to append to the object, the filename reported in the <code>Content-Disposition</code> HTTP header was an empty string, resulting in errors on some servers. Starting with Firefox 7, the filename <code>blob</code> is sent."
           },
           "ie": {
             "version_added": "10"
@@ -36,10 +37,10 @@
             "version_added": "5"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true,
+            "version_added": "≤37",
             "notes": "XHR in Android 4.0 sends empty content for <code>FormData</code> with <code>blob</code>."
           }
         },
@@ -58,7 +59,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -67,7 +68,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -85,10 +86,10 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -154,7 +155,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -184,7 +185,7 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "3",
@@ -317,10 +318,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "37"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "37"
             },
             "safari": {
               "version_added": "11"
@@ -359,28 +360,28 @@
               "version_added": "39"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "39"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "37"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "37"
             },
             "safari": {
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "50"
             }
           },
           "status": {
@@ -407,28 +408,28 @@
               "version_added": "39"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "39"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "37"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "37"
             },
             "safari": {
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "50"
             }
           },
           "status": {
@@ -551,16 +552,16 @@
               "version_added": "39"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "39"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "37"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "37"
             },
             "safari": {
               "version_added": "11"
@@ -572,7 +573,7 @@
               "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "50"
             }
           },
           "status": {
@@ -602,13 +603,13 @@
               "version_added": "44"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "37"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "37"
             },
             "safari": {
               "version_added": "11"

--- a/api/Geolocation.json
+++ b/api/Geolocation.json
@@ -8,7 +8,7 @@
             "version_added": "5"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,35 +23,23 @@
           "ie": {
             "version_added": "9"
           },
-          "opera": [
-            {
-              "version_added": "16"
-            },
-            {
-              "version_added": "10.6",
-              "version_removed": "15"
-            }
-          ],
-          "opera_android": [
-            {
-              "version_added": "16"
-            },
-            {
-              "version_added": "11",
-              "version_removed": "14"
-            }
-          ],
+          "opera": {
+            "version_added": "10.6"
+          },
+          "opera_android": {
+            "version_added": "11"
+          },
           "safari": {
             "version_added": "5"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "5"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -68,7 +56,7 @@
               "version_added": "5"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -82,35 +70,23 @@
             "ie": {
               "version_added": "9"
             },
-            "opera": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10.6",
-                "version_removed": "15"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "11",
-                "version_removed": "14"
-              }
-            ],
+            "opera": {
+              "version_added": "10.6"
+            },
+            "opera_android": {
+              "version_added": "11"
+            },
             "safari": {
-              "version_added": true
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -128,7 +104,7 @@
               "version_added": "5"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -142,35 +118,23 @@
             "ie": {
               "version_added": "9"
             },
-            "opera": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10.6",
-                "version_removed": "15"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "11",
-                "version_removed": "14"
-              }
-            ],
+            "opera": {
+              "version_added": "10.6"
+            },
+            "opera_android": {
+              "version_added": "11"
+            },
             "safari": {
-              "version_added": true
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -251,35 +215,23 @@
             "ie": {
               "version_added": "9"
             },
-            "opera": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10.6",
-                "version_removed": "15"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "11",
-                "version_removed": "14"
-              }
-            ],
+            "opera": {
+              "version_added": "10.6"
+            },
+            "opera_android": {
+              "version_added": "11"
+            },
             "safari": {
-              "version_added": true
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -5,19 +5,19 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": true
@@ -35,10 +35,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -622,40 +622,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onchange",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -670,40 +670,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onclick",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1453,40 +1453,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onerror",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "10"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
-              "version_added": null
+              "version_added": "11.6"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari": {
-              "version_added": null
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1885,40 +1885,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onload",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This PR sets and updates the version numbers for various misc. APIs from A through G based upon manual testing. The data is as follows:

	api.AbortController
		- Sufficient Data, No Changes
	api.AudioContext
		- Sufficient Data, Mirrored to Other Browsers
	api.BatteryManager
		- Safari (iOS) - not sure how I can get the version number for this
	api.Blob
		- Sufficient Data, Mirrored to Other Browsers
	api.Blob.arrayBuffer
		- Sufficient Data, No Changes
	api.Blob.Blob
		- Sufficient Data, Mirrored to Other Browsers
	api.Body
		- Sufficient Data, Mirrored to Other Browsers
	api.Body.blob
		- Sufficient Data, Mirrored to Other Browsers
	api.Body.json
		- Sufficient Data, Mirrored to Other Browsers
	api.Body.text
		- Sufficient Data, Mirrored to Other Browsers
	api.BroadcastChannel
		- Sufficient Data, No Changes
	api.Cache
		- Sufficient Data, No Changes
	api.Cache.delete
		- Sufficient Data, No Changes
	api.CacheStorage
		- Sufficient Data, Mirrored to Other Browsers
	api.ChildNode.remove
		- Sufficient Data, Mirrored to Other Browsers
	api.Clipboard
		- Sufficient Data, No Changes
	api.Crypto.getRandomValues
		- Sufficient Data, Mirrored to Other Browsers
	api.CSSStyleDeclaration.setProperty
		- IE - 9
		- Opera - 9
	api.DataTransfer
		- Chrome - incorrect data, 3
	api.DataTransfer.setData
		- Chrome - 3
		- Firefox - 10
		- IE - false
		- Opera - 12
		- Safari - 5
	api.DeviceMotionEvent
		- Chrome - 31
		- IE - 11
		- Opera - Blink
		- Safari - false
	api.DeviceOrientationEvent
		- IE - 11
		- Opera - Blink
		- Safari - false
	api.Document.fullscreen
		- IE - false
		- Safari - 6 (as webkitIsFullScreen)
	api.Document.fullscreenEnabled
		- No BCD
	api.DOMParser
		- Sufficient Data, Mirrored to Other Browsers
	api.DOMString
		- No BCD
	api.DOMTokenList
		- Firefox - 3
		- Opera - 11.5
	api.DragEvent
		- Chrome - incorrect data, 3
		- Opera - 12
	api.WindowOrWorkerGlobalScope.fetch
		- Sufficient Data, No Changes
	api.File
		- Sufficient Data, Mirrored to Other Browsers
	api.File.File
		- Sufficient Data, Mirrored to Other Browsers
	api.File.getasbinary
		- No BCD
	api.FileList
		- Chrome - 1
		- Firefox - 3
		- IE - 10
		- Opera - 11.1
		- Safari - 4
	api.FileReader
		- Sufficient Data, Mirrored to Other Browsers
	api.FileReader.onload
		- Sufficient Data, Mirrored to Other Browsers
	api.FileReader.readAsArrayBuffer
		- Sufficient Data, Mirrored to Other Browsers
	api.FileReader.readAsBinaryString
		- Sufficient Data, Mirrored to Other Browsers
	api.FileReader.readAsDataUrl
		- Sufficient Data, Mirrored to Other Browsers
	api.FileReader.readAsText
		- Sufficient Data, Mirrored to Other Browsers
	api.FileSystem
		- Sufficient Data, No Changes
	api.FileSystemSync
		- Opera - incorrect data, Blink
		- Safari - incorrect data, 6 w/ webkit prefix
	api.FileSystemSync.name
		- Opera - incorrect data, Blink
		- Safari - incorrect data, 6
	api.FileSystemSync.root
		- Opera - incorrect data, Blink
		- Safari - incorrect data, 6
	api.FormData
		- Sufficient Data, Mirrored to Other Browsers
	api.FormData.append
		- Sufficient Data, Mirrored to Other Browsers
	api.FormData.entries
		- Opera - Blink
	api.FormData.FormData
		- Sufficient Data, Mirrored to Other Browsers
	api.FormData.get
		- Opera - Blink
	api.FormData.getAll
		- Opera - Blink
	api.FormData.set
		- Opera - incorrect data, Blink
	api.FormData.values
		- IE - false
		- Opera - Blink
	api.Geolocation
		- Opera - incorrect data, 10.6 and was supported during Opera 14/15
	api.Geolocation.clearWatch
		- Opera - incorrect data, 10.6 and was supported during Opera 14/15
		- Safari - 5
	api.Geolocation.getCurrentPosition
		- Opera - incorrect data, 10.6 and was supported during Opera 14/15
		- Safari - 5
	api.Geolocation.watchPosition
		- Opera - incorrect data, 10.6 and was supported during Opera 14/15
		- Safari - 5
	api.GlobalEventHandlers.onchange
		- Chrome - 1
		- Firefox - 1
		- IE - 9
		- Opera - 9
		- Safari - 3
	api.GlobalEventHandlers.onclick
		- Chrome - 1
		- Firefox - 1
		- IE - 9
		- Opera - 9
		- Safari - 3
	api.GlobalEventHandlers.onerror
		- Chrome - 10
		- Firefox - 1
		- IE - 9
		- Opera - 11.6
		- Safari - 6
	api.GlobalEventHandlers.onload
		- Chrome - 1
		- Firefox - 1
		- IE - 9
		- Opera - 9
		- Safari - 3