### PR TITLE
Firefox Android doesn't support prefers-color-scheme

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1297,7 +1297,7 @@
                 "version_added": "67"
               },
               "firefox_android": {
-                "version_added": "67"
+                "version_added": false
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
Successor to #5799.  It turns out that Firefox Android doesn't have support for `prefers-color-scheme` with Android just yet.  This PR fixes #5798 by setting FxA's support to `false`.