### PR TITLE
Revert nodejs version bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: stable
+node_js: 'lts/carbon'
 sudo: false
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: 'lts/dubnium'
+node_js: stable
 sudo: false
 notifications:
   email: false

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "extend": "3.0.2"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=8.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Apparently, we are breaking packages by bumping our engine version. I think this isn't our goal, so I propose we revert this and release 1.0.14 with the old requirements.

Alternatively, we could leave it in (and release 2.0.0 to properly communicate it) and ask people to definitely use a higher nodejs versions, but this won't work for people that are forced use older nodejs versions for longer (which apparently happens as reported here https://github.com/mdn/browser-compat-data/issues/5852#issuecomment-602508859)