### PR TITLE
Update Chrome/Safari data for CSS font-kerning

### DIFF
--- a/css/properties/font-kerning.json
+++ b/css/properties/font-kerning.json
@@ -11,7 +11,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "18",
+                "version_added": "29",
                 "version_removed": "33"
               }
             ],
@@ -21,7 +21,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "18",
+                "version_added": "29",
                 "version_removed": "33"
               }
             ],
@@ -69,7 +69,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "15",
+                "version_added": "16",
                 "version_removed": "20"
               }
             ],
@@ -79,7 +79,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "14",
+                "version_added": "16",
                 "version_removed": "20"
               }
             ],
@@ -117,7 +117,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "≤37",
+                "version_added": "4.4",
                 "version_removed": "4.4.3"
               }
             ]

--- a/css/properties/font-kerning.json
+++ b/css/properties/font-kerning.json
@@ -5,16 +5,27 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-kerning",
           "support": {
-            "chrome": {
-              "prefix": "-webkit-",
-              "version_added": "32"
-            },
-            "chrome_android": {
-              "prefix": "-webkit-",
-              "version_added": "32"
-            },
+            "chrome": [
+              {
+                "version_added": "33"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "18",
+                "version_removed": "33"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "33"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "18",
+                "version_removed": "33"
+              }
+            ],
             "edge": {
-              "prefix": "-webkit-",
               "version_added": "79"
             },
             "firefox": [
@@ -52,28 +63,61 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "prefix": "-webkit-",
-              "version_added": "19"
-            },
-            "opera_android": {
-              "prefix": "-webkit-",
-              "version_added": "19"
-            },
-            "safari": {
-              "version_added": "7"
-            },
-            "safari_ios": {
-              "version_added": "7"
-            },
-            "samsunginternet_android": {
-              "version_added": "2.0",
-              "prefix": "-webkit-"
-            },
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "37"
-            }
+            "opera": [
+              {
+                "version_added": "20"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "15",
+                "version_removed": "20"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "20"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "14",
+                "version_removed": "20"
+              }
+            ],
+            "safari": [
+              {
+                "version_added": "9"
+              },
+              {
+                "version_added": "6",
+                "prefix": "-webkit"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "6",
+                "prefix": "-webkit"
+              }
+            ],
+            "samsunginternet_android": [
+              {
+                "version_added": "2.0"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1.0",
+                "version_removed": "2.0"
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "4.4.3"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "≤37",
+                "version_removed": "4.4.3"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/font-kerning.json
+++ b/css/properties/font-kerning.json
@@ -94,6 +94,9 @@
             ],
             "safari_ios": [
               {
+                "version_added": "9"
+              },
+              {
                 "version_added": "6",
                 "prefix": "-webkit"
               }


### PR DESCRIPTION
Upon review of our data for the `font-kerning` property, it seems we had a few issues.  First, it turns out Chrome supports the property without a prefix, as does Safari, in their latest versions.  Chrome removed the prefix entirely when it added non-prefixed support in M33, and Safari added non-prefixed support along with prefixed support in Safari 9.  This PR updates the data accordingly.  (Data comes from manual testing.)

Part of work for #5933.