### PR TITLE
Safari 13.1 is released

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -156,11 +156,18 @@
         "13": {
           "release_date": "2019-09-19",
           "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_13_release_notes",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "608.2.11"
         },
         "13.1": {
+          "release_date": "2020-03-24",
+          "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_13_1_beta_release_notes",
+          "status": "current",
+          "engine": "WebKit",
+          "engine_version": "609.1.20"
+        },
+        "14": {
           "status": "beta",
           "engine": "WebKit"
         }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -145,6 +145,13 @@
           "engine_version": "608.2.11"
         },
         "13.4": {
+          "release_date": "2020-03-24",
+          "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_13_1_beta_release_notes",
+          "status": "current",
+          "engine": "WebKit",
+          "engine_version": "609.1.20"
+        },
+        "14": {
           "status": "beta",
           "engine": "WebKit"
         }


### PR DESCRIPTION
As of March 24, Safari 13.1 is no longer in beta.  This PR updates the data accordingly.  Unfortunately the release notes still say "beta" for some odd reason.

Release date was sourced from https://www.whatismybrowser.com/guides/the-latest-version/safari.  WebKit version was sourced from my own Safari edition.