### PR TITLE
Add WebExtensions Tabs.Tab.successorTabId

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1000,6 +1000,27 @@
               }
             }
           },
+          "successorId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": null
+                },
+                "firefox_android": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                }
+              }
+            }
+          },
           "title": {
             "__compat": {
               "support": {

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1000,7 +1000,7 @@
               }
             }
           },
-          "successorId": {
+          "successorTabId": {
             "__compat": {
               "support": {
                 "chrome": {

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1004,19 +1004,19 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
-                  "version_added": null
+                  "version_added": "65"
                 },
                 "firefox_android": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": false
                 }
               }
             }


### PR DESCRIPTION
Fixes #4986.  This PR adds basic compatibility data for the `successorId` property of the `tabs.Tab` WebExtensions API.  All browsers are set to `null` for now, as I'm not familiar with how to test WebExtensions yet, and I'd like to get this feature in so we can remember to add versions in the future.

Note: Travis CI was having some weird issues during this time, so there are no CI results. This PR passes the test, luckily.