### PR TITLE
CSS alt text for the content property is not supported in safari

### DIFF
--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -77,10 +77,10 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "3"
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": "1"
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "1.0"


### PR DESCRIPTION
This sub-feature appears to not be supported in Safari. Example: https://codepen.io/mfairchild365/pen/LYpNZda - manually tested in Safari 13.1 for MacOS and Safari for iOS 13.4.1.

Safari issue: https://bugs.webkit.org/show_bug.cgi?id=159022

A checklist to help your pull request get merged faster:
- [x] Summarize your changes
- [x] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [x] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
