### PR TITLE
Add row for CSS content property alt-text

### DIFF
--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -48,6 +48,54 @@
             "deprecated": false
           }
         },
+        "alt_text": {
+          "__compat": {
+            "description": "Alt text",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": "18"
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": "14"
+              },
+              "safari": {
+                "version_added": "3"
+              },
+              "safari_ios": {
+                "version_added": "1"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0"
+              },
+              "webview_android": {
+                "version_added": "1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "element_replacement": {
           "__compat": {
             "description": "Element replacement",

--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -50,7 +50,7 @@
         },
         "alt_text": {
           "__compat": {
-            "description": "Alt text",
+            "description": "Alternative text after <code>/</code>",
             "support": {
               "chrome": {
                 "version_added": "1"


### PR DESCRIPTION
Part of work for #5933.  It was determined that Firefox doesn't have support for alt text in the `content` property, so this PR adds a new feature for alt text.  All data was determined via manual testing.