### PR TITLE
Update rejectionhandled & unhandledrejection data

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -6774,7 +6774,7 @@
               "version_added": "49"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "49"
             },
             "edge": {
               "version_added": "≤79"
@@ -6808,22 +6808,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "36"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "49"
             }
           },
           "status": {
@@ -9519,10 +9519,10 @@
               "version_added": "49"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "49"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "≤79"
             },
             "firefox": [
               {
@@ -9553,22 +9553,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "36"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "49"
             }
           },
           "status": {


### PR DESCRIPTION
This change aligns the browser-version data for the `rejectionhandled` and `unhandledrejection` events with the existing browser-version data we already have for `PromiseRejectionEvent`.

For additional confirmation of the Safari version data, see:

https://developer.apple.com/safari/technology-preview/release-notes/#r30
> Added support for Unhandled Promise Rejection events

*“Support for promise rejection events (unhandledrejection)”* changeset
https://trac.webkit.org/changeset/215916/webkit (Apr 27, 2017)