### PR TITLE
Correct `width: stretch` data for Safari

### DIFF
--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -429,11 +429,11 @@
                 "version_added": "14"
               },
               "safari": {
-                "prefix": "-webkit-",
+                "alternative_name": "-webkit-fill-available",
                 "version_added": "6.1"
               },
               "safari_ios": {
-                "prefix": "-webkit-",
+                "alternative_name": "-webkit-fill-available",
                 "version_added": "6.1"
               },
               "samsunginternet_android": {


### PR DESCRIPTION
We have been discussing Safari’s support for the `width: stretch` value in Autoprefixer’s repository: https://github.com/postcss/autoprefixer/issues/1294.

Summary:

1. The current MDN data states that `width: stretch` is prefixed in Safari, which would mean `-webkit-stretch`, but such a value does not exist.
2. Instead, Safari supports the `-webkit-fill-available` value, just like Chromium-based browsers.
3. I have confirmed this in Safari on desktop.

For more details, see the linked discussion.
