### PR TITLE
Fix mdn_url values for CSS combinator features

### DIFF
--- a/css/selectors/adjacent_sibling.json
+++ b/css/selectors/adjacent_sibling.json
@@ -4,7 +4,7 @@
       "adjacent_sibling": {
         "__compat": {
           "description": "Adjacent sibling combinator (<code>A + B</code>)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Adjacent_sibling_selectors",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Adjacent_sibling_combinator",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/css/selectors/child.json
+++ b/css/selectors/child.json
@@ -4,7 +4,7 @@
       "child": {
         "__compat": {
           "description": "Child combinator (<code>A &gt; B</code>)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Child_selectors",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Child_combinator",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/css/selectors/descendant.json
+++ b/css/selectors/descendant.json
@@ -4,7 +4,7 @@
       "descendant": {
         "__compat": {
           "description": "Descendant combinator (<code>A B</code>)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Descendant_selectors",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Descendant_combinator",
           "support": {
             "chrome": [
               {

--- a/css/selectors/general_sibling.json
+++ b/css/selectors/general_sibling.json
@@ -4,7 +4,7 @@
       "general_sibling": {
         "__compat": {
           "description": "General sibling combinator (<code>A ~ B</code>)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/General_sibling_selectors",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/General_sibling_combinator",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
In, for example, `css/selectors/adjacent_sibling.json`, the `mdn_url` https://developer.mozilla.org/docs/Web/CSS/Adjacent_sibling_selectors is outdated and now just redirects to https://developer.mozilla.org/docs/Web/CSS/Adjacent_sibling_combinator. Same for several other features in the css/selectors subtree.