### PR TITLE
Complete nodejs support data for JS operators

### DIFF
--- a/javascript/operators/arithmetic.json
+++ b/javascript/operators/arithmetic.json
@@ -26,7 +26,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -78,7 +78,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -130,7 +130,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -245,7 +245,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -297,7 +297,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -349,7 +349,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -401,7 +401,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -453,7 +453,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -505,7 +505,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"

--- a/javascript/operators/assignment.json
+++ b/javascript/operators/assignment.json
@@ -26,7 +26,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -78,7 +78,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -130,7 +130,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -182,7 +182,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -234,7 +234,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -349,7 +349,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -401,7 +401,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -453,7 +453,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -505,7 +505,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -557,7 +557,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -609,7 +609,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -661,7 +661,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"

--- a/javascript/operators/bitwise.json
+++ b/javascript/operators/bitwise.json
@@ -26,7 +26,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -78,7 +78,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -130,7 +130,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -182,7 +182,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -234,7 +234,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -286,7 +286,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -338,7 +338,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"

--- a/javascript/operators/comma.json
+++ b/javascript/operators/comma.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "4"

--- a/javascript/operators/comparison.json
+++ b/javascript/operators/comparison.json
@@ -26,7 +26,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -78,7 +78,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -130,7 +130,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -182,7 +182,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -234,7 +234,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -286,7 +286,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -338,7 +338,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -390,7 +390,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"

--- a/javascript/operators/conditional.json
+++ b/javascript/operators/conditional.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/delete.json
+++ b/javascript/operators/delete.json
@@ -25,7 +25,7 @@
               "version_added": "4"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "9"

--- a/javascript/operators/destructuring.json
+++ b/javascript/operators/destructuring.json
@@ -78,7 +78,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "6.0.0"
               },
               "opera": {
                 "version_added": "36"

--- a/javascript/operators/function.json
+++ b/javascript/operators/function.json
@@ -25,7 +25,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/function_star.json
+++ b/javascript/operators/function_star.json
@@ -26,7 +26,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": "6.0.0"
+              "version_added": "4.0.0"
             },
             "opera": {
               "version_added": "36"

--- a/javascript/operators/function_star.json
+++ b/javascript/operators/function_star.json
@@ -26,7 +26,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "6.0.0"
             },
             "opera": {
               "version_added": "36"

--- a/javascript/operators/grouping.json
+++ b/javascript/operators/grouping.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/in.json
+++ b/javascript/operators/in.json
@@ -25,7 +25,7 @@
               "version_added": "5.5"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "4"

--- a/javascript/operators/instanceof.json
+++ b/javascript/operators/instanceof.json
@@ -25,7 +25,7 @@
               "version_added": "5"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "4"

--- a/javascript/operators/logical.json
+++ b/javascript/operators/logical.json
@@ -26,7 +26,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -78,7 +78,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"
@@ -130,7 +130,7 @@
                 "version_added": "3"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "3"

--- a/javascript/operators/new.json
+++ b/javascript/operators/new.json
@@ -25,7 +25,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/object_initializer.json
+++ b/javascript/operators/object_initializer.json
@@ -26,7 +26,7 @@
               "version_added": "1"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "4"
@@ -76,7 +76,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "34"
@@ -127,7 +127,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "6.0.0"
               },
               "opera": {
                 "version_added": "34"
@@ -178,7 +178,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "6.0.0"
               },
               "opera": {
                 "version_added": "34"

--- a/javascript/operators/object_initializer.json
+++ b/javascript/operators/object_initializer.json
@@ -76,7 +76,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "0.1.100"
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": "34"
@@ -127,7 +127,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "6.0.0"
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": "34"
@@ -178,7 +178,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "6.0.0"
+                "version_added": "4.0.0"
               },
               "opera": {
                 "version_added": "34"

--- a/javascript/operators/property_accessors.json
+++ b/javascript/operators/property_accessors.json
@@ -26,7 +26,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "4"

--- a/javascript/operators/spread.json
+++ b/javascript/operators/spread.json
@@ -151,7 +151,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "6.0.0"
               },
               "opera": {
                 "version_added": "37"

--- a/javascript/operators/super.json
+++ b/javascript/operators/super.json
@@ -25,7 +25,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": "5.0.0"
+              "version_added": "6.0.0"
             },
             "opera": {
               "version_added": "29"

--- a/javascript/operators/super.json
+++ b/javascript/operators/super.json
@@ -25,7 +25,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "5.0.0"
             },
             "opera": {
               "version_added": "29"

--- a/javascript/operators/this.json
+++ b/javascript/operators/this.json
@@ -25,7 +25,7 @@
               "version_added": "4"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "9.5"

--- a/javascript/operators/typeof.json
+++ b/javascript/operators/typeof.json
@@ -25,7 +25,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "3"

--- a/javascript/operators/void.json
+++ b/javascript/operators/void.json
@@ -25,7 +25,7 @@
               "version_added": "5"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "4"


### PR DESCRIPTION
Basic JS features are supported in the first nodejs version we're recording (0.1.100). Other data was based on the Chrome/v8 numbers. 