### PR TITLE
Make privacy an optional permission

### DIFF
--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -440,6 +440,28 @@
             }
           }
         },
+        "privacy": {
+          "__compat": {
+            "description": "<code>privacy</code>",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "75"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              }
+            }
+          }
+        },
         "tabHide": {
           "__compat": {
             "description": "<code>tabHide</code>",


### PR DESCRIPTION
This change the privacy permission to the list of permissions that be can be requested optionally. Investigation suggested that this permission had always been optional in other browsers clearly.
For more details see [1618399](https://bugzilla.mozilla.org/show_bug.cgi?id=1618399) and the updated [schema](https://hg.mozilla.org/mozilla-central/diff/52ab307bf354039defa16b797105b94cd6387cf1/toolkit/components/extensions/schemas/privacy.json). Confirmation that this is optional in Chrome is provided in [chrome.permissions](https://developer.chrome.com/apps/permissions) in the section "Permissions that can not be specified as optional".

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
