### PR TITLE
Mark StaticRange() supported in Safari 13.1/13.4

### DIFF
--- a/api/StaticRange.json
+++ b/api/StaticRange.json
@@ -78,10 +78,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
See https://github.com/mdn/browser-compat-data/pull/5072 for previous discussion — in which we decided to keep Safari `version_added` as `false` until such time as a 13.1 (or later) version.