### PR TITLE
Canvas context filter not supported until Edge 79

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -2002,7 +2002,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "80"
             },
             "firefox": [
               {

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -2002,7 +2002,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": "80"
+              "version_added": "79"
             },
             "firefox": [
               {


### PR DESCRIPTION
Edge does not support filter until the Chromium-based version 79.

Screenshots from MDN's own examples taken in Edge 44 (last version before version jump to 79 to match Chromium versions).

**Should appear blurred:**

![Screen Shot 2020-03-27 at 8 36 27 AM](https://user-images.githubusercontent.com/6756989/77756776-39cbe580-7006-11ea-9d90-ebda0825dee3.png)

**Should have drop shadow behind image:**

![Screen Shot 2020-03-27 at 8 38 46 AM](https://user-images.githubusercontent.com/6756989/77756852-6c75de00-7006-11ea-8f09-7899798bfeac.png)