### PR TITLE
Complete nodejs support data for JS Math & Number

### DIFF
--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -26,7 +26,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -78,7 +78,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -130,7 +130,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -182,7 +182,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -234,7 +234,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -286,7 +286,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -338,7 +338,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -390,7 +390,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -442,7 +442,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -494,7 +494,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -598,7 +598,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -702,7 +702,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -754,7 +754,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -910,7 +910,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -1014,7 +1014,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -1118,7 +1118,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -1222,7 +1222,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -1430,7 +1430,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -1638,7 +1638,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -1690,7 +1690,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -1742,7 +1742,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -1794,7 +1794,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -1846,7 +1846,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -1950,7 +1950,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -2054,7 +2054,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -2106,7 +2106,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -25,7 +25,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "3"
@@ -180,7 +180,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -284,7 +284,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -336,7 +336,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -388,7 +388,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -441,7 +441,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -493,7 +493,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -857,7 +857,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "7"
@@ -909,7 +909,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "7"
@@ -1017,7 +1017,7 @@
                 "version_added": "5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -1065,9 +1065,16 @@
                 "ie": {
                   "version_added": "11"
                 },
-                "nodejs": {
-                  "version_added": true
-                },
+                "nodejs": [
+                  {
+                    "version_added": "13.0.0"
+                  },
+                  {
+                    "version_added": "0.12",
+                    "partial_implementation": true,
+                    "notes": "Prior to Node.js 13.0.0, only the locale data for <code>en-us</code> is available by default. When other English locales are specified, the function silently falls back to <code>en-us</code>. When other languages are specified, it throws a <code>RangeError</code>. In order to make full ICU (locale) data available for versions prior to 13, see docs on the <code>--with-full-icu=</code> flag and how to provide the data."
+                  }
+                ],
                 "opera": {
                   "version_added": "15"
                 },
@@ -1116,7 +1123,7 @@
                   "version_added": "11"
                 },
                 "nodejs": {
-                  "version_added": true
+                  "version_added": "0.12"
                 },
                 "opera": {
                   "version_added": "15"
@@ -1169,7 +1176,7 @@
                 "version_added": "5.5"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "7"
@@ -1273,7 +1280,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -1325,7 +1332,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"


### PR DESCRIPTION
For https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math#Browser_compatibility and For https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#Browser_compatibility

Basic JS Math & Number functionality was in v8 2.2 and that is used in the first nodejs version we are recording (0.1.100).

The Intl data is from discussions in #5068