### PR TITLE
Update Safari support for ::part

### DIFF
--- a/css/selectors/part.json
+++ b/css/selectors/part.json
@@ -44,10 +44,10 @@
               "version_added": "52"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
As of Safari 13.1, there's now support for CSS Shadow Parts.  This PR updates the compatibility data for `::part` based upon this data.

Source: https://developer.apple.com/documentation/safari_release_notes/safari_13_1_beta_release_notes

Part of work for #5933.