### PR TITLE
Replace outdated mdn_url for HTMLElement/style

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -3014,7 +3014,7 @@
       },
       "style": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/style",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementCSSInlineStyle/style",
           "support": {
             "chrome": {
               "version_added": "45"


### PR DESCRIPTION
https://developer.mozilla.org/docs/Web/API/HTMLElement/style just redirects to https://developer.mozilla.org/docs/Web/API/ElementCSSInlineStyle/style