### PR TITLE
Update IE support for api.HTMLElement.innerText

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1144,7 +1144,8 @@
               "version_added": "45"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": "8",
+              "notes": "Internet Explorer 5.5 initially implemented this feature on the <code>Element</code> API rather than the <code>HTMLElement</code> API."
             },
             "opera": {
               "version_added": "9.6"

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -20,7 +20,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": "8"
+            "version_added": "5.5"
           },
           "opera": {
             "version_added": "8"
@@ -1144,8 +1144,7 @@
               "version_added": "45"
             },
             "ie": {
-              "version_added": "8",
-              "notes": "Internet Explorer 5.5 initially implemented this feature on the <code>Element</code> API rather than the <code>HTMLElement</code> API."
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": "9.6"


### PR DESCRIPTION
This PR fixes #4212.  Upon testing, it appears that `innerText` was implemented in IE since 5.5, specifically through the Element API since the HTMLElement API didn't exist until IE 8.