### PR TITLE
SubmitEvent supported in Chrome 81

### DIFF
--- a/api/SubmitEvent.json
+++ b/api/SubmitEvent.json
@@ -6,10 +6,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubmitEvent",
         "support": {
           "chrome": {
-            "version_added": 81
+            "version_added": "81"
           },
           "chrome_android": {
-            "version_added": 81
+            "version_added": "81"
           },
           "edge": {
             "version_added": null
@@ -39,7 +39,7 @@
             "version_added": null
           },
           "webview_android": {
-            "version_added": 81
+            "version_added": "81"
           }
         },
         "status": {
@@ -55,10 +55,10 @@
           "description": "<code>SubmitEvent()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": 81
+              "version_added": "81"
             },
             "chrome_android": {
-              "version_added": 81
+              "version_added": "81"
             },
             "edge": {
               "version_added": null
@@ -88,7 +88,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": 81
+              "version_added": "81"
             }
           },
           "status": {
@@ -105,10 +105,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubmitEvent/submitter",
           "support": {
             "chrome": {
-              "version_added": 81
+              "version_added": "81"
             },
             "chrome_android": {
-              "version_added": 81
+              "version_added": "81"
             },
             "edge": {
               "version_added": null
@@ -138,7 +138,7 @@
               "version_added": null
             },
             "webview_android": {
-              "version_added": 81
+              "version_added": "81"
             }
           },
           "status": {

--- a/api/SubmitEvent.json
+++ b/api/SubmitEvent.json
@@ -1,0 +1,153 @@
+{
+  "api": {
+    "SubmitEvent": {
+      "__compat": {
+        "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#the-submitevent-interface",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubmitEvent",
+        "support": {
+          "chrome": {
+            "version_added": 81
+          },
+          "chrome_android": {
+            "version_added": 81
+          },
+          "edge": {
+            "version_added": null
+          },
+          "firefox": {
+            "version_added": null
+          },
+          "firefox_android": {
+            "version_added": null
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": null
+          },
+          "opera_android": {
+            "version_added": null
+          },
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": {
+            "version_added": null
+          },
+          "samsunginternet_android": {
+            "version_added": null
+          },
+          "webview_android": {
+            "version_added": 81
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "SubmitEvent": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#submitevent",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubmitEvent/SubmitEvent",
+          "description": "<code>SubmitEvent()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": 81
+            },
+            "chrome_android": {
+              "version_added": 81
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": 81
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "submitter": {
+        "__compat": {
+          "description": "The <code>submitter</code> property",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-submitevent-submitter",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubmitEvent/submitter",
+          "support": {
+            "chrome": {
+              "version_added": 81
+            },
+            "chrome_android": {
+              "version_added": 81
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": 81
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/SubmitEvent.json
+++ b/api/SubmitEvent.json
@@ -100,7 +100,6 @@
       },
       "submitter": {
         "__compat": {
-          "description": "The <code>submitter</code> property",
           "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-submitevent-submitter",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubmitEvent/submitter",
           "support": {


### PR DESCRIPTION
  - based on #5882
  - changed browsers with `false` to `null`
  - changed `clipboardData` to `submitter`
  - added `spec_url`s and a `description`
  - added Chrome 81 support

Source https://www.chromestatus.com/feature/5187248926490624