### PR TITLE
Make data for width: fit-content consistent

### DIFF
--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -157,9 +157,15 @@
                   "version_added": "22"
                 }
               ],
-              "chrome_android": {
-                "version_added": "46"
-              },
+              "chrome_android": [
+                {
+                  "version_added": "46"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "25"
+                }
+              ],
               "edge": [
                 {
                   "version_added": "79"
@@ -189,9 +195,15 @@
                   "version_added": "15"
                 }
               ],
-              "opera_android": {
-                "version_added": "33"
-              },
+              "opera_android": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "14"
+                }
+              ],
               "safari": [
                 {
                   "version_added": "11"
@@ -210,13 +222,24 @@
                   "version_added": "7"
                 }
               ],
-              "samsunginternet_android": {
-                "alternative_name": "-webkit-fill-available",
-                "version_added": "5.0"
-              },
-              "webview_android": {
-                "version_added": "46"
-              }
+              "samsunginternet_android": [
+                {
+                  "version_added": "5.0"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "1.5"
+                }
+              ],
+              "webview_android": [
+                {
+                  "version_added": "46"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "≤37"
+                }
+              ]
             },
             "status": {
               "experimental": false,


### PR DESCRIPTION
This PR makes the data for the `fit-content` feature consistent across Chromium browsers.  `fit-content` is supported both with and without a prefix in Chrome, however this wasn't reflected in Android Chromium browsers (this was confirmed in manual testing).  Furthermore, Samsung Internet was labeled as supported under `-webkit-fill-available`, which is inaccurate (that's for `stretch`).