### PR TITLE
Set correct compatibility for storage event in safari

### DIFF
--- a/api/StorageEvent.json
+++ b/api/StorageEvent.json
@@ -77,10 +77,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/StorageEvent.json
+++ b/api/StorageEvent.json
@@ -77,10 +77,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
Set `StorageEvent() constructor` compatibility to `true` in Safari. I tried looking at test in the [`Web Platform Tests`](wpt.fyi) project but couldn't find any appropriate to link here.

I just tested this in my local browser like so:

```js
> new StorageEvent()
< TypeError: Not enough arguments
> new StorageEvent('storage')
< StorageEvent {isTrusted: false, key: null, oldValue: null, newValue: null, url: "", …}
```
