### PR TITLE
Update `n` standard track state

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -992,7 +992,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }


### PR DESCRIPTION
As de-facto standard, compatible with every known JS engine, and as [Stage 3](https://github.com/tc39/proposals#stage-3) TC39 [proposal](https://github.com/tc39/proposal-regexp-legacy-features), the `RegExp.$n` feature should stop warning users about being not standard, as it's one of the few de-facto standard JS features we have since about ever (see every browser, and Node, support the `n` feature, and the Stage 3 proposal is not going to change that, actually is going to ufficialize its usage).

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [x] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
