### PR TITLE
Chromium has no unprefixed support for text-emphasis-*

### DIFF
--- a/css/properties/text-emphasis-color.json
+++ b/css/properties/text-emphasis-color.json
@@ -53,13 +53,13 @@
               "version_added": false
             },
             "opera": {
-                "prefix": "-webkit-",
-                "version_added": "15"
-              },
+              "prefix": "-webkit-",
+              "version_added": "15"
+            },
             "opera_android": {
-                "prefix": "-webkit-",
-                "version_added": "14"
-              },
+              "prefix": "-webkit-",
+              "version_added": "14"
+            },
             "safari": [
               {
                 "version_added": "6.1"

--- a/css/properties/text-emphasis-color.json
+++ b/css/properties/text-emphasis-color.json
@@ -5,33 +5,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-emphasis-color",
           "support": {
-            "chrome": [
-              {
-                "version_added": "25"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "25"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "25"
-              }
-            ],
-            "edge": [
-              {
-                "version_added": "79"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "79"
-              }
-            ],
+            "chrome": {
+              "prefix": "-webkit-",
+              "version_added": "25"
+            },
+            "chrome_android": {
+              "prefix": "-webkit-",
+              "version_added": "25"
+            },
+            "edge": {
+              "prefix": "-webkit-",
+              "version_added": "79"
+            },
             "firefox": [
               {
                 "version_added": "46"
@@ -67,24 +52,14 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "15"
-              },
-              {
+            "opera": {
                 "prefix": "-webkit-",
                 "version_added": "15"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "14"
               },
-              {
+            "opera_android": {
                 "prefix": "-webkit-",
                 "version_added": "14"
-              }
-            ],
+              },
             "safari": [
               {
                 "version_added": "6.1"
@@ -103,24 +78,14 @@
                 "version_added": "7"
               }
             ],
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": "4.4"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "4.4"
-              }
-            ]
+            "samsunginternet_android": {
+              "prefix": "-webkit-",
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "prefix": "-webkit-",
+              "version_added": "4.4"
+            }
           },
           "status": {
             "experimental": false,

--- a/css/properties/text-emphasis-position.json
+++ b/css/properties/text-emphasis-position.json
@@ -53,13 +53,13 @@
               "version_added": false
             },
             "opera": {
-                "prefix": "-webkit-",
-                "version_added": "15"
-              },
+              "prefix": "-webkit-",
+              "version_added": "15"
+            },
             "opera_android": {
-                "prefix": "-webkit-",
-                "version_added": "14"
-              },
+              "prefix": "-webkit-",
+              "version_added": "14"
+            },
             "safari": [
               {
                 "version_added": "6.1"

--- a/css/properties/text-emphasis-position.json
+++ b/css/properties/text-emphasis-position.json
@@ -5,33 +5,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-emphasis-position",
           "support": {
-            "chrome": [
-              {
-                "version_added": "25"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "25"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "25"
-              }
-            ],
-            "edge": [
-              {
-                "version_added": "79"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "79"
-              }
-            ],
+            "chrome": {
+              "prefix": "-webkit-",
+              "version_added": "25"
+            },
+            "chrome_android": {
+              "prefix": "-webkit-",
+              "version_added": "25"
+            },
+            "edge": {
+              "prefix": "-webkit-",
+              "version_added": "79"
+            },
             "firefox": [
               {
                 "version_added": "46"
@@ -67,24 +52,14 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "15"
-              },
-              {
+            "opera": {
                 "prefix": "-webkit-",
                 "version_added": "15"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "14"
               },
-              {
+            "opera_android": {
                 "prefix": "-webkit-",
                 "version_added": "14"
-              }
-            ],
+              },
             "safari": [
               {
                 "version_added": "6.1"
@@ -103,24 +78,14 @@
                 "version_added": "7"
               }
             ],
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": "4.4"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "4.4"
-              }
-            ]
+            "samsunginternet_android": {
+              "prefix": "-webkit-",
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "prefix": "-webkit-",
+              "version_added": "4.4"
+            }
           },
           "status": {
             "experimental": false,

--- a/css/properties/text-emphasis-style.json
+++ b/css/properties/text-emphasis-style.json
@@ -5,33 +5,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-emphasis-style",
           "support": {
-            "chrome": [
-              {
-                "version_added": "25"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "25"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "25"
-              }
-            ],
-            "edge": [
-              {
-                "version_added": "79"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "79"
-              }
-            ],
+            "chrome": {
+              "prefix": "-webkit-",
+              "version_added": "25"
+            },
+            "chrome_android": {
+              "prefix": "-webkit-",
+              "version_added": "25"
+            },
+            "edge": {
+              "prefix": "-webkit-",
+              "version_added": "79"
+            },
             "firefox": [
               {
                 "version_added": "46"
@@ -67,24 +52,14 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "15"
-              },
-              {
+            "opera": {
                 "prefix": "-webkit-",
                 "version_added": "15"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "14"
               },
-              {
+            "opera_android": {
                 "prefix": "-webkit-",
                 "version_added": "14"
-              }
-            ],
+              },
             "safari": [
               {
                 "version_added": "6.1"
@@ -103,24 +78,14 @@
                 "version_added": "7"
               }
             ],
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": "4.4"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "4.4"
-              }
-            ]
+            "samsunginternet_android": {
+              "prefix": "-webkit-",
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "prefix": "-webkit-",
+              "version_added": "4.4"
+            }
           },
           "status": {
             "experimental": false,

--- a/css/properties/text-emphasis-style.json
+++ b/css/properties/text-emphasis-style.json
@@ -53,13 +53,13 @@
               "version_added": false
             },
             "opera": {
-                "prefix": "-webkit-",
-                "version_added": "15"
-              },
+              "prefix": "-webkit-",
+              "version_added": "15"
+            },
             "opera_android": {
-                "prefix": "-webkit-",
-                "version_added": "14"
-              },
+              "prefix": "-webkit-",
+              "version_added": "14"
+            },
             "safari": [
               {
                 "version_added": "6.1"

--- a/css/properties/text-emphasis.json
+++ b/css/properties/text-emphasis.json
@@ -53,13 +53,13 @@
               "version_added": false
             },
             "opera": {
-                "prefix": "-webkit-",
-                "version_added": "15"
-              },
+              "prefix": "-webkit-",
+              "version_added": "15"
+            },
             "opera_android": {
-                "prefix": "-webkit-",
-                "version_added": "14"
-              },
+              "prefix": "-webkit-",
+              "version_added": "14"
+            },
             "safari": [
               {
                 "version_added": "6.1"

--- a/css/properties/text-emphasis.json
+++ b/css/properties/text-emphasis.json
@@ -5,33 +5,18 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-emphasis",
           "support": {
-            "chrome": [
-              {
-                "version_added": "25"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "25"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "25"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "25"
-              }
-            ],
-            "edge": [
-              {
-                "version_added": "79"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "79"
-              }
-            ],
+            "chrome": {
+              "prefix": "-webkit-",
+              "version_added": "25"
+            },
+            "chrome_android": {
+              "prefix": "-webkit-",
+              "version_added": "25"
+            },
+            "edge": {
+              "prefix": "-webkit-",
+              "version_added": "79"
+            },
             "firefox": [
               {
                 "version_added": "46"
@@ -67,24 +52,14 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "15"
-              },
-              {
+            "opera": {
                 "prefix": "-webkit-",
                 "version_added": "15"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "14"
               },
-              {
+            "opera_android": {
                 "prefix": "-webkit-",
                 "version_added": "14"
-              }
-            ],
+              },
             "safari": [
               {
                 "version_added": "6.1"
@@ -103,24 +78,14 @@
                 "version_added": "7"
               }
             ],
-            "samsunginternet_android": [
-              {
-                "version_added": "1.5"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "1.5"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": "4.4"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "4.4"
-              }
-            ]
+            "samsunginternet_android": {
+              "prefix": "-webkit-",
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "prefix": "-webkit-",
+              "version_added": "4.4"
+            }
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
After some research, it appears that Chrome oddly has no support for the `text-emphasis` properties without a prefix, yet Safari does.  This PR updates our data to indicate as such.

Part of work for #5933.