### PR TITLE
Remove Chrome 82.

### DIFF
--- a/api/XRSystem.json
+++ b/api/XRSystem.json
@@ -4,26 +4,14 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSystem",
         "support": {
-          "chrome": [
-            {
-              "version_added": "82"
-            },
-            {
-              "alternative_name": "XR",
-              "version_added": "79",
-              "version_removed": "82"
-            }
-          ],
-          "chrome_android": [
-            {
-              "version_added": "82"
-            },
-            {
-              "alternative_name": "XR",
-              "version_added": "79",
-              "version_removed": "82"
-            }
-          ],
+          "chrome": {
+            "alternative_name": "XR",
+            "version_added": "79"
+          },
+          "chrome_android": {
+            "alternative_name": "XR",
+            "version_added": "79"
+          },
           "edge": {
             "version_added": "79",
             "alternative_name": "XR"

--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -569,10 +569,10 @@
           "engine": "Blink",
           "engine_version": "81"
         },
-        "82": {
+        "83": {
           "status": "nightly",
           "engine": "Blink",
-          "engine_version": "82"
+          "engine_version": "83"
         }
       }
     }

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -405,11 +405,6 @@
           "status": "beta",
           "engine": "Blink",
           "engine_version": "81"
-        },
-        "82": {
-          "status": "nightly",
-          "engine": "Blink",
-          "engine_version": "82"
         }
       }
     }

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -405,6 +405,11 @@
           "status": "beta",
           "engine": "Blink",
           "engine_version": "81"
+        },
+        "83": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "83"
         }
       }
     }

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -397,10 +397,10 @@
           "engine": "Blink",
           "engine_version": "81"
         },
-        "82": {
+        "83": {
           "status": "nightly",
           "engine": "Blink",
-          "engine_version": "82"
+          "engine_version": "83"
         }
       }
     }

--- a/css/at-rules/supports.json
+++ b/css/at-rules/supports.json
@@ -80,13 +80,13 @@
             "description": "<code>selector()</code>",
             "support": {
               "chrome": {
-                "version_added": "82"
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": "82"
+                "version_added": false
               },
               "edge": {
-                "version_added": "82"
+                "version_added": false
               },
               "firefox": [
                 {
@@ -137,7 +137,7 @@
                 "notes": "See <a href='https://crbug.com/979041'>bug 979041</a>."
               },
               "webview_android": {
-                "version_added": "82"
+                "version_added": false
               }
             },
             "status": {


### PR DESCRIPTION
https://9to5google.com/2020/03/23/google-chrome-and-chrome-os-are-set-to-skip-version-82-due-to-delays/