### PR TITLE
Correct meta[name=referrer] misspelling "referer"

### DIFF
--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -524,7 +524,7 @@
               }
             }
           },
-          "referer": {
+          "referrer": {
             "__compat": {
               "description": "referrer value",
               "support": {


### PR DESCRIPTION
https://html.spec.whatwg.org/multipage/#meta-referrer