### PR TITLE
Break out SameSite features; mention Safari bug

### DIFF
--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -172,12 +172,26 @@
               "opera_android": {
                 "version_added": "41"
               },
-              "safari": {
-                "version_added": "12"
-              },
-              "safari_ios": {
-                "version_added": "12.2"
-              },
+              "safari": [
+                {
+                  "version_added": "13"
+                },
+                {
+                  "version_added": "12",
+                  "partial_implementation": true,
+                  "notes": "Treats <code>SameSite=None</code> and invalid values as <code>Strict</code> in macOS before 10.15 Catalina. See <a href='https://webkit.org/b/198181'>bug 198181</a>."
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "13"
+                },
+                {
+                  "version_added": "12.2",
+                  "partial_implementation": true,
+                  "notes": "Treats <code>SameSite=None</code> and invalid values as <code>Strict</code> in iOS before 13. See <a href='https://webkit.org/b/198181'>bug 198181</a>."
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": "5.0"
               },
@@ -189,6 +203,54 @@
               "experimental": false,
               "standard_track": true,
               "deprecated": false
+            }
+          },
+          "Lax": {
+            "__compat": {
+              "description": "<code>SameSite=Lax</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "51"
+                },
+                "chrome_android": {
+                  "version_added": "51"
+                },
+                "edge": {
+                  "version_added": "16"
+                },
+                "firefox": {
+                  "version_added": "60"
+                },
+                "firefox_android": {
+                  "version_added": "60"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "39"
+                },
+                "opera_android": {
+                  "version_added": "41"
+                },
+                "safari": {
+                  "version_added": "12"
+                },
+                "safari_ios": {
+                  "version_added": "12.2"
+                },
+                "samsunginternet_android": {
+                  "version_added": "5.0"
+                },
+                "webview_android": {
+                  "version_added": "51"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           },
           "Lax_default": {
@@ -237,6 +299,102 @@
                 },
                 "webview_android": {
                   "version_added": "80"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "None": {
+            "__compat": {
+              "description": "<code>SameSite=None</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "51"
+                },
+                "chrome_android": {
+                  "version_added": "51"
+                },
+                "edge": {
+                  "version_added": "16"
+                },
+                "firefox": {
+                  "version_added": "60"
+                },
+                "firefox_android": {
+                  "version_added": "60"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "39"
+                },
+                "opera_android": {
+                  "version_added": "41"
+                },
+                "safari": {
+                  "version_added": "13"
+                },
+                "safari_ios": {
+                  "version_added": "13"
+                },
+                "samsunginternet_android": {
+                  "version_added": "5.0"
+                },
+                "webview_android": {
+                  "version_added": "51"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "Strict": {
+            "__compat": {
+              "description": "<code>SameSite=Strict</code>",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": null
+                },
+                "firefox_android": {
+                  "version_added": null
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
                 }
               },
               "status": {

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -174,7 +174,8 @@
               },
               "safari": [
                 {
-                  "version_added": "13"
+                  "version_added": "13",
+                  "notes": "Safari 13 on macOS 10.14 (Mojave), treats <code>SameSite=None</code> and invalid values as <code>Strict</code>. This is fixed in version 10.15 (Catalina) and later."
                 },
                 {
                   "version_added": "12",

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -289,10 +289,10 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "samsunginternet_android": {
                   "version_added": false
@@ -415,7 +415,7 @@
                   "version_added": "80"
                 },
                 "edge": {
-                  "version_added": "≤79"
+                  "version_added": "80"
                 },
                 "firefox": {
                   "version_added": "69",
@@ -440,10 +440,10 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "samsunginternet_android": {
                   "version_added": false

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -361,40 +361,40 @@
               "description": "<code>SameSite=Strict</code>",
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": "51"
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": "51"
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": "16"
                 },
                 "firefox": {
-                  "version_added": null
+                  "version_added": "60"
                 },
                 "firefox_android": {
-                  "version_added": null
+                  "version_added": "60"
                 },
                 "ie": {
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "39"
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": "41"
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": "12"
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": "12.2"
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "5.0"
                 },
                 "webview_android": {
-                  "version_added": null
+                  "version_added": "51"
                 }
               },
               "status": {

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -337,7 +337,8 @@
                   "version_added": "41"
                 },
                 "safari": {
-                  "version_added": "13"
+                  "version_added": "13",
+                  "notes": "Not supported prior to macOS before version 10.15 (Catalina)."
                 },
                 "safari_ios": {
                   "version_added": "13"

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -264,7 +264,7 @@
                   "version_added": "80"
                 },
                 "edge": {
-                  "version_added": "≤79"
+                  "version_added": "80"
                 },
                 "firefox": {
                   "version_added": "69",


### PR DESCRIPTION
Fixes https://github.com/mdn/browser-compat-data/issues/4997

This PR adds the bug that's present in Safari 12 (as filed by @stof and also verified by other sources like caniuse, https://caniuse.com/#feat=same-site-cookie-attribute)

Further, this PR breaks out the three values `Lax`, `None`, `Strict` as requested by @jpmedley in the same issue. They are set to the same support values as the main feature except for `None` where Safari only supported in version 13.

As identified in review, the Edge version for lax by default was wrong, so this PR updates that as well.