### PR TITLE
Narrow range for yargs dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "mdn-confluence": "^1.0.3",
     "ora": "^4.0.3",
     "prettier": "^1.19.1",
-    "yargs": "^15.1.0"
+    "yargs": "~15.1.0"
   },
   "scripts": {
     "confluence": "node ./node_modules/mdn-confluence/main/generate.es6.js --output-dir=. --bcd-module=./index.js",


### PR DESCRIPTION
After a discussion today, @Elchi3 and I decided to experiment with narrowing the range of versions allowed for dev dependencies so that:

1. All BCD developers are more likely to have matching minor versions for dev dependencies
2. Dependabot upgrades will be reflected in `package.json` more regularly

We're trying this out with yargs first, to get a sense of the frequency and impact of Dependabot PRs.