### PR TITLE
Remove Safari 4.1 from BCD

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -58,12 +58,6 @@
           "engine": "WebKit",
           "engine_version": "530.17"
         },
-        "4.1": {
-          "release_date": "2010-06-07",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "533.16"
-        },
         "5": {
           "release_date": "2010-06-07",
           "status": "retired",

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -177,7 +177,7 @@
                 "version_added": "10.1"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -1113,7 +1113,7 @@
                 "version_added": "11"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"

--- a/css/properties/background-repeat.json
+++ b/css/properties/background-repeat.json
@@ -179,7 +179,7 @@
                 "version_added": "11"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4"

--- a/css/properties/background-size.json
+++ b/css/properties/background-size.json
@@ -88,7 +88,7 @@
             ],
             "safari": [
               {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               {
                 "prefix": "-webkit-",
@@ -162,7 +162,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"

--- a/css/properties/border-radius.json
+++ b/css/properties/border-radius.json
@@ -127,7 +127,7 @@
               },
               "safari": {
                 "version_added": "3",
-                "notes": "Before Safari 4.1, the slash <code>/</code> notation is unsupported. If two values are specified, then an elliptical border is drawn on all four corners. <code>-webkit-border-radius: 40px 10px;</code> is equivalent to <code>border-radius: 40px / 10px;</code>."
+                "notes": "Before Safari 5, the slash <code>/</code> notation is unsupported. If two values are specified, then an elliptical border is drawn on all four corners. <code>-webkit-border-radius: 40px 10px;</code> is equivalent to <code>border-radius: 40px / 10px;</code>."
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -225,7 +225,7 @@
                 "version_added": "11"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"

--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -81,7 +81,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -135,7 +135,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -189,7 +189,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -251,7 +251,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -413,7 +413,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -465,7 +465,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -515,7 +515,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -671,7 +671,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -731,7 +731,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -793,7 +793,7 @@
                 }
               ],
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -949,7 +949,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -1145,7 +1145,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -1199,7 +1199,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -1253,7 +1253,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -1307,7 +1307,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -1361,7 +1361,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -1415,7 +1415,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -1519,7 +1519,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -1573,7 +1573,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -1625,7 +1625,7 @@
                 "version_added": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -1677,7 +1677,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -1731,7 +1731,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -1785,7 +1785,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -1839,7 +1839,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -1893,7 +1893,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -1945,7 +1945,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -1995,7 +1995,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -2047,7 +2047,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -2273,7 +2273,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -2333,7 +2333,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -2383,7 +2383,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -2433,7 +2433,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -2757,7 +2757,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -2913,7 +2913,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -3117,7 +3117,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -3313,7 +3313,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -3415,7 +3415,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -3525,7 +3525,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -3573,7 +3573,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -3633,7 +3633,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -3685,7 +3685,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -3747,7 +3747,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -3799,7 +3799,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -3861,7 +3861,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -3913,7 +3913,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -4087,7 +4087,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -4353,7 +4353,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -4413,7 +4413,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -4461,7 +4461,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -4513,7 +4513,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -4567,7 +4567,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -4621,7 +4621,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -4675,7 +4675,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -4729,7 +4729,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -5047,7 +5047,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -5149,7 +5149,7 @@
                 "version_removed": "32"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -5249,7 +5249,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"

--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -276,7 +276,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "3.2"

--- a/css/selectors/-webkit-inner-spin-button.json
+++ b/css/selectors/-webkit-inner-spin-button.json
@@ -31,7 +31,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "4.1"
+              "version_added": "5"
             },
             "safari_ios": {
               "version_added": "4.2"

--- a/css/selectors/-webkit-outer-spin-button.json
+++ b/css/selectors/-webkit-outer-spin-button.json
@@ -32,7 +32,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "4.1",
+              "version_added": "5",
               "version_removed": "5.1"
             },
             "safari_ios": {

--- a/css/types/length-percentage.json
+++ b/css/types/length-percentage.json
@@ -420,7 +420,7 @@
                 "version_added": "12"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4"

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -420,7 +420,7 @@
                 "version_added": "12"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4"

--- a/css/types/ratio.json
+++ b/css/types/ratio.json
@@ -31,7 +31,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "4.1"
+              "version_added": "5"
             },
             "safari_ios": {
               "version_added": "4.2"

--- a/html/elements/article.json
+++ b/html/elements/article.json
@@ -30,7 +30,7 @@
               "version_added": "11.1"
             },
             "safari": {
-              "version_added": "4.1"
+              "version_added": "5"
             },
             "safari_ios": {
               "version_added": "4.2"

--- a/html/elements/aside.json
+++ b/html/elements/aside.json
@@ -30,7 +30,7 @@
               "version_added": "11.1"
             },
             "safari": {
-              "version_added": "4.1"
+              "version_added": "5"
             },
             "safari_ios": {
               "version_added": "4.2"

--- a/html/elements/footer.json
+++ b/html/elements/footer.json
@@ -30,7 +30,7 @@
               "version_added": "11.1"
             },
             "safari": {
-              "version_added": "4.1"
+              "version_added": "5"
             },
             "safari_ios": {
               "version_added": "4.2"

--- a/html/elements/header.json
+++ b/html/elements/header.json
@@ -30,7 +30,7 @@
               "version_added": "11.1"
             },
             "safari": {
-              "version_added": "4.1"
+              "version_added": "5"
             },
             "safari_ios": {
               "version_added": "4.2"

--- a/html/elements/hgroup.json
+++ b/html/elements/hgroup.json
@@ -30,7 +30,7 @@
               "version_added": "11.1"
             },
             "safari": {
-              "version_added": "4.1"
+              "version_added": "5"
             },
             "safari_ios": {
               "version_added": "4.2"

--- a/html/elements/nav.json
+++ b/html/elements/nav.json
@@ -30,7 +30,7 @@
               "version_added": "11.1"
             },
             "safari": {
-              "version_added": "4.1"
+              "version_added": "5"
             },
             "safari_ios": {
               "version_added": "4.2"

--- a/html/elements/section.json
+++ b/html/elements/section.json
@@ -30,7 +30,7 @@
               "version_added": "11.1"
             },
             "safari": {
-              "version_added": "4.1"
+              "version_added": "5"
             },
             "safari_ios": {
               "version_added": "4.2"

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -1430,7 +1430,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4"
@@ -1482,7 +1482,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4"

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -2270,7 +2270,7 @@
                 "version_added": "11"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"
@@ -2322,7 +2322,7 @@
                 "version_added": "11"
               },
               "safari": {
-                "version_added": "4.1"
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "4.2"


### PR DESCRIPTION
This PR fixes #4679.  From my research, Safari 4.1 is just a port of Safari 5.0, tailored for Mac OS X 10.4.  Safari 5 only has a few additional features regarding the browser's UI, which we wouldn't track here in BCD -- as such, I think it makes more sense to remove Safari 4.1.