### PR TITLE
Complete nodejs support for JS String

### DIFF
--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -25,7 +25,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "3"
@@ -77,7 +77,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -130,7 +130,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -182,7 +182,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -234,7 +234,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -286,7 +286,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -338,7 +338,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -390,7 +390,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -505,7 +505,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -620,7 +620,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -672,7 +672,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -724,7 +724,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -776,7 +776,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -957,7 +957,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -1009,7 +1009,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -1061,7 +1061,7 @@
                 "version_added": "6"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -1113,7 +1113,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -1165,7 +1165,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -1220,7 +1220,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "7"
@@ -1268,9 +1268,16 @@
                 "ie": {
                   "version_added": "11"
                 },
-                "nodejs": {
-                  "version_added": null
-                },
+                "nodejs": [
+                  {
+                    "version_added": "13.0.0"
+                  },
+                  {
+                    "version_added": "0.12",
+                    "partial_implementation": true,
+                    "notes": "Prior to Node.js 13.0.0, only the locale data for <code>en-us</code> is available by default. When other English locales are specified, the function silently falls back to <code>en-us</code>. When other languages are specified, it throws a <code>RangeError</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                  }
+                ],
                 "opera": {
                   "version_added": "15"
                 },
@@ -1319,7 +1326,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": "0.12"
                 },
                 "opera": {
                   "version_added": "15"
@@ -1372,7 +1379,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -1874,7 +1881,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -1978,7 +1985,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -2082,7 +2089,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -2134,7 +2141,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -2186,7 +2193,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -2301,7 +2308,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -2353,7 +2360,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -2405,7 +2412,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -2457,7 +2464,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -2509,7 +2516,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -2564,7 +2571,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -2612,9 +2619,16 @@
                 "ie": {
                   "version_added": "6"
                 },
-                "nodejs": {
-                  "version_added": null
-                },
+                "nodejs": [
+                  {
+                    "version_added": "13.0.0"
+                  },
+                  {
+                    "version_added": "0.12",
+                    "partial_implementation": true,
+                    "notes": "Prior to Node.js 13.0.0, only the locale data for <code>en-us</code> is available by default. When other English locales are specified, the function silently falls back to <code>en-us</code>. When other languages are specified, it throws a <code>RangeError</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                  }
+                ],
                 "opera": {
                   "version_added": "45"
                 },
@@ -2669,7 +2683,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -2717,9 +2731,16 @@
                 "ie": {
                   "version_added": "6"
                 },
-                "nodejs": {
-                  "version_added": null
-                },
+                "nodejs": [
+                  {
+                    "version_added": "13.0.0"
+                  },
+                  {
+                    "version_added": "0.12",
+                    "partial_implementation": true,
+                    "notes": "Prior to Node.js 13.0.0, only the locale data for <code>en-us</code> is available by default. When other English locales are specified, the function silently falls back to <code>en-us</code>. When other languages are specified, it throws a <code>RangeError</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                  }
+                ],
                 "opera": {
                   "version_added": "45"
                 },
@@ -2771,7 +2792,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -2875,7 +2896,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -2927,7 +2948,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -2979,7 +3000,7 @@
                 "version_added": "9"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "10.5"
@@ -3244,7 +3265,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -3296,7 +3317,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"


### PR DESCRIPTION
For https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#Browser_compatibility

Basic JS String functionality was in v8 2.2 and that is used in the first nodejs version we are recording (0.1.100).

The Intl data is from discussions in #5068