### PR TITLE
Replace outdated webkit-scrollbar-* mdn_url values

### DIFF
--- a/css/selectors/-webkit-resizer.json
+++ b/css/selectors/-webkit-resizer.json
@@ -4,7 +4,7 @@
       "-webkit-resizer": {
         "__compat": {
           "description": "::-webkit-resizer",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-webkit-resizer",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-webkit-scrollbar",
           "support": {
             "chrome": {
               "version_added": "2"

--- a/css/selectors/-webkit-scrollbar-button.json
+++ b/css/selectors/-webkit-scrollbar-button.json
@@ -4,7 +4,7 @@
       "-webkit-scrollbar-button": {
         "__compat": {
           "description": "::-webkit-scrollbar-button",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-webkit-scrollbar-button",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-webkit-scrollbar",
           "support": {
             "chrome": {
               "version_added": "2"

--- a/css/selectors/-webkit-scrollbar-corner.json
+++ b/css/selectors/-webkit-scrollbar-corner.json
@@ -4,7 +4,7 @@
       "-webkit-scrollbar-corner": {
         "__compat": {
           "description": "::-webkit-scrollbar-corner",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-webkit-scrollbar-corner",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-webkit-scrollbar",
           "support": {
             "chrome": {
               "version_added": "2"

--- a/css/selectors/-webkit-scrollbar-thumb.json
+++ b/css/selectors/-webkit-scrollbar-thumb.json
@@ -4,7 +4,7 @@
       "-webkit-scrollbar-thumb": {
         "__compat": {
           "description": "::-webkit-scrollbar-thumb",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-webkit-scrollbar-thumb",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-webkit-scrollbar",
           "support": {
             "chrome": {
               "version_added": "2"

--- a/css/selectors/-webkit-scrollbar-track-piece.json
+++ b/css/selectors/-webkit-scrollbar-track-piece.json
@@ -4,7 +4,7 @@
       "-webkit-scrollbar-track-piece": {
         "__compat": {
           "description": "::-webkit-scrollbar-track-piece",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-webkit-scrollbar-track-piece",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-webkit-scrollbar",
           "support": {
             "chrome": {
               "version_added": "2"

--- a/css/selectors/-webkit-scrollbar-track.json
+++ b/css/selectors/-webkit-scrollbar-track.json
@@ -4,7 +4,7 @@
       "-webkit-scrollbar-track": {
         "__compat": {
           "description": "::-webkit-scrollbar-track",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-webkit-scrollbar-track",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::-webkit-scrollbar",
           "support": {
             "chrome": {
               "version_added": "2"


### PR DESCRIPTION
`css/selectors/-webkit-scrollbar-*` features have outdated `mdn_url` values that now redirect to https://developer.mozilla.org/docs/Web/CSS/::-webkit-scrollbar. This change updates them.