### PR TITLE
Drop "prefix" key for "slot" attribute Safari data

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1590,8 +1590,7 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "10",
-              "prefix": "-webkit-"
+              "version_added": "10"
             },
             "safari_ios": {
               "version_added": "10"


### PR DESCRIPTION
https://trac.webkit.org/changeset/189950/webkit shows that when the `slot` attribute was first added to WebKit, it was added with exactly that `slot` name, unprefixed. In particular see:

* https://trac.webkit.org/changeset/189950/webkit#file19
* https://trac.webkit.org/changeset/189950/webkit#file27

And the implementation was never changed to add a prefix to the attribute name:

https://trac.webkit.org/log/webkit/trunk/Source/WebCore/html/HTMLAttributeNames.in

And certainly at this point, in current Safari, support for it is implemented with no prefix required.