### PR TITLE
Replace outdated overflow-clip-* mdn_url values

### DIFF
--- a/css/properties/overflow-clip-box-block.json
+++ b/css/properties/overflow-clip-box-block.json
@@ -3,7 +3,7 @@
     "properties": {
       "overflow-clip-box-block": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/CSS/overflow-clip-box-block",
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Gecko/Chrome/CSS/overflow-clip-box-block",
           "support": {
             "chrome": {
               "version_added": false

--- a/css/properties/overflow-clip-box-inline.json
+++ b/css/properties/overflow-clip-box-inline.json
@@ -3,7 +3,7 @@
     "properties": {
       "overflow-clip-box-inline": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/CSS/overflow-clip-box-inline",
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Gecko/Chrome/CSS/overflow-clip-box-inline",
           "support": {
             "chrome": {
               "version_added": false

--- a/css/properties/overflow-clip-box.json
+++ b/css/properties/overflow-clip-box.json
@@ -3,7 +3,7 @@
     "properties": {
       "overflow-clip-box": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/CSS/overflow-clip-box",
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Gecko/Chrome/CSS/overflow-clip-box",
           "support": {
             "chrome": {
               "version_added": false


### PR DESCRIPTION
This replaces several outdated `mdn_url` values for `css/properties/overflow-clip-*` features with the URLs that they now redirect to.