### PR TITLE
Mark SpeechRecognition as prefix-required in Edge

### DIFF
--- a/api/SpeechRecognition.json
+++ b/api/SpeechRecognition.json
@@ -15,7 +15,9 @@
             "notes": "You'll need to serve your code through a web server for recognition to work."
           },
           "edge": {
-            "version_added": "≤79"
+            "prefix": "webkit",
+            "version_added": "≤79",
+            "notes": "You'll need to serve your code through a web server for recognition to work."
           },
           "firefox": {
             "version_added": false


### PR DESCRIPTION
All `SpeechRecognition` members are already marked as `"prefix": "webkit"` for Edge, along with `"notes": "You'll need to serve your code through a web server for recognition to work."` — but  the `SpeechRecognition` interface itself isn’t marked as such.

I can’t find any indication anywhere that Edge 79+ has diverged from Chrome by un-prefixing `SpeechRecognition`, nor by not restricting use of `SpeechRecognition` to be code served from a web server.