### PR TITLE
update ios CSS.escape compat

### DIFF
--- a/api/CSS.json
+++ b/api/CSS.json
@@ -533,7 +533,7 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "5.0"


### PR DESCRIPTION
It was [added to STP](https://developer.apple.com/safari/technology-preview/release-notes/) in September 2016, and I confirmed it made the cut in safari on ios 10 with test devices