### PR TITLE
Note about type='text/css' in Fx75

### DIFF
--- a/html/elements/style.json
+++ b/html/elements/style.json
@@ -265,7 +265,8 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "notes": "Prior to 75, Firefox accepted any media (MIME) type. Starting in 75, Firefox accepts only 'text/css', per the spec."
               },
               "firefox_android": {
                 "version_added": "4"

--- a/html/elements/style.json
+++ b/html/elements/style.json
@@ -266,7 +266,7 @@
               },
               "firefox": {
                 "version_added": "1",
-                "notes": "Prior to 75, Firefox accepted any media (MIME) type. Starting in 75, Firefox accepts only 'text/css', per the spec."
+                "notes": "Prior to 75, Firefox accepted any CSS media (MIME) type, with optional parameters. Starting in 75, this has been restricted to the string 'text/css', per the spec."
               },
               "firefox_android": {
                 "version_added": "4"


### PR DESCRIPTION
- [Bugzilla bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1614329)
- [Sprints issue](https://github.com/mdn/sprints/issues/2923)
