### PR TITLE
Update versions for ANGLE_instanced_arrays API

### DIFF
--- a/api/ANGLE_instanced_arrays.json
+++ b/api/ANGLE_instanced_arrays.json
@@ -12,35 +12,46 @@
             "version_added": "30",
             "alternative_name": "ANGLEInstancedArrays"
           },
-          "edge": {
-            "version_added": "12"
-          },
+          "edge": [
+            {
+              "version_added": "79",
+              "alternative_name": "ANGLEInstancedArrays"
+            },
+            {
+              "version_added": "12",
+              "version_removed": "79"
+            }
+          ],
           "firefox": {
             "version_added": "33"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "33"
           },
           "ie": {
             "version_added": "11"
           },
           "opera": {
-            "version_added": true
+            "version_added": "17",
+            "alternative_name": "ANGLEInstancedArrays"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "18",
+            "alternative_name": "ANGLEInstancedArrays"
           },
           "safari": {
-            "version_added": null
+            "version_added": "7"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "7"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "2.0",
+            "alternative_name": "ANGLEInstancedArrays"
           },
           "webview_android": {
-            "version_added": "≤37"
+            "version_added": "4.4",
+            "alternative_name": "ANGLEInstancedArrays"
           }
         },
         "status": {
@@ -66,28 +77,28 @@
               "version_added": "33"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "33"
             },
             "ie": {
               "version_added": "11"
             },
             "opera": {
-              "version_added": true
+              "version_added": "17"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "safari": {
-              "version_added": null
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -114,28 +125,28 @@
               "version_added": "33"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "33"
             },
             "ie": {
               "version_added": "11"
             },
             "opera": {
-              "version_added": true
+              "version_added": "17"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "safari": {
-              "version_added": null
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -162,28 +173,28 @@
               "version_added": "33"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "33"
             },
             "ie": {
               "version_added": "11"
             },
             "opera": {
-              "version_added": true
+              "version_added": "17"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "safari": {
-              "version_added": null
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "4.4"
             }
           },
           "status": {

--- a/api/ANGLE_instanced_arrays.json
+++ b/api/ANGLE_instanced_arrays.json
@@ -26,7 +26,7 @@
             "version_added": "33"
           },
           "firefox_android": {
-            "version_added": "33"
+            "version_added": true
           },
           "ie": {
             "version_added": "11"
@@ -43,7 +43,7 @@
             "version_added": "7"
           },
           "safari_ios": {
-            "version_added": "7"
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": "2.0",
@@ -77,7 +77,7 @@
               "version_added": "33"
             },
             "firefox_android": {
-              "version_added": "33"
+              "version_added": true
             },
             "ie": {
               "version_added": "11"
@@ -92,7 +92,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -125,7 +125,7 @@
               "version_added": "33"
             },
             "firefox_android": {
-              "version_added": "33"
+              "version_added": true
             },
             "ie": {
               "version_added": "11"
@@ -140,7 +140,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -173,7 +173,7 @@
               "version_added": "33"
             },
             "firefox_android": {
-              "version_added": "33"
+              "version_added": true
             },
             "ie": {
               "version_added": "11"
@@ -188,7 +188,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "2.0"


### PR DESCRIPTION
This PR updates the versions for the ANGLE_instanced_arrays API based upon manual testing and mirroring data.  Data is as follows:

```
api.ANGLE_instanced_arrays
	- Opera - Blink
	- Safari - 7
api.ANGLE_instanced_arrays.drawArraysInstancedANGLE
	- Opera - Blink
	- Safari - 7
api.ANGLE_instanced_arrays.drawElementsInstancedANGLE
	- Opera - Blink
	- Safari - 7
api.ANGLE_instanced_arrays.vertexAttribDivisorANGLE
	- Opera - Blink
	- Safari - 7
```