### PR TITLE
Update Safari support for TypedArray.copyWithin

### DIFF
--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -344,10 +344,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "10"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "10"
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -344,7 +344,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "10"
+                "version_added": "9.1"
               },
               "safari_ios": {
                 "version_added": "10"

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -347,7 +347,7 @@
                 "version_added": "9.1"
               },
               "safari_ios": {
-                "version_added": "10"
+                "version_added": "9.3"
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
Added in https://bugs.webkit.org/show_bug.cgi?id=148035 which is part of Safari 10.