### PR TITLE
Opera 67 now supports nullish coalescing operator

### DIFF
--- a/javascript/operators/nullish_coalescing.json
+++ b/javascript/operators/nullish_coalescing.json
@@ -29,7 +29,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "67.0"
+              "version_added": "67"
             },
             "opera_android": {
               "version_added": false

--- a/javascript/operators/nullish_coalescing.json
+++ b/javascript/operators/nullish_coalescing.json
@@ -29,7 +29,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "67.0"
             },
             "opera_android": {
               "version_added": false


### PR DESCRIPTION
A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- Simply changed "false" to "67.0" for Opera.
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- Appears to be an undocumented feature.
- [x] Data: if you tested something, describe how you tested with details like browser and version
- Using plnkr.co, I ran this plunk: http://plnkr.co/Eqx3qAbWccRM9arP
Totally works in Chrome, Firefox, and Safari as expected. It failed with a syntax error in Opera 66. I then upgraded to Opera 67. Ran that plunk again and it absolutely worked just like in the other browsers.
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [x] Link to related issues or pull requests, if any
- #5987 
