### PR TITLE
Safari macOS 13.1/iOS 13.4 supports optional chaining

### DIFF
--- a/javascript/operators/optional_chaining.json
+++ b/javascript/operators/optional_chaining.json
@@ -83,10 +83,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
It was enabled in JavaScriptCore by default in November, but probably only became available in public Safari with the latest updates.

Also verified in the JS console.