### PR TITLE
Complete nodejs support data for JS statements

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -143,7 +143,7 @@
               "version_added": "11"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "3"
@@ -195,7 +195,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "4"
@@ -312,7 +312,7 @@
               "version_added": "11"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "6.0.0"
             },
             "opera": {
               "version_added": "9"
@@ -364,7 +364,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "4"
@@ -416,7 +416,7 @@
               "version_added": "4"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "10"
@@ -470,7 +470,7 @@
                 "version_added": "4"
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.1.100"
               },
               "opera": {
                 "version_added": "4"
@@ -635,7 +635,7 @@
               "version_added": "4"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "4"
@@ -688,7 +688,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "3"
@@ -850,7 +850,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "3"
@@ -1022,7 +1022,7 @@
               "version_added": "6"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "36"
@@ -1077,7 +1077,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.12"
             },
             "opera": {
               "version_added": "25"
@@ -1127,7 +1127,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": null
+                "version_added": "10.0.0"
               },
               "opera": {
                 "version_added": "50"
@@ -1178,7 +1178,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "6.5.0"
               },
               "opera": {
                 "version_added": "38"
@@ -1231,7 +1231,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "3"
@@ -1396,7 +1396,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "6.0.0"
               },
               "opera": {
                 "version_added": "36"
@@ -1447,7 +1447,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "6.0.0"
               },
               "opera": {
                 "version_added": "37"
@@ -1552,7 +1552,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "3"
@@ -1837,20 +1837,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": true
-                },
-                {
-                  "version_added": true,
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--enable-experimental-web-platform-features"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": false
+              },
               "opera": {
                 "version_added": false
               },
@@ -1905,6 +1894,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "10.4.0"
+            },
             "opera": {
               "version_added": "51"
             },
@@ -1955,7 +1947,7 @@
               "version_added": "4"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "4"
@@ -2133,7 +2125,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "3"
@@ -2185,7 +2177,7 @@
               "version_added": "4"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "4"
@@ -2237,7 +2229,7 @@
               "version_added": "5"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "4"
@@ -2290,7 +2282,7 @@
               "version_added": "5"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "4"
@@ -2446,7 +2438,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "3"
@@ -2498,7 +2490,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "3"
@@ -2550,7 +2542,7 @@
               "version_added": "3"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.1.100"
             },
             "opera": {
               "version_added": "4"

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1004,10 +1004,10 @@
           "spec_url": "https://tc39.es/ecma262/#sec-for-in-and-for-of-statements",
           "support": {
             "chrome": {
-              "version_added": "49"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "49"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1025,22 +1025,22 @@
               "version_added": "0.1.100"
             },
             "opera": {
-              "version_added": "36"
+              "version_added": "2"
             },
             "opera_android": {
-              "version_added": "36"
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "49"
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
Completes https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements#Browser_compatibility

Basic features are set to the very first nodejs version and other data is from https://node.green/.