### PR TITLE
macOS + Firefox 56+ don't support :checked on option elements

### DIFF
--- a/css/selectors/checked.json
+++ b/css/selectors/checked.json
@@ -19,7 +19,10 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": "Support for styling <code>&lt;option&rt;</code> elements was removed in Firefox 56.  Due to OS limitations, styling of <code>&lt;option&rt;</code> elements does not work on macOS."
+              "notes": [
+                "Support for styling <code>&lt;option&rt;</code> elements was removed in Firefox 56.",
+                "On macOS, styling <code>&lt;option&rt;</code> elements has no effect."
+              ]
             },
             "firefox_android": {
               "version_added": "4",

--- a/css/selectors/checked.json
+++ b/css/selectors/checked.json
@@ -20,7 +20,7 @@
             "firefox": {
               "version_added": "1",
               "notes": [
-                "Support for styling <code>&lt;option&rt;</code> elements was removed in Firefox 56.",
+                "From Firefox 56, <code>&lt;option&rt;</code> elements cannot be styled.",
                 "On macOS, styling <code>&lt;option&rt;</code> elements has no effect."
               ]
             },

--- a/css/selectors/checked.json
+++ b/css/selectors/checked.json
@@ -7,34 +7,41 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:checked",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "Due to OS limitations, styling of <code>&lt;option&rt;</code> elements does not work on macOS."
             },
             "chrome_android": {
               "version_added": "18"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "notes": "Due to OS limitations, styling of <code>&lt;option&rt;</code> elements does not work on macOS."
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "Support for styling <code>&lt;option&rt;</code> elements was removed in Firefox 56.  Due to OS limitations, styling of <code>&lt;option&rt;</code> elements does not work on macOS."
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "4",
+              "notes": "Support for styling <code>&lt;option&rt;</code> elements was removed in Firefox 56."
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
-              "version_added": "9"
+              "version_added": "9",
+              "notes": "Due to OS limitations, styling of <code>&lt;option&rt;</code> elements does not work on macOS."
             },
             "opera_android": {
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "3.1",
+              "notes": "Due to OS limitations, styling of <code>&lt;option&rt;</code> elements does not work on macOS."
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "3.1",
+              "notes": "Due to OS limitations, styling of <code>&lt;option&rt;</code> elements does not work on iOS/iPadOS."
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/selectors/checked.json
+++ b/css/selectors/checked.json
@@ -8,14 +8,14 @@
           "support": {
             "chrome": {
               "version_added": "1",
-              "notes": "Due to OS limitations, styling of <code>&lt;option&rt;</code> elements does not work on macOS."
+              "notes": "On macOS, styling <code>&lt;option&rt;</code> elements has no effect."
             },
             "chrome_android": {
               "version_added": "18"
             },
             "edge": {
               "version_added": "12",
-              "notes": "Due to OS limitations, styling of <code>&lt;option&rt;</code> elements does not work on macOS."
+              "notes": "On macOS, styling <code>&lt;option&rt;</code> elements has no effect."
             },
             "firefox": {
               "version_added": "1",
@@ -23,25 +23,25 @@
             },
             "firefox_android": {
               "version_added": "4",
-              "notes": "Support for styling <code>&lt;option&rt;</code> elements was removed in Firefox 56."
+              "notes": "From Firefox 56, <code>&lt;option&rt;</code> elements cannot be styled."
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
               "version_added": "9",
-              "notes": "Due to OS limitations, styling of <code>&lt;option&rt;</code> elements does not work on macOS."
+              "notes": "On macOS, styling <code>&lt;option&rt;</code> elements has no effect."
             },
             "opera_android": {
               "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.1",
-              "notes": "Due to OS limitations, styling of <code>&lt;option&rt;</code> elements does not work on macOS."
+              "notes": "Styling <code>&lt;option&rt;</code> elements has no effect."
             },
             "safari_ios": {
               "version_added": "3.1",
-              "notes": "Due to OS limitations, styling of <code>&lt;option&rt;</code> elements does not work on iOS/iPadOS."
+              "notes": "Styling <code>&lt;option&rt;</code> elements has no effect."
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
Due to OS limitations, styling of `<option>` elements is not permitted on macOS, iOS, and iPadOS devices.  Furthermore, it appears that styling of `<option>` elements was removed in Firefox 56.  This PR updates the `:checked` selector to reflect such information.

Part of work for #5933.