### PR TITLE
Add data for link[rel="icon"]

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -732,7 +732,7 @@
                   "version_added": "2"
                 },
                 "firefox_android": {
-                  "version_added": "68"
+                  "version_added": "4"
                 },
                 "ie": {
                   "version_added": "11"

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -714,6 +714,58 @@
               }
             }
           },
+          "icon": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "4",
+                  "notes": "If both ICO and PNG are available, will use ICO over PNG if ICO has better matching sizes set. (Per caniuse.com.)"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12",
+                  "notes": "In version 79 and later (Blink-based Edge), if both ICO and PNG are available, will use ICO over PNG if ICO has better matching sizes set. (Per caniuse.com.)"
+                },
+                "firefox": {
+                  "version_added": "2"
+                },
+                "firefox_android": {
+                  "version_added": "68"
+                },
+                "ie": {
+                  "version_added": "11"
+                },
+                "opera": {
+                  "version_added": "9",
+                  "notes": "In version 15 and later (Blink-based Opera), if both ICO and PNG are available, will use ICO over PNG if ICO has better matching sizes set. (Per caniuse.com.)"
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": "3.1",
+                  "notes": "If both ICO and PNG are available, will ALWAYS use ICO file, regardless of sizes set. (Per caniuse.com.)"
+                },
+                "safari_ios": {
+                  "version_added": false,
+                  "notes": "Does not use favicons at all (but may have alternative for bookmarks, etc.). (Per caniuse.com.)"
+                },
+                "samsunginternet_android": {
+                  "version_added": "4.0"
+                },
+                "webview_android": {
+                  "version_added": "38"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "manifest": {
             "__compat": {
               "support": {


### PR DESCRIPTION
This change adds `link[rel="icon"]` and essentially just ports over the existing browser-version data from caniuse at https://github.com/Fyrd/caniuse/blob/master/features-json/link-icon-png.json

https://caniuse.com/#feat=link-icon-png