### PR TITLE
Chrome/Safari support color-adjust with alt. name

### DIFF
--- a/css/properties/color-adjust.json
+++ b/css/properties/color-adjust.json
@@ -6,16 +6,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color-adjust",
           "support": {
             "chrome": {
-              "prefix": "-webkit-",
-              "version_added": "49"
+              "version_added": "49",
+              "alternative_name": "-webkit-print-color-adjust"
             },
             "chrome_android": {
-              "prefix": "-webkit-",
-              "version_added": "49"
+              "version_added": "49",
+              "alternative_name": "-webkit-print-color-adjust"
             },
             "edge": {
-              "prefix": "-webkit-",
-              "version_added": "79"
+              "version_added": "79",
+              "alternative_name": "-webkit-print-color-adjust"
             },
             "firefox": {
               "version_added": "48"
@@ -27,28 +27,28 @@
               "version_added": false
             },
             "opera": {
-              "prefix": "-webkit-",
-              "version_added": "15"
+              "version_added": "15",
+              "alternative_name": "-webkit-print-color-adjust"
             },
             "opera_android": {
-              "prefix": "-webkit-",
-              "version_added": "36"
+              "version_added": "36",
+              "alternative_name": "-webkit-print-color-adjust"
             },
             "safari": {
-              "prefix": "-webkit-",
-              "version_added": "6"
+              "version_added": "6",
+              "alternative_name": "-webkit-print-color-adjust"
             },
             "safari_ios": {
-              "prefix": "-webkit-",
-              "version_added": "6"
+              "version_added": "6",
+              "alternative_name": "-webkit-print-color-adjust"
             },
             "samsunginternet_android": {
               "version_added": "5.0",
-              "prefix": "-webkit-"
+              "alternative_name": "-webkit-print-color-adjust"
             },
             "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "49"
+              "version_added": "49",
+              "alternative_name": "-webkit-print-color-adjust"
             }
           },
           "status": {


### PR DESCRIPTION
After review, it turns out that Chrome and Safari support this feature not with a prefix, but an alternate name.  This PR updates the data to reflect said alternate name.

Sources: manual testing, https://stackoverflow.com/a/51147616/670839

Part of work for #5933.