### PR TITLE
Add data for Safari 13.1 and iOS 13.4 beta

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -165,6 +165,10 @@
           "status": "current",
           "engine": "WebKit",
           "engine_version": "608.2.11"
+        },
+        "13.1": {
+          "status": "beta",
+          "engine": "WebKit"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -143,6 +143,10 @@
           "status": "current",
           "engine": "WebKit",
           "engine_version": "608.2.11"
+        },
+        "13.4": {
+          "status": "beta",
+          "engine": "WebKit"
         }
       }
     }


### PR DESCRIPTION
This PR adds basic data for Safari 13.1 and Safari iOS 13.4.  Both are currently in beta and it is uncertain when the final release date or engine version is -- as such, this PR leaves said data unfilled for a later follow-up.

This fixes #5831 and unblocks #5830.