### PR TITLE
Update link rel="preconnect" data

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -864,7 +864,7 @@
                   "version_added": "46"
                 },
                 "chrome_android": {
-                  "version_added": "42"
+                  "version_added": "46"
                 },
                 "edge": {
                   "version_added": "79"
@@ -884,13 +884,13 @@
                   "version_added": "33"
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": "33"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "11.1"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "11.3"
                 },
                 "samsunginternet_android": {
                   "version_added": "4.0"


### PR DESCRIPTION
Fixes #4913.  There were some differences between the CanIUse data and ours, so this PR updates them accordingly.  Namely: Safari was set to `false` in our data, though CanIUse indicated support since 11.1.  Furthermore, this fixes Chrome Android's version number and updates Opera Android's.