### PR TITLE
Add data for meta[name="theme-color"]

### DIFF
--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -625,6 +625,64 @@
                 "deprecated": true
               }
             }
+          },
+          "theme-color": {
+            "__compat": {
+              "support": {
+                "chrome": [
+                  {
+                    "version_added": "73",
+                    "partial_implementation": true,
+                    "notes": "Desktop Chrome only uses the color on installed progressive web apps. (Per caniuse.com.)"
+                  },
+                  {
+                    "version_added": "39",
+                    "version_removed": "72",
+                    "partial_implementation": true,
+                    "notes": "Desktop Chrome 39-72 claimed to have support, but did not actually use the color anywhere. Chrome for Android did use the color in the toolbar. (Per caniuse.com.)"
+                  }
+                ],
+                "chrome_android": {
+                  "version_added": "80",
+                  "notes": "Chrome for Android does not use the color on devices with native dark-mode enabled. (Per caniuse.com.)"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": "6.2"
+                },
+                "webview_android": {
+                  "version_added": false
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
This change adds `meta[name="theme-color"]` and just ports over the existing browser-version data from caniuse at https://github.com/Fyrd/caniuse/blob/master/features-json/meta-theme-color.json

See https://caniuse.com/#feat=meta-theme-color