### PR TITLE
No WorkerNavigator.permissons in Firefox yet

### DIFF
--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -109,10 +109,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "46"
+              "version_added": null,
             },
             "firefox_android": {
-              "version_added": "46"
+              "version_added": null,
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1193373 tracks implementing this.  This can be checked by browsing to https://worker-playground.glitch.me/ and pasting `navigator.permissions` into the top box.  (Also, we don't define the `partial interface WorkerNavigator` in https://searchfox.org/mozilla-central/source/dom/webidl/WorkerNavigator.webidl.)