### PR TITLE
Update `gap` Safari support

### DIFF
--- a/css/properties/gap.json
+++ b/css/properties/gap.json
@@ -198,14 +198,24 @@
               "qq_android": {
                 "version_added": null
               },
-              "safari": {
-                "version_added": "10.1",
-                "alternative_name": "grid-gap"
-              },
-              "safari_ios": {
-                "version_added": "10.3",
-                "alternative_name": "grid-gap"
-              },
+              "safari": [
+                {
+                  "version_added": "10.1",
+                  "alternative_name": "grid-gap"
+                },
+                {
+                  "version_added": "12"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "10.3",
+                  "alternative_name": "grid-gap"
+                },
+                {
+                  "version_added": "12"
+                }
+              ],
               "samsunginternet_android": [
                 {
                   "version_added": "9.0"


### PR DESCRIPTION
When I tested `gap`, it seems to work in Safari 12+.

I haven't tested this on iOS, but usually mobile support mirrors desktop?

---

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
