### PR TITLE
Add Location.p.ancestorOrigins

### DIFF
--- a/api/Location.json
+++ b/api/Location.json
@@ -47,6 +47,54 @@
           "deprecated": false
         }
       },
+      "ancestorOrigins": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Location/ancestorOrigins",
+          "support": {
+            "chrome": {
+              "version_added": "20"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": "4.4"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "assign": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Location/assign",


### PR DESCRIPTION
The way I determined the browser versions for this is:

1. Started at https://trac.webkit.org/changeset/113945/webkit, revision 113945, which is the actual commit which added this feature to the WebKit sources.
2. Found from https://trac.webkit.org/log/webkit/tags/Safari-536.7/Source that the tag for WebKit 536.7 includes everything up to change 114002, so that’s the earliest tag which contains revision 113945.
3. Found from `browsers/safari.json` that Safari 6, engine version 536.25, was the earliest Safari release after 536.7.
4. Found from `browsers/chrome.json` that Chrome 20, engine version 536.10, was the earliest Chrome release after 536.7.
5. Set version data for other browsers based on the above version info.

Note that https://bugzilla.mozilla.org/show_bug.cgi?id=1085214 is the open Firefox bug for this.