### PR TITLE
Complete nodejs support data for JS Date

### DIFF
--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -26,7 +26,7 @@
               "notes": "The <a href='https://en.wikipedia.org/wiki/ISO_8601'>ISO8601 Date Format</a> is not supported in Internet Explorer 8 or earlier."
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "3"
@@ -78,7 +78,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -130,7 +130,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -182,7 +182,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -234,7 +234,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -286,7 +286,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -338,7 +338,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -390,7 +390,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -442,7 +442,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -494,7 +494,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -546,7 +546,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -598,7 +598,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -650,7 +650,7 @@
                 "version_added": "5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -702,7 +702,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -754,7 +754,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -806,7 +806,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -858,7 +858,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -910,7 +910,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -962,7 +962,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -1014,7 +1014,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -1066,7 +1066,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -1118,7 +1118,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -1170,7 +1170,7 @@
                 "version_added": "9"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "10.5"
@@ -1222,7 +1222,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -1272,7 +1272,7 @@
                   "version_added": "9"
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "0.12"
                 },
                 "opera": {
                   "version_added": "6"
@@ -1325,7 +1325,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -1377,7 +1377,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -1429,7 +1429,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -1481,7 +1481,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -1533,7 +1533,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -1585,7 +1585,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -1637,7 +1637,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -1689,7 +1689,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -1741,7 +1741,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -1793,7 +1793,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -1845,7 +1845,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -1897,7 +1897,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -1949,7 +1949,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -2001,7 +2001,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -2053,7 +2053,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -2105,7 +2105,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -2157,7 +2157,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "5"
@@ -2209,7 +2209,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -2261,7 +2261,7 @@
                 "version_added": "9"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "10.5"
@@ -2313,7 +2313,7 @@
                 "version_added": "8"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "10.5"
@@ -2368,7 +2368,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "5"
@@ -2418,7 +2418,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": true
+                  "version_added": "0.12"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2467,10 +2467,16 @@
                 "ie": {
                   "version_added": "11"
                 },
-                "nodejs": {
-                  "version_added": "0.12",
-                  "notes": "Prior to NodeJS 13, only the locale data for <code>en-us</code> is available by default. When other English locales are specified, the function silently falls back to <code>en-us</code>. When other languages are specified, it throws a <code>RangeError</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
-                },
+                "nodejs": [
+                  {
+                    "version_added": "13.0.0"
+                  },
+                  {
+                    "version_added": "0.12",
+                    "partial_implementation": true,
+                    "notes": "Prior to NodeJS 13.0.0, only the locale data for <code>en-us</code> is available by default. When other English locales are specified, the function silently falls back to <code>en-us</code>. When other languages are specified, it throws a <code>RangeError</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                  }
+                ],
                 "opera": {
                   "version_added": "15"
                 },
@@ -2519,7 +2525,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": true
+                  "version_added": "0.12"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2628,7 +2634,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -2678,7 +2684,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": true
+                  "version_added": "0.12"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2727,10 +2733,16 @@
                 "ie": {
                   "version_added": "11"
                 },
-                "nodejs": {
-                  "version_added": "0.12",
-                  "notes": "Prior to NodeJS 13, only the locale data for <code>en-us</code> is available by default. When other English locales are specified, the function silently falls back to <code>en-us</code>. When other languages are specified, it throws a <code>RangeError</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
-                },
+                "nodejs": [
+                  {
+                    "version_added": "13.0.0"
+                  },
+                  {
+                    "version_added": "0.12",
+                    "partial_implementation": true,
+                    "notes": "Prior to NodeJS 13.0.0, only the locale data for <code>en-us</code> is available by default. When other English locales are specified, the function silently falls back to <code>en-us</code>. When other languages are specified, it throws a <code>RangeError</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                  }
+                ],
                 "opera": {
                   "version_added": "15"
                 },
@@ -2779,7 +2791,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": true
+                  "version_added": "0.12"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2835,7 +2847,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "5"
@@ -2885,7 +2897,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": true
+                  "version_added": "0.12"
                 },
                 "opera": {
                   "version_added": "15"
@@ -2934,10 +2946,16 @@
                 "ie": {
                   "version_added": "11"
                 },
-                "nodejs": {
-                  "version_added": "0.12",
-                  "notes": "Prior to NodeJS 13, only the locale data for <code>en-us</code> is available by default. When other English locales are specified, the function silently falls back to <code>en-us</code> When other languages are specified, it throws a <code>RangeError</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
-                },
+                "nodejs": [
+                  {
+                    "version_added": "13.0.0"
+                  },
+                  {
+                    "version_added": "0.12",
+                    "partial_implementation": true,
+                    "notes": "Prior to NodeJS 13.0.0, only the locale data for <code>en-us</code> is available by default. When other English locales are specified, the function silently falls back to <code>en-us</code>. When other languages are specified, it throws a <code>RangeError</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                  }
+                ],
                 "opera": {
                   "version_added": "15"
                 },
@@ -2986,7 +3004,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": true
+                  "version_added": "0.12"
                 },
                 "opera": {
                   "version_added": "15"
@@ -3092,7 +3110,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -3144,7 +3162,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "5"
@@ -3196,7 +3214,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -3248,7 +3266,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -2474,7 +2474,7 @@
                   {
                     "version_added": "0.12",
                     "partial_implementation": true,
-                    "notes": "Prior to NodeJS 13.0.0, only the locale data for <code>en-us</code> is available by default. When other English locales are specified, the function silently falls back to <code>en-us</code>. When other languages are specified, it throws a <code>RangeError</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                    "notes": "Prior to Node.js 13.0.0, only the locale data for <code>en-us</code> is available by default. When other English locales are specified, the function silently falls back to <code>en-us</code>. When other languages are specified, it throws a <code>RangeError</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
                   }
                 ],
                 "opera": {
@@ -2740,7 +2740,7 @@
                   {
                     "version_added": "0.12",
                     "partial_implementation": true,
-                    "notes": "Prior to NodeJS 13.0.0, only the locale data for <code>en-us</code> is available by default. When other English locales are specified, the function silently falls back to <code>en-us</code>. When other languages are specified, it throws a <code>RangeError</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                    "notes": "Prior to Node.js 13.0.0, only the locale data for <code>en-us</code> is available by default. When other English locales are specified, the function silently falls back to <code>en-us</code>. When other languages are specified, it throws a <code>RangeError</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
                   }
                 ],
                 "opera": {
@@ -2953,7 +2953,7 @@
                   {
                     "version_added": "0.12",
                     "partial_implementation": true,
-                    "notes": "Prior to NodeJS 13.0.0, only the locale data for <code>en-us</code> is available by default. When other English locales are specified, the function silently falls back to <code>en-us</code>. When other languages are specified, it throws a <code>RangeError</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                    "notes": "Prior to Node.js 13.0.0, only the locale data for <code>en-us</code> is available by default. When other English locales are specified, the function silently falls back to <code>en-us</code>. When other languages are specified, it throws a <code>RangeError</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
                   }
                 ],
                 "opera": {


### PR DESCRIPTION
For https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#Browser_compatibility

Basic JS Date functionality was in v8 2.2 and that is used in the first nodejs version we are recording (0.1.100).

The Intl data is from discussions in #5068