### PR TITLE
Add Michael Smith as a BCD Peer

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -60,6 +60,7 @@ It is important to recognize that being a Peer is a privilege, not a right. That
 - Ryan Johnson (@escattone), Mozilla
 - Joe Medley (@jpmedley), Google
 - Eric Shepherd (@a2sheppy), Mozilla
+- Michael Smith (@sideshowbarker), W3C
 
 A Peer who shows an above-average level of contribution to the project, particularly with respect to its strategic direction and long-term health, may be nominated to become an Owner, described below.
 


### PR DESCRIPTION
I have nominated @sideshowbarker to be a BCD Peer and the [BCD Owners Group](https://github.com/mdn/browser-compat-data/blob/master/GOVERNANCE.md#list-of-current-owners) agreed with that nomination. 

Mike has accepted the invite to be a BCD Peer and also has read, and agreed to abide by, the Mozilla Commit Access Requirements. See https://github.com/mdn/mdn/issues/89

Requesting review from @ddbeck since he saw the email thread with all owners agreeing. (no need to request all owners to r+ here again)

Fixes https://github.com/mdn/mdn/issues/89

Please join me in welcoming @sideshowbarker to the team :tada: 