### PR TITLE
[CSS: width: stretch] Correct Safari data

### DIFF
--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -429,11 +429,11 @@
                 "version_added": "14"
               },
               "safari": {
-                "prefix": "-webkit-",
+                "alternative_name": "-webkit-fill-available",
                 "version_added": "6.1"
               },
               "safari_ios": {
-                "prefix": "-webkit-",
+                "alternative_name": "-webkit-fill-available",
                 "version_added": "6.1"
               },
               "samsunginternet_android": {


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [X] Summarize your changes
`stretch` was implemented as `-webkit-fill-available`: 
- [X] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
https://trac.webkit.org/changeset/120849/webkit.
- [X] Data: if you tested something, describe how you tested with details like browser and version
https://github.com/postcss/autoprefixer/issues/1294#issuecomment-609639339
- [X] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [X] Link to related issues or pull requests, if any
https://github.com/postcss/autoprefixer/issues/1294