### PR TITLE
Update Chromium support for min-intrinsic

### DIFF
--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -329,7 +329,7 @@
                 },
                 {
                   "alternative_name": "min-intrinsic",
-                  "version_added": "22",
+                  "version_added": "25",
                   "version_removed": "48"
                 }
               ],

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -319,7 +319,7 @@
                 },
                 {
                   "alternative_name": "min-intrinsic",
-                  "version_added": "22",
+                  "version_added": "1",
                   "version_removed": "48"
                 }
               ],
@@ -329,7 +329,7 @@
                 },
                 {
                   "alternative_name": "min-intrinsic",
-                  "version_added": "25",
+                  "version_added": "1",
                   "version_removed": "48"
                 }
               ],
@@ -401,7 +401,7 @@
                 },
                 {
                   "alternative_name": "min-intrinsic",
-                  "version_added": "1.5",
+                  "version_added": "1.0",
                   "version_removed": "5.0"
                 }
               ],
@@ -411,7 +411,7 @@
                 },
                 {
                   "alternative_name": "min-intrinsic",
-                  "version_added": "≤37",
+                  "version_added": "1",
                   "version_removed": "48"
                 }
               ]

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -319,21 +319,23 @@
                 },
                 {
                   "alternative_name": "min-intrinsic",
-                  "version_added": "22"
+                  "version_added": "22",
+                  "version_removed": "48"
                 }
               ],
-              "chrome_android": {
-                "version_added": "46"
-              },
-              "edge": [
+              "chrome_android": [
                 {
-                  "version_added": "79"
+                  "version_added": "46"
                 },
                 {
                   "alternative_name": "min-intrinsic",
-                  "version_added": "79"
+                  "version_added": "22",
+                  "version_removed": "48"
                 }
               ],
+              "edge": {
+                "version_added": "79"
+              },
               "firefox": [
                 {
                   "version_added": "66"
@@ -355,12 +357,26 @@
               "ie": {
                 "version_added": false
               },
-              "opera": {
-                "version_added": "44"
-              },
-              "opera_android": {
-                "version_added": "43"
-              },
+              "opera": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "alternative_name": "min-intrinsic",
+                  "version_added": "15",
+                  "version_removed": "35"
+                }
+              ],
+              "opera_android": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "alternative_name": "min-intrinsic",
+                  "version_added": "14",
+                  "version_removed": "35"
+                }
+              ],
               "safari": [
                 {
                   "version_added": "11"
@@ -379,12 +395,26 @@
                   "version_added": "1"
                 }
               ],
-              "samsunginternet_android": {
-                "version_added": "5.0"
-              },
-              "webview_android": {
-                "version_added": "46"
-              }
+              "samsunginternet_android": [
+                {
+                  "version_added": "5.0"
+                },
+                {
+                  "alternative_name": "min-intrinsic",
+                  "version_added": "1.5",
+                  "version_removed": "5.0"
+                }
+              ],
+              "webview_android": [
+                {
+                  "version_added": "46"
+                },
+                {
+                  "alternative_name": "min-intrinsic",
+                  "version_added": "≤37",
+                  "version_removed": "48"
+                }
+              ]
             },
             "status": {
               "experimental": false,

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -329,7 +329,7 @@
                 },
                 {
                   "alternative_name": "min-intrinsic",
-                  "version_added": "1",
+                  "version_added": "18",
                   "version_removed": "48"
                 }
               ],


### PR DESCRIPTION
Chrome dropped support for `min-intrinsic` in M48.  This PR updates our data accordingly.  (Determined via manual testing, as well as https://www.chromestatus.com/feature/5758434351775744.)

Furthermore, it appears there was a sight issue in our data.  `min-intrinsic` was labeled as supported since Chrome 22, however this conflicts with the fact that `intrinsic` was supported since Chrome 1 (see #5962), and from manual testing that reveals support for `intrinsic` in Chrome 1.

Part of work for #5933.