### PR TITLE
Update safari and safari_ios support for RTCDataChannel

### DIFF
--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -46,7 +46,7 @@
             "version_added": true
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": "2.0"
@@ -629,10 +629,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -924,10 +924,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -972,10 +972,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -1021,10 +1021,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -1357,10 +1357,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "6.0"


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any

I've experimenting with [RTCDataChannel](https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel) and I found some feature that Safari and Safari on iOS supports.

I tested by creating RTCDataChannel by calling the RTCPeerConnection's createDataChannel() method and tested on "send", "onopen", "onmessage", "open event" and "message event" by transferring some data via the created data channel. I tested on Safari with version 13.1,  and Safari on iOS 13.3.1.