### PR TITLE
Update Safari’s and iOS’s support for Clipboard API

### DIFF
--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -29,7 +29,7 @@
             "version_added": "47"
           },
           "safari": {
-            "version_added": false
+            "version_added": "13.1"
           },
           "safari_ios": {
             "version_added": false
@@ -92,7 +92,7 @@
               "version_added": "54"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
               "version_added": false
@@ -142,7 +142,7 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
               "version_added": false
@@ -206,7 +206,7 @@
               "version_added": "54"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
               "version_added": false
@@ -256,7 +256,7 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
               "version_added": false

--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -32,7 +32,7 @@
             "version_added": "13.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "13.4"
           },
           "samsunginternet_android": {
             "version_added": "9.0"
@@ -95,7 +95,7 @@
               "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -145,7 +145,7 @@
               "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -209,7 +209,7 @@
               "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -259,7 +259,7 @@
               "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": "9.0"

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -405,7 +405,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
               "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -408,7 +408,7 @@
               "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": "9.0"


### PR DESCRIPTION
The [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API) is now available in Safari 13.1 and on iOS 13.4. See [New WebKit Features in Safari 13.1](https://webkit.org/blog/10247/new-webkit-features-in-safari-13-1/).