### PR TITLE
Single number support for ratio CSS type behind a flag in Firefox

### DIFF
--- a/css/types/ratio.json
+++ b/css/types/ratio.json
@@ -63,7 +63,14 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "70"
+                "version_added": "70",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.aspect-ratio-number.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": {
                 "version_added": false


### PR DESCRIPTION
It turns out that single value support is disabled by default in Firefox.  This PR updates our data to reflect this information.

Related bugs: https://bugzil.la/1565562, https://bugzil.la/1621090

Part of work for #5933.