### PR TITLE
Document.registerElement removed in Chrome 80

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -9127,13 +9127,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/registerElement",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "35",
+              "version_removed": "80"
             },
             "chrome_android": {
-              "version_added": "35"
+              "version_added": "35",
+              "version_removed": "80"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "79",
+              "version_removed": "80"
             },
             "firefox": {
               "version_added": "31",
@@ -9171,7 +9174,8 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "25"
+              "version_added": "25",
+              "version_removed": "67"
             },
             "opera_android": {
               "version_added": "25"
@@ -9186,7 +9190,8 @@
               "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "37",
+              "version_removed": "80"
             }
           },
           "status": {


### PR DESCRIPTION
Fixes #5070.  Supporting details are in the issue.