### PR TITLE
Mark AbortController as supported in Safari 12.1+

### DIFF
--- a/api/AbortController.json
+++ b/api/AbortController.json
@@ -28,16 +28,26 @@
           "opera_android": {
             "version_added": "47"
           },
-          "safari": {
-            "version_added": "11.1",
-            "partial_implementation": true,
-            "notes": "Even though <code>window.AbortController</code> is defined, it doesn't really abort <code>fetch</code> requests. See <a href='https://webkit.org/b/174980'>bug 174980</a>."
-          },
-          "safari_ios": {
-            "version_added": "11.3",
-            "partial_implementation": true,
-            "notes": "Even though <code>window.AbortController</code> is defined, it doesn't really abort <code>fetch</code> requests. See <a href='https://webkit.org/b/174980'>bug 174980</a>."
-          },
+          "safari": [
+            {
+              "version_added": "12.1"
+            },
+            {
+              "version_added": "11.1",
+              "partial_implementation": true,
+              "notes": "Even though <code>window.AbortController</code> is defined, it doesn't really abort <code>fetch</code> requests. See <a href='https://webkit.org/b/174980'>bug 174980</a>."
+            }
+          ],
+          "safari_ios": [
+            {
+              "version_added": "12.2"
+            },
+            {
+              "version_added": "11.3",
+              "partial_implementation": true,
+              "notes": "Even though <code>window.AbortController</code> is defined, it doesn't really abort <code>fetch</code> requests. See <a href='https://webkit.org/b/174980'>bug 174980</a>."
+            }
+          ],
           "samsunginternet_android": {
             "version_added": "9.0"
           },
@@ -80,12 +90,26 @@
             "opera_android": {
               "version_added": "47"
             },
-            "safari": {
-              "version_added": "11.1"
-            },
-            "safari_ios": {
-              "version_added": "11.3"
-            },
+            "safari": [
+              {
+                "version_added": "12.1"
+              },
+              {
+                "version_added": "11.1",
+                "partial_implementation": true,
+                "notes": "Even though <code>window.AbortController</code> is defined, it doesn't really abort <code>fetch</code> requests. See <a href='https://webkit.org/b/174980'>bug 174980</a>."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "12.2"
+              },
+              {
+                "version_added": "11.3",
+                "partial_implementation": true,
+                "notes": "Even though <code>window.AbortController</code> is defined, it doesn't really abort <code>fetch</code> requests. See <a href='https://webkit.org/b/174980'>bug 174980</a>."
+              }
+          ],
             "samsunginternet_android": {
               "version_added": "9.0"
             },
@@ -128,12 +152,26 @@
             "opera_android": {
               "version_added": "47"
             },
-            "safari": {
-              "version_added": "11.1"
-            },
-            "safari_ios": {
-              "version_added": "11.3"
-            },
+            "safari": [
+              {
+                "version_added": "12.1"
+              },
+              {
+                "version_added": "11.1",
+                "partial_implementation": true,
+                "notes": "Even though <code>window.AbortController</code> is defined, it doesn't really abort <code>fetch</code> requests. See <a href='https://webkit.org/b/174980'>bug 174980</a>."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "12.2"
+              },
+              {
+                "version_added": "11.3",
+                "partial_implementation": true,
+                "notes": "Even though <code>window.AbortController</code> is defined, it doesn't really abort <code>fetch</code> requests. See <a href='https://webkit.org/b/174980'>bug 174980</a>."
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "9.0"
             },
@@ -176,12 +214,26 @@
             "opera_android": {
               "version_added": "47"
             },
-            "safari": {
-              "version_added": "11.1"
-            },
-            "safari_ios": {
-              "version_added": "11.3"
-            },
+            "safari": [
+              {
+                "version_added": "12.1"
+              },
+              {
+                "version_added": "11.1",
+                "partial_implementation": true,
+                "notes": "Even though <code>window.AbortController</code> is defined, it doesn't really abort <code>fetch</code> requests. See <a href='https://webkit.org/b/174980'>bug 174980</a>."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "12.2"
+              },
+              {
+                "version_added": "11.3",
+                "partial_implementation": true,
+                "notes": "Even though <code>window.AbortController</code> is defined, it doesn't really abort <code>fetch</code> requests. See <a href='https://webkit.org/b/174980'>bug 174980</a>."
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "9.0"
             },

--- a/api/AbortController.json
+++ b/api/AbortController.json
@@ -109,7 +109,7 @@
                 "partial_implementation": true,
                 "notes": "Even though <code>window.AbortController</code> is defined, it doesn't really abort <code>fetch</code> requests. See <a href='https://webkit.org/b/174980'>bug 174980</a>."
               }
-          ],
+            ],
             "samsunginternet_android": {
               "version_added": "9.0"
             },


### PR DESCRIPTION
https://developer.apple.com/safari/technology-preview/release-notes/ indicates that support for “abortable fetch” (aka AbortController) was added to Safari in Safari Technology Preview 74 — which corresponds to desktop Safari 12.1, iOS Safari 12.2.

See also https://caniuse.com/#feat=abortcontroller