### PR TITLE
Update outdated mdn_url values for CryptoKey

### DIFF
--- a/api/CryptoKey.json
+++ b/api/CryptoKey.json
@@ -49,7 +49,7 @@
       },
       "algorithm": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CryptoKey/algorithm",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CryptoKey",
           "support": {
             "chrome": {
               "version_added": "37"
@@ -97,7 +97,7 @@
       },
       "extractable": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CryptoKey/extractable",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CryptoKey",
           "support": {
             "chrome": {
               "version_added": "37"
@@ -145,7 +145,7 @@
       },
       "type": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CryptoKey/type",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CryptoKey",
           "support": {
             "chrome": {
               "version_added": "37"
@@ -193,7 +193,7 @@
       },
       "usages": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CryptoKey/usages",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CryptoKey",
           "support": {
             "chrome": {
               "version_added": "37"


### PR DESCRIPTION
Members of the `CryptoKey` interface are all documented just in the https://developer.mozilla.org/en-US/docs/Web/API/CryptoKey article itself rather than in separate articles of their own.