### PR TITLE
Add data for link[rel="prerender"]

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -957,42 +957,43 @@
           },
           "prerender": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Link_types/prerender",
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": "13"
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": "18"
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": "79"
                 },
                 "firefox": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox_android": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": "11"
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "15"
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": "14"
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": "1.5"
                 },
                 "webview_android": {
-                  "version_added": null
+                  "version_added": "4.4"
                 }
               },
               "status": {


### PR DESCRIPTION
This change ports over the existing browser-version data from caniuse at https://github.com/Fyrd/caniuse/blob/master/features-json/link-rel-prerender.json