### PR TITLE
Complete nodejs support data for JS Array

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -1948,7 +1948,7 @@
                   {
                     "version_added": "0.12",
                     "partial_implementation": true,
-                    "notes": "Prior to NodeJS 13.0.0, only the locale data for <code>en-us</code> is available by default. When other English locales are specified, the function silently falls back to <code>en-us</code>. When other languages are specified, it throws a <code>RangeError</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                    "notes": "Prior to Node.js 13.0.0, only the locale data for <code>en-us</code> is available by default. When other English locales are specified, the function silently falls back to <code>en-us</code>. When other languages are specified, it throws a <code>RangeError</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
                   }
                 ],
                 "opera": {

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -25,7 +25,7 @@
               "version_added": "4"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "4"
@@ -77,7 +77,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -129,7 +129,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -285,7 +285,7 @@
                 "version_added": "9"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "9.5"
@@ -400,7 +400,7 @@
                 "version_added": "9"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "9.5"
@@ -682,7 +682,7 @@
                 "version_added": "9"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "9.5"
@@ -849,7 +849,7 @@
                 "version_added": "9"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "9.5"
@@ -901,7 +901,7 @@
                 "version_added": "9"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "10.5"
@@ -953,7 +953,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -1057,7 +1057,7 @@
                 "version_added": "9"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "9.5"
@@ -1109,7 +1109,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -1161,7 +1161,7 @@
                 "version_added": "9"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "9.5"
@@ -1317,7 +1317,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -1369,7 +1369,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -1421,7 +1421,7 @@
                 "version_added": "9"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "10.5"
@@ -1473,7 +1473,7 @@
                 "version_added": "9"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "10.5"
@@ -1525,7 +1525,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -1577,7 +1577,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -1629,7 +1629,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -1681,7 +1681,7 @@
                 "version_added": "9"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "9.5"
@@ -1733,7 +1733,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -1837,7 +1837,7 @@
                 "notes": "From Internet Explorer 5.5 through 8, all elements of the array will not be deleted if <code>deleteCount</code> is omitted. This behavior was fixed in Internet Explorer 9."
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -1892,7 +1892,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -1941,9 +1941,16 @@
                 "ie": {
                   "version_added": false
                 },
-                "nodejs": {
-                  "version_added": null
-                },
+                "nodejs": [
+                  {
+                    "version_added": "13.0.0"
+                  },
+                  {
+                    "version_added": "0.12",
+                    "partial_implementation": true,
+                    "notes": "Prior to NodeJS 13.0.0, only the locale data for <code>en-us</code> is available by default. When other English locales are specified, the function silently falls back to <code>en-us</code>. When other languages are specified, it throws a <code>RangeError</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                  }
+                ],
                 "opera": {
                   "version_added": "15"
                 },
@@ -1993,7 +2000,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "0.12"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2099,7 +2106,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -2203,7 +2210,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"


### PR DESCRIPTION
Completes nodejs data for one of our most trafficked MDN pages – Array: 
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#Browser_compatibility

Basic JS Array functionality was in v8 2.2 and that is used in the first nodejs version we are recording (0.1.100). 

The Intl data is from https://github.com/mdn/browser-compat-data/pull/5068