### PR TITLE
feat(html): Add global enterkeyhint attribute

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -877,7 +877,7 @@
               "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": "13.1"
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -874,10 +874,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -846,6 +846,54 @@
           }
         }
       },
+      "enterkeyhint": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/enterkeyhint",
+          "support": {
+            "chrome": {
+              "version_added": "77"
+            },
+            "chrome_android": {
+              "version_added": "77"
+            },
+            "edge": {
+              "version_added": "false"
+            },
+            "firefox": {
+              "version_added": "false"
+            },
+            "firefox_android": {
+              "version_added": "false"
+            },
+            "ie": {
+              "version_added": "false"
+            },
+            "opera": {
+              "version_added": "false"
+            },
+            "opera_android": {
+              "version_added": "false"
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "13.1"
+            },
+            "samsunginternet_android": {
+              "version_added": "false"
+            },
+            "webview_android": {
+              "version_added": "false"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "exportparts": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/exportparts",

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -857,34 +857,34 @@
               "version_added": "77"
             },
             "edge": {
-              "version_added": "false"
+              "version_added": false
             },
             "firefox": {
-              "version_added": "false"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "false"
+              "version_added": false
             },
             "ie": {
-              "version_added": "false"
+              "version_added": false
             },
             "opera": {
-              "version_added": "false"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "false"
+              "version_added": false
             },
             "safari": {
-              "version_added": "13.1"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "13.1"
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "false"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "false"
+              "version_added": false
             }
           },
           "status": {

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -848,7 +848,6 @@
       },
       "enterkeyhint": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/enterkeyhint",
           "support": {
             "chrome": {
               "version_added": "77"


### PR DESCRIPTION

## Summarize your changes

Add global enterkeyhint attribute

## Data
- [`enterkeyhint` in the WHATWG spec](https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-enterkeyhint-attribute)
- [`enterkeyhint` chrome platform status](https://www.chromestatus.com/feature/5654529808793600)
- https://codepen.io/eps1lon/pen/bGVEZep?editors=1111 if it logs `undefined` then the attribute isn't supported yet

## Link to related issues or pull requests
https://github.com/mdn/sprints/issues/3109