### PR TITLE
IE doesn't support changes to animation-duration

### DIFF
--- a/css/properties/animation-duration.json
+++ b/css/properties/animation-duration.json
@@ -82,7 +82,8 @@
             ],
             "ie": {
               "version_added": "10",
-              "notes": "Internet Explorer does not respond to changes to this property, whether programmatic or via developer tools."
+              "partial_implementation": true,
+              "notes": "Once the element has loaded, changing the value of this property has no effect."
             },
             "opera": [
               {

--- a/css/properties/animation-duration.json
+++ b/css/properties/animation-duration.json
@@ -81,7 +81,8 @@
               }
             ],
             "ie": {
-              "version_added": "10"
+              "version_added": "10",
+              "notes": "Internet Explorer does not respond to changes to this property, whether programmatic or via developer tools."
             },
             "opera": [
               {


### PR DESCRIPTION
Apparently Internet Explorer doesn't support changes to `animation-duration`.  This PR adds a note to indicate as such.

Part of work for #5933.