### PR TITLE
Cache API is supported in Safari iOS

### DIFF
--- a/api/Cache.json
+++ b/api/Cache.json
@@ -37,7 +37,7 @@
             "version_added": "11"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "11"
           },
           "samsunginternet_android": {
             "version_added": "4.0",
@@ -91,7 +91,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "4.0",
@@ -146,7 +146,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "5.0",
@@ -197,7 +197,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -246,7 +246,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -295,7 +295,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -345,7 +345,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -398,7 +398,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "4.0",


### PR DESCRIPTION
Fixes #4938.  Turns out the Cache API is fully supported in iOS!

~Note: Travis CI was having some weird issues with GitHub integration around this time. The test has actually passed even though it says it's pending!~ (Fixed)