### PR TITLE
Mark WeakMap.p.clear as removed in Node.js 4.0.0

### DIFF
--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -318,7 +318,8 @@
                 "version_added": "11"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.12",
+                "version_removed": "4.0.0"
               },
               "opera": {
                 "version_added": "25",


### PR DESCRIPTION
https://chromium.googlesource.com/v8/v8.git/+/chromium/2513/ChangeLog#3518 indicates that `Weak{Map,Set}.prototype.clear` was removed in V8 3.31.15, which per https://nodejs.org/en/download/releases/ corresponds to io.js 1.0.0 — and so the closest BCD nodejs version for that is 4.0.0.

https://chromium.googlesource.com/v8/v8.git/+/chromium/2513/ChangeLog#6701 indicates that `WeakMap.prototype.clear` was added in V8 3.20.1, which per https://nodejs.org/en/download/releases/ corresponds to Node.js 0.11.4 — and so the closest BCD nodejs version for that is 0.12.

Fixes https://github.com/mdn/browser-compat-data/issues/5841