### PR TITLE
Update username & password data for Location

### DIFF
--- a/api/Location.json
+++ b/api/Location.json
@@ -344,46 +344,48 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Location/password",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": false
             },
             "firefox": {
-              "version_added": "26"
+              "version_added": "26",
+              "version_removed": "45"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "26",
+              "version_removed": "45"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
-              "version_added": true
+              "version_added": false
             }
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -736,46 +738,48 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Location/username",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": false
             },
             "firefox": {
-              "version_added": "26"
+              "version_added": "26",
+              "version_removed": "45"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "26",
+              "version_removed": "45"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
-              "version_added": true
+              "version_added": false
             }
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
`Location` doesn't expose `password` and `username` members in any current browsers, and there are no such members in the current spec for Location:

https://bugzilla.mozilla.org/show_bug.cgi?id=1213815

Firefox between versions 26 and 45 did expose `username` and `password` members for `Location`, but apparently no other browsers ever did.

Relevant Firefox bugs:

* https://bugzilla.mozilla.org/show_bug.cgi?id=887364 (Firefox 26 addition)
* https://bugzilla.mozilla.org/show_bug.cgi?id=1213815 (Firefox 45 removal)

Change histories for `Location` IDL in WebKit and Blink:

* https://github.com/WebKit/webkit/commits/master/Source/WebCore/page/Location.idl
* https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/core/frame/location.idl;bpv=1;bpt=0