### PR TITLE
IE/Edge treats all custom elements as the same type until Edge 16

### DIFF
--- a/css/selectors/first-of-type.json
+++ b/css/selectors/first-of-type.json
@@ -14,7 +14,7 @@
             },
             "edge": {
               "version_added": "12",
-              "notes": "Until EdgeHTML 16, Microsoft Edge treats all unknown elements as the same element type."
+              "notes": "Until EdgeHTML 16, Microsoft Edge treats all unknown elements (such as custom elements) as the same element type."
             },
             "firefox": {
               "version_added": "3.5"

--- a/css/selectors/first-of-type.json
+++ b/css/selectors/first-of-type.json
@@ -13,7 +13,8 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "notes": "Until EdgeHTML 16, Microsoft Edge treats all unknown elements as the same element type."
             },
             "firefox": {
               "version_added": "3.5"
@@ -22,7 +23,8 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "9"
+              "version_added": "9",
+              "notes": "Internet Explorer treats all unknown elements as the same element type."
             },
             "opera": {
               "version_added": "9.5"

--- a/css/selectors/first-of-type.json
+++ b/css/selectors/first-of-type.json
@@ -24,7 +24,7 @@
             },
             "ie": {
               "version_added": "9",
-              "notes": "Internet Explorer treats all unknown elements as the same element type."
+              "notes": "Internet Explorer treats all unknown elements (such as custom elements) as the same element type."
             },
             "opera": {
               "version_added": "9.5"

--- a/css/selectors/last-of-type.json
+++ b/css/selectors/last-of-type.json
@@ -13,7 +13,8 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "notes": "Until EdgeHTML 16, Microsoft Edge treats all unknown elements as the same element type."
             },
             "firefox": {
               "version_added": "3.5"
@@ -22,7 +23,8 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "9"
+              "version_added": "9",
+              "notes": "Internet Explorer treats all unknown elements as the same element type."
             },
             "opera": {
               "version_added": "9.5"

--- a/css/selectors/last-of-type.json
+++ b/css/selectors/last-of-type.json
@@ -14,7 +14,7 @@
             },
             "edge": {
               "version_added": "12",
-              "notes": "Until EdgeHTML 16, Microsoft Edge treats all unknown elements as the same element type."
+              "notes": "Until EdgeHTML 16, Microsoft Edge treats all unknown elements (such as custom elements) as the same element type."
             },
             "firefox": {
               "version_added": "3.5"
@@ -24,7 +24,7 @@
             },
             "ie": {
               "version_added": "9",
-              "notes": "Internet Explorer treats all unknown elements as the same element type."
+              "notes": "Internet Explorer treats all unknown elements (such as custom elements) as the same element type."
             },
             "opera": {
               "version_added": "9.5"

--- a/css/selectors/nth-last-of-type.json
+++ b/css/selectors/nth-last-of-type.json
@@ -13,7 +13,8 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "notes": "Until EdgeHTML 16, Microsoft Edge treats all unknown elements as the same element type."
             },
             "firefox": {
               "version_added": "3.5"
@@ -22,7 +23,8 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "9"
+              "version_added": "9",
+              "notes": "Internet Explorer treats all unknown elements as the same element type."
             },
             "opera": {
               "version_added": "9.5"

--- a/css/selectors/nth-last-of-type.json
+++ b/css/selectors/nth-last-of-type.json
@@ -14,7 +14,7 @@
             },
             "edge": {
               "version_added": "12",
-              "notes": "Until EdgeHTML 16, Microsoft Edge treats all unknown elements as the same element type."
+              "notes": "Until EdgeHTML 16, Microsoft Edge treats all unknown elements (such as custom elements) as the same element type."
             },
             "firefox": {
               "version_added": "3.5"
@@ -24,7 +24,7 @@
             },
             "ie": {
               "version_added": "9",
-              "notes": "Internet Explorer treats all unknown elements as the same element type."
+              "notes": "Internet Explorer treats all unknown elements (such as custom elements) as the same element type."
             },
             "opera": {
               "version_added": "9.5"

--- a/css/selectors/nth-of-type.json
+++ b/css/selectors/nth-of-type.json
@@ -13,7 +13,8 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "notes": "Until EdgeHTML 16, Microsoft Edge treats all unknown elements as the same element type."
             },
             "firefox": {
               "version_added": "3.5"
@@ -22,7 +23,8 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "9"
+              "version_added": "9",
+              "notes": "Internet Explorer treats all unknown elements as the same element type."
             },
             "opera": {
               "version_added": "9.5"

--- a/css/selectors/nth-of-type.json
+++ b/css/selectors/nth-of-type.json
@@ -14,7 +14,7 @@
             },
             "edge": {
               "version_added": "12",
-              "notes": "Until EdgeHTML 16, Microsoft Edge treats all unknown elements as the same element type."
+              "notes": "Until EdgeHTML 16, Microsoft Edge treats all unknown elements (such as custom elements) as the same element type."
             },
             "firefox": {
               "version_added": "3.5"
@@ -24,7 +24,7 @@
             },
             "ie": {
               "version_added": "9",
-              "notes": "Internet Explorer treats all unknown elements as the same element type."
+              "notes": "Internet Explorer treats all unknown elements (such as custom elements) as the same element type."
             },
             "opera": {
               "version_added": "9.5"

--- a/css/selectors/only-of-type.json
+++ b/css/selectors/only-of-type.json
@@ -13,7 +13,8 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "notes": "Until EdgeHTML 16, Microsoft Edge treats all unknown elements as the same element type."
             },
             "firefox": {
               "version_added": "3.5"
@@ -22,7 +23,8 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "9"
+              "version_added": "9",
+              "notes": "Internet Explorer treats all unknown elements as the same element type."
             },
             "opera": {
               "version_added": "9.5"

--- a/css/selectors/only-of-type.json
+++ b/css/selectors/only-of-type.json
@@ -14,7 +14,7 @@
             },
             "edge": {
               "version_added": "12",
-              "notes": "Until EdgeHTML 16, Microsoft Edge treats all unknown elements as the same element type."
+              "notes": "Until EdgeHTML 16, Microsoft Edge treats all unknown elements (such as custom elements) as the same element type."
             },
             "firefox": {
               "version_added": "3.5"
@@ -24,7 +24,7 @@
             },
             "ie": {
               "version_added": "9",
-              "notes": "Internet Explorer treats all unknown elements as the same element type."
+              "notes": "Internet Explorer treats all unknown elements (such as custom elements) as the same element type."
             },
             "opera": {
               "version_added": "9.5"


### PR DESCRIPTION
This PR fixes #4845 by adding compatibility notes to the `:???-of-type` CSS selectors.

~Note: Travis CI was having some weird issues with GitHub integration around this time.  The test has actually passed even though it says it's pending!~ (Fixed)