### PR TITLE
Separate ::cue(<selector>) support into subfeature

### DIFF
--- a/css/selectors/cue.json
+++ b/css/selectors/cue.json
@@ -17,14 +17,10 @@
             },
             "firefox": {
               "version_added": "55",
-              "notes": [
-                "Firefox currently does not support a parameter on <code>::cue</code>.",
-                "Correct limitations to the CSS properties permitted within <code>::cue</code> were implemented in Firefox 69. See <a href='https://developer.mozilla.org/docs/Web/CSS/::cue#Permitted_properties'>Permitted properties</a> for a list of the allowed properties."
-              ]
+              "notes": "Correct limitations to the CSS properties permitted within <code>::cue</code> were implemented in Firefox 69. See <a href='https://developer.mozilla.org/docs/Web/CSS/::cue#Permitted_properties'>Permitted properties</a> for a list of the allowed properties."
             },
             "firefox_android": {
-              "version_added": "55",
-              "notes": "Firefox currently does not support a parameter on <code>::cue</code>."
+              "version_added": "55"
             },
             "ie": {
               "version_added": false
@@ -52,6 +48,54 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "with_parameter": {
+          "__compat": {
+            "description": "<code>::cue(&lt;selector&gt;)</code>",
+            "support": {
+              "chrome": {
+                "version_added": "26"
+              },
+              "chrome_android": {
+                "version_added": "26"
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": "14"
+              },
+              "safari": {
+                "version_added": "6.1"
+              },
+              "safari_ios": {
+                "version_added": "6.1"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.5"
+              },
+              "webview_android": {
+                "version_added": "≤37"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }

--- a/css/selectors/cue.json
+++ b/css/selectors/cue.json
@@ -17,7 +17,7 @@
             },
             "firefox": {
               "version_added": "55",
-              "notes": "Correct limitations to the CSS properties permitted within <code>::cue</code> were implemented in Firefox 69. See <a href='https://developer.mozilla.org/docs/Web/CSS/::cue#Permitted_properties'>Permitted properties</a> for a list of the allowed properties."
+              "notes": "From Firefox 69, only allowed properties apply to the <code>::cue</code> pseudo-element with no argument. See <a href='https://developer.mozilla.org/docs/Web/CSS/::cue#Permitted_properties'>Permitted properties</a> for a list of the allowed properties."
             },
             "firefox_android": {
               "version_added": "55"
@@ -50,7 +50,7 @@
             "deprecated": false
           }
         },
-        "with_parameter": {
+        "selector_argument": {
           "__compat": {
             "description": "<code>::cue(&lt;selector&gt;)</code>",
             "support": {


### PR DESCRIPTION
This PR separates the `::cue` selector into two features: one for basic support (`::cue` without a parameter), and a subfeature that indicates support with a parameter (`::cue(<selector>)`).  The [spec](https://w3c.github.io/webvtt/#the-cue-pseudo-element) talks about it kind of like two separate selectors, and since Firefox doesn't have support for the second of the two, I think it makes more sense to separate them.

This fixes #4892.