### PR TITLE
Create function to run "global" linters

### DIFF
--- a/test/lint.js
+++ b/test/lint.js
@@ -175,7 +175,7 @@ const testGlobal = (testName, test) => {
   test();
 
   if (globalHasErrors) {
-    filesWithErrors += 1;
+    filesWithErrors.set(testName, testName);
     spinner.fail();
   } else {
     spinner.succeed();

--- a/test/lint.js
+++ b/test/lint.js
@@ -36,6 +36,11 @@ const argv = yargs
   .alias('help', '?')
   .parse(process.argv.slice(2));
 
+/** @type {object} */
+const spinner = ora({
+  stream: process.stdout,
+});
+
 /**
  * @param {string[]} files
  * @return {boolean}
@@ -66,10 +71,7 @@ function load(...files) {
           hasDescriptionsErrors = false;
         const relativeFilePath = path.relative(process.cwd(), file);
 
-        const spinner = ora({
-          stream: process.stdout,
-          text: relativeFilePath,
-        });
+        spinner.text = relativeFilePath;
 
         if (!IS_CI) {
           // Continuous integration environments don't allow overwriting


### PR DESCRIPTION
This PR was cherry-picked from #5300 to combine our "global" tests into one function with a structure similar to the file testing function, including using the ora spinner, and basing the error count off of console errors instead of return values.

In https://github.com/mdn/browser-compat-data/pull/5300#issuecomment-608533211, it was also suggested that a different name besides "global test" is used.  Perhaps "non-data"?