### PR TITLE
Add intrinsic and make width: fit-content consistent

### DIFF
--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -155,11 +155,27 @@
                 {
                   "prefix": "-webkit-",
                   "version_added": "22"
+                },
+                {
+                  "alternative_name": "intrinsic",
+                  "version_added": "1",
+                  "version_removed": "48"
                 }
               ],
-              "chrome_android": {
-                "version_added": "46"
-              },
+              "chrome_android": [
+                {
+                  "version_added": "46"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "25"
+                },
+                {
+                  "alternative_name": "intrinsic",
+                  "version_added": "1",
+                  "version_removed": "48"
+                }
+              ],
               "edge": [
                 {
                   "version_added": "79"
@@ -187,11 +203,27 @@
                 {
                   "prefix": "-webkit-",
                   "version_added": "15"
+                },
+                {
+                  "alternative_name": "intrinsic",
+                  "version_added": "15",
+                  "version_removed": "35"
                 }
               ],
-              "opera_android": {
-                "version_added": "33"
-              },
+              "opera_android": [
+                {
+                  "version_added": "33"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "14"
+                },
+                {
+                  "alternative_name": "intrinsic",
+                  "version_added": "14",
+                  "version_removed": "35"
+                }
+              ],
               "safari": [
                 {
                   "version_added": "11"
@@ -199,6 +231,10 @@
                 {
                   "prefix": "-webkit-",
                   "version_added": "6.1"
+                },
+                {
+                  "alternative_name": "intrinsic",
+                  "version_added": "2"
                 }
               ],
               "safari_ios": [
@@ -208,15 +244,40 @@
                 {
                   "prefix": "-webkit-",
                   "version_added": "7"
+                },
+                {
+                  "alternative_name": "intrinsic",
+                  "version_added": "1"
                 }
               ],
-              "samsunginternet_android": {
-                "alternative_name": "-webkit-fill-available",
-                "version_added": "5.0"
-              },
-              "webview_android": {
-                "version_added": "46"
-              }
+              "samsunginternet_android": [
+                {
+                  "version_added": "5.0"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "1.5"
+                },
+                {
+                  "alternative_name": "intrinsic",
+                  "version_added": "1.0",
+                  "version_removed": "5.0"
+                }
+              ],
+              "webview_android": [
+                {
+                  "version_added": "46"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "≤37"
+                },
+                {
+                  "alternative_name": "intrinsic",
+                  "version_added": "1",
+                  "version_removed": "48"
+                }
+              ],
             },
             "status": {
               "experimental": false,

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -172,7 +172,7 @@
                 },
                 {
                   "alternative_name": "intrinsic",
-                  "version_added": "1",
+                  "version_added": "18",
                   "version_removed": "48"
                 }
               ],
@@ -277,7 +277,7 @@
                   "version_added": "1",
                   "version_removed": "48"
                 }
-              ],
+              ]
             },
             "status": {
               "experimental": false,


### PR DESCRIPTION
Chrome and Safari had support for `fit-content` under both the `intrinsic` keyword since Chrome 1 and Safari 2.  However, Chrome removed `intrinsic` in M48 (see https://www.chromestatus.com/feature/5758434351775744).   This PR updates `fit-content` to reflect said information.

Additionally, this PR makes the data for the `fit-content` feature consistent across Chromium browsers.  `fit-content` is supported both with and without a prefix in Chrome, however this wasn't reflected in Android Chromium browsers (this was confirmed in manual testing).  Samsung Internet was labeled as supported under `-webkit-fill-available`, which is inaccurate (that's for `stretch`).