### PR TITLE
Chrome implements `@supports selector(…)` in v83 | Microsoft Edge is skipping version 82

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -71,10 +71,10 @@
           "engine": "Blink",
           "engine_version": "81"
         },
-        "82": {
+        "83": {
           "status": "nightly",
           "engine": "Blink",
-          "engine_version": "82"
+          "engine_version": "83"
         }
       }
     }

--- a/css/at-rules/supports.json
+++ b/css/at-rules/supports.json
@@ -80,13 +80,13 @@
             "description": "<code>selector()</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "83"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "83"
               },
               "edge": {
-                "version_added": false
+                "version_added": "82"
               },
               "firefox": [
                 {
@@ -117,8 +117,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/979041'>bug 979041</a>."
+                "version_added": "69"
               },
               "opera_android": {
                 "version_added": false,
@@ -137,7 +136,7 @@
                 "notes": "See <a href='https://crbug.com/979041'>bug 979041</a>."
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "83"
               }
             },
             "status": {

--- a/css/at-rules/supports.json
+++ b/css/at-rules/supports.json
@@ -86,7 +86,7 @@
                 "version_added": "83"
               },
               "edge": {
-                "version_added": "82"
+                "version_added": "83"
               },
               "firefox": [
                 {


### PR DESCRIPTION
This was incorrectly removed in #5880.

This is shipping in **Chromium 82**/**Google Chrome 83**: https://crbug.com/979041#c13

---

review?(@jpmedley)