### PR TITLE
Firefox 75 supports nonce

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1802,7 +1802,7 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "75"
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
This bug adds support for `nonce` in Firefox 75: https://bugzilla.mozilla.org/show_bug.cgi?id=1374612