### PR TITLE
Update Feature-Policy `xr-spatial-tracking` data

### DIFF
--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -1806,13 +1806,13 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/xr-spatial-tracking",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "79"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "79"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false

--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -1824,7 +1824,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "66"
               },
               "opera_android": {
                 "version_added": false


### PR DESCRIPTION
## Summary
Chrome for desktop and Android 79, Edge 79 added support for Feature-Policy directive [`xr-spatial-tracking`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy/xr-spatial-tracking) when they launched WebXR Device API.

## Data
[Chromium bug 1003842](https://bugs.chromium.org/p/chromium/issues/detail?id=1003842): Chromium previously supported `xr-spatial-tracking` as `xr`, but renamed it shortly before launch in 79 (following the spec change).

A checklist to help your pull request get merged faster:
- [ ] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
