### PR TITLE
Add Network Error Logging compatibility data

### DIFF
--- a/http/headers/nel.json
+++ b/http/headers/nel.json
@@ -1,0 +1,54 @@
+{
+  "http": {
+    "headers": {
+      "NEL": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/NEL",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/http/headers/nel.json
+++ b/http/headers/nel.json
@@ -5,11 +5,23 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/NEL",
           "support": {
-            "chrome": {
-              "version_added": "69"
-            },
+            "chrome": [
+              {
+                "version_added": "71"
+              },
+              {
+                "version_added": "69",
+                "flags": [
+                  {
+                    "type": "runtime_flag",
+                    "name": "Reporting",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "71"
             },
             "edge": {
               "version_added": "79"
@@ -39,7 +51,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "71"
             }
           },
           "status": {

--- a/http/headers/nel.json
+++ b/http/headers/nel.json
@@ -36,10 +36,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "58"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "50"
             },
             "safari": {
               "version_added": false
@@ -48,7 +48,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.2"
             },
             "webview_android": {
               "version_added": "71"


### PR DESCRIPTION
**Spec**: https://www.w3.org/TR/network-error-logging/
**Chrome version source**: https://www.chromestatus.com/feature/5391249376804864
**Edge version source**: x-ref https://en.wikipedia.org/wiki/Microsoft_Edge#Release_history to find first Blink-based build > Chrome 69

**Documentation**: https://wiki.developer.mozilla.org/en-US/docs/Web/HTTP/Network_Error_Logging


> Network Error Logging is a mechanism that can be configured via the NEL HTTP response header. This experimental header allows web sites and applications to opt-in to receive reports about failed (and, if desired, successful) network fetches from supporting browsers.