### PR TITLE
Chrome 80 removed Feature-Policy vr directive

### DIFF
--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -1752,14 +1752,17 @@
             "support": {
               "chrome": {
                 "version_added": "62",
+                "version_removed": "80",
                 "notes": "WebVR API was never enabled by default in any production builds and was replaced by WebXR Device API."
               },
               "chrome_android": {
                 "version_added": "62",
+                "version_removed": "80",
                 "notes": "WebVR API was never enabled by default in any production builds and was replaced by WebXR Device API."
               },
               "edge": {
                 "version_added": "79",
+                "version_removed": "80",
                 "notes": "WebVR API was never enabled by default in any production builds and was replaced by WebXR Device API."
               },
               "firefox": {
@@ -1773,10 +1776,12 @@
               },
               "opera": {
                 "version_added": "49",
+                "version_removed": "67",
                 "notes": "WebVR API was never enabled by default in any production builds and was replaced by WebXR Device API."
               },
               "opera_android": {
                 "version_added": "46",
+                "version_removed": true,
                 "notes": "WebVR API was never enabled by default in any production builds and was replaced by WebXR Device API."
               },
               "safari": {
@@ -1787,11 +1792,11 @@
               },
               "samsunginternet_android": {
                 "version_added": "8.0",
+                "version_removed": true,
                 "notes": "WebVR API was never enabled by default in any production builds and was replaced by WebXR Device API."
               },
               "webview_android": {
-                "version_added": "62",
-                "notes": "WebVR API was never enabled by default in any production builds and was replaced by WebXR Device API."
+                "version_added": false
               }
             },
             "status": {


### PR DESCRIPTION
Chrome 80 removed WebVR API and dropped `Feature-Policy` header `vr` directive that controlled it. Also, Android WebView never supported WebVR to begin with.

## Data
 - [Chrome status " WebVR v1.1 (deprecated)"](https://chromestatus.com/feature/4532810371039232)
 - [Issue 960132: ☂ Remove WebVR](https://bugs.chromium.org/p/chromium/issues/detail?id=960132) landed in 80.
   - [Commit that removed Feature-Policy `vr` directive](https://chromium.googlesource.com/chromium/src.git/+/6b783608ee8f511047323c9f6e64d22cd5dde7cb%5E%21/#F1)

A checklist to help your pull request get merged faster:
- [ ] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
