### PR TITLE
Add BackgroundFetch Data

### DIFF
--- a/api/BackgroundFetchEvent.json
+++ b/api/BackgroundFetchEvent.json
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "62"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "53"
           },
           "safari": {
             "version_added": false
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "11.0"
           },
           "webview_android": {
             "version_added": false
@@ -71,10 +71,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
               "version_added": false
@@ -119,10 +119,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/BackgroundFetchEvent.json
+++ b/api/BackgroundFetchEvent.json
@@ -1,0 +1,149 @@
+{
+  "api": {
+    "BackgroundFetchEvent": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchEvent",
+        "support": {
+          "chrome": {
+            "version_added": "74"
+          },
+          "chrome_android": {
+            "version_added": "74"
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": false,
+          "deprecated": false
+        }
+      },
+      "BackgroundFetchEvent": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchEvent/BackgroundFetchEvent",
+          "description": "<code>BackgroundFetchEvent()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
+      "registration": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchEvent/registration",
+          "support": {
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/BackgroundFetchManager.json
+++ b/api/BackgroundFetchManager.json
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "62"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "53"
           },
           "safari": {
             "version_added": false
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "11.0"
           },
           "webview_android": {
             "version_added": false
@@ -70,10 +70,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
               "version_added": false
@@ -118,10 +118,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -130,7 +130,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
               "version_added": false
@@ -166,10 +166,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -178,7 +178,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/BackgroundFetchManager.json
+++ b/api/BackgroundFetchManager.json
@@ -1,8 +1,8 @@
 {
   "api": {
-    "BackgroundFetchEvent": {
+    "BackgroundFetchManager": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchEvent",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchManager",
         "support": {
           "chrome": {
             "version_added": "74"
@@ -47,10 +47,9 @@
           "deprecated": false
         }
       },
-      "BackgroundFetchEvent": {
+      "fetch": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchEvent/BackgroundFetchEvent",
-          "description": "<code>BackgroundFetchEvent()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchManager/fetch",
           "support": {
             "chrome": {
               "version_added": "74"
@@ -96,9 +95,57 @@
           }
         }
       },
-      "registration": {
+      "get": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchEvent/registration",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchManager/get",
+          "support": {
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getIds": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchManager/getIds",
           "support": {
             "chrome": {
               "version_added": "74"

--- a/api/BackgroundFetchRecord.json
+++ b/api/BackgroundFetchRecord.json
@@ -1,8 +1,8 @@
 {
   "api": {
-    "BackgroundFetchEvent": {
+    "BackgroundFetchRecord": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchEvent",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchRecord",
         "support": {
           "chrome": {
             "version_added": "74"
@@ -47,10 +47,9 @@
           "deprecated": false
         }
       },
-      "BackgroundFetchEvent": {
+      "request": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchEvent/BackgroundFetchEvent",
-          "description": "<code>BackgroundFetchEvent()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchRecord/request",
           "support": {
             "chrome": {
               "version_added": "74"
@@ -96,9 +95,9 @@
           }
         }
       },
-      "registration": {
+      "responseReady": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchEvent/registration",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchRecord/responseReady",
           "support": {
             "chrome": {
               "version_added": "74"

--- a/api/BackgroundFetchRecord.json
+++ b/api/BackgroundFetchRecord.json
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "62"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "53"
           },
           "safari": {
             "version_added": false
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "11.0"
           },
           "webview_android": {
             "version_added": false
@@ -70,10 +70,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
               "version_added": false
@@ -118,10 +118,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -130,7 +130,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/BackgroundFetchRegistration.json
+++ b/api/BackgroundFetchRegistration.json
@@ -1,0 +1,628 @@
+{
+  "api": {
+    "BackgroundFetchRegistration": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchRegistration",
+        "support": {
+          "chrome": {
+            "version_added": "74"
+          },
+          "chrome_android": {
+            "version_added": "74"
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "abort": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchRegistration/abott",
+          "support": {
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "downloaded": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchRegistration/downloaded",
+          "support": {
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "downloadTotal": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchRegistration/downloadTotal",
+          "support": {
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "failureReason": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchRegistration/failureReason",
+          "support": {
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "id": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchRegistration/id",
+          "support": {
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "match": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchRegistration/match",
+          "support": {
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "matchAll": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchRegistration/matchAll",
+          "support": {
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onprogress": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchRegistration/onprogress",
+          "support": {
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "recordsAvailable": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchRegistration/recordsAvailable",
+          "support": {
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "result": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchRegistration/result",
+          "support": {
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uploaded": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchRegistration/uploaded",
+          "support": {
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uploadTotal": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchRegistration/uploadTotal",
+          "support": {
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/BackgroundFetchRegistration.json
+++ b/api/BackgroundFetchRegistration.json
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "62"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "53"
           },
           "safari": {
             "version_added": false
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "11.0"
           },
           "webview_android": {
             "version_added": false
@@ -70,10 +70,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
               "version_added": false
@@ -118,10 +118,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -130,7 +130,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
               "version_added": false
@@ -166,10 +166,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -178,7 +178,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
               "version_added": false
@@ -214,10 +214,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -226,7 +226,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
               "version_added": false
@@ -262,10 +262,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -274,7 +274,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
               "version_added": false
@@ -310,10 +310,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -322,7 +322,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
               "version_added": false
@@ -358,10 +358,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -370,7 +370,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
               "version_added": false
@@ -406,10 +406,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -418,7 +418,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
               "version_added": false
@@ -454,10 +454,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -466,7 +466,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
               "version_added": false
@@ -502,10 +502,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -514,7 +514,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
               "version_added": false
@@ -550,10 +550,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -562,7 +562,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
               "version_added": false
@@ -598,10 +598,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -610,7 +610,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/BackgroundFetchRegistration.json
+++ b/api/BackgroundFetchRegistration.json
@@ -49,7 +49,7 @@
       },
       "abort": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchRegistration/abott",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchRegistration/abort",
           "support": {
             "chrome": {
               "version_added": "74"

--- a/api/BackgroundFetchUpdateUIEvent.json
+++ b/api/BackgroundFetchUpdateUIEvent.json
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "62"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "53"
           },
           "safari": {
             "version_added": false
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "11.0"
           },
           "webview_android": {
             "version_added": false
@@ -71,10 +71,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
               "version_added": false
@@ -119,10 +119,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/BackgroundFetchUpdateUIEvent.json
+++ b/api/BackgroundFetchUpdateUIEvent.json
@@ -1,8 +1,8 @@
 {
   "api": {
-    "BackgroundFetchEvent": {
+    "BackgroundFetchUpdateUIEvent": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchEvent",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchUpdateUIEvent",
         "support": {
           "chrome": {
             "version_added": "74"
@@ -47,10 +47,10 @@
           "deprecated": false
         }
       },
-      "BackgroundFetchEvent": {
+      "BackgroundFetchUpdateUIEvent": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchEvent/BackgroundFetchEvent",
-          "description": "<code>BackgroundFetchEvent()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchUpdateUIEvent/BackgroundFetchUpdateUIEvent",
+          "description": "<code>BackgroundFetchUpdateUIEvent()</code> constructor",
           "support": {
             "chrome": {
               "version_added": "74"
@@ -96,9 +96,9 @@
           }
         }
       },
-      "registration": {
+      "updateUI": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchEvent/registration",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchUpdateUIEvent/updateUI",
           "support": {
             "chrome": {
               "version_added": "74"

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -464,6 +464,198 @@
           }
         }
       },
+      "onbackgroundfetchabort": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/onbackgroundfetchsuccess",
+          "support": {
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onbackgroundfetchclick": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/onbackgroundfetchsuccess",
+          "support": {
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onbackgroundfetchfail": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/onbackgroundfetchsuccess",
+          "support": {
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onbackgroundfetchsuccess": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/onbackgroundfetchsuccess",
+          "support": {
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "oncanmakepayment": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/oncanmakepayment",

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -466,7 +466,7 @@
       },
       "onbackgroundfetchabort": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/onbackgroundfetchsuccess",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/onbackgroundfetchabort",
           "support": {
             "chrome": {
               "version_added": "74"

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -514,7 +514,7 @@
       },
       "onbackgroundfetchclick": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/onbackgroundfetchsuccess",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/onbackgroundfetchclick",
           "support": {
             "chrome": {
               "version_added": "74"

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -487,10 +487,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -499,7 +499,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
               "version_added": false
@@ -535,10 +535,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -547,7 +547,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
               "version_added": false
@@ -583,10 +583,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -595,7 +595,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
               "version_added": false
@@ -631,10 +631,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -643,7 +643,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -562,7 +562,7 @@
       },
       "onbackgroundfetchfail": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/onbackgroundfetchsuccess",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/onbackgroundfetchfail",
           "support": {
             "chrome": {
               "version_added": "74"

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -119,6 +119,54 @@
           }
         }
       },
+      "backgroundFetch": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/backgroundFetch",
+          "support": {
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getNotifications": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/getNotifications",

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -142,10 +142,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false
@@ -154,7 +154,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
[This CL](https://chromium.googlesource.com/chromium/src/+/821c5a89bd0a540e2d54177a7ec625c1934ed855) shows when the runtime flag for these interfaces was flipped from experimental to stable as well as which interfaces were affected.

[The status entry](https://www.chromestatus.com/features/5712608971718656) shows that the features are not supported in WebView.

