### PR TITLE
Api/xhr progress event ie

### DIFF
--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -129,7 +129,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true
@@ -178,7 +178,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true
@@ -375,7 +375,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -424,7 +424,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true
@@ -473,7 +473,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true
@@ -1906,7 +1906,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true
@@ -1954,7 +1954,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true

--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -674,7 +674,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true

--- a/api/XMLHttpRequestEventTarget.json
+++ b/api/XMLHttpRequestEventTarget.json
@@ -67,7 +67,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true
@@ -115,7 +115,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true
@@ -163,7 +163,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true
@@ -211,7 +211,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true
@@ -259,7 +259,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true
@@ -355,7 +355,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "8"
             },
             "opera": {
               "version_added": true

--- a/api/XMLHttpRequestEventTarget.json
+++ b/api/XMLHttpRequestEventTarget.json
@@ -307,7 +307,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true

--- a/api/XMLHttpRequestUpload.json
+++ b/api/XMLHttpRequestUpload.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": null
+            "version_added": "10"
           },
           "opera": {
             "version_added": true


### PR DESCRIPTION
Adds missing IE compatibility data for events on XMLHttpRequest, XMLHttpRequestEventTarget and support for XMLHttpRequest.upload

Information gathered from manual testing on the actual browsers
