### PR TITLE
Mark CSP nonce as supported in Safari 10+

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1817,10 +1817,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "8.0"


### PR DESCRIPTION
Safari has had support for CSP nonces since Technology Preview 1 (Safari 10).

See “Introducing Safari Technology Preview" blog post (30 March 2016)
https://webkit.org/blog/6017/introducing-safari-technology-preview/

> Content Security Policy Level 2
> You can define a policy for your web application to mitigate content
> injection vulnerabilities, such as cross-site scripting (XSS). Level 2
> expands on Level 1 with support for <script> and <style> hashes, nonces, and
> new policy directives to control which websites can embed your web content.

See also: 
* “Implement the script-nonce Content Security Policy directive” feature bug
  https://bugs.webkit.org/show_bug.cgi?id=89577
* “Implement support for script and style nonces” changeset (10 March 2016)
  https://trac.webkit.org/changeset/197944/webkit