### PR TITLE
IE has no support for Element.toggleAttribute

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -8303,7 +8303,7 @@
               "version_added": "63"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "56"


### PR DESCRIPTION
Element.toggleAttribute came into DOM only in 2018, so IE probably does not have it:
https://github.com/whatwg/dom/commit/980a633468b56577313021e0c38e74df44affe84

A quick test in the IE11 developer tools confirms that `Element.prototype.toggleAttribute` is indeed `undefined`.
