### PR TITLE
Deprecate BeforeInstallPromptEvent & appinstalled

### DIFF
--- a/api/BeforeInstallPromptEvent.json
+++ b/api/BeforeInstallPromptEvent.json
@@ -43,8 +43,8 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": true,
-          "deprecated": false
+          "standard_track": false,
+          "deprecated": true
         }
       },
       "BeforeInstallPromptEvent": {
@@ -91,8 +91,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -140,7 +140,7 @@
           "status": {
             "experimental": true,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -187,8 +187,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -235,8 +235,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }

--- a/api/Window.json
+++ b/api/Window.json
@@ -4484,8 +4484,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -4532,8 +4532,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
https://github.com/w3c/manifest/pull/836 removed `appinstalled` and `BeforeInstallPromptEvent` from the Manifest spec. https://github.com/w3c/manifest/commit/8c7fd7b