### PR TITLE
Update versions for misc. APIs (H-M)

### DIFF
--- a/api/HTMLAudioElement.json
+++ b/api/HTMLAudioElement.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAudioElement",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -23,22 +23,22 @@
             "version_added": "9"
           },
           "opera": {
-            "version_added": true
+            "version_added": "10.5"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "11"
           },
           "safari": {
-            "version_added": true
+            "version_added": "3.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "2"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {

--- a/api/History.json
+++ b/api/History.json
@@ -5,40 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/History",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"
           },
           "opera": {
-            "version_added": true
+            "version_added": "3"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "10.1"
           },
           "safari": {
-            "version_added": true
+            "version_added": "1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -247,17 +247,18 @@
               "version_added": "5"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
               "version_added": "4",
-              "notes": "In Firefox 2 through 5, the passed object is serialized using JSON. Starting in Firefox 6, the object is serialized using <a href='https://developer.mozilla.org/docs/DOM/The_structured_clone_algorithm'>the structured clone algorithm</a>. This allows a wider variety of objects to be safely passed."
+              "notes": "Until Firefox 5, the passed object is serialized using JSON. Starting in Firefox 6, the object is serialized using <a href='https://developer.mozilla.org/docs/DOM/The_structured_clone_algorithm'>the structured clone algorithm</a>. This allows a wider variety of objects to be safely passed."
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4",
+              "notes": "Until Firefox 5, the passed object is serialized using JSON. Starting in Firefox 6, the object is serialized using <a href='https://developer.mozilla.org/docs/DOM/The_structured_clone_algorithm'>the structured clone algorithm</a>. This allows a wider variety of objects to be safely passed."
             },
             "ie": {
               "version_added": "10"
@@ -266,7 +267,7 @@
               "version_added": "11.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11.5"
             },
             "safari": {
               "version_added": "5"
@@ -275,10 +276,10 @@
               "version_added": "4.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -344,17 +345,18 @@
               "version_added": "5"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
               "version_added": "4",
-              "notes": "In Firefox 2 through 5, the passed object is serialized using JSON. Starting in Firefox 6, the object is serialized using <a href='https://developer.mozilla.org/docs/DOM/The_structured_clone_algorithm'>the structured clone algorithm</a>. This allows a wider variety of objects to be safely passed."
+              "notes": "Until Firefox 5, the passed object is serialized using JSON. Starting in Firefox 6, the object is serialized using <a href='https://developer.mozilla.org/docs/DOM/The_structured_clone_algorithm'>the structured clone algorithm</a>. This allows a wider variety of objects to be safely passed."
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4",
+              "notes": "Until Firefox 5, the passed object is serialized using JSON. Starting in Firefox 6, the object is serialized using <a href='https://developer.mozilla.org/docs/DOM/The_structured_clone_algorithm'>the structured clone algorithm</a>. This allows a wider variety of objects to be safely passed."
             },
             "ie": {
               "version_added": "10"
@@ -363,7 +365,7 @@
               "version_added": "11.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11.5"
             },
             "safari": {
               "version_added": "5"
@@ -372,10 +374,10 @@
               "version_added": "4.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -8,7 +8,7 @@
             "version_added": "4"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -35,10 +35,10 @@
             "version_added": "3.2"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -33,7 +33,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "38"
+          },
+          "opera_android": {
+            "version_added": "41"
           },
           "safari": {
             "version_added": "12.1"

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -5,40 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyboardEvent",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "9"
           },
           "opera": {
-            "version_added": true
+            "version_added": "12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "12.1"
           },
           "safari": {
-            "version_added": true
+            "version_added": "3.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "2"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -437,40 +437,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyboardEvent/code",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "48"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "48"
             },
             "edge": {
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "38"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "38"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "35"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "35"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "48"
             }
           },
           "status": {
@@ -1426,10 +1426,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -1599,7 +1599,7 @@
               "version_added": "26"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "26"
             },
             "edge": {
               "version_added": "12"
@@ -1608,16 +1608,16 @@
               "version_added": "3"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "9"
             },
             "opera": {
-              "version_added": "11.6"
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari": {
               "version_added": "5"
@@ -1626,10 +1626,10 @@
               "version_added": "5.1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1910,10 +1910,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": "10.1"
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "safari": {
               "version_added": "5.1"

--- a/api/Location.json
+++ b/api/Location.json
@@ -5,37 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Location",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
+          },
+          "chrome_android": {
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "3"
           },
           "opera": {
-            "version_added": true
+            "version_added": "3"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "10.1"
           },
           "safari": {
-            "version_added": true
+            "version_added": "1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -49,40 +52,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Location/assign",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -536,42 +539,42 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Location/reload",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12",
-              "notes": "If a page added to <em>Trusted Sites</em> contains a cross-origin iframe, then calling <code>reload()</code> from within the iframe reloads the trusted page (in other words, the top page reloads, not the iframe)."
+              "notes": "In EdgeHTML versions of Edge, if a page added to <em>Trusted Sites</em> contains a cross-origin iframe, then calling <code>reload()</code> from within the iframe reloads the trusted page (in other words, the top page reloads, not the iframe).  This behavior was fixed in Edge 79."
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": true,
+              "version_added": "5.5",
               "notes": "If a page added to <em>Trusted Sites</em> contains a cross-origin iframe, then calling <code>reload()</code> from within the iframe reloads the trusted page (in other words, the top page reloads, not the iframe)."
             },
             "opera": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -586,40 +589,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Location/replace",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
-              "version_added": true
+              "version_added": "3"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -221,17 +221,31 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "60"
+              },
+              {
+                "version_added": "57",
+                "version_removed": "60",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform features",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Available as a member of <code>Navigator</code> instead of <code>MediaDevices</code> in Opera 57 and 58."
+              }
+            ],
             "opera_android": {
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -22,7 +22,7 @@
             "notes": "Prior to Firefox 58, using <code>MediaStream.addTrack()</code> on a stream obtained using <code>getUserMedia()</code>, then attempting to record the resulting stream would result in only recording the original stream without the added tracks (severe bug)."
           },
           "ie": {
-            "version_added": null
+            "version_added": false
           },
           "opera": {
             "version_added": "36"
@@ -31,10 +31,10 @@
             "version_added": "36"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "5.0"
@@ -70,7 +70,7 @@
               "version_added": "25"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "36"
@@ -79,10 +79,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -117,7 +117,7 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "36"
@@ -126,10 +126,10 @@
                 "version_added": "36"
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -166,7 +166,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "36"
@@ -175,10 +175,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -215,7 +215,7 @@
               "version_added": "25"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "36"
@@ -224,10 +224,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -265,7 +265,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "36",
@@ -276,10 +276,10 @@
               "version_removed": "44"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0",
@@ -317,7 +317,7 @@
               "version_added": "25"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "36"
@@ -326,10 +326,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -382,7 +382,7 @@
               "version_added": "25"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "36"
@@ -391,10 +391,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -438,7 +438,7 @@
               "version_added": "25"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "36"
@@ -447,10 +447,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -486,7 +486,7 @@
               "version_added": "25"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "36"
@@ -495,10 +495,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -534,7 +534,7 @@
               "version_added": "65"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "36"
@@ -543,10 +543,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -582,7 +582,7 @@
               "version_added": "65"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "36"
@@ -591,10 +591,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -630,7 +630,7 @@
               "version_added": "25"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "36"
@@ -639,10 +639,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -678,7 +678,7 @@
               "version_added": "25"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "36"
@@ -687,10 +687,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -727,7 +727,7 @@
               "version_added": "25"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "36"
@@ -736,10 +736,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -775,7 +775,7 @@
               "version_added": "25"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "36"
@@ -784,10 +784,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -823,7 +823,7 @@
               "version_added": "25"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "36"
@@ -832,10 +832,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -871,7 +871,7 @@
               "version_added": "25"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "36"
@@ -880,10 +880,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -919,7 +919,7 @@
               "version_added": "25"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "36"
@@ -928,10 +928,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -983,7 +983,7 @@
               "version_added": "25"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "36"
@@ -992,10 +992,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -1039,7 +1039,7 @@
               "version_added": "25"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "36"
@@ -1048,10 +1048,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -1103,7 +1103,7 @@
               "version_added": "25"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "36"
@@ -1112,10 +1112,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -1151,7 +1151,7 @@
               "version_added": null
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "36"
@@ -1160,10 +1160,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -1201,7 +1201,7 @@
               "version_added": "25"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "36"
@@ -1210,10 +1210,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/MediaSource.json
+++ b/api/MediaSource.json
@@ -47,8 +47,7 @@
             "version_added": "41"
           },
           "ie": {
-            "version_added": "11",
-            "notes": "Only works on Windows 8+."
+            "version_added": "11"
           },
           "opera": [
             {
@@ -74,7 +73,7 @@
             "version_added": "8"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "8"
           },
           "samsunginternet_android": [
             {

--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -4,14 +4,26 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStream",
         "support": {
-          "chrome": {
-            "version_added": "14"
-          },
-          "chrome_android": {
-            "version_added": "18"
-          },
+          "chrome": [
+            {
+              "version_added": "55"
+            },
+            {
+              "version_added": "21",
+              "prefix": "webkit"
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "55"
+            },
+            {
+              "version_added": "25",
+              "prefix": "webkit"
+            }
+          ],
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "15"
@@ -22,24 +34,48 @@
           "ie": {
             "version_added": false
           },
-          "opera": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": false
-          },
+          "opera": [
+            {
+              "version_added": "42"
+            },
+            {
+              "version_added": "15",
+              "prefix": "webkit"
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": "42"
+            },
+            {
+              "version_added": "14",
+              "prefix": "webkit"
+            }
+          ],
           "safari": {
-            "version_added": true
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "11"
           },
-          "samsunginternet_android": {
-            "version_added": "1.0"
-          },
-          "webview_android": {
-            "version_added": "37"
-          }
+          "samsunginternet_android": [
+            {
+              "version_added": "6.0"
+            },
+            {
+              "version_added": "1.5",
+              "prefix": "webkit"
+            }
+          ],
+          "webview_android": [
+            {
+              "version_added": "55"
+            },
+            {
+              "version_added": "≤37",
+              "prefix": "webkit"
+            }
+          ]
         },
         "status": {
           "experimental": false,
@@ -53,7 +89,7 @@
           "description": "<code>MediaStream()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "19"
+              "version_added": "21"
             },
             "chrome_android": {
               "version_added": "25"

--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -5,13 +5,13 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrack",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "29"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "29"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "22"
@@ -23,22 +23,22 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "16"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "16"
           },
           "safari": {
-            "version_added": true
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "11"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "2.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -8,7 +8,7 @@
             "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -17,28 +17,28 @@
             "version_added": "4"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"
           },
           "opera": {
-            "version_added": true
+            "version_added": "10.6"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "11"
           },
           "safari": {
-            "version_added": "10"
+            "version_added": "4"
           },
           "safari_ios": {
             "version_added": "3"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -77,7 +77,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "4"
             },
             "safari_ios": {
               "version_added": "3"
@@ -125,7 +125,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "4"
             },
             "safari_ios": {
               "version_added": "3"
@@ -173,7 +173,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "4"
             },
             "safari_ios": {
               "version_added": "3"
@@ -221,7 +221,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "4"
             },
             "safari_ios": {
               "version_added": "3"
@@ -269,7 +269,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "4"
             },
             "safari_ios": {
               "version_added": "3"
@@ -365,7 +365,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "4"
             },
             "safari_ios": {
               "version_added": "3"

--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -5,40 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "9"
           },
           "opera": {
-            "version_added": true
+            "version_added": "10.6"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "11"
           },
           "safari": {
-            "version_added": true
+            "version_added": "3.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "2"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -264,7 +264,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -273,34 +273,28 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
-            "ie": [
-              {
-                "version_added": "9"
-              },
-              {
-                "version_added": true,
-                "notes": "<a href='https://www.quirksmode.org/js/events_properties.html#button'>Different convention</a> used prior to version 9."
-              }
-            ],
+            "ie": {
+              "version_added": "9"
+            },
             "opera": {
-              "version_added": true
+              "version_added": "10.6"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -364,40 +358,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/clientX",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "10.6"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
-              "version_added": true
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -475,7 +469,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -991,7 +985,7 @@
               "version_added": "43"
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -1087,7 +1081,7 @@
               "version_added": "43"
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -1499,7 +1493,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -1595,7 +1589,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -1744,13 +1738,13 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": "5"
+              "version_added": "10.6"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
-              "version_added": "1"
+              "version_added": "3.1"
             },
             "safari_ios": {
               "version_added": true
@@ -1789,7 +1783,7 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -1837,7 +1831,7 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "9"
             },
             "opera": {
               "version_added": true

--- a/api/MutationObserver.json
+++ b/api/MutationObserver.json
@@ -74,11 +74,11 @@
           ],
           "webview_android": [
             {
-              "version_added": true
+              "version_added": "≤37"
             },
             {
-              "version_added": true,
-              "version_removed": true,
+              "version_added": "≤37",
+              "version_removed": "≤37",
               "prefix": "WebKit"
             }
           ]
@@ -266,7 +266,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR sets and updates the version numbers for various misc. APIs from H through M based upon manual testing. The data is as follows:

	api.Headers
		- Sufficient Data, No Change
	api.History
		- Chrome - 1
		- Firefox - 1
		- Opera - 3
		- Safari - 1
	api.History.pushState
		- Sufficient Data, Mirrored to Other Browsers
	api.History.replaceState
		- Sufficient Data, Mirrored to Other Browsers
	api.HTMLAudioElement
		- Chrome - 1
		- Opera - 10.5
		- Safari - 3.1
	api.ImageData
		- Sufficient Data, Mirrored to Other Browsers
	api.IntersectionObserver
		- Opera - Blink
	api.KeyboardEvent
		- Chrome - 1
		- Firefox - 1.5
		- IE - 9
		- Opera - 12.1
		- Safari - 3.1
	api.KeyboardEvent.code
		- Chrome - 48
		- Firefox - 38
		- IE - false
		- Opera - Blink
		- Safari - 10
	api.KeyboardEvent.key
		- Safari - 10
	api.KeyboardEvent.keyCode
		- Sufficient Data, Mirrored to Other Browsers
	api.Location
		- Chrome - 1
		- Firefox - 1
		- IE - 3
		- Opera - 3
		- Safari - 1
	api.Location.assign
		- Chrome - 1
		- Firefox - 1
		- IE - 5.5
		- Opera - 3
		- Safari - 3
	api.Location.reload
		- Chrome - 1
		- Firefox - 1
		- IE - 5.5
		- Opera - 3
		- Safari - 1
	api.Location.replace
		- Chrome - 1
		- Firefox - 1
		- IE - 5.5
		- Opera - 3
		- Safari - 1
	api.MediaDevices
		- Sufficient Data, No Change
	api.MediaDevices.enumerateDevices
		- Sufficient Data, No Change
	api.MediaDevices.getDisplayMedia
		- Opera - Blink
		- Safari - 13
	api.MediaDevices.getUserMedia
		- Sufficient Data, No Change
	api.MediaRecorder
		- IE - false
		- Safari - false
	api.MediaSource
		- Sufficient Data, No Change
	api.MediaStream
		- Chrome - incorrect data, 55 (21 with webkit prefix)
		- Edge - 12
		- Opera - Blink
		- Safari - 11
	api.MediaStreamTrack
		- Chrome - 29
		- Edge - 12
		- IE - false
		- Opera - Blink
		- Safari - 11
	api.MessageEvent
		- Opera - 10.6
		- Safari - incorrect data, 4
	api.MessageEvent.MessageEvent
		- Safari - incorrect data, 6
	api.MessageEvent.data
		- Safari - incorrect data, 4
	api.MessageEvent.initMessageEvent
		- Safari - incorrect data, 4
	api.MessageEvent.lastEventId
		- Safari - incorrect data, 4
	api.MessageEvent.origin
		- Safari - incorrect data, 4
	api.MessageEvent.ports
		- Safari - incorrect data, 4
	api.MouseEvent
		- Chrome - 1
		- Firefox - 1
		- IE - 9
		- Opera - 10.6
		- Safari - 3.1
	api.MouseEvent.button
		- IE - 9
		- Opera - 10.6
	api.MouseEvent.clientX
		- Chrome - 1
		- Firefox - 1
		- Opera - 10.6
		- Safari - 3.1
	api.MutationObserver
		- Sufficient Data, Mirrored to Other Browsers
	api.MutationObserver.observe
		- Sufficient Data, Mirrored to Other Browsers

Note: there were a lot of inconsistencies found in Internet Explorer, where subfeatures were set to versions lower than the API's general support from what I found.  I have no idea how that would be possible based upon my testing, but I'm guessing it's one of those weird IE ActiveX things or something?