### PR TITLE
Mark api.Document.origin as unsupported in Edge + Opera

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -7460,7 +7460,8 @@
               "version_removed": "71"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "version_removed": "79"
             },
             "firefox": {
               "version_added": false
@@ -7472,10 +7473,12 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "28",
+              "version_removed": "58"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "28",
+              "version_removed": "50"
             },
             "safari": {
               "version_added": true


### PR DESCRIPTION
Fixes #5855.  Chrome dropped support for this feature, however our Edge and Opera data did not indicate as such.  This PR adds a `version_added` to Edge, and mirrors Chrome data to Opera.