### PR TITLE
Inputmode info for Firefox

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1028,7 +1028,7 @@
                 ],
                 "notes": [
                   "Before version 77, Firefox does not support <code>inputmode</code> when <code>contenteditable</code> is <code>true</code>.",
-                  "Before version 75, Firefox accepts values from an earlier specification. From version 75, it accepts values from the WHATWG Living Standard. See <a href="https://bugzil.la/1509527">bug 1509527</a>."
+                  "Before version 75, Firefox accepts values from an earlier specification. From version 75, it accepts values from the WHATWG Living Standard. See <a href='https://bugzil.la/1509527'>bug 1509527</a>."
                 ]
               },
               {

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1033,8 +1033,8 @@
               },
               {
                 "version_added": "17",
-                "version_removed": "23",
-              },
+                "version_removed": "23"
+              }
             ],
             "firefox_android": {
               "version_added": false

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1016,21 +1016,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": { 
-              [
-                {"version_added": "17",
-                 "notes": "Prior to 75, Firefox used values from an earlier spec version; in 75, it was updated to match the WHATWG Living Standard as of that time. However, Firefox does not support inputmode when contenteditable is true (see <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1424284'>bug 1424284</a>)."
-                },
-                {"version_added": "23",
-                 "flags": [
-                   {"type": "preference",
+            "firefox": [
+              {
+                "version_added": "17",
+                "notes": "Prior to 75, Firefox used values from an earlier spec version; in 75, it was updated to match the WHATWG Living Standard as of that time. However, Firefox does not support inputmode when contenteditable is true (see https://bugzil.la/1424284)."
+              },
+              {
+                "version_added": "23",
+                "flags": [
+                  {
+                    "type": "preference",
                     "name": "dom.forms.inputmode",
                     "value_to_set": "true"
-                   }
-                 ]
-                },
-              ]
-            },
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1027,8 +1027,8 @@
                   }
                 ],
                 "notes": [
-                  "Prior to version 77, Firefox did not support <code>inputmode</code> when <code>contenteditable</code> is <code>true</code>.",
-                  "Prior to version 75, Firefox used values from an earlier spec version; in 75, it was updated to match the WHATWG Living Standard as of that time."
+                  "Before version 77, Firefox does not support <code>inputmode</code> when <code>contenteditable</code> is <code>true</code>.",
+                  "Before version 75, Firefox accepts values from an earlier specification. From version 75, it accepts values from the WHATWG Living Standard. See <a href="https://bugzil.la/1509527">bug 1509527</a>."
                 ]
               },
               {

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1019,7 +1019,10 @@
             "firefox": [
               {
                 "version_added": "17",
-                "notes": "Prior to 75, Firefox used values from an earlier spec version; in 75, it was updated to match the WHATWG Living Standard as of that time. However, Firefox does not support inputmode when contenteditable is true (see https://bugzil.la/1424284)."
+                "notes": [
+                  "Firefox does not support <code>inputmode</code> when <code>contenteditable</code> is <code>true</code> (see <a href='https://bugzil.la/1424284'>bug 1424284</a>).",
+                  "Prior to 75, Firefox used values from an earlier spec version; in 75, it was updated to match the WHATWG Living Standard as of that time."
+                ]
               },
               {
                 "version_added": "23",

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1018,13 +1018,6 @@
             },
             "firefox": [
               {
-                "version_added": "17",
-                "notes": [
-                  "Firefox does not support <code>inputmode</code> when <code>contenteditable</code> is <code>true</code> (see <a href='https://bugzil.la/1424284'>bug 1424284</a>).",
-                  "Prior to 75, Firefox used values from an earlier spec version; in 75, it was updated to match the WHATWG Living Standard as of that time."
-                ]
-              },
-              {
                 "version_added": "23",
                 "flags": [
                   {
@@ -1032,8 +1025,16 @@
                     "name": "dom.forms.inputmode",
                     "value_to_set": "true"
                   }
+                ],
+                "notes": [
+                  "Prior to version 77, Firefox did not support <code>inputmode</code> when <code>contenteditable</code> is <code>true</code>.",
+                  "Prior to version 75, Firefox used values from an earlier spec version; in 75, it was updated to match the WHATWG Living Standard as of that time."
                 ]
-              }
+              },
+              {
+                "version_added": "17",
+                "version_removed": "23",
+              },
             ],
             "firefox_android": {
               "version_added": false

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1016,8 +1016,20 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": false
+            "firefox": { 
+              [
+                {"version_added": "17",
+                 "notes": "Prior to 75, Firefox used values from an earlier spec version; in 75, it was updated to match the WHATWG Living Standard as of that time. However, Firefox does not support inputmode when contenteditable is true (see <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1424284'>bug 1424284</a>)."
+                },
+                {"version_added": "23",
+                 "flags": [
+                   {"type": "preference",
+                    "name": "dom.forms.inputmode",
+                    "value_to_set": "true"
+                   }
+                 ]
+                },
+              ]
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
[Sprint issue](https://github.com/mdn/sprints/issues/2925)
- First implemented in [17](https://bugzilla.mozilla.org/show_bug.cgi?id=746142)
- Put behind dom.forms.inputmode pref in [23](https://bugzilla.mozilla.org/show_bug.cgi?id=857355)
- [Still not unpreffed](https://bugzilla.mozilla.org/show_bug.cgi?id=1205133)
- Updated values to match the spec in [75](https://bugzilla.mozilla.org/show_bug.cgi?id=1509527) 

