### PR TITLE
Samsung Internet doesn't support flags

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -3447,44 +3447,9 @@
                 }
               ]
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "9.0",
-                "partial_implementation": true,
-                "notes": "Does not support the <code>subtree</code> option.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              },
-              {
-                "version_added": "4.0",
-                "version_removed": "9.0",
-                "partial_implementation": true,
-                "notes": "Does not return any animations added via CSS and does not support the <code>subtree</code> option.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              },
-              {
-                "alternative_name": "getAnimationPlayers",
-                "version_added": "3.0",
-                "version_removed": "4.0",
-                "partial_implementation": true,
-                "notes": "Does not return any animations added via CSS and does not support the <code>subtree</code> option.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -429,13 +429,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": "10.0",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features"
-                  }
-                ]
+                "version_added": false
               },
               "webview_android": {
                 "version_added": false

--- a/html/elements/video.json
+++ b/html/elements/video.json
@@ -336,13 +336,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": "10.0",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-productivity-features"
-                  }
-                ]
+                "version_added": false
               },
               "webview_android": {
                 "version_added": false

--- a/test/linter/test-versions.js
+++ b/test/linter/test-versions.js
@@ -22,7 +22,7 @@ const VERSION_RANGE_BROWSERS = {
 };
 
 /** @type string[] */
-const FLAGLESS_BROWSERS = ['webview_android'];
+const FLAGLESS_BROWSERS = ['samsunginternet_android', 'webview_android'];
 
 for (const browser of Object.keys(browsers)) {
   validBrowserVersions[browser] = Object.keys(browsers[browser].releases);


### PR DESCRIPTION
This PR fixes #4753.  It was confirmed that Samsung Internet doesn't have flags (other than a small set that they wish not to announce).  This PR removes a few support statements that indicate support behind a flag, as well as prevents flagged support in future PRs.