### PR TITLE
Update versions for misc. APIs (N-S)

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -5,40 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "4"
           },
           "opera": {
-            "version_added": true
+            "version_added": "3"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "10.1"
           },
           "safari": {
-            "version_added": true
+            "version_added": "1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -690,7 +690,7 @@
               "version_added": "5"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -704,35 +704,23 @@
             "ie": {
               "version_added": "9"
             },
-            "opera": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "10.6",
-                "version_removed": "15"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "11",
-                "version_removed": "14"
-              }
-            ],
+            "opera": {
+              "version_added": "10.6"
+            },
+            "opera_android": {
+              "version_added": "11"
+            },
             "safari": {
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/NavigatorLanguage.json
+++ b/api/NavigatorLanguage.json
@@ -5,40 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorLanguage",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "11"
           },
           "opera": {
-            "version_added": true
+            "version_added": "4"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "10.1"
           },
           "safari": {
-            "version_added": true
+            "version_added": "1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -52,27 +52,21 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorLanguage/language",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Returns the browser UI language, not the value of the <code>Accept-Language</code> <a href='https://developer.mozilla.org/docs/Web/HTTP/Headers'>HTTP header</a>."
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "notes": "Returns the browser UI language, not the value of the <code>Accept-Language</code> <a href='https://developer.mozilla.org/docs/Web/HTTP/Headers'>HTTP header</a>."
             },
             "edge": {
               "version_added": "12",
               "notes": "In Chromium versions of Edge, this returns the browser UI language, not the value of the <code>Accept-Language</code> <a href='https://developer.mozilla.org/docs/Web/HTTP/Headers'>HTTP header</a>."
             },
-            "firefox": [
-              {
-                "version_added": "1",
-                "notes": "Prior to Firefox 4 this property's value was also part of the user agent string, as reported by <code>navigator.userAgent</code>."
-              },
-              {
-                "version_added": "5",
-                "notes": "Starting in Firefox 5.0 this property's value is based on the value of the <code>Accept-Language</code> <a href='https://developer.mozilla.org/docs/Web/HTTP/Headers'>HTTP header</a>."
-              }
-            ],
+            "firefox": {
+              "version_added": "1",
+              "notes": "Prior to Firefox 4, this property's value was also part of the user agent string, as reported by <code>navigator.userAgent</code>. Starting in Firefox 5, this property's value is based on the value of the <code>Accept-Language</code> <a href='https://developer.mozilla.org/docs/Web/HTTP/Headers'>HTTP header</a>."
+            },
             "firefox_android": {
               "version_added": "4"
             },
@@ -81,23 +75,23 @@
               "notes": "Closest available (non-standard) properties are <code>userLanguage</code> and <code>browserLanguage</code>."
             },
             "opera": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "notes": "Returns the browser UI language, not the value of the <code>Accept-Language</code> <a href='https://developer.mozilla.org/docs/Web/HTTP/Headers'>HTTP header</a>."
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Returns the browser UI language, not the value of the <code>Accept-Language</code> <a href='https://developer.mozilla.org/docs/Web/HTTP/Headers'>HTTP header</a>."
             }
           },

--- a/api/NavigatorOnLine.json
+++ b/api/NavigatorOnLine.json
@@ -5,40 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorOnLine",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "3.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "8"
           },
           "opera": {
-            "version_added": true
+            "version_added": "3"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "10.1"
           },
           "safari": {
-            "version_added": true
+            "version_added": "5"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "4.2"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -52,25 +52,19 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorOnLine/onLine",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Earlier versions of Chrome incorrectly return true when a tab is first opened, but it starts reporting the correct connectivity status after the first network event. Windows: 11, Mac: 14, Chrome OS: 13, Linux: Always returns <code>true</code>. For history, see <a href='https://crbug.com/7469'>crbug.com/7469</a>."
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "3.5",
-                "notes": "Since Firefox 4 the browser returns <code>true</code> when 'Work Offline' mode is disabled and <code>false</code> when it is enabled, regardless of actual connectivity."
-              },
-              {
-                "version_added": "4",
-                "notes": "Since Firefox 41, on OS X and Windows, the returned values follow the actual network connectivity, unless 'Work offline' mode is selected (where it will always return <code>false</code>)."
-              }
-            ],
+            "firefox": {
+              "version_added": "3.5",
+              "notes": "Since Firefox 4 the browser returns <code>true</code> when 'Work Offline' mode is disabled and <code>false</code> when it is enabled, regardless of actual connectivity. Since Firefox 41, on OS X and Windows, the returned values follow the actual network connectivity, unless 'Work offline' mode is selected (where it will always return <code>false</code>)."
+            },
             "firefox_android": {
               "version_added": "4"
             },
@@ -79,23 +73,24 @@
               "notes": "in Internet Explorer 8 'online' and 'offline' events are raised on the <code>document.body</code>; under IE 9 they are raised on both <code>document.body</code> and <code>window</code>."
             },
             "opera": {
-              "version_added": false,
-              "notes": "Since Opera 11.10, the browser returns <code>true</code> when 'Work Offline' mode is disabled and <code>false</code> when it is enabled, regardless of actual connectivity."
+              "version_added": "3",
+              "notes": "From Opera 11.1 until Opera 12.1, the browser returns <code>true</code> when 'Work Offline' mode is disabled and <code>false</code> when it is enabled, regardless of actual connectivity."
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "10.1",
+              "notes": "From Opera 11.1 until Opera 12.1, the browser returns <code>true</code> when 'Work Offline' mode is disabled and <code>false</code> when it is enabled, regardless of actual connectivity."
             },
             "safari": {
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Faulty in a WebView component, see Issue <a href='http://code.google.com/p/android/issues/detail?id=16760'>bug 16760</a>."
             }
           },

--- a/api/Node.json
+++ b/api/Node.json
@@ -5,11 +5,11 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Node",
         "support": {
           "chrome": {
-            "version_added": true,
+            "version_added": "1",
             "notes": "WebKit and old versions of Blink incorrectly do not make <code>Node</code> inherit from <code>EventTarget</code>."
           },
           "chrome_android": {
-            "version_added": true,
+            "version_added": "18",
             "notes": "WebKit and old versions of Blink incorrectly do not make <code>Node</code> inherit from <code>EventTarget</code>."
           },
           "edge": {
@@ -25,27 +25,27 @@
             "version_added": "5"
           },
           "opera": {
-            "version_added": true,
+            "version_added": "7",
             "notes": "WebKit and old versions of Blink incorrectly do not make <code>Node</code> inherit from <code>EventTarget</code>."
           },
           "opera_android": {
-            "version_added": true,
+            "version_added": "10.1",
             "notes": "WebKit and old versions of Blink incorrectly do not make <code>Node</code> inherit from <code>EventTarget</code>."
           },
           "safari": {
-            "version_added": true,
+            "version_added": "1.1",
             "notes": "WebKit and old versions of Blink incorrectly do not make <code>Node</code> inherit from <code>EventTarget</code>."
           },
           "safari_ios": {
-            "version_added": true,
+            "version_added": "1",
             "notes": "WebKit and old versions of Blink incorrectly do not make <code>Node</code> inherit from <code>EventTarget</code>."
           },
           "samsunginternet_android": {
-            "version_added": true,
+            "version_added": "1.0",
             "notes": "WebKit and old versions of Blink incorrectly do not make <code>Node</code> inherit from <code>EventTarget</code>."
           },
           "webview_android": {
-            "version_added": true,
+            "version_added": "1",
             "notes": "WebKit and old versions of Blink incorrectly do not make <code>Node</code> inherit from <code>EventTarget</code>."
           }
         },
@@ -60,40 +60,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Node/appendChild",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "5"
             },
             "opera": {
-              "version_added": true
+              "version_added": "7"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -204,10 +204,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Node/childNodes",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -219,25 +219,25 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5"
             },
             "opera": {
-              "version_added": true
+              "version_added": "7"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -252,40 +252,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Node/cloneNode",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
-              "version_added": true
+              "version_added": "7"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -421,41 +421,41 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Node/contains",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "16"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "9"
             },
             "ie": {
               "version_added": "9",
               "notes": "Only supports <code>contains</code> for HTML elements and not for SVG elements."
             },
             "opera": {
-              "version_added": true
+              "version_added": "7"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -773,22 +773,22 @@
               "version_added": "3"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "7"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1327,40 +1327,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Node/nextSibling",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "8"
             },
             "opera": {
-              "version_added": true
+              "version_added": "7"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1479,40 +1479,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Node/nodeType",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "6"
             },
             "opera": {
-              "version_added": true
+              "version_added": "7"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1731,10 +1731,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Node/parentElement",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1746,26 +1746,26 @@
               "version_added": "9"
             },
             "ie": {
-              "version_added": true,
+              "version_added": "9",
               "notes": "Only supported on <code>Element</code>."
             },
             "opera": {
-              "version_added": true
+              "version_added": "7"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1780,10 +1780,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Node/parentNode",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1795,25 +1795,25 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "6"
             },
             "opera": {
-              "version_added": true
+              "version_added": "7"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1934,40 +1934,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Node/removeChild",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "5"
             },
             "opera": {
-              "version_added": true
+              "version_added": "7"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -2000,16 +2000,16 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": "2"
+              "version_added": "7"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -2128,10 +2128,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Node/textContent",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2143,25 +2143,25 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {

--- a/api/NodeList.json
+++ b/api/NodeList.json
@@ -5,40 +5,40 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/NodeList",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "8"
           },
           "opera": {
-            "version_added": true
+            "version_added": "8"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "10.1"
           },
           "safari": {
-            "version_added": true
+            "version_added": "3"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {

--- a/api/ParentNode.json
+++ b/api/ParentNode.json
@@ -199,7 +199,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -218,7 +218,7 @@
               "version_added": "10"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "4"
@@ -227,10 +227,10 @@
               "version_added": "9"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {

--- a/api/Performance.json
+++ b/api/Performance.json
@@ -46,7 +46,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -116,9 +116,16 @@
                 "version_removed": "2.0"
               }
             ],
-            "webview_android": {
-              "version_added": true
-            }
+            "webview_android": [
+              {
+                "version_added": "≤37"
+              },
+              {
+                "version_added": "≤37",
+                "version_removed": "≤37",
+                "prefix": "webkit"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -50,10 +50,10 @@
             }
           ],
           "safari": {
-            "version_added": true
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "11"
           },
           "samsunginternet_android": [
             {
@@ -66,7 +66,7 @@
             }
           ],
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/Range.json
+++ b/api/Range.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Range",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -28,19 +28,19 @@
             "version_added": "9"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "10.1"
           },
           "safari": {
-            "version_added": true
+            "version_added": "1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {

--- a/api/Request.json
+++ b/api/Request.json
@@ -49,9 +49,20 @@
               ]
             }
           ],
-          "firefox_android": {
-            "version_added": true
-          },
+          "firefox_android": [
+            {
+              "version_added": "39"
+            },
+            {
+              "version_added": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.fetch.enabled"
+                }
+              ]
+            }
+          ],
           "ie": {
             "version_added": false
           },
@@ -110,9 +121,20 @@
                 ]
               }
             ],
-            "firefox_android": {
-              "version_added": true
-            },
+            "firefox_android": [
+              {
+                "version_added": "39"
+              },
+              {
+                "version_added": "34",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.fetch.enabled"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/Response.json
+++ b/api/Response.json
@@ -49,9 +49,20 @@
               ]
             }
           ],
-          "firefox_android": {
-            "version_added": true
-          },
+          "firefox_android": [
+            {
+              "version_added": "39"
+            },
+            {
+              "version_added": "34",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.fetch.enabled"
+                }
+              ]
+            }
+          ],
           "ie": {
             "version_added": false
           },

--- a/api/Selection.json
+++ b/api/Selection.json
@@ -5,42 +5,42 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Selection",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true,
+            "version_added": "1",
             "notes": "The <a href='https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onselectionchange'><code>GlobalEventHandlers.onselectionchange</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onselectstart'><code>GlobalEventHandlers.onselectstart</code></a> event handlers are supported as of Firefox 52."
           },
           "firefox_android": {
-            "version_added": true,
+            "version_added": "4",
             "notes": "The <a href='https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onselectionchange'><code>GlobalEventHandlers.onselectionchange</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onselectstart'><code>GlobalEventHandlers.onselectstart</code></a> event handlers are supported as of Firefox 52."
           },
           "ie": {
             "version_added": "9"
           },
           "opera": {
-            "version_added": true
+            "version_added": "9"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "10.1"
           },
           "safari": {
-            "version_added": true
+            "version_added": "1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {

--- a/api/SpeechRecognition.json
+++ b/api/SpeechRecognition.json
@@ -11,7 +11,7 @@
           },
           "chrome_android": {
             "prefix": "webkit",
-            "version_added": true,
+            "version_added": "33",
             "notes": "You'll need to serve your code through a web server for recognition to work."
           },
           "edge": {
@@ -40,12 +40,12 @@
           },
           "samsunginternet_android": {
             "prefix": "webkit",
-            "version_added": true,
+            "version_added": "2.0",
             "notes": "You'll need to serve your code through a web server for recognition to work."
           },
           "webview_android": {
             "prefix": "webkit",
-            "version_added": true,
+            "version_added": "4.4.3",
             "notes": "You'll need to serve your code through a web server for recognition to work."
           }
         },

--- a/api/Storage.json
+++ b/api/Storage.json
@@ -38,7 +38,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -133,7 +133,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -277,7 +277,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -325,7 +325,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR sets and updates the version numbers for various misc. APIs from N through S based upon manual testing. The data is as follows:

	api.Navigator
		- Chrome - 1
		- Firefox - 1
		- IE - 4
		- Opera - 3
		- Safari - 1
	api.Navigator.geolocation
		- Sufficient Data, Mirrored to Other Browsers
		- Opera - has a weird gap in data that indicates lack of support in first Blink editions -- this is not valid
	api.Navigator.getUserMedia
		- Sufficient Data, No Change
	api.Navigator.sendBeacon
		- Sufficient Data, No Change
	api.Navigator.share
		- Sufficient Data, No Change
	api.NavigatorLanguage
		- Basing this data off of api.NavigatorLanguage.language (earliest implemented subfeature)
	api.NavigatorLanguage.language
		- Chrome - 1
		- Opera - 4
		- Safari - 1
	api.NavigatorOnLine
		- Basing this data off of api.NavigatorOnLine.onLine (pretty much the only subfeature)
	api.NavigatorOnLine.onLine
		- Chrome - 1
		- Firefox - weirdness with notes, fixed
		- Opera - incorrect data, 3
	api.Node
		- Chrome - 1
		- Opera - 7
		- Safari - 1.1
	api.Node.appendChild
		- Chrome - 1
		- Firefox - 1
		- Opera - 7
		- Safari - 1.1
	api.Node.childNodes
		- Chrome - 1
		- IE - 5
		- Opera - 7
		- Safari - 1.2
	api.Node.cloneNode
		- Chrome - 1
		- Firefox - 1
		- IE - 6
		- Opera - 7
		- Safari - 1.1
	api.Node.contains
		- Chrome - 16
		- Firefox - 9
		- Opera - 7
		- Safari - 1.1
	api.Node.insertBefore
		- Opera - 7
		- Safari - 1.1
	api.Node.nextSibling
		- Chrome - 1
		- Firefox - 1
		- Opera - 7
		- Safari - 1.1
	api.Node.nodeType
		- Chrome - 1
		- Firefox - 1
		- IE - 6
		- Opera - 7
		- Safari - 1.1
	api.Node.parentElement
		- Chrome - 1
		- IE - 9
		- Opera - 7
		- Safari - 1.1
	api.Node.parentNode
		- Chrome - 1
		- IE - 6
		- Opera - 7
		- Safari - 1.1
	api.Node.removeChild
		- Chrome - 1
		- Firefox - 1
		- Opera - 7
		- Safari - 1.1
	api.Node.replaceChild
		- Safari - 1.1
	api.Node.textContent
		- Chrome - 1
		- IE - 9
		- Opera - 9
	api.NodeList
		- Chrome - 1
		- Firefox - 1
		- IE - 8
		- Opera - 8
		- Safari - 3
	api.NodeList.forEach
		- Sufficient Data, No Change
	api.Notification
		- Sufficient Data, No Change (can't really test with mobile devices)
	api.Notification.requestPermission
		- Sufficient Data, No Change (can't really test with mobile devices)
	api.OffscreenCanvas
		- Sufficient Data, No Change
	api.ParentNode.append
		- Sufficient Data, No Change
	api.ParentNode.children
		- Sufficient Data, Mirrored to Other Browsers
	api.ParentNode.prepend
		- Sufficient Data, No Change
	api.Performance
		- Sufficient Data, Mirrored to Other Browsers
	api.Performance.now
		- Sufficient Data, Mirrored to Other Browsers
	api.Range
		- Chrome - 1
		- Safari - 1
	api.ReadableStream
		- Sufficient Data, No Change
	api.Request
		- Sufficient Data, Mirrored to Other Browsers
	api.Request.credentials
		- Sufficient Data, No Change
	api.Request.headers
		- Sufficient Data, No Change
	api.Request.mode
		- Sufficient Data, No Change
	api.Request.Request
		- Sufficient Data, Mirrored to Other Browsers
	api.ResizeObserver
		- Sufficient Data, No Change
	api.Response
		- Sufficient Data, Mirrored to Other Browsers
	api.Response.headers
		- Sufficient Data, No Change
	api.Response.status
		- Sufficient Data, No Change
	api.RTCPeerConnection
		- Safari - 11
	api.ScrollToOptions
		- How exactly do you test support for this?  This isn't an API; it's just a predefined dictionary.
	api.Selection
		- Chrome - 1
		- Firefox - 1
		- Opera - 9
		- Safari - 1
	api.ServiceWorkerRegistration.showNotification
		- Sufficient Data, No Changes
	api.SpeechRecognition
		- Sufficient Data, Mirrored to Other Browsers
	api.SpeechSynthesis
		- Sufficient Data, No Change
	api.Storage
		- Sufficient Data, Mirrored to Other Browsers
	api.Storage.getItem
		- Sufficient Data, Mirrored to Other Browsers
	api.Storage.removeItem
		- Sufficient Data, Mirrored to Other Browsers
	api.Storage.setItem
		- Sufficient Data, Mirrored to Other Browsers