### PR TITLE
Fix Chromium support for content property alt text

### DIFF
--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -53,10 +53,10 @@
             "description": "Alternative text after <code>/</code>",
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": "77"
               },
               "chrome_android": {
-                "version_added": "18"
+                "version_added": "77"
               },
               "edge": {
                 "version_added": "79"
@@ -71,10 +71,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "15"
+                "version_added": "64"
               },
               "opera_android": {
-                "version_added": "14"
+                "version_added": "55"
               },
               "safari": {
                 "version_added": false
@@ -83,10 +83,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": "1.0"
+                "version_added": false
               },
               "webview_android": {
-                "version_added": "1"
+                "version_added": "77"
               }
             },
             "status": {


### PR DESCRIPTION
It looks like the values for this feature were copied from the parent feature. Upon a little digging, this feature appears to have [landed in Chromium 77](https://www.chromestatus.com/features/4550056227110912).

A follow up to #5993.
