### PR TITLE
Updated Chrome support for tel input

### DIFF
--- a/html/elements/input/tel.json
+++ b/html/elements/input/tel.json
@@ -8,7 +8,7 @@
             "description": "<code>type=\"tel\"</code>",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": false
               },
               "chrome_android": {
                 "version_added": true


### PR DESCRIPTION
Chrome does not support the tel input, at least as of 80.0.3987.132 it does not on MacOS.
This is further supported by https://www.w3schools.com/tags/att_input_type_tel.asp

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
