### PR TITLE
Display lowest version_added for arrays in consistency linter

### DIFF
--- a/test/linter/test-consistency.js
+++ b/test/linter/test-consistency.js
@@ -120,7 +120,7 @@ class ConsistencyChecker {
     Object.keys(inconsistentSubfeaturesByBrowser).forEach(browser => {
       const subfeatures = inconsistentSubfeaturesByBrowser[browser];
       const errortype = 'unsupported';
-      const parent_value = data.__compat.support[browser].version_added;
+      const parent_value = this.getVersionAdded(data.__compat.support[browser]);
 
       errors.push({
         errortype,
@@ -162,7 +162,7 @@ class ConsistencyChecker {
     Object.keys(inconsistentSubfeaturesByBrowser).forEach(browser => {
       const subfeatures = inconsistentSubfeaturesByBrowser[browser];
       const errortype = 'support_unknown';
-      const parent_value = data.__compat.support[browser].version_added;
+      const parent_value = this.getVersionAdded(data.__compat.support[browser]);
 
       errors.push({
         errortype,
@@ -203,7 +203,7 @@ class ConsistencyChecker {
     Object.keys(inconsistentSubfeaturesByBrowser).forEach(browser => {
       const subfeatures = inconsistentSubfeaturesByBrowser[browser];
       const errortype = 'subfeature_earlier_implementation';
-      const parent_value = data.__compat.support[browser].version_added;
+      const parent_value = this.getVersionAdded(data.__compat.support[browser]);
 
       errors.push({
         errortype,
@@ -389,7 +389,7 @@ function testConsistency(filename) {
         subfeatures.forEach(subfeature => {
           console.error(
             chalk`{red       → {bold ${path.join('.')}.${subfeature[0]}}: ${
-              subfeature[1] === undefined ? '[Array]' : subfeature[1]
+              subfeature[1]
             }}`,
           );
         });


### PR DESCRIPTION
Kind of a follow-up to #5833.  While working on some additional versions, I realized that when a subfeature has an earlier version than its parent, the linter prints the parent version as well.  However, we didn't have it print "[Array]" when the parent feature has an array for support.  Even so, I realize that simply printing "[Array]" is not as helpful.

The consistency linter already has a function that gets the earliest `version_added` from an array (or just the `version_added` of a single support statement), so I figured that we should hook it up to the output, removing the need to print "[Array]" at all.

This PR hooks up all output of parent values with the `getVersionAdded` function, so that the earliest `version_added` in an array is printed, rather than "[Array]".