### PR TITLE
Update versions for misc. APIs (T-Z)

### DIFF
--- a/api/TouchEvent.json
+++ b/api/TouchEvent.json
@@ -8,18 +8,24 @@
             "version_added": "22"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "25"
           },
-          "edge": {
-            "version_added": "≤18",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "Standards Preview",
-                "value_to_set": "true"
-              }
-            ]
-          },
+          "edge": [
+            {
+              "version_added": "79"
+            },
+            {
+              "version_added": "≤18",
+              "version_removed": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Standards Preview",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox": [
             {
               "version_added": "52"
@@ -37,10 +43,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
             "version_added": false
@@ -49,10 +55,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -91,7 +97,7 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": "12"
+              "version_added": true
             },
             "safari": {
               "version_added": false

--- a/api/URL.json
+++ b/api/URL.json
@@ -40,7 +40,7 @@
             ]
           },
           "ie": {
-            "version_added": true
+            "version_added": "10"
           },
           "nodejs": [
             {
@@ -118,10 +118,10 @@
           "description": "<code>URL()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "19"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -133,29 +133,28 @@
               "version_added": "26"
             },
             "ie": {
-              "version_added": true,
-              "version_removed": "11"
+              "version_added": false
             },
             "nodejs": {
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -809,7 +808,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -910,16 +909,16 @@
               "version_added": "7.5.0"
             },
             "opera": {
-              "version_added": true
+              "version_added": "38"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/URLSearchParams.json
+++ b/api/URLSearchParams.json
@@ -43,7 +43,7 @@
             "version_added": "10.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "10.3"
           },
           "samsunginternet_android": {
             "version_added": "5.0"
@@ -98,10 +98,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -207,10 +207,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocket",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "4"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -40,28 +40,33 @@
               "version_removed": "14",
               "prefix": "Moz",
               "notes": "Message size limited to 16 MB (see <a href='https://bugzil.la/711205'>bug 711205</a>)."
+            },
+            {
+              "version_added": "4",
+              "version_removed": "6",
+              "notes": "Message size limited to 16 MB (see <a href='https://bugzil.la/711205'>bug 711205</a>)."
             }
           ],
           "ie": {
-            "version_added": true
+            "version_added": "10"
           },
           "opera": {
-            "version_added": true
+            "version_added": "12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "12.1"
           },
           "safari": {
-            "version_added": true
+            "version_added": "5"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "4.2"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -227,10 +232,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocket/close",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -245,29 +250,36 @@
                 "notes": "Parameters not supported, see <a href='https://bugzil.la/674716'>bug 674716</a>."
               }
             ],
-            "firefox_android": {
-              "version_added": true
-            },
+            "firefox_android": [
+              {
+                "version_added": "8"
+              },
+              {
+                "version_added": "4",
+                "version_removed": "8",
+                "notes": "Parameters not supported, see <a href='https://bugzil.la/674716'>bug 674716</a>."
+              }
+            ],
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -814,40 +826,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocket/readyState",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "19"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "19"
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "30"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "30"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -862,10 +874,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocket/send",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -891,29 +903,47 @@
                 "notes": "Only parameter of type <code>String</code> supported. Returns <code>boolean</code>."
               }
             ],
-            "firefox_android": {
-              "version_added": true
-            },
+            "firefox_android": [
+              {
+                "version_added": "18",
+                "notes": "See <a href='https://bugzil.la/775368'>bug 775368</a>."
+              },
+              {
+                "version_added": "14",
+                "version_removed": "18",
+                "notes": "Only parameter of type <code>ArrayBuffer</code> and <code>String</code> supported."
+              },
+              {
+                "version_added": "8",
+                "version_removed": "14",
+                "notes": "Only parameter of type <code>String</code> supported."
+              },
+              {
+                "version_added": "4",
+                "version_removed": "8",
+                "notes": "Only parameter of type <code>String</code> supported. Returns <code>boolean</code>."
+              }
+            ],
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR sets and updates the version numbers for various misc. APIs from T through Z based upon manual testing. The data is as follows:

	api.TouchEvent
		- Opera - Blink
		- Safari - false (supported on iOS, just not sure when)
	api.URL
		- IE - 10
	api.URL.createObjectURL
		- Sufficient Data, No Changes
	api.URL.revokeObjectURL
		- Sufficient Data, Mirrored to Other Browsers
	api.URL.searchParams
		- Opera - Blink
	api.URL.URL
		- Chrome - 19
		- IE - false
		- Opera - Blink
		- Safari - 6
	api.URLSearchParams
		- Sufficient Data, Mirrored to Other Browsers
	api.URLSearchParams.append
		- Safari - 10.1
	api.URLSearchParams.URLSearchParams
		- Safari - 10.1
	api.WebSocket
		- Chrome - 4
		- IE - 10
		- Opera - 12.1
		- Safari - 5
	api.WebSocket.close
		- Chrome - 4
		- IE - 10
		- Opera - 12.1
		- Safari - 5
	api.WebSocket.readyState
		- Chrome - 43
		- Firefox - 19
		- IE - 10
		- Opera - Blink
		- Safari - 10
	api.WebSocket.send
		- Chrome - 4
		- IE - 10
		- Opera - 12.1
		- Safari - 5