### PR TITLE
Add data for link[rel="prefetch"]

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -859,42 +859,43 @@
           },
           "prefetch": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Link_types/prefetch",
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": "8"
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": "18"
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": "12"
                 },
                 "firefox": {
-                  "version_added": null
+                  "version_added": "2"
                 },
                 "firefox_android": {
-                  "version_added": null
+                  "version_added": "4"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": "11"
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "15"
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": "14"
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "1.5"
                 },
                 "webview_android": {
-                  "version_added": null
+                  "version_added": "4.4"
                 }
               },
               "status": {


### PR DESCRIPTION
This change ports over the existing browser-version data from caniuse at https://github.com/Fyrd/caniuse/blob/master/features-json/link-rel-prefetch.json

Per https://bugs.webkit.org/show_bug.cgi?id=194539, Safari still really does not have `link[rel="prefetch"]` support.

---

I doublechecked the version data from caniuse, making it more accurate in a couple of places, and filling in some places for which it didn’t provide any data.