### PR TITLE
Add Web NFC API

### DIFF
--- a/api/NDEFMessage.json
+++ b/api/NDEFMessage.json
@@ -7,22 +7,9 @@
           "chrome": {
             "version_added": false
           },
-          "chrome_android": [
-            {
-              "version_added": "81",
-              "version_removed": "83",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-webnfc",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
-            {
-              "version_added": "84"
-            }
-          ],
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
             "version_added": false
           },
@@ -68,22 +55,9 @@
             "chrome": {
               "version_added": false
             },
-            "chrome_android": [
-              {
-                "version_added": "81",
-                "version_removed": "83",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-webnfc",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "84"
-              }
-            ],
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": false
             },
@@ -129,22 +103,9 @@
             "chrome": {
               "version_added": false
             },
-            "chrome_android": [
-              {
-                "version_added": "81",
-                "version_removed": "83",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-webnfc",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "84"
-              }
-            ],
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": false
             },
@@ -190,22 +151,9 @@
             "chrome": {
               "version_added": false
             },
-            "chrome_android": [
-              {
-                "version_added": "81",
-                "version_removed": "83",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-webnfc",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "84"
-              }
-            ],
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": false
             },

--- a/api/NDEFMessage.json
+++ b/api/NDEFMessage.json
@@ -1,0 +1,188 @@
+{
+  "api": {
+    "NDEFMessage": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFMessage",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": [
+            {
+              "version_added": "81",
+              "version_removed": "83",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-webnfc",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            {
+              "version_added": "84"
+            }
+          ],
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "NDEFMessage": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFMessage/NDEFMessage",
+          "description": "<code>NDEFMessage()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": [
+              {
+                "version_added": "81",
+                "version_removed": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-webnfc",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "84"
+              }
+            ],
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "records": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFMessage/records",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": [
+              {
+                "version_added": "81",
+                "version_removed": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-webnfc",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "84"
+              }
+            ],
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/NDEFMessage.json
+++ b/api/NDEFMessage.json
@@ -182,6 +182,67 @@
             "deprecated": false
           }
         }
+      },
+      "secure_context_required": {
+        "__compat": {
+          "description": "Secure context required",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": [
+              {
+                "version_added": "81",
+                "version_removed": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-webnfc",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "84"
+              }
+            ],
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/NDEFReader.json
+++ b/api/NDEFReader.json
@@ -7,22 +7,9 @@
           "chrome": {
             "version_added": false
           },
-          "chrome_android": [
-            {
-              "version_added": "81",
-              "version_removed": "83",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-webnfc",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
-            {
-              "version_added": "84"
-            }
-          ],
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
             "version_added": false
           },
@@ -68,22 +55,9 @@
             "chrome": {
               "version_added": false
             },
-            "chrome_android": [
-              {
-                "version_added": "81",
-                "version_removed": "83",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-webnfc",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "84"
-              }
-            ],
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": false
             },
@@ -129,22 +103,9 @@
             "chrome": {
               "version_added": false
             },
-            "chrome_android": [
-              {
-                "version_added": "81",
-                "version_removed": "83",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-webnfc",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "84"
-              }
-            ],
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": false
             },
@@ -190,22 +151,9 @@
             "chrome": {
               "version_added": false
             },
-            "chrome_android": [
-              {
-                "version_added": "81",
-                "version_removed": "83",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-webnfc",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "84"
-              }
-            ],
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": false
             },
@@ -251,22 +199,9 @@
             "chrome": {
               "version_added": false
             },
-            "chrome_android": [
-              {
-                "version_added": "81",
-                "version_removed": "83",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-webnfc",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "84"
-              }
-            ],
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": false
             },
@@ -312,22 +247,9 @@
             "chrome": {
               "version_added": false
             },
-            "chrome_android": [
-              {
-                "version_added": "81",
-                "version_removed": "83",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-webnfc",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "84"
-              }
-            ],
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": false
             },

--- a/api/NDEFReader.json
+++ b/api/NDEFReader.json
@@ -1,0 +1,310 @@
+{
+  "api": {
+    "NDEFReader": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFReader",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": [
+            {
+              "version_added": "81",
+              "version_removed": "83",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-webnfc",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            {
+              "version_added": "84"
+            }
+          ],
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "NDEFReader": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFReader/NDEFReader",
+          "description": "<code>NDEFReader()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": [
+              {
+                "version_added": "81",
+                "version_removed": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-webnfc",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "84"
+              }
+            ],
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onerror": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFReader/onerror",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": [
+              {
+                "version_added": "81",
+                "version_removed": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-webnfc",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "84"
+              }
+            ],
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onread": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFReader/onread",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": [
+              {
+                "version_added": "81",
+                "version_removed": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-webnfc",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "84"
+              }
+            ],
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "scan": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFReader/scan",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": [
+              {
+                "version_added": "81",
+                "version_removed": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-webnfc",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "84"
+              }
+            ],
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/NDEFReader.json
+++ b/api/NDEFReader.json
@@ -304,6 +304,67 @@
             "deprecated": false
           }
         }
+      },
+      "secure_context_required": {
+        "__compat": {
+          "description": "Secure context required",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": [
+              {
+                "version_added": "81",
+                "version_removed": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-webnfc",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "84"
+              }
+            ],
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/NDEFReadingEvent.json
+++ b/api/NDEFReadingEvent.json
@@ -7,22 +7,9 @@
           "chrome": {
             "version_added": false
           },
-          "chrome_android": [
-            {
-              "version_added": "81",
-              "version_removed": "83",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-webnfc",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
-            {
-              "version_added": "84"
-            }
-          ],
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
             "version_added": false
           },
@@ -68,22 +55,9 @@
             "chrome": {
               "version_added": false
             },
-            "chrome_android": [
-              {
-                "version_added": "81",
-                "version_removed": "83",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-webnfc",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "84"
-              }
-            ],
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": false
             },
@@ -129,22 +103,9 @@
             "chrome": {
               "version_added": false
             },
-            "chrome_android": [
-              {
-                "version_added": "81",
-                "version_removed": "83",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-webnfc",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "84"
-              }
-            ],
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": false
             },
@@ -190,22 +151,9 @@
             "chrome": {
               "version_added": false
             },
-            "chrome_android": [
-              {
-                "version_added": "81",
-                "version_removed": "83",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-webnfc",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "84"
-              }
-            ],
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": false
             },
@@ -251,22 +199,9 @@
             "chrome": {
               "version_added": false
             },
-            "chrome_android": [
-              {
-                "version_added": "81",
-                "version_removed": "83",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-webnfc",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "84"
-              }
-            ],
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": false
             },

--- a/api/NDEFReadingEvent.json
+++ b/api/NDEFReadingEvent.json
@@ -1,0 +1,249 @@
+{
+  "api": {
+    "NDEFReadingEvent": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFReadingEvent",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": [
+            {
+              "version_added": "81",
+              "version_removed": "83",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-webnfc",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            {
+              "version_added": "84"
+            }
+          ],
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "NDEFReadingEvent": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFReadingEvent/NDEFReadingEvent",
+          "description": "<code>NDEFReadingEvent()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": [
+              {
+                "version_added": "81",
+                "version_removed": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-webnfc",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "84"
+              }
+            ],
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "message": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFReadingEvent/message",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": [
+              {
+                "version_added": "81",
+                "version_removed": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-webnfc",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "84"
+              }
+            ],
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "serialNumber": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFReadingEvent/serialNumber",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": [
+              {
+                "version_added": "81",
+                "version_removed": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-webnfc",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "84"
+              }
+            ],
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/NDEFReadingEvent.json
+++ b/api/NDEFReadingEvent.json
@@ -183,6 +183,67 @@
           }
         }
       },
+      "secure_context_required": {
+        "__compat": {
+          "description": "Secure context required",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": [
+              {
+                "version_added": "81",
+                "version_removed": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-webnfc",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "84"
+              }
+            ],
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "serialNumber": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFReadingEvent/serialNumber",

--- a/api/NDEFRecord.json
+++ b/api/NDEFRecord.json
@@ -1,0 +1,554 @@
+{
+  "api": {
+    "NDEFRecord": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFRecord",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": [
+            {
+              "version_added": "81",
+              "version_removed": "83",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-webnfc",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            {
+              "version_added": "84"
+            }
+          ],
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "NDEFRecord": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFRecord/NDEFRecord",
+          "description": "<code>NDEFRecord()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": [
+              {
+                "version_added": "81",
+                "version_removed": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-webnfc",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "84"
+              }
+            ],
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "data": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFRecord/data",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": [
+              {
+                "version_added": "81",
+                "version_removed": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-webnfc",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "84"
+              }
+            ],
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "encoding": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFRecord/encoding",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": [
+              {
+                "version_added": "81",
+                "version_removed": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-webnfc",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "84"
+              }
+            ],
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "id": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFRecord/id",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": [
+              {
+                "version_added": "81",
+                "version_removed": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-webnfc",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "84"
+              }
+            ],
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "lang": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFRecord/lang",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": [
+              {
+                "version_added": "81",
+                "version_removed": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-webnfc",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "84"
+              }
+            ],
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mediaType": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFRecord/mediaType",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": [
+              {
+                "version_added": "81",
+                "version_removed": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-webnfc",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "84"
+              }
+            ],
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "recordType": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFRecord/recordType",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": [
+              {
+                "version_added": "81",
+                "version_removed": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-webnfc",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "84"
+              }
+            ],
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "toRecords": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFRecord/toRecords",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": [
+              {
+                "version_added": "81",
+                "version_removed": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-webnfc",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "84"
+              }
+            ],
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/NDEFRecord.json
+++ b/api/NDEFRecord.json
@@ -488,6 +488,67 @@
           }
         }
       },
+      "secure_context_required": {
+        "__compat": {
+          "description": "Secure context required",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": [
+              {
+                "version_added": "81",
+                "version_removed": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-webnfc",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "84"
+              }
+            ],
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "toRecords": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFRecord/toRecords",

--- a/api/NDEFRecord.json
+++ b/api/NDEFRecord.json
@@ -7,22 +7,9 @@
           "chrome": {
             "version_added": false
           },
-          "chrome_android": [
-            {
-              "version_added": "81",
-              "version_removed": "83",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-webnfc",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
-            {
-              "version_added": "84"
-            }
-          ],
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
             "version_added": false
           },
@@ -68,22 +55,9 @@
             "chrome": {
               "version_added": false
             },
-            "chrome_android": [
-              {
-                "version_added": "81",
-                "version_removed": "83",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-webnfc",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "84"
-              }
-            ],
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": false
             },
@@ -129,22 +103,9 @@
             "chrome": {
               "version_added": false
             },
-            "chrome_android": [
-              {
-                "version_added": "81",
-                "version_removed": "83",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-webnfc",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "84"
-              }
-            ],
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": false
             },
@@ -190,22 +151,9 @@
             "chrome": {
               "version_added": false
             },
-            "chrome_android": [
-              {
-                "version_added": "81",
-                "version_removed": "83",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-webnfc",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "84"
-              }
-            ],
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": false
             },
@@ -251,22 +199,9 @@
             "chrome": {
               "version_added": false
             },
-            "chrome_android": [
-              {
-                "version_added": "81",
-                "version_removed": "83",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-webnfc",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "84"
-              }
-            ],
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": false
             },
@@ -312,22 +247,9 @@
             "chrome": {
               "version_added": false
             },
-            "chrome_android": [
-              {
-                "version_added": "81",
-                "version_removed": "83",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-webnfc",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "84"
-              }
-            ],
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": false
             },
@@ -373,22 +295,9 @@
             "chrome": {
               "version_added": false
             },
-            "chrome_android": [
-              {
-                "version_added": "81",
-                "version_removed": "83",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-webnfc",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "84"
-              }
-            ],
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": false
             },
@@ -434,22 +343,9 @@
             "chrome": {
               "version_added": false
             },
-            "chrome_android": [
-              {
-                "version_added": "81",
-                "version_removed": "83",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-webnfc",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "84"
-              }
-            ],
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": false
             },
@@ -495,22 +391,9 @@
             "chrome": {
               "version_added": false
             },
-            "chrome_android": [
-              {
-                "version_added": "81",
-                "version_removed": "83",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-webnfc",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "84"
-              }
-            ],
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": false
             },
@@ -556,22 +439,9 @@
             "chrome": {
               "version_added": false
             },
-            "chrome_android": [
-              {
-                "version_added": "81",
-                "version_removed": "83",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-webnfc",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "84"
-              }
-            ],
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": false
             },

--- a/api/NDEFWriter.json
+++ b/api/NDEFWriter.json
@@ -122,6 +122,67 @@
           }
         }
       },
+      "secure_context_required": {
+        "__compat": {
+          "description": "Secure context required",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": [
+              {
+                "version_added": "81",
+                "version_removed": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-webnfc",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "84"
+              }
+            ],
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "write": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFWriter/write",

--- a/api/NDEFWriter.json
+++ b/api/NDEFWriter.json
@@ -7,22 +7,9 @@
           "chrome": {
             "version_added": false
           },
-          "chrome_android": [
-            {
-              "version_added": "81",
-              "version_removed": "83",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-webnfc",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
-            {
-              "version_added": "84"
-            }
-          ],
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
             "version_added": false
           },
@@ -68,22 +55,9 @@
             "chrome": {
               "version_added": false
             },
-            "chrome_android": [
-              {
-                "version_added": "81",
-                "version_removed": "83",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-webnfc",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "84"
-              }
-            ],
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": false
             },
@@ -129,22 +103,9 @@
             "chrome": {
               "version_added": false
             },
-            "chrome_android": [
-              {
-                "version_added": "81",
-                "version_removed": "83",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-webnfc",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "84"
-              }
-            ],
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": false
             },
@@ -190,22 +151,9 @@
             "chrome": {
               "version_added": false
             },
-            "chrome_android": [
-              {
-                "version_added": "81",
-                "version_removed": "83",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-webnfc",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "84"
-              }
-            ],
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": false
             },

--- a/api/NDEFWriter.json
+++ b/api/NDEFWriter.json
@@ -1,0 +1,188 @@
+{
+  "api": {
+    "NDEFWriter": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFWriter",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": [
+            {
+              "version_added": "81",
+              "version_removed": "83",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-webnfc",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            {
+              "version_added": "84"
+            }
+          ],
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "NDEFWriter": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFWriter/NDEFWriter",
+          "description": "<code>NDEFWriter()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": [
+              {
+                "version_added": "81",
+                "version_removed": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-webnfc",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "84"
+              }
+            ],
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "write": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFWriter/write",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": [
+              {
+                "version_added": "81",
+                "version_removed": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-webnfc",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "84"
+              }
+            ],
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Chrome implemented Web NFC API ([spec](https://w3c.github.io/web-nfc/)) which enables sites to interact with NFC devices (read/write small amounts of data from/to compatible NFC tags, exchange data with NFC devices supporting a simple NDEF record format).

Note 1: "Web NFC" is not the same as Firefox OS [NFC API].
Note 2: Liter fails because `browsers/chrome_android.json` stops at version 83, and this data covers up to 84. Should we wait for 84 to reach Nightly or just add it as "planned"?

## Data
 - Chrome for Android launches origin trials in 81-83, with official launch planned for 84.
[Chrome platform status](https://chromestatus.com/features/6261030015467520)
[Chrome issue](https://bugs.chromium.org/p/chromium/issues/detail?id=520391)
 - [Safari does not plan to implement](https://lists.webkit.org/pipermail/webkit-dev/2020-January/031007.html)
 - [Specification](https://w3c.github.io/web-nfc/)

A checklist to help your pull request get merged faster:
- [ ] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
