### PR TITLE
Add JavaScript engine to browser schema

### DIFF
--- a/schemas/browsers-schema.md
+++ b/schemas/browsers-schema.md
@@ -66,6 +66,10 @@ The release objects consist of the following properties:
 
 - An optional `engine_version` property which is the version of the browser's engine. This may or may not differ from the browser version.
 
+- An optional `js_engine` property which is the name of the browser's JavaScript engine.
+
+- An optional `js_engine_version` property which is the version of the browser's JavaScript engine.
+
 ### Exports
 
 This structure is exported for consumers of `mdn-browser-compat-data`:

--- a/schemas/browsers.schema.json
+++ b/schemas/browsers.schema.json
@@ -68,9 +68,35 @@
           "type": "string",
           "description": "Version of the engine corresponding to the browser version."
         },
+        "js_engine": {
+          "type": "string",
+          "enum": [
+            "V8",
+            "Chakra",
+            "JavaScriptCore",
+            "SpiderMonkey",
+            "Linear A",
+            "Linear B",
+            "Futhark",
+            "Carakan"
+          ],
+          "description": "Name of the browser's underlying JavaScript engine."
+        },
+        "js_engine_version": {
+          "type": "string",
+          "description": "Version of the  JavaScriptengine corresponding to the browser version."
+        },
         "status": {
           "type": "string",
-          "enum": ["retired", "current", "exclusive", "beta", "nightly", "esr", "planned"],
+          "enum": [
+            "retired",
+            "current",
+            "exclusive",
+            "beta",
+            "nightly",
+            "esr",
+            "planned"
+          ],
           "description": "The status of the given browser release (e.g. current, retired, beta, nightly)."
         }
       },


### PR DESCRIPTION
This PR adds a new feature to the browser file schema: JavaScript engines.  During work upon the mirroring script, I realized that we didn't have a mapping of V8 versions to Blink versions, which disallowed us from being able to mirror Chrome data to NodeJS.  This PR will allow us the ability to mirror from Chrome to NodeJS by adding JavaScript engine name and version fields to the browser schema.

Since this PR adds new functionality, we should perhaps release it as a part of 2.0 (or a 1.1.x release).

Fixes #4954.