### PR TITLE
Correct note for classes for Opera

### DIFF
--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -127,11 +127,11 @@
             ],
             "opera": {
               "version_added": "36",
-              "notes": "From Chrome 29 to 35 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
+              "notes": "From Opera 29 to 35 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
             },
             "opera_android": {
               "version_added": "36",
-              "notes": "From Chrome 29 to 35 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
+              "notes": "From Opera 29 to 35 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
             },
             "safari": {
               "version_added": "9"
@@ -204,11 +204,11 @@
             ],
             "opera": {
               "version_added": "36",
-              "notes": "From Chrome 29 to 35 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
+              "notes": "From Opera 29 to 35 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
             },
             "opera_android": {
               "version_added": "36",
-              "notes": "From Chrome 29 to 35 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
+              "notes": "From Opera 29 to 35 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
             },
             "safari": {
               "version_added": "9"
@@ -387,11 +387,11 @@
             ],
             "opera": {
               "version_added": "36",
-              "notes": "From Chrome 29 to 35 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
+              "notes": "From Opera 29 to 35 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
             },
             "opera_android": {
               "version_added": "36",
-              "notes": "From Chrome 29 to 35 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
+              "notes": "From Opera 29 to 35 strict mode is required. Non-strict mode support can be enabled using the flag \"Enable Experimental JavaScript\"."
             },
             "safari": {
               "version_added": "9"


### PR DESCRIPTION
Updates description of notes for Opera in JavaScript classes. Notes had incorrectly "Chrome" in it, instead of "Opera". Fixes #5996