### PR TITLE
Remove double spacing in notes

### DIFF
--- a/api/Console.json
+++ b/api/Console.json
@@ -21,7 +21,7 @@
           },
           "ie": {
             "version_added": "8",
-            "notes": "In Internet Explorer 8 and 9, the <code>console</code> object is <code>undefined</code> when the developer tools are not open.  This behavior was fixed in Internet Explorer 10."
+            "notes": "In Internet Explorer 8 and 9, the <code>console</code> object is <code>undefined</code> when the developer tools are not open. This behavior was fixed in Internet Explorer 10."
           },
           "nodejs": {
             "version_added": "0.1.100"
@@ -320,7 +320,7 @@
               },
               "edge": {
                 "version_added": "12",
-                "notes": "In EdgeHTML, <code>%c</code> is not supported, and <code>%d</code> outputs a 0 if the specified value isn't a number.  This behavior has been fixed in Chromium versions of Edge."
+                "notes": "In EdgeHTML, <code>%c</code> is not supported, and <code>%d</code> outputs a 0 if the specified value isn't a number. This behavior has been fixed in Chromium versions of Edge."
               },
               "firefox": {
                 "version_added": "9"
@@ -532,7 +532,7 @@
               },
               "edge": {
                 "version_added": "12",
-                "notes": "In EdgeHTML, <code>%c</code> is not supported, and <code>%d</code> outputs a 0 if the specified value isn't a number.  This behavior has been fixed in Chromium versions of Edge."
+                "notes": "In EdgeHTML, <code>%c</code> is not supported, and <code>%d</code> outputs a 0 if the specified value isn't a number. This behavior has been fixed in Chromium versions of Edge."
               },
               "firefox": {
                 "version_added": "9"
@@ -876,7 +876,7 @@
               },
               "edge": {
                 "version_added": "12",
-                "notes": "In EdgeHTML, <code>%c</code> is not supported, and <code>%d</code> outputs a 0 if the specified value isn't a number.  This behavior has been fixed in Chromium versions of Edge."
+                "notes": "In EdgeHTML, <code>%c</code> is not supported, and <code>%d</code> outputs a 0 if the specified value isn't a number. This behavior has been fixed in Chromium versions of Edge."
               },
               "firefox": {
                 "version_added": "9"
@@ -979,7 +979,7 @@
               },
               "edge": {
                 "version_added": "12",
-                "notes": "In EdgeHTML, <code>%c</code> is not supported, and <code>%d</code> outputs a 0 if the specified value isn't a number.  This behavior has been fixed in Chromium versions of Edge."
+                "notes": "In EdgeHTML, <code>%c</code> is not supported, and <code>%d</code> outputs a 0 if the specified value isn't a number. This behavior has been fixed in Chromium versions of Edge."
               },
               "firefox": {
                 "version_added": "9"
@@ -1492,7 +1492,7 @@
               },
               "edge": {
                 "version_added": "12",
-                "notes": "In EdgeHTML, <code>%c</code> is not supported, and <code>%d</code> outputs a 0 if the specified value isn't a number.  This behavior has been fixed in Chromium versions of Edge."
+                "notes": "In EdgeHTML, <code>%c</code> is not supported, and <code>%d</code> outputs a 0 if the specified value isn't a number. This behavior has been fixed in Chromium versions of Edge."
               },
               "firefox": {
                 "version_added": "9"

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -540,7 +540,7 @@
             },
             "edge": {
               "version_added": "12",
-              "notes": "EdgeHTML versions of edge only trim whitespace - it doesn't remove duplicates.  This behavior was fixed in Chromium versions of Edge."
+              "notes": "EdgeHTML versions of edge only trim whitespace - it doesn't remove duplicates. This behavior was fixed in Chromium versions of Edge."
             },
             "firefox": {
               "version_added": "55"

--- a/api/Document.json
+++ b/api/Document.json
@@ -3201,7 +3201,7 @@
             "firefox": {
               "version_added": "3.5",
               "partial_implementation": true,
-              "notes": "Firefox doesn't set the mouse coordinates during the drag event.  See <a href='https://bugzil.la/505521'>bug 505521</a>."
+              "notes": "Firefox doesn't set the mouse coordinates during the drag event. See <a href='https://bugzil.la/505521'>bug 505521</a>."
             },
             "firefox_android": {
               "version_added": false
@@ -3254,7 +3254,7 @@
               "version_added": "3.5",
               "partial_implementation": true,
               "notes": [
-                "Firefox doesn't set the mouse coordinates during the drag event.  See <a href='https://bugzil.la/505521'>bug 505521</a>.",
+                "Firefox doesn't set the mouse coordinates during the drag event. See <a href='https://bugzil.la/505521'>bug 505521</a>.",
                 "In Firefox, <code>dragend</code> is not dispatched if the source node is moved or removed during the drag (e.g. on <code>drop</code> or <code>dragover</code>). See <a href='https://bugzil.la/460801'>bug 460801</a> for details."
               ]
             },
@@ -5309,7 +5309,7 @@
             },
             "edge": {
               "version_added": "12",
-              "notes": "In EdgeHTML, this returns an <code>HTMLCollection</code>, not a <code>NodeList</code>.  This behavior was fixed in Chromium versions of Edge."
+              "notes": "In EdgeHTML, this returns an <code>HTMLCollection</code>, not a <code>NodeList</code>. This behavior was fixed in Chromium versions of Edge."
             },
             "firefox": {
               "version_added": "1"

--- a/api/Element.json
+++ b/api/Element.json
@@ -6357,7 +6357,7 @@
             },
             "edge": {
               "version_added": "12",
-              "notes": "This function doesn't respect boolean attributes' default values.  See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/12087679/'>bug 12087679</a>."
+              "notes": "This function doesn't respect boolean attributes' default values. See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/12087679/'>bug 12087679</a>."
             },
             "firefox": {
               "version_added": "1"

--- a/api/Location.json
+++ b/api/Location.json
@@ -644,11 +644,11 @@
             },
             "firefox": {
               "version_added": "22",
-              "notes": "Before Firefox 53, the <code>search</code> property returned wrong parts of the URL. For example, for a URL of http://z.com/x?a=true&b=false,  <code>search</code> would return \"\", rather than \"?a=true&b=false\"."
+              "notes": "Before Firefox 53, the <code>search</code> property returned wrong parts of the URL. For example, for a URL of http://z.com/x?a=true&b=false, <code>search</code> would return \"\", rather than \"?a=true&b=false\"."
             },
             "firefox_android": {
               "version_added": "22",
-              "notes": "Before Firefox 53, the <code>search</code> property returned wrong parts of the URL. For example, for a URL of http://z.com/x?a=true&b=false,  <code>search</code> would return \"\", rather than \"?a=true&b=false\"."
+              "notes": "Before Firefox 53, the <code>search</code> property returned wrong parts of the URL. For example, for a URL of http://z.com/x?a=true&b=false, <code>search</code> would return \"\", rather than \"?a=true&b=false\"."
             },
             "ie": {
               "version_added": true

--- a/api/MutationObserverInit.json
+++ b/api/MutationObserverInit.json
@@ -105,7 +105,7 @@
             ],
             "edge": {
               "version_added": "12",
-              "notes": "In EdgeHTML versions of Edge, this requires <code>attributes: true</code> when using <code>attributeFilter</code>.  If <code>attributes: true</code> is not present, EdgeHTML will throw a syntax error.  This behavior was fixed in Chromium versions of Edge."
+              "notes": "In EdgeHTML versions of Edge, this requires <code>attributes: true</code> when using <code>attributeFilter</code>. If <code>attributes: true</code> is not present, EdgeHTML will throw a syntax error. This behavior was fixed in Chromium versions of Edge."
             },
             "firefox": {
               "version_added": "14"
@@ -115,7 +115,7 @@
             },
             "ie": {
               "version_added": "11",
-              "notes": "Internet Explorer requires <code>attributes: true</code> when using <code>attributeFilter</code>.  If <code>attributes: true</code> is not present, Internet Explorer will throw a syntax error."
+              "notes": "Internet Explorer requires <code>attributes: true</code> when using <code>attributeFilter</code>. If <code>attributes: true</code> is not present, Internet Explorer will throw a syntax error."
             },
             "opera": {
               "version_added": "15"

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1874,7 +1874,7 @@
               "version_added": true,
               "notes": [
                 "Starting in Firefox 55, if neither <code>audioCapabilities</code> nor <code>videoCapabilities</code> is specified in <code>supportedConfigurations</code>, a warning is output to the web console.",
-                "In addition, starting in Firefox 55,  if in <code>supportedConfigurations</code>, either <code>audioCapabilities</code>'s or <code>videoCapabilities</code>'s <code>contentType</code> value doesn't specify a </code>\"codecs\"</code> substring to define allowed codecs within the media wrapper, a warning is output to the web console. See note below table for example and correction.",
+                "In addition, starting in Firefox 55, if in <code>supportedConfigurations</code>, either <code>audioCapabilities</code>'s or <code>videoCapabilities</code>'s <code>contentType</code> value doesn't specify a </code>\"codecs\"</code> substring to define allowed codecs within the media wrapper, a warning is output to the web console. See note below table for example and correction.",
                 "In the future, if neither <code>audioCapabilities</code> nor <code>videoCapabilities</code> is specified in the <code>supportedConfigurations</code>, a <code>NotSupported</code> exception will be thrown."
               ]
             },
@@ -1882,7 +1882,7 @@
               "version_added": true,
               "notes": [
                 "Starting in Firefox 55, if neither <code>audioCapabilities</code> nor <code>videoCapabilities</code> is specified in <code>supportedConfigurations</code>, a warning is output to the web console.",
-                "In addition, starting in Firefox 55,  if in <code>supportedConfigurations</code>, either <code>audioCapabilities</code>'s or <code>videoCapabilities</code>'s <code>contentType</code> value doesn't specify a </code>\"codecs\"</code> substring to define allowed codecs within the media wrapper, a warning is output to the web console. See note below table for example and correction.",
+                "In addition, starting in Firefox 55, if in <code>supportedConfigurations</code>, either <code>audioCapabilities</code>'s or <code>videoCapabilities</code>'s <code>contentType</code> value doesn't specify a </code>\"codecs\"</code> substring to define allowed codecs within the media wrapper, a warning is output to the web console. See note below table for example and correction.",
                 "In the future, if neither <code>audioCapabilities</code> nor <code>videoCapabilities</code> is specified in the <code>supportedConfigurations</code>, a <code>NotSupported</code> exception will be thrown."
               ]
             },

--- a/api/NonDocumentTypeChildNode.json
+++ b/api/NonDocumentTypeChildNode.json
@@ -108,7 +108,7 @@
             },
             "edge": {
               "version_added": "12",
-              "notes": "In EdgeHTML, this was only implemented for <code>Element</code>, not for <code>CharacterData</code>.  This behavior was fixed in Chromium versions of Edge."
+              "notes": "In EdgeHTML, this was only implemented for <code>Element</code>, not for <code>CharacterData</code>. This behavior was fixed in Chromium versions of Edge."
             },
             "firefox": {
               "version_added": "3.5"
@@ -159,7 +159,7 @@
             },
             "edge": {
               "version_added": "12",
-              "notes": "In EdgeHTML, this was only implemented for <code>Element</code>, not for <code>CharacterData</code>.  This behavior was fixed in Chromium versions of Edge."
+              "notes": "In EdgeHTML, this was only implemented for <code>Element</code>, not for <code>CharacterData</code>. This behavior was fixed in Chromium versions of Edge."
             },
             "firefox": {
               "version_added": "3.5"

--- a/css/selectors/first-child.json
+++ b/css/selectors/first-child.json
@@ -24,7 +24,7 @@
             "ie": {
               "version_added": "7",
               "notes": [
-                "Internet Explorer 7 doesn't update  <code>:first-child</code> styles when elements are added dynamically.",
+                "Internet Explorer 7 doesn't update <code>:first-child</code> styles when elements are added dynamically.",
                 "In Internet Explorer 8, if an element is inserted dynamically by clicking on a link, then the <code>:first-child</code> style isn't applied until the link loses focus."
               ]
             },

--- a/http/headers/cross-origin-resource-policy.json
+++ b/http/headers/cross-origin-resource-policy.json
@@ -7,11 +7,11 @@
           "support": {
             "chrome": {
               "version_added": "73",
-              "notes": "Until version 75, downloads for files with this header would fail in Chrome.  See <a href='https://crbug.com/952834'>bug 952834</a>."
+              "notes": "Until version 75, downloads for files with this header would fail in Chrome. See <a href='https://crbug.com/952834'>bug 952834</a>."
             },
             "chrome_android": {
               "version_added": "73",
-              "notes": "Until version 75, downloads for files with this header would fail in Chrome.  See <a href='https://crbug.com/952834'>bug 952834</a>."
+              "notes": "Until version 75, downloads for files with this header would fail in Chrome. See <a href='https://crbug.com/952834'>bug 952834</a>."
             },
             "edge": {
               "version_added": "79"
@@ -54,7 +54,7 @@
             },
             "webview_android": {
               "version_added": "73",
-              "notes": "Until version 75, downloads for files with this header would fail in WebView.  See <a href='https://crbug.com/952834'>bug 952834</a>."
+              "notes": "Until version 75, downloads for files with this header would fail in WebView. See <a href='https://crbug.com/952834'>bug 952834</a>."
             }
           },
           "status": {

--- a/http/headers/expect-ct.json
+++ b/http/headers/expect-ct.json
@@ -7,7 +7,7 @@
           "support": {
             "chrome": {
               "version_added": "61",
-              "notes": "Before later builds of Chrome 64, invalid Expect-CT reports would be sent. Newer versions do not send reports after 10 weeks from the build date.  See <a href='https://crbug.com/786563'>bug 786563</a>."
+              "notes": "Before later builds of Chrome 64, invalid Expect-CT reports would be sent. Newer versions do not send reports after 10 weeks from the build date. See <a href='https://crbug.com/786563'>bug 786563</a>."
             },
             "chrome_android": {
               "version_added": "61"

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -2469,7 +2469,7 @@
                 },
                 "nodejs": {
                   "version_added": "0.12",
-                  "notes": "Prior to NodeJS 13, only the locale data for <code>en-us</code> is available by default.  When other English locales are specified, the function silently falls back to <code>en-us</code>.  When other languages are specified, it throws a <code>RangeError</code>.  In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                  "notes": "Prior to NodeJS 13, only the locale data for <code>en-us</code> is available by default. When other English locales are specified, the function silently falls back to <code>en-us</code>. When other languages are specified, it throws a <code>RangeError</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
                 },
                 "opera": {
                   "version_added": "15"
@@ -2729,7 +2729,7 @@
                 },
                 "nodejs": {
                   "version_added": "0.12",
-                  "notes": "Prior to NodeJS 13, only the locale data for <code>en-us</code> is available by default.  When other English locales are specified, the function silently falls back to <code>en-us</code>.  When other languages are specified, it throws a <code>RangeError</code>.  In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                  "notes": "Prior to NodeJS 13, only the locale data for <code>en-us</code> is available by default. When other English locales are specified, the function silently falls back to <code>en-us</code>. When other languages are specified, it throws a <code>RangeError</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
                 },
                 "opera": {
                   "version_added": "15"
@@ -2936,7 +2936,7 @@
                 },
                 "nodejs": {
                   "version_added": "0.12",
-                  "notes": "Prior to NodeJS 13, only the locale data for <code>en-us</code> is available by default.  When other English locales are specified, the function silently falls back to <code>en-us</code>.  When other languages are specified, it throws a <code>RangeError</code>.  In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                  "notes": "Prior to NodeJS 13, only the locale data for <code>en-us</code> is available by default. When other English locales are specified, the function silently falls back to <code>en-us</code> When other languages are specified, it throws a <code>RangeError</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
                 },
                 "opera": {
                   "version_added": "15"

--- a/webextensions/api/devtools.json
+++ b/webextensions/api/devtools.json
@@ -381,7 +381,7 @@
                     "version_added": "79"
                   },
                   "firefox": {
-                    "notes": "The expression must evaluate to an object that can be serialized to JSON, or nothing is shown in the sidebar. In particular, JavaScript cyclic objects and DOM nodes are not supported.  See <a href='https://bugzil.la/1403130'>bug 1403130</a>.",
+                    "notes": "The expression must evaluate to an object that can be serialized to JSON, or nothing is shown in the sidebar. In particular, JavaScript cyclic objects and DOM nodes are not supported. See <a href='https://bugzil.la/1403130'>bug 1403130</a>.",
                     "version_added": "57"
                   },
                   "firefox_android": {


### PR DESCRIPTION
This PR is related to #4829.  Throughout the repo, we've had a few notes that have double-spacing in between sentences (sometimes in other inopportune locations), and several PRs that include these changes.  This removes the double spacing within these notes to maintain single spacing throughout the entire repository.