### PR TITLE
Update NumberFormat.formatToParts for IE11

### DIFF
--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -179,7 +179,7 @@
                   "version_added": "58"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "nodejs": {
                   "version_added": null

--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -179,7 +179,7 @@
                   "version_added": "58"
                 },
                 "ie": {
-                  "version_added": "11"
+                  "version_added": null
                 },
                 "nodejs": {
                   "version_added": null


### PR DESCRIPTION
IE11 does not support this method:

![image](https://user-images.githubusercontent.com/515955/77864434-39388680-7274-11ea-95ae-23d00e353c19.png)
